### PR TITLE
Update version to 0.1.10, enhance README for code quality enforcement…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ Many data tools support Parquet natively (Tableau, Apache Spark, etc.)
 - **Atomic writes**: For each training record, activate creature, collect ALL neuron data (activations, errors), then write ALL neuron rows together
 - **Parallelization allowed**: Since training dataset is already randomized, we CAN process different training records in parallel
 - **Per-record atomicity**: Each parallel task must process one complete training record (activate → collect all neurons → write all neurons atomically)
-- **Cross-neuron alignment**: Record i in neuron A must correspond to record i in neuron B (they were written together from the same training record)
+- **Cross-neuron alignment**: Records with the same `obs_index` across different neurons correspond to the same training record
 - **No mixing**: Never mix data from different training records within a single discovery record write
+- **Matching by obs_index**: TypeScript matches records across neurons by `obs_index` (not by array position), so record order from Rust doesn't matter
 
 ## JSON Interface
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ The current DenoJS implementation requires extreme filtering of the training dat
    - All new tests should pass after implementation
    - **Always read this README before making any changes**
 
-2. **Code Quality Enforcement**: Run quality checks after every code change
-   - Execute `./quality.sh` after making any code modifications
-   - Fix all linting issues automatically
+2. **Code Quality Enforcement**: **MUST run quality checks after EVERY code change**
+   - **CRITICAL**: Execute `./quality.sh` after making ANY code modifications
+   - This script runs formatting, linting, type checking, and all tests
+   - Fix all linting issues automatically before committing
    - Ensure code formatting and quality standards are maintained
+   - **Never commit code without running `./quality.sh` first**
 
 ### Prerequisites
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,26 @@ pub struct RecordDiscoveryOutput {
     pub error: Option<String>,
 }
 
+/// Safely truncate a UTF-8 string at character boundaries
+///
+/// Returns a string truncated to at most `max_bytes` bytes, ensuring the
+/// truncation occurs at a valid UTF-8 character boundary to avoid panics.
+fn truncate_utf8_safe(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    // Find the last valid character boundary at or before max_bytes
+    // We iterate through character boundaries and keep the last one <= max_bytes
+    let mut last_valid_boundary = 0;
+    for (idx, _) in s.char_indices() {
+        if idx > max_bytes {
+            break;
+        }
+        last_valid_boundary = idx;
+    }
+    &s[..last_valid_boundary]
+}
+
 /// Main entry point for recording discovery data
 ///
 /// Takes JSON input and returns JSON output for easy integration with TypeScript/DenoJS
@@ -159,7 +179,7 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
 
     // DEBUG: Log first 500 chars of input JSON to verify structure
     let input_preview = if input_str.len() > 500 {
-        format!("{}...", &input_str[..500])
+        format!("{}...", truncate_utf8_safe(input_str, 500))
     } else {
         input_str.to_string()
     };
@@ -323,7 +343,7 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
 
     // DEBUG: Log first 1000 chars of JSON to verify errors are included
     let json_preview = if json_string.len() > 1000 {
-        format!("{}...", &json_string[..1000])
+        format!("{}...", truncate_utf8_safe(&json_string, 1000))
     } else {
         json_string.clone()
     };
@@ -472,5 +492,67 @@ mod tests {
             assert_eq!(parsed_read["success"], false);
             assert_eq!(parsed_read["error"].as_str(), Some(error_msg));
         }
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe_ascii() {
+        // Test with ASCII (single-byte characters)
+        let s = "Hello, World!";
+        assert_eq!(truncate_utf8_safe(s, 5), "Hello");
+        assert_eq!(truncate_utf8_safe(s, 13), s);
+        assert_eq!(truncate_utf8_safe(s, 100), s);
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe_multibyte() {
+        // Test with multi-byte UTF-8 characters (each emoji is 4 bytes)
+        let s = "Hello 🦀 World 🌍";
+        // "Hello 🦀" is 11 bytes: "Hello " (6) + "🦀" (4) + " W" (2) = 12 bytes
+        // But we want to test truncation at byte 11, which should cut before "🦀"
+        let truncated = truncate_utf8_safe(s, 11);
+        // Should truncate at character boundary, not in middle of emoji
+        assert!(truncated.len() <= 11);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe_boundary_at_500() {
+        // Test the specific case mentioned in the issue: truncation at byte 500
+        // Create a string with multi-byte characters near position 500
+        let mut s = String::new();
+        for _ in 0..100 {
+            s.push_str("🦀"); // Each emoji is 4 bytes, so 100 emojis = 400 bytes
+        }
+        s.push_str("Hello"); // Add 5 more bytes = 405 bytes total
+
+        // Truncate at 500 - should return full string since it's < 500
+        assert_eq!(truncate_utf8_safe(&s, 500), s.as_str());
+
+        // Truncate at 400 - should cut at character boundary (after 100 emojis)
+        let truncated = truncate_utf8_safe(&s, 400);
+        assert_eq!(truncated.len(), 400); // Exactly 100 emojis
+        assert!(truncated.is_char_boundary(truncated.len()));
+
+        // Truncate at 401 - should include first character of "Hello" (H = 1 byte)
+        let truncated2 = truncate_utf8_safe(&s, 401);
+        assert_eq!(truncated2.len(), 401);
+        assert!(truncated2.is_char_boundary(truncated2.len()));
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe_empty() {
+        let s = "";
+        assert_eq!(truncate_utf8_safe(s, 0), "");
+        assert_eq!(truncate_utf8_safe(s, 100), "");
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe_exact_boundary() {
+        // Test truncation exactly at a character boundary
+        let s = "Hello🦀World";
+        // "Hello" = 5 bytes, "🦀" starts at byte 5
+        let truncated = truncate_utf8_safe(s, 5);
+        assert_eq!(truncated, "Hello");
+        assert_eq!(truncated.len(), 5);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,23 @@ pub struct SynapseJson {
     pub weight: f32,
 }
 
+/// Pre-computed neuron data for a single neuron
+#[derive(Debug, Deserialize)]
+pub struct NeuronData {
+    pub neuron_uuid: String,
+    pub activation: f32,
+    #[serde(default)]
+    pub value: Option<f32>,
+    pub errors: Vec<f32>,
+}
+
 /// Training data record
 #[derive(Debug, Deserialize)]
 pub struct TrainingRecord {
     pub input: Vec<f32>,
     pub output: Vec<f32>,
+    #[serde(default)]
+    pub neuron_data: Option<Vec<NeuronData>>,
 }
 
 /// JSON output from record_discovery function
@@ -73,7 +85,9 @@ pub struct RecordDiscoveryOutput {
 ///
 /// Takes JSON input and returns JSON output for easy integration with TypeScript/DenoJS
 /// Always returns a JSON string, even on error (with success=false)
-pub fn record_discovery(input_json: &str) -> Result<String> {
+///
+/// This is the internal Rust function. For FFI, use `record_discovery`.
+pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     // Parse input JSON - if this fails, return JSON error
     let input: RecordDiscoveryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
@@ -111,6 +125,271 @@ pub fn record_discovery(input_json: &str) -> Result<String> {
     };
 
     Ok(serde_json::to_string(&output)?)
+}
+
+/// FFI export for recording discovery data
+///
+/// # Safety
+/// This function is unsafe because it deals with raw C strings.
+/// The caller must ensure:
+/// - input_json is a valid null-terminated C string
+/// - The returned pointer is freed using free_discovery_result
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+
+    // Read input C string
+    let input_str = unsafe {
+        if input_json.is_null() {
+            let error = r#"{"success":false,"error":"Null input pointer"}"#;
+            return CString::new(error).unwrap().into_raw();
+        }
+        match CStr::from_ptr(input_json).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+        }
+    };
+
+    // DEBUG: Log that we're calling the internal function
+    eprintln!("[DEBUG Rust lib] record_discovery FFI called, calling internal function");
+
+    // DEBUG: Log first 500 chars of input JSON to verify structure
+    let input_preview = if input_str.len() > 500 {
+        format!("{}...", &input_str[..500])
+    } else {
+        input_str.to_string()
+    };
+    eprintln!("[DEBUG Rust lib] Input JSON preview (first 500 chars): {input_preview}");
+
+    // Parse JSON to verify structure (for debugging only)
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(input_str) {
+        eprintln!("[DEBUG Rust lib] JSON parsed successfully");
+        // Log training_data length and first record's neuron_data if available
+        if let Some(training_data) = v.get("training_data").and_then(|td| td.as_array()) {
+            eprintln!(
+                "[DEBUG Rust lib] training_data.length={}",
+                training_data.len()
+            );
+            if let Some(first_record) = training_data.first() {
+                if let Some(neuron_data) =
+                    first_record.get("neuron_data").and_then(|nd| nd.as_array())
+                {
+                    eprintln!(
+                        "[DEBUG Rust lib] First record neuron_data.length={}",
+                        neuron_data.len()
+                    );
+                    if let Some(hidden3) = neuron_data
+                        .iter()
+                        .find(|n| n.get("neuron_uuid").and_then(|u| u.as_str()) == Some("hidden-3"))
+                    {
+                        eprintln!(
+                            "[DEBUG Rust lib] First record hidden-3: activation={:?}, errors={:?}",
+                            hidden3.get("activation"),
+                            hidden3.get("errors")
+                        );
+                    }
+                }
+            }
+        }
+    } else {
+        eprintln!("[DEBUG Rust lib] JSON parse failed (but continuing anyway)");
+    }
+
+    // Call the Rust function with original string
+    let result = match record_discovery_internal(input_str) {
+        Ok(json) => {
+            eprintln!("[DEBUG Rust lib] record_discovery_internal succeeded");
+            json
+        }
+        Err(e) => {
+            eprintln!("[DEBUG Rust lib] record_discovery_internal failed: {e}");
+            let error_json = format!(r#"{{"success":false,"error":"{e}"}}"#);
+            return CString::new(error_json).unwrap().into_raw();
+        }
+    };
+
+    // Return as C string
+    match CString::new(result) {
+        Ok(c_string) => c_string.into_raw(),
+        Err(_) => {
+            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+            CString::new(error).unwrap().into_raw()
+        }
+    }
+}
+
+/// JSON input for read_discovery_records function
+#[derive(Debug, Deserialize)]
+pub struct ReadDiscoveryInput {
+    pub parquet_file: String,
+    pub neuron_uuid: String,
+}
+
+/// JSON output from read_discovery_records function
+#[derive(Debug, Serialize)]
+pub struct ReadDiscoveryOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub records: Option<Vec<DiscoverRecordJson>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// JSON representation of DiscoverRecord for serialization
+#[derive(Debug, Serialize)]
+pub struct DiscoverRecordJson {
+    pub obs_index: u32,
+    pub neuron_uuid: String,
+    pub value: Option<f32>,
+    pub activation: f32,
+    pub errors: Vec<f32>,
+}
+
+/// Read discovery records from Parquet file for a specific neuron
+///
+/// Takes JSON input and returns JSON output for easy integration with TypeScript/DenoJS
+pub fn read_discovery_records(input_json: &str) -> Result<String> {
+    use crate::parquet_format::read_records_from_parquet;
+    use crate::types::DiscoverRecord;
+
+    // Parse input JSON
+    let input: ReadDiscoveryInput = match serde_json::from_str(input_json) {
+        Ok(input) => input,
+        Err(e) => {
+            let output = ReadDiscoveryOutput {
+                success: false,
+                records: None,
+                error: Some(format!("Failed to parse input JSON: {e}")),
+            };
+            return Ok(serde_json::to_string(&output)?);
+        }
+    };
+
+    // Read records from Parquet
+    let records: Vec<DiscoverRecord> =
+        match read_records_from_parquet(&input.parquet_file, &input.neuron_uuid) {
+            Ok(records) => records,
+            Err(e) => {
+                let output = ReadDiscoveryOutput {
+                    success: false,
+                    records: None,
+                    error: Some(e.to_string()),
+                };
+                return Ok(serde_json::to_string(&output)?);
+            }
+        };
+
+    // Convert to JSON format
+    let json_records: Vec<DiscoverRecordJson> = records
+        .into_iter()
+        .map(|r| {
+            // DEBUG: Log first few records
+            if r.neuron_uuid == "hidden-3" && r.obs_index < 3 {
+                eprintln!("[DEBUG Rust lib read] Converting record: obs_index={}, activation={}, errors.len()={}, errors={:?}", 
+                    r.obs_index, r.activation, r.errors.len(), &r.errors[..r.errors.len().min(3)]);
+            }
+            DiscoverRecordJson {
+                obs_index: r.obs_index,
+                neuron_uuid: r.neuron_uuid,
+                value: r.value,
+                activation: r.activation,
+                errors: r.errors,
+            }
+        })
+        .collect();
+
+    let output = ReadDiscoveryOutput {
+        success: true,
+        records: Some(json_records),
+        error: None,
+    };
+
+    let json_string = serde_json::to_string(&output)?;
+
+    // DEBUG: Log first 1000 chars of JSON to verify errors are included
+    let json_preview = if json_string.len() > 1000 {
+        format!("{}...", &json_string[..1000])
+    } else {
+        json_string.clone()
+    };
+    eprintln!("[DEBUG Rust lib read] JSON output preview (first 1000 chars): {json_preview}");
+
+    Ok(json_string)
+}
+
+/// FFI export for reading discovery records
+///
+/// # Safety
+/// This function is unsafe because it deals with raw C strings.
+/// The caller must ensure:
+/// - input_json is a valid null-terminated C string
+/// - The returned pointer is freed using free_discovery_result
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn read_discovery_records_ffi(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+
+    // Read input C string
+    let input_str = unsafe {
+        if input_json.is_null() {
+            let error = r#"{"success":false,"error":"Null input pointer"}"#;
+            return CString::new(error).unwrap().into_raw();
+        }
+        match CStr::from_ptr(input_json).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+        }
+    };
+
+    // DEBUG: Log that we're calling the internal function
+    eprintln!("[DEBUG Rust lib] read_discovery_records_ffi called, calling internal function");
+
+    // Call the Rust function
+    let result = match read_discovery_records(input_str) {
+        Ok(json) => {
+            eprintln!("[DEBUG Rust lib] read_discovery_records succeeded");
+            json
+        }
+        Err(e) => {
+            eprintln!("[DEBUG Rust lib] read_discovery_records failed: {e}");
+            let error_json = format!(r#"{{"success":false,"error":"{e}"}}"#);
+            return CString::new(error_json).unwrap().into_raw();
+        }
+    };
+
+    // Return as C string
+    match CString::new(result) {
+        Ok(c_string) => c_string.into_raw(),
+        Err(_) => {
+            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+            CString::new(error).unwrap().into_raw()
+        }
+    }
+}
+
+/// FFI export for freeing memory allocated by read_discovery_records_ffi
+///
+/// # Safety
+/// This function is unsafe because it frees memory allocated by Rust.
+/// The caller must ensure ptr was returned by read_discovery_records_ffi.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn free_discovery_result(ptr: *mut std::ffi::c_char) {
+    use std::ffi::CString;
+    if !ptr.is_null() {
+        unsafe {
+            let _ = CString::from_raw(ptr);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ mod tests {
         // Create a string with multi-byte characters near position 500
         let mut s = String::new();
         for _ in 0..100 {
-            s.push_str("🦀"); // Each emoji is 4 bytes, so 100 emojis = 400 bytes
+            s.push('🦀'); // Each emoji is 4 bytes, so 100 emojis = 400 bytes
         }
         s.push_str("Hello"); // Add 5 more bytes = 405 bytes total
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,19 +317,12 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
     // Convert to JSON format
     let json_records: Vec<DiscoverRecordJson> = records
         .into_iter()
-        .map(|r| {
-            // DEBUG: Log first few records
-            if r.neuron_uuid == "hidden-3" && r.obs_index < 3 {
-                eprintln!("[DEBUG Rust lib read] Converting record: obs_index={}, activation={}, errors.len()={}, errors={:?}", 
-                    r.obs_index, r.activation, r.errors.len(), &r.errors[..r.errors.len().min(3)]);
-            }
-            DiscoverRecordJson {
-                obs_index: r.obs_index,
-                neuron_uuid: r.neuron_uuid,
-                value: r.value,
-                activation: r.activation,
-                errors: r.errors,
-            }
+        .map(|r| DiscoverRecordJson {
+            obs_index: r.obs_index,
+            neuron_uuid: r.neuron_uuid,
+            value: r.value,
+            activation: r.activation,
+            errors: r.errors,
         })
         .collect();
 
@@ -340,14 +333,6 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
     };
 
     let json_string = serde_json::to_string(&output)?;
-
-    // DEBUG: Log first 1000 chars of JSON to verify errors are included
-    let json_preview = if json_string.len() > 1000 {
-        format!("{}...", truncate_utf8_safe(&json_string, 1000))
-    } else {
-        json_string.clone()
-    };
-    eprintln!("[DEBUG Rust lib read] JSON output preview (first 1000 chars): {json_preview}");
 
     Ok(json_string)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
             );
             if let Some(first_record) = training_data.first() {
                 if let Some(neuron_data) =
-                    first_record.get("neuron_data").and_then(|nd| nd.as_array())
+                    first_record.get("neuron_data").and_then(|neuron_data_val| neuron_data_val.as_array())
                 {
                     eprintln!(
                         "[DEBUG Rust lib] First record neuron_data.length={}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,8 +175,9 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
                 training_data.len()
             );
             if let Some(first_record) = training_data.first() {
-                if let Some(neuron_data) =
-                    first_record.get("neuron_data").and_then(|neuron_data_val| neuron_data_val.as_array())
+                if let Some(neuron_data) = first_record
+                    .get("neuron_data")
+                    .and_then(|neuron_data_val| neuron_data_val.as_array())
                 {
                     eprintln!(
                         "[DEBUG Rust lib] First record neuron_data.length={}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,17 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
         }
         Err(e) => {
             eprintln!("[DEBUG Rust lib] record_discovery_internal failed: {e}");
-            let error_json = format!(r#"{{"success":false,"error":"{e}"}}"#);
+            // Properly serialize error message to avoid JSON injection issues
+            let output = RecordDiscoveryOutput {
+                success: false,
+                temp_dir: None,
+                file: None,
+                error: Some(e.to_string()),
+            };
+            let error_json = serde_json::to_string(&output).unwrap_or_else(|_| {
+                // Fallback if serialization fails (shouldn't happen)
+                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+            });
             return CString::new(error_json).unwrap().into_raw();
         }
     };
@@ -362,7 +372,16 @@ pub extern "C" fn read_discovery_records_ffi(
         }
         Err(e) => {
             eprintln!("[DEBUG Rust lib] read_discovery_records failed: {e}");
-            let error_json = format!(r#"{{"success":false,"error":"{e}"}}"#);
+            // Properly serialize error message to avoid JSON injection issues
+            let output = ReadDiscoveryOutput {
+                success: false,
+                records: None,
+                error: Some(e.to_string()),
+            };
+            let error_json = serde_json::to_string(&output).unwrap_or_else(|_| {
+                // Fallback if serialization fails (shouldn't happen)
+                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+            });
             return CString::new(error_json).unwrap().into_raw();
         }
     };
@@ -414,5 +433,44 @@ mod tests {
         let parsed: RecordDiscoveryInput = serde_json::from_str(input).unwrap();
         assert_eq!(parsed.creature.input, 2);
         assert_eq!(parsed.creature.output, 1);
+    }
+
+    #[test]
+    fn test_error_message_json_escaping() {
+        // Test that error messages with special characters are properly escaped
+        let error_messages = vec![
+            r#"Error with "quotes""#,
+            r#"Error with \backslash"#,
+            "Error with\nnewline",
+            r#"Error with "quotes" and \backslash and\nnewline"#,
+            r#"Error with "multiple" "quotes" and \multiple\backslashes"#,
+        ];
+
+        for error_msg in error_messages {
+            // Test RecordDiscoveryOutput
+            let output = RecordDiscoveryOutput {
+                success: false,
+                temp_dir: None,
+                file: None,
+                error: Some(error_msg.to_string()),
+            };
+            let json = serde_json::to_string(&output).unwrap();
+            // Verify JSON is valid and can be parsed back
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed["success"], false);
+            assert_eq!(parsed["error"].as_str(), Some(error_msg));
+
+            // Test ReadDiscoveryOutput
+            let read_output = ReadDiscoveryOutput {
+                success: false,
+                records: None,
+                error: Some(error_msg.to_string()),
+            };
+            let read_json = serde_json::to_string(&read_output).unwrap();
+            // Verify JSON is valid and can be parsed back
+            let parsed_read: serde_json::Value = serde_json::from_str(&read_json).unwrap();
+            assert_eq!(parsed_read["success"], false);
+            assert_eq!(parsed_read["error"].as_str(), Some(error_msg));
+        }
     }
 }

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -245,7 +245,6 @@ pub fn read_records_from_parquet(
 
     for batch_result in reader {
         let batch = batch_result.context("Failed to read record batch")?;
-        total_rows += batch.num_rows();
         let debug_msg = format!(
             "[DEBUG Rust parquet read] Read batch with {} rows",
             batch.num_rows()
@@ -306,6 +305,7 @@ pub fn read_records_from_parquet(
         debug_log(&debug_msg4);
 
         // DEBUG: Log all column values for first few rows to verify data
+        // Check BEFORE incrementing total_rows so we can detect the first batch
         if total_rows == 0 && batch.num_rows() > 0 {
             // Log first 5 rows to see the pattern
             for row_idx in 0..batch.num_rows().min(5) {
@@ -333,6 +333,9 @@ pub fn read_records_from_parquet(
                 debug_log(&debug_msg);
             }
         }
+
+        // Increment total_rows after debug logging check
+        total_rows += batch.num_rows();
 
         // Filter by neuron UUID and collect records
         for i in 0..batch.num_rows() {

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -1,15 +1,41 @@
 //! Parquet file format handling for discovery records
 
 use anyhow::{Context, Result};
-use arrow::array::{Float32Array, ListArray, StringArray, UInt32Array};
+use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 use std::fs::File;
+use std::io::Write;
 use std::sync::Arc;
 
 use crate::types::DiscoverRecord;
+
+/// Write debug message to file
+fn debug_log(msg: &str) {
+    // Always print to stderr first (this should appear in test output)
+    eprintln!("{msg}");
+
+    // Also write to file
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/neat_ai_discovery_debug.log")
+    {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{msg}") {
+                eprintln!("[DEBUG ERROR] Failed to write to debug log: {e}");
+            }
+            if let Err(e) = file.flush() {
+                eprintln!("[DEBUG ERROR] Failed to flush debug log: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("[DEBUG ERROR] Failed to open debug log file: {e}");
+        }
+    }
+}
 
 /// Parquet schema for discovery records
 pub fn create_schema() -> Schema {
@@ -40,11 +66,34 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
         .context("Failed to create ArrowWriter")?;
 
+    // DEBUG: Log first few records before creating arrays
+    if !records.is_empty() {
+        let debug_msg = format!(
+            "[DEBUG Rust parquet write] Preparing {} records for Parquet",
+            records.len()
+        );
+        debug_log(&debug_msg);
+        if let Some(hidden3_record) = records.iter().find(|r| r.neuron_uuid == "hidden-3") {
+            let debug_msg2 = format!("[DEBUG Rust parquet write] First hidden-3 record: obs_index={}, activation={}, errors.len()={}", 
+                hidden3_record.obs_index, hidden3_record.activation, hidden3_record.errors.len());
+            debug_log(&debug_msg2);
+        }
+    }
+
     // Prepare arrays
     let obs_indices: Vec<u32> = records.iter().map(|r| r.obs_index).collect();
     let neuron_uuids: Vec<String> = records.iter().map(|r| r.neuron_uuid.clone()).collect();
     let values: Vec<Option<f32>> = records.iter().map(|r| r.value).collect();
     let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
+
+    // DEBUG: Verify array data
+    if !activations.is_empty() {
+        let debug_msg = format!(
+            "[DEBUG Rust parquet write] activations[0]={}, obs_indices[0]={}",
+            activations[0], obs_indices[0]
+        );
+        debug_log(&debug_msg);
+    }
 
     // Collect error values and validate total count to prevent i32 overflow
     // Arrow's OffsetBuffer uses i32 for offsets, so the total error value count
@@ -64,10 +113,32 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
         error_values.extend_from_slice(&record.errors);
     }
 
+    // DEBUG: Log error_values for first hidden-3 record
+    if let Some(hidden3_idx) = records.iter().position(|r| r.neuron_uuid == "hidden-3") {
+        let mut error_offset = 0;
+        for (idx, record) in records.iter().enumerate() {
+            if idx < hidden3_idx {
+                error_offset += record.errors.len();
+            } else if idx == hidden3_idx {
+                let debug_msg = format!("[DEBUG Rust parquet write] First hidden-3 record at index {}, error_offset={}, errors.len()={}, error_values[{}..{}]={:?}",
+                    hidden3_idx, error_offset, record.errors.len(),
+                    error_offset, error_offset + record.errors.len().min(3),
+                    &error_values[error_offset..(error_offset + record.errors.len().min(3))]);
+                debug_log(&debug_msg);
+                break;
+            }
+        }
+    }
+
     let obs_index_array = Arc::new(UInt32Array::from(obs_indices));
     let neuron_uuid_array = Arc::new(StringArray::from(neuron_uuids));
     let value_array = Arc::new(Float32Array::from(values));
     let activation_array = Arc::new(Float32Array::from(activations));
+
+    // DEBUG: Verify array lengths match
+    let debug_msg = format!("[DEBUG Rust parquet write] Array lengths: obs_indices={}, neuron_uuids={}, values={}, activations={}, error_values={}", 
+        obs_index_array.len(), neuron_uuid_array.len(), value_array.len(), activation_array.len(), error_values.len());
+    debug_log(&debug_msg);
 
     // Build ListArray for errors
     // from_lengths converts lengths to cumulative offsets, which must fit in i32
@@ -80,6 +151,29 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
         error_value_array,
         None, // No nulls - all error lists are non-null
     )?);
+
+    // DEBUG: Log what we're about to write
+    if !obs_index_array.is_empty() {
+        let debug_msg = format!("[DEBUG Rust parquet write] Creating RecordBatch with {} rows. First row: obs_index={}, uuid={}, activation={}, value={:?}", 
+            obs_index_array.len(),
+            obs_index_array.value(0),
+            neuron_uuid_array.value(0),
+            activation_array.value(0),
+            if value_array.is_null(0) { None } else { Some(value_array.value(0)) }
+        );
+        debug_log(&debug_msg);
+
+        // Check if first row is hidden-3
+        if neuron_uuid_array.value(0) == "hidden-3" {
+            let errors_list = errors_array.value(0);
+            if let Some(errors_inner) = errors_list.as_any().downcast_ref::<Float32Array>() {
+                let debug_msg2 = format!("[DEBUG Rust parquet write] First row is hidden-3! errors.len()={}, first_error={}", 
+                    errors_inner.len(),
+                    if !errors_inner.is_empty() { errors_inner.value(0) } else { 0.0 });
+                debug_log(&debug_msg2);
+            }
+        }
+    }
 
     let batch = RecordBatch::try_new(
         schema,
@@ -99,6 +193,196 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     writer.close().context("Failed to close Parquet writer")?;
 
     Ok(())
+}
+
+/// Read discovery records from a Parquet file, filtered by neuron UUID
+pub fn read_records_from_parquet(
+    file_path: &str,
+    neuron_uuid: &str,
+) -> Result<Vec<DiscoverRecord>> {
+    debug_log(&format!("[DEBUG Rust parquet read] Starting read_records_from_parquet for neuron_uuid={neuron_uuid}, file_path={file_path}"));
+    use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+
+    // DEBUG: Log file info
+    if let Ok(metadata) = std::fs::metadata(file_path) {
+        eprintln!(
+            "[DEBUG Rust read] Opening Parquet file: {}, size={} bytes, neuron_uuid={}",
+            file_path,
+            metadata.len(),
+            neuron_uuid
+        );
+    }
+
+    let file = File::open(file_path)
+        .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .context("Failed to create Parquet reader builder")?;
+
+    // DEBUG: Log the schema from the Parquet file
+    let file_schema = builder.schema();
+    let debug_msg = format!(
+        "[DEBUG Rust parquet read] Parquet file schema has {} fields",
+        file_schema.fields().len()
+    );
+    debug_log(&debug_msg);
+    for (idx, field) in file_schema.fields().iter().enumerate() {
+        let debug_msg2 = format!(
+            "[DEBUG Rust parquet read] Schema field {}: name={}, type={:?}",
+            idx,
+            field.name(),
+            field.data_type()
+        );
+        debug_log(&debug_msg2);
+    }
+
+    let reader = builder.build().context("Failed to build Parquet reader")?;
+
+    let mut records = Vec::new();
+    let mut total_rows = 0;
+
+    for batch_result in reader {
+        let batch = batch_result.context("Failed to read record batch")?;
+        total_rows += batch.num_rows();
+        let debug_msg = format!(
+            "[DEBUG Rust parquet read] Read batch with {} rows",
+            batch.num_rows()
+        );
+        debug_log(&debug_msg);
+
+        // DEBUG: Log batch schema
+        let batch_schema = batch.schema();
+        let debug_msg2 = format!(
+            "[DEBUG Rust parquet read] Batch schema has {} fields",
+            batch_schema.fields().len()
+        );
+        debug_log(&debug_msg2);
+        for (idx, field) in batch_schema.fields().iter().enumerate() {
+            let debug_msg3 = format!(
+                "[DEBUG Rust parquet read] Batch field {}: name={}, type={:?}",
+                idx,
+                field.name(),
+                field.data_type()
+            );
+            debug_log(&debug_msg3);
+        }
+
+        // Get columns - use schema field names to find correct columns instead of hardcoded indices
+        let obs_index_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .context("Failed to cast obs_index column")?;
+        let neuron_uuid_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("Failed to cast neuron_uuid column")?;
+        let value_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .context("Failed to cast value column")?;
+        let activation_col = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .context("Failed to cast activation column")?;
+        let errors_col = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .context("Failed to cast errors column")?;
+
+        // DEBUG: Verify column types match expectations
+        let debug_msg4 = format!("[DEBUG Rust parquet read] Column types: col0={:?}, col1={:?}, col2={:?}, col3={:?}, col4={:?}", 
+            batch.column(0).data_type(),
+            batch.column(1).data_type(),
+            batch.column(2).data_type(),
+            batch.column(3).data_type(),
+            batch.column(4).data_type());
+        debug_log(&debug_msg4);
+
+        // DEBUG: Log all column values for first few rows to verify data
+        if total_rows == 0 && batch.num_rows() > 0 {
+            // Log first 5 rows to see the pattern
+            for row_idx in 0..batch.num_rows().min(5) {
+                let uuid_val = neuron_uuid_col.value(row_idx);
+                let obs_idx_val = obs_index_col.value(row_idx);
+                let activation_val = activation_col.value(row_idx);
+                let value_val = if value_col.is_null(row_idx) {
+                    None
+                } else {
+                    Some(value_col.value(row_idx))
+                };
+                let errors_list_val = errors_col.value(row_idx);
+                let errors_array_inner = errors_list_val
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .unwrap();
+                let errors_len = errors_array_inner.len();
+                let first_error = if errors_len > 0 {
+                    errors_array_inner.value(0)
+                } else {
+                    0.0
+                };
+
+                let debug_msg = format!("[DEBUG Rust parquet read] Row {row_idx}: obs_index={obs_idx_val}, uuid={uuid_val}, value={value_val:?}, activation={activation_val}, errors.len()={errors_len}, first_error={first_error}");
+                debug_log(&debug_msg);
+            }
+        }
+
+        // Filter by neuron UUID and collect records
+        for i in 0..batch.num_rows() {
+            let uuid = neuron_uuid_col.value(i);
+            if uuid == neuron_uuid {
+                let obs_index = obs_index_col.value(i);
+                let value = if value_col.is_null(i) {
+                    None
+                } else {
+                    Some(value_col.value(i))
+                };
+                let activation = activation_col.value(i);
+
+                // Extract errors array
+                let errors_list = errors_col.value(i);
+                let errors_array = errors_list
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .context("Failed to cast errors array")?;
+                let errors: Vec<f32> = (0..errors_array.len())
+                    .map(|j| errors_array.value(j))
+                    .collect();
+
+                // DEBUG: Log first few records for hidden-3 with detailed info
+                if uuid == "hidden-3" && records.len() < 3 {
+                    let debug_msg = format!("[DEBUG Rust parquet read] Row {}: obs_index={}, activation={}, value={:?}, errors_list.len()={}, errors_array.len()={}, errors={:?}", 
+                        i, obs_index, activation, value, errors_list.len(), errors_array.len(), &errors[..errors.len().min(3)]);
+                    debug_log(&debug_msg);
+                }
+
+                records.push(DiscoverRecord::new(
+                    obs_index,
+                    uuid.to_string(),
+                    value,
+                    activation,
+                    errors,
+                ));
+            }
+        }
+    }
+
+    let debug_msg = format!(
+        "[DEBUG Rust parquet read] Total rows processed: {}, Records found for {}: {}",
+        total_rows,
+        neuron_uuid,
+        records.len()
+    );
+    debug_log(&debug_msg);
+
+    Ok(records)
 }
 
 #[cfg(test)]

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -183,6 +183,8 @@ pub fn read_records_from_parquet(
         }
     }
 
+    // Note: Records are returned in Parquet read order (not sorted by obs_index)
+    // TypeScript sorts records by obs_index after reading for cross-neuron matching
     Ok(records)
 }
 
@@ -299,5 +301,36 @@ mod tests {
 
         let result = write_records_to_parquet(file_path, &records);
         assert!(result.is_ok(), "Validation should allow valid error counts");
+    }
+
+    #[test]
+    fn test_read_records_from_parquet_preserves_obs_index() {
+        // Test that records maintain their obs_index when reading, even if written out of order
+        // Note: Records are NOT sorted by Rust - TypeScript handles sorting after reading
+        let temp_file = NamedTempFile::new().unwrap();
+        let file_path = temp_file.path().to_str().unwrap();
+
+        // Write records in non-sequential order
+        let records = vec![
+            DiscoverRecord::new(5, "neuron-1".to_string(), Some(0.5), 0.7, vec![0.1]),
+            DiscoverRecord::new(2, "neuron-1".to_string(), Some(0.6), 0.8, vec![0.15]),
+            DiscoverRecord::new(8, "neuron-1".to_string(), Some(0.7), 0.9, vec![0.2]),
+            DiscoverRecord::new(1, "neuron-1".to_string(), Some(0.4), 0.6, vec![0.05]),
+            DiscoverRecord::new(3, "neuron-1".to_string(), Some(0.65), 0.85, vec![0.18]),
+        ];
+
+        write_records_to_parquet(file_path, &records).unwrap();
+
+        // Read back records
+        let read_records = read_records_from_parquet(file_path, "neuron-1").unwrap();
+
+        // Verify all records are present with correct obs_index values
+        assert_eq!(read_records.len(), 5, "Should have 5 records");
+        let obs_indices: Vec<u32> = read_records.iter().map(|r| r.obs_index).collect();
+        assert!(obs_indices.contains(&1), "Should contain obs_index 1");
+        assert!(obs_indices.contains(&2), "Should contain obs_index 2");
+        assert!(obs_indices.contains(&3), "Should contain obs_index 3");
+        assert!(obs_indices.contains(&5), "Should contain obs_index 5");
+        assert!(obs_indices.contains(&8), "Should contain obs_index 8");
     }
 }

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -1,41 +1,15 @@
 //! Parquet file format handling for discovery records
 
 use anyhow::{Context, Result};
-use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
+use arrow::array::{Float32Array, ListArray, StringArray, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 use std::fs::File;
-use std::io::Write;
 use std::sync::Arc;
 
 use crate::types::DiscoverRecord;
-
-/// Write debug message to file
-fn debug_log(msg: &str) {
-    // Always print to stderr first (this should appear in test output)
-    eprintln!("{msg}");
-
-    // Also write to file
-    match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/tmp/neat_ai_discovery_debug.log")
-    {
-        Ok(mut file) => {
-            if let Err(e) = writeln!(file, "{msg}") {
-                eprintln!("[DEBUG ERROR] Failed to write to debug log: {e}");
-            }
-            if let Err(e) = file.flush() {
-                eprintln!("[DEBUG ERROR] Failed to flush debug log: {e}");
-            }
-        }
-        Err(e) => {
-            eprintln!("[DEBUG ERROR] Failed to open debug log file: {e}");
-        }
-    }
-}
 
 /// Parquet schema for discovery records
 pub fn create_schema() -> Schema {
@@ -66,34 +40,11 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
         .context("Failed to create ArrowWriter")?;
 
-    // DEBUG: Log first few records before creating arrays
-    if !records.is_empty() {
-        let debug_msg = format!(
-            "[DEBUG Rust parquet write] Preparing {} records for Parquet",
-            records.len()
-        );
-        debug_log(&debug_msg);
-        if let Some(hidden3_record) = records.iter().find(|r| r.neuron_uuid == "hidden-3") {
-            let debug_msg2 = format!("[DEBUG Rust parquet write] First hidden-3 record: obs_index={}, activation={}, errors.len()={}", 
-                hidden3_record.obs_index, hidden3_record.activation, hidden3_record.errors.len());
-            debug_log(&debug_msg2);
-        }
-    }
-
     // Prepare arrays
     let obs_indices: Vec<u32> = records.iter().map(|r| r.obs_index).collect();
     let neuron_uuids: Vec<String> = records.iter().map(|r| r.neuron_uuid.clone()).collect();
     let values: Vec<Option<f32>> = records.iter().map(|r| r.value).collect();
     let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
-
-    // DEBUG: Verify array data
-    if !activations.is_empty() {
-        let debug_msg = format!(
-            "[DEBUG Rust parquet write] activations[0]={}, obs_indices[0]={}",
-            activations[0], obs_indices[0]
-        );
-        debug_log(&debug_msg);
-    }
 
     // Collect error values and validate total count to prevent i32 overflow
     // Arrow's OffsetBuffer uses i32 for offsets, so the total error value count
@@ -113,32 +64,10 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
         error_values.extend_from_slice(&record.errors);
     }
 
-    // DEBUG: Log error_values for first hidden-3 record
-    if let Some(hidden3_idx) = records.iter().position(|r| r.neuron_uuid == "hidden-3") {
-        let mut error_offset = 0;
-        for (idx, record) in records.iter().enumerate() {
-            if idx < hidden3_idx {
-                error_offset += record.errors.len();
-            } else if idx == hidden3_idx {
-                let debug_msg = format!("[DEBUG Rust parquet write] First hidden-3 record at index {}, error_offset={}, errors.len()={}, error_values[{}..{}]={:?}",
-                    hidden3_idx, error_offset, record.errors.len(),
-                    error_offset, error_offset + record.errors.len().min(3),
-                    &error_values[error_offset..(error_offset + record.errors.len().min(3))]);
-                debug_log(&debug_msg);
-                break;
-            }
-        }
-    }
-
     let obs_index_array = Arc::new(UInt32Array::from(obs_indices));
     let neuron_uuid_array = Arc::new(StringArray::from(neuron_uuids));
     let value_array = Arc::new(Float32Array::from(values));
     let activation_array = Arc::new(Float32Array::from(activations));
-
-    // DEBUG: Verify array lengths match
-    let debug_msg = format!("[DEBUG Rust parquet write] Array lengths: obs_indices={}, neuron_uuids={}, values={}, activations={}, error_values={}", 
-        obs_index_array.len(), neuron_uuid_array.len(), value_array.len(), activation_array.len(), error_values.len());
-    debug_log(&debug_msg);
 
     // Build ListArray for errors
     // from_lengths converts lengths to cumulative offsets, which must fit in i32
@@ -151,29 +80,6 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
         error_value_array,
         None, // No nulls - all error lists are non-null
     )?);
-
-    // DEBUG: Log what we're about to write
-    if !obs_index_array.is_empty() {
-        let debug_msg = format!("[DEBUG Rust parquet write] Creating RecordBatch with {} rows. First row: obs_index={}, uuid={}, activation={}, value={:?}", 
-            obs_index_array.len(),
-            obs_index_array.value(0),
-            neuron_uuid_array.value(0),
-            activation_array.value(0),
-            if value_array.is_null(0) { None } else { Some(value_array.value(0)) }
-        );
-        debug_log(&debug_msg);
-
-        // Check if first row is hidden-3
-        if neuron_uuid_array.value(0) == "hidden-3" {
-            let errors_list = errors_array.value(0);
-            if let Some(errors_inner) = errors_list.as_any().downcast_ref::<Float32Array>() {
-                let debug_msg2 = format!("[DEBUG Rust parquet write] First row is hidden-3! errors.len()={}, first_error={}", 
-                    errors_inner.len(),
-                    if !errors_inner.is_empty() { errors_inner.value(0) } else { 0.0 });
-                debug_log(&debug_msg2);
-            }
-        }
-    }
 
     let batch = RecordBatch::try_new(
         schema,
@@ -200,20 +106,9 @@ pub fn read_records_from_parquet(
     file_path: &str,
     neuron_uuid: &str,
 ) -> Result<Vec<DiscoverRecord>> {
-    debug_log(&format!("[DEBUG Rust parquet read] Starting read_records_from_parquet for neuron_uuid={neuron_uuid}, file_path={file_path}"));
     use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
-
-    // DEBUG: Log file info
-    if let Ok(metadata) = std::fs::metadata(file_path) {
-        eprintln!(
-            "[DEBUG Rust read] Opening Parquet file: {}, size={} bytes, neuron_uuid={}",
-            file_path,
-            metadata.len(),
-            neuron_uuid
-        );
-    }
 
     let file = File::open(file_path)
         .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
@@ -221,52 +116,12 @@ pub fn read_records_from_parquet(
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
 
-    // DEBUG: Log the schema from the Parquet file
-    let file_schema = builder.schema();
-    let debug_msg = format!(
-        "[DEBUG Rust parquet read] Parquet file schema has {} fields",
-        file_schema.fields().len()
-    );
-    debug_log(&debug_msg);
-    for (idx, field) in file_schema.fields().iter().enumerate() {
-        let debug_msg2 = format!(
-            "[DEBUG Rust parquet read] Schema field {}: name={}, type={:?}",
-            idx,
-            field.name(),
-            field.data_type()
-        );
-        debug_log(&debug_msg2);
-    }
-
     let reader = builder.build().context("Failed to build Parquet reader")?;
 
     let mut records = Vec::new();
-    let mut total_rows = 0;
 
     for batch_result in reader {
         let batch = batch_result.context("Failed to read record batch")?;
-        let debug_msg = format!(
-            "[DEBUG Rust parquet read] Read batch with {} rows",
-            batch.num_rows()
-        );
-        debug_log(&debug_msg);
-
-        // DEBUG: Log batch schema
-        let batch_schema = batch.schema();
-        let debug_msg2 = format!(
-            "[DEBUG Rust parquet read] Batch schema has {} fields",
-            batch_schema.fields().len()
-        );
-        debug_log(&debug_msg2);
-        for (idx, field) in batch_schema.fields().iter().enumerate() {
-            let debug_msg3 = format!(
-                "[DEBUG Rust parquet read] Batch field {}: name={}, type={:?}",
-                idx,
-                field.name(),
-                field.data_type()
-            );
-            debug_log(&debug_msg3);
-        }
 
         // Get columns - use schema field names to find correct columns instead of hardcoded indices
         let obs_index_col = batch
@@ -295,48 +150,6 @@ pub fn read_records_from_parquet(
             .downcast_ref::<ListArray>()
             .context("Failed to cast errors column")?;
 
-        // DEBUG: Verify column types match expectations
-        let debug_msg4 = format!("[DEBUG Rust parquet read] Column types: col0={:?}, col1={:?}, col2={:?}, col3={:?}, col4={:?}", 
-            batch.column(0).data_type(),
-            batch.column(1).data_type(),
-            batch.column(2).data_type(),
-            batch.column(3).data_type(),
-            batch.column(4).data_type());
-        debug_log(&debug_msg4);
-
-        // DEBUG: Log all column values for first few rows to verify data
-        // Check BEFORE incrementing total_rows so we can detect the first batch
-        if total_rows == 0 && batch.num_rows() > 0 {
-            // Log first 5 rows to see the pattern
-            for row_idx in 0..batch.num_rows().min(5) {
-                let uuid_val = neuron_uuid_col.value(row_idx);
-                let obs_idx_val = obs_index_col.value(row_idx);
-                let activation_val = activation_col.value(row_idx);
-                let value_val = if value_col.is_null(row_idx) {
-                    None
-                } else {
-                    Some(value_col.value(row_idx))
-                };
-                let errors_list_val = errors_col.value(row_idx);
-                let errors_array_inner = errors_list_val
-                    .as_any()
-                    .downcast_ref::<Float32Array>()
-                    .unwrap();
-                let errors_len = errors_array_inner.len();
-                let first_error = if errors_len > 0 {
-                    errors_array_inner.value(0)
-                } else {
-                    0.0
-                };
-
-                let debug_msg = format!("[DEBUG Rust parquet read] Row {row_idx}: obs_index={obs_idx_val}, uuid={uuid_val}, value={value_val:?}, activation={activation_val}, errors.len()={errors_len}, first_error={first_error}");
-                debug_log(&debug_msg);
-            }
-        }
-
-        // Increment total_rows after debug logging check
-        total_rows += batch.num_rows();
-
         // Filter by neuron UUID and collect records
         for i in 0..batch.num_rows() {
             let uuid = neuron_uuid_col.value(i);
@@ -359,13 +172,6 @@ pub fn read_records_from_parquet(
                     .map(|j| errors_array.value(j))
                     .collect();
 
-                // DEBUG: Log first few records for hidden-3 with detailed info
-                if uuid == "hidden-3" && records.len() < 3 {
-                    let debug_msg = format!("[DEBUG Rust parquet read] Row {}: obs_index={}, activation={}, value={:?}, errors_list.len()={}, errors_array.len()={}, errors={:?}", 
-                        i, obs_index, activation, value, errors_list.len(), errors_array.len(), &errors[..errors.len().min(3)]);
-                    debug_log(&debug_msg);
-                }
-
                 records.push(DiscoverRecord::new(
                     obs_index,
                     uuid.to_string(),
@@ -376,14 +182,6 @@ pub fn read_records_from_parquet(
             }
         }
     }
-
-    let debug_msg = format!(
-        "[DEBUG Rust parquet read] Total rows processed: {}, Records found for {}: {}",
-        total_rows,
-        neuron_uuid,
-        records.len()
-    );
-    debug_log(&debug_msg);
 
     Ok(records)
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,37 +2,11 @@
 
 use anyhow::{Context, Result};
 use std::fs;
-use std::io::Write;
 use std::path::Path;
 
 use crate::parquet_format::write_records_to_parquet;
 use crate::types::DiscoverRecord;
 use crate::RecordDiscoveryInput;
-
-/// Write debug message to file
-fn debug_log(msg: &str) {
-    // Always print to stderr first (this should appear in test output)
-    eprintln!("{msg}");
-
-    // Also write to file
-    match std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/tmp/neat_ai_discovery_debug.log")
-    {
-        Ok(mut file) => {
-            if let Err(e) = writeln!(file, "{msg}") {
-                eprintln!("[DEBUG ERROR] Failed to write to debug log: {e}");
-            }
-            if let Err(e) = file.flush() {
-                eprintln!("[DEBUG ERROR] Failed to flush debug log: {e}");
-            }
-        }
-        Err(e) => {
-            eprintln!("[DEBUG ERROR] Failed to open debug log file: {e}");
-        }
-    }
-}
 
 /// Result of recording discovery data
 #[derive(Debug)]
@@ -48,10 +22,6 @@ pub struct RecordResult {
 /// Since the training dataset is already randomized, parallelization is allowed,
 /// but each training record must be processed atomically (all neurons written together).
 pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResult> {
-    debug_log(&format!(
-        "[DEBUG Rust record] record_discovery_data called with {} training records",
-        input.training_data.len()
-    ));
     // Create temp directory
     let temp_dir = Path::new(&input.temp_dir);
     let temp_dir_str = input.temp_dir.clone();
@@ -117,18 +87,6 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
         // Use pre-computed neuron_data if available (from TypeScript)
         // Otherwise, we would need to activate the creature here (not implemented)
         if let Some(neuron_data) = &training_record.neuron_data {
-            // DEBUG: Log first record's neuron_data for hidden-3
-            if obs_index == 0 {
-                if let Some(hidden3_data) = neuron_data.iter().find(|n| n.neuron_uuid == "hidden-3")
-                {
-                    let debug_msg = format!("[DEBUG Rust record] First record, hidden-3: activation={}, errors.len()={}, errors={:?}",
-                        hidden3_data.activation,
-                        hidden3_data.errors.len(),
-                        &hidden3_data.errors[..hidden3_data.errors.len().min(3)]);
-                    debug_log(&debug_msg);
-                }
-            }
-
             // Process each neuron from pre-computed data
             for neuron_info in neuron_data {
                 // Skip input neurons and non-existent neurons (match TypeScript behavior)
@@ -153,14 +111,6 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
                     neuron_info.activation,
                     neuron_info.errors.clone(),
                 );
-
-                // DEBUG: Verify record data before pushing
-                if obs_index == 0 && neuron_info.neuron_uuid == "hidden-3" {
-                    let debug_msg = format!("[DEBUG Rust record] Creating record: obs_index={}, uuid={}, activation={}, errors.len()={}, errors={:?}",
-                        record.obs_index, record.neuron_uuid, record.activation,
-                        record.errors.len(), &record.errors[..record.errors.len().min(3)]);
-                    debug_log(&debug_msg);
-                }
 
                 all_records.push(record);
             }
@@ -202,32 +152,8 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("Invalid file path"))?;
 
-    // DEBUG: Log what we're writing
-    if !all_records.is_empty() {
-        let debug_msg = format!(
-            "[DEBUG Rust record] Writing {} records to {}",
-            all_records.len(),
-            parquet_path
-        );
-        debug_log(&debug_msg);
-        if let Some(first_record) = all_records.iter().find(|r| r.neuron_uuid == "hidden-3") {
-            let debug_msg2 = format!("[DEBUG Rust record] First hidden-3 record in all_records: obs_index={}, activation={}, errors.len()={}", 
-                first_record.obs_index, first_record.activation, first_record.errors.len());
-            debug_log(&debug_msg2);
-        }
-    }
-
     write_records_to_parquet(parquet_path, &all_records)
         .context("Failed to write records to Parquet")?;
-
-    // DEBUG: Verify file was written
-    if let Ok(metadata) = std::fs::metadata(parquet_path) {
-        let debug_msg = format!(
-            "[DEBUG Rust record] Parquet file written, size={} bytes",
-            metadata.len()
-        );
-        debug_log(&debug_msg);
-    }
 
     Ok(RecordResult {
         temp_dir: input.temp_dir.clone(),

--- a/src/record.rs
+++ b/src/record.rs
@@ -131,17 +131,19 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
 
             // Process each neuron from pre-computed data
             for neuron_info in neuron_data {
-                // Skip input neurons (match TypeScript behavior)
-                let neuron = input
+                // Skip input neurons and non-existent neurons (match TypeScript behavior)
+                let neuron = match input
                     .creature
                     .neurons
                     .iter()
-                    .find(|n| n.uuid == neuron_info.neuron_uuid);
+                    .find(|n| n.uuid == neuron_info.neuron_uuid)
+                {
+                    Some(n) => n,
+                    None => continue, // Skip non-existent neurons to prevent invalid discovery data
+                };
 
-                if let Some(neuron) = neuron {
-                    if neuron.neuron_type == "input" {
-                        continue;
-                    }
+                if neuron.neuron_type == "input" {
+                    continue;
                 }
 
                 let record = DiscoverRecord::new(
@@ -935,7 +937,79 @@ mod tests {
         assert_eq!(
             obs_index_counts.get(&5),
             Some(&2),
-            "obs_index 5 should appear exactly twice (once per neuron)"
+            "            obs_index 5 should appear exactly twice (once per neuron)"
+        );
+    }
+
+    #[test]
+    fn test_record_discovery_data_skips_non_existent_neurons() {
+        // Test that neuron_data containing UUIDs that don't exist in creature.neurons
+        // are skipped and don't create invalid records
+        let temp_dir = TempDir::new().unwrap();
+        let mut input = create_test_input();
+        input.temp_dir = temp_dir.path().to_str().unwrap().to_string();
+
+        // Create training data with a non-existent neuron UUID
+        input.training_data = vec![crate::TrainingRecord {
+            input: vec![0.1, 0.2],
+            output: vec![0.5],
+            neuron_data: Some(vec![
+                crate::NeuronData {
+                    neuron_uuid: "hidden-1".to_string(), // Exists in creature
+                    activation: 0.5,
+                    value: Some(0.4),
+                    errors: vec![0.1],
+                },
+                crate::NeuronData {
+                    neuron_uuid: "non-existent-neuron".to_string(), // Does NOT exist in creature
+                    activation: 0.9,
+                    value: Some(0.8),
+                    errors: vec![0.2],
+                },
+                crate::NeuronData {
+                    neuron_uuid: "output-0".to_string(), // Exists in creature
+                    activation: 0.5,
+                    value: Some(0.5),
+                    errors: vec![0.0],
+                },
+            ]),
+        }];
+
+        let result = record_discovery_data(&input).unwrap();
+
+        // Verify file was created
+        let parquet_file = Path::new(&result.temp_dir).join(&result.file);
+        assert!(parquet_file.exists());
+
+        // Read the parquet file and verify only existing neurons have records
+        use crate::parquet_format::read_records_from_parquet;
+
+        // hidden-1 should have records
+        let hidden1_records =
+            read_records_from_parquet(parquet_file.to_str().unwrap(), "hidden-1").unwrap();
+        assert_eq!(
+            hidden1_records.len(),
+            1,
+            "Should have 1 record for hidden-1 (existing neuron)"
+        );
+
+        // output-0 should have records
+        let output0_records =
+            read_records_from_parquet(parquet_file.to_str().unwrap(), "output-0").unwrap();
+        assert_eq!(
+            output0_records.len(),
+            1,
+            "Should have 1 record for output-0 (existing neuron)"
+        );
+
+        // non-existent-neuron should NOT have records
+        let non_existent_records =
+            read_records_from_parquet(parquet_file.to_str().unwrap(), "non-existent-neuron")
+                .unwrap();
+        assert_eq!(
+            non_existent_records.len(),
+            0,
+            "Should have 0 records for non-existent-neuron (should be skipped)"
         );
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,11 +2,37 @@
 
 use anyhow::{Context, Result};
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use crate::parquet_format::write_records_to_parquet;
 use crate::types::DiscoverRecord;
 use crate::RecordDiscoveryInput;
+
+/// Write debug message to file
+fn debug_log(msg: &str) {
+    // Always print to stderr first (this should appear in test output)
+    eprintln!("{msg}");
+
+    // Also write to file
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/neat_ai_discovery_debug.log")
+    {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{msg}") {
+                eprintln!("[DEBUG ERROR] Failed to write to debug log: {e}");
+            }
+            if let Err(e) = file.flush() {
+                eprintln!("[DEBUG ERROR] Failed to flush debug log: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("[DEBUG ERROR] Failed to open debug log file: {e}");
+        }
+    }
+}
 
 /// Result of recording discovery data
 #[derive(Debug)]
@@ -22,6 +48,10 @@ pub struct RecordResult {
 /// Since the training dataset is already randomized, parallelization is allowed,
 /// but each training record must be processed atomically (all neurons written together).
 pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResult> {
+    debug_log(&format!(
+        "[DEBUG Rust record] record_discovery_data called with {} training records",
+        input.training_data.len()
+    ));
     // Create temp directory
     let temp_dir = Path::new(&input.temp_dir);
     let temp_dir_str = input.temp_dir.clone();
@@ -72,17 +102,7 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
     }
 
     for &obs_index in &indices_to_process {
-        let _training_record = &input.training_data[obs_index];
-
-        // For each training record, we need to:
-        // 1. Activate creature with training_record.input
-        // 2. Get all neuron activations and errors
-        // 3. Collect all neuron data atomically
-
-        // TODO: This is a placeholder - actual implementation needs to:
-        // - Activate the creature (requires Creature implementation or FFI)
-        // - Get neuron activations and errors
-        // - For now, we'll create placeholder records
+        let training_record = &input.training_data[obs_index];
 
         // Safely convert obs_index from usize to u32
         // This will never fail because we validated the length above
@@ -94,27 +114,60 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
             )
         })?;
 
-        // Process each neuron
-        for neuron in &input.creature.neurons {
-            // Skip input neurons for now (match TypeScript behavior)
-            if neuron.neuron_type == "input" {
-                continue;
+        // Use pre-computed neuron_data if available (from TypeScript)
+        // Otherwise, we would need to activate the creature here (not implemented)
+        if let Some(neuron_data) = &training_record.neuron_data {
+            // DEBUG: Log first record's neuron_data for hidden-3
+            if obs_index == 0 {
+                if let Some(hidden3_data) = neuron_data.iter().find(|n| n.neuron_uuid == "hidden-3")
+                {
+                    let debug_msg = format!("[DEBUG Rust record] First record, hidden-3: activation={}, errors.len()={}, errors={:?}",
+                        hidden3_data.activation,
+                        hidden3_data.errors.len(),
+                        &hidden3_data.errors[..hidden3_data.errors.len().min(3)]);
+                    debug_log(&debug_msg);
+                }
             }
 
-            // Placeholder: In real implementation, these would come from creature activation
-            let activation = 0.0; // TODO: Get from creature.activate()
-            let value = None; // TODO: Get from creature state
-            let errors = vec![]; // TODO: Get from creature.record()
+            // Process each neuron from pre-computed data
+            for neuron_info in neuron_data {
+                // Skip input neurons (match TypeScript behavior)
+                let neuron = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .find(|n| n.uuid == neuron_info.neuron_uuid);
 
-            let record = DiscoverRecord::new(
-                obs_index_u32,
-                neuron.uuid.clone(),
-                value,
-                activation,
-                errors,
-            );
+                if let Some(neuron) = neuron {
+                    if neuron.neuron_type == "input" {
+                        continue;
+                    }
+                }
 
-            all_records.push(record);
+                let record = DiscoverRecord::new(
+                    obs_index_u32,
+                    neuron_info.neuron_uuid.clone(),
+                    neuron_info.value,
+                    neuron_info.activation,
+                    neuron_info.errors.clone(),
+                );
+
+                // DEBUG: Verify record data before pushing
+                if obs_index == 0 && neuron_info.neuron_uuid == "hidden-3" {
+                    let debug_msg = format!("[DEBUG Rust record] Creating record: obs_index={}, uuid={}, activation={}, errors.len()={}, errors={:?}",
+                        record.obs_index, record.neuron_uuid, record.activation,
+                        record.errors.len(), &record.errors[..record.errors.len().min(3)]);
+                    debug_log(&debug_msg);
+                }
+
+                all_records.push(record);
+            }
+        } else {
+            // No pre-computed data - this should not happen in normal operation
+            // TypeScript should always provide neuron_data
+            return Err(anyhow::anyhow!(
+                "No pre-computed neuron_data provided. TypeScript must compute activations and errors before calling Rust."
+            ));
         }
     }
 
@@ -147,8 +200,32 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("Invalid file path"))?;
 
+    // DEBUG: Log what we're writing
+    if !all_records.is_empty() {
+        let debug_msg = format!(
+            "[DEBUG Rust record] Writing {} records to {}",
+            all_records.len(),
+            parquet_path
+        );
+        debug_log(&debug_msg);
+        if let Some(first_record) = all_records.iter().find(|r| r.neuron_uuid == "hidden-3") {
+            let debug_msg2 = format!("[DEBUG Rust record] First hidden-3 record in all_records: obs_index={}, activation={}, errors.len()={}", 
+                first_record.obs_index, first_record.activation, first_record.errors.len());
+            debug_log(&debug_msg2);
+        }
+    }
+
     write_records_to_parquet(parquet_path, &all_records)
         .context("Failed to write records to Parquet")?;
+
+    // DEBUG: Verify file was written
+    if let Ok(metadata) = std::fs::metadata(parquet_path) {
+        let debug_msg = format!(
+            "[DEBUG Rust record] Parquet file written, size={} bytes",
+            metadata.len()
+        );
+        debug_log(&debug_msg);
+    }
 
     Ok(RecordResult {
         temp_dir: input.temp_dir.clone(),
@@ -186,10 +263,38 @@ mod tests {
                 crate::TrainingRecord {
                     input: vec![0.1, 0.2],
                     output: vec![0.5],
+                    neuron_data: Some(vec![
+                        crate::NeuronData {
+                            neuron_uuid: "hidden-1".to_string(),
+                            activation: 0.5,
+                            value: Some(0.4),
+                            errors: vec![0.1],
+                        },
+                        crate::NeuronData {
+                            neuron_uuid: "output-0".to_string(),
+                            activation: 0.5,
+                            value: Some(0.5),
+                            errors: vec![0.0],
+                        },
+                    ]),
                 },
                 crate::TrainingRecord {
                     input: vec![0.3, 0.4],
                     output: vec![0.6],
+                    neuron_data: Some(vec![
+                        crate::NeuronData {
+                            neuron_uuid: "hidden-1".to_string(),
+                            activation: 0.6,
+                            value: Some(0.5),
+                            errors: vec![0.15],
+                        },
+                        crate::NeuronData {
+                            neuron_uuid: "output-0".to_string(),
+                            activation: 0.6,
+                            value: Some(0.6),
+                            errors: vec![0.0],
+                        },
+                    ]),
                 },
             ],
             temp_dir: ".discovery/test".to_string(),
@@ -242,6 +347,20 @@ mod tests {
             .map(|_| crate::TrainingRecord {
                 input: vec![0.1, 0.2],
                 output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.5,
+                        value: Some(0.4),
+                        errors: vec![0.1],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -282,6 +401,20 @@ mod tests {
             .map(|_| crate::TrainingRecord {
                 input: vec![0.1, 0.2],
                 output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.5,
+                        value: Some(0.4),
+                        errors: vec![0.1],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -304,6 +437,20 @@ mod tests {
             .map(|i| crate::TrainingRecord {
                 input: vec![i as f32, (i * 2) as f32],
                 output: vec![i as f32],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: i as f32 * 0.1,
+                        value: Some(i as f32 * 0.1),
+                        errors: vec![i as f32 * 0.01],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: i as f32,
+                        value: Some(i as f32),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -369,6 +516,20 @@ mod tests {
             .map(|_| crate::TrainingRecord {
                 input: vec![0.1, 0.2],
                 output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.5,
+                        value: Some(0.4),
+                        errors: vec![0.1],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -385,6 +546,107 @@ mod tests {
     }
 
     #[test]
+    fn test_record_discovery_data_with_neuron_data() {
+        // Test that when neuron_data is provided, it writes correctly and can be read back
+        let temp_dir = TempDir::new().unwrap();
+        let mut input = create_test_input();
+        input.temp_dir = temp_dir.path().to_str().unwrap().to_string();
+
+        // Create training data with pre-computed neuron_data (simulating TypeScript behavior)
+        input.training_data = vec![
+            crate::TrainingRecord {
+                input: vec![0.1, 0.2],
+                output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.7,
+                        value: Some(0.6),
+                        errors: vec![0.1, 0.2],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
+            },
+            crate::TrainingRecord {
+                input: vec![0.3, 0.4],
+                output: vec![0.6],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.8,
+                        value: Some(0.7),
+                        errors: vec![0.15, 0.25],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.6,
+                        value: Some(0.6),
+                        errors: vec![0.0],
+                    },
+                ]),
+            },
+        ];
+
+        let result = record_discovery_data(&input).unwrap();
+
+        // Verify file was created
+        let parquet_file = Path::new(&result.temp_dir).join(&result.file);
+        assert!(parquet_file.exists());
+
+        // Read back records for each neuron and verify they match
+        use crate::parquet_format::read_records_from_parquet;
+
+        // Read hidden-1 records
+        let hidden1_records =
+            read_records_from_parquet(parquet_file.to_str().unwrap(), "hidden-1").unwrap();
+
+        assert_eq!(
+            hidden1_records.len(),
+            2,
+            "Should have 2 records for hidden-1"
+        );
+        assert_eq!(hidden1_records[0].obs_index, 0);
+        assert_eq!(hidden1_records[0].activation, 0.7);
+        assert_eq!(hidden1_records[0].value, Some(0.6));
+        assert_eq!(hidden1_records[0].errors, vec![0.1, 0.2]);
+        assert_eq!(hidden1_records[1].obs_index, 1);
+        assert_eq!(hidden1_records[1].activation, 0.8);
+        assert_eq!(hidden1_records[1].value, Some(0.7));
+        assert_eq!(hidden1_records[1].errors, vec![0.15, 0.25]);
+
+        // Read output-0 records
+        let output0_records =
+            read_records_from_parquet(parquet_file.to_str().unwrap(), "output-0").unwrap();
+
+        assert_eq!(
+            output0_records.len(),
+            2,
+            "Should have 2 records for output-0"
+        );
+        assert_eq!(output0_records[0].obs_index, 0);
+        assert_eq!(output0_records[0].activation, 0.5);
+        assert_eq!(output0_records[0].value, Some(0.5));
+        assert_eq!(output0_records[0].errors, vec![0.0]);
+        assert_eq!(output0_records[1].obs_index, 1);
+        assert_eq!(output0_records[1].activation, 0.6);
+        assert_eq!(output0_records[1].value, Some(0.6));
+        assert_eq!(output0_records[1].errors, vec![0.0]);
+
+        // Verify records are sorted by obs_index (critical for TypeScript analysis)
+        for i in 0..hidden1_records.len() - 1 {
+            assert!(
+                hidden1_records[i].obs_index < hidden1_records[i + 1].obs_index,
+                "Records should be sorted by obs_index"
+            );
+        }
+    }
+
+    #[test]
     fn test_record_discovery_data_without_record_indices_processes_all() {
         // Test that when record_indices is None, all records are processed
         let temp_dir = TempDir::new().unwrap();
@@ -396,6 +658,20 @@ mod tests {
             .map(|_| crate::TrainingRecord {
                 input: vec![0.1, 0.2],
                 output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.5,
+                        value: Some(0.4),
+                        errors: vec![0.1],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -459,6 +735,20 @@ mod tests {
             .map(|_| crate::TrainingRecord {
                 input: vec![0.1, 0.2],
                 output: vec![0.5],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: 0.5,
+                        value: Some(0.4),
+                        errors: vec![0.1],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: 0.5,
+                        value: Some(0.5),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 
@@ -538,6 +828,7 @@ mod tests {
         input.training_data = vec![crate::TrainingRecord {
             input: vec![0.1, 0.2],
             output: vec![0.5],
+            neuron_data: Some(vec![]), // Empty because no non-input neurons
         }];
 
         let result = record_discovery_data(&input);
@@ -567,6 +858,20 @@ mod tests {
             .map(|i| crate::TrainingRecord {
                 input: vec![i as f32, (i * 2) as f32],
                 output: vec![i as f32],
+                neuron_data: Some(vec![
+                    crate::NeuronData {
+                        neuron_uuid: "hidden-1".to_string(),
+                        activation: i as f32 * 0.1,
+                        value: Some(i as f32 * 0.1),
+                        errors: vec![i as f32 * 0.01],
+                    },
+                    crate::NeuronData {
+                        neuron_uuid: "output-0".to_string(),
+                        activation: i as f32,
+                        value: Some(i as f32),
+                        errors: vec![0.0],
+                    },
+                ]),
             })
             .collect();
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -565,11 +565,15 @@ mod tests {
         assert_eq!(output0_records[1].value, Some(0.6));
         assert_eq!(output0_records[1].errors, vec![0.0]);
 
-        // Verify records are sorted by obs_index (critical for TypeScript analysis)
-        for i in 0..hidden1_records.len() - 1 {
+        // Verify records can be matched by obs_index across neurons
+        // (TypeScript handles sorting, we just need obs_index to be present for matching)
+        for hidden_record in &hidden1_records {
+            let obs_idx = hidden_record.obs_index;
+            // Find corresponding record in output-0 with same obs_index
+            let matching_output = output0_records.iter().find(|r| r.obs_index == obs_idx);
             assert!(
-                hidden1_records[i].obs_index < hidden1_records[i + 1].obs_index,
-                "Records should be sorted by obs_index"
+                matching_output.is_some(),
+                "Should find matching record with obs_index {obs_idx} in output-0"
             );
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use neat_ai_discovery::record_discovery;
+use neat_ai_discovery::record_discovery_internal;
 use tempfile::TempDir;
 
 #[test]
@@ -32,14 +32,28 @@ fn test_record_discovery_integration() {
                 "output": 1
             }},
             "training_data": [
-                {{"input": [0.1, 0.2], "output": [0.5]}},
-                {{"input": [0.3, 0.4], "output": [0.6]}}
+                {{
+                    "input": [0.1, 0.2],
+                    "output": [0.5],
+                    "neuron_data": [
+                        {{"neuron_uuid": "hidden-1", "activation": 0.7, "value": 0.6, "errors": [0.1]}},
+                        {{"neuron_uuid": "output-0", "activation": 0.5, "value": 0.5, "errors": [0.0]}}
+                    ]
+                }},
+                {{
+                    "input": [0.3, 0.4],
+                    "output": [0.6],
+                    "neuron_data": [
+                        {{"neuron_uuid": "hidden-1", "activation": 0.8, "value": 0.7, "errors": [0.15]}},
+                        {{"neuron_uuid": "output-0", "activation": 0.6, "value": 0.6, "errors": [0.0]}}
+                    ]
+                }}
             ],
             "temp_dir": "{temp_path}"
         }}"#
     );
 
-    let result = record_discovery(&input).unwrap();
+    let result = record_discovery_internal(&input).unwrap();
     let output: serde_json::Value = serde_json::from_str(&result).unwrap();
 
     assert_eq!(output["success"], true);
@@ -55,10 +69,10 @@ fn test_record_discovery_integration() {
 #[test]
 fn test_record_discovery_invalid_json() {
     // Invalid JSON should return JSON error response, not a Rust error
-    let result = record_discovery("invalid json");
+    let result = record_discovery_internal("invalid json");
     assert!(
         result.is_ok(),
-        "record_discovery should return Ok(String) even on invalid JSON"
+        "record_discovery_internal should return Ok(String) even on invalid JSON"
     );
 
     let output_str = result.unwrap();
@@ -80,10 +94,10 @@ fn test_record_discovery_invalid_json() {
 fn test_record_discovery_missing_fields() {
     // Missing fields should return JSON error response, not a Rust error
     let input = r#"{"creature": {}}"#;
-    let result = record_discovery(input);
+    let result = record_discovery_internal(input);
     assert!(
         result.is_ok(),
-        "record_discovery should return Ok(String) even on missing fields"
+        "record_discovery_internal should return Ok(String) even on missing fields"
     );
 
     let output_str = result.unwrap();
@@ -131,10 +145,10 @@ fn test_record_discovery_returns_json_error_on_failure() {
     );
 
     // Should return JSON string, not a Rust error
-    let result = record_discovery(&input);
+    let result = record_discovery_internal(&input);
     assert!(
         result.is_ok(),
-        "record_discovery should return Ok(String) even on failure"
+        "record_discovery_internal should return Ok(String) even on failure"
     );
 
     let output_str = result.unwrap();
@@ -144,11 +158,12 @@ fn test_record_discovery_returns_json_error_on_failure() {
     // Should have success=false and an error message
     assert_eq!(output["success"], false);
     assert!(output["error"].is_string());
+    let error_msg = output["error"].as_str().unwrap();
     assert!(
-        output["error"]
-            .as_str()
-            .unwrap()
-            .contains("non-input neurons"),
-        "Error message should explain the issue"
+        error_msg.contains("no non-input neurons")
+            || error_msg.contains("non-input neurons")
+            || error_msg.contains("No discovery records")
+            || error_msg.contains("No pre-computed neuron_data"),
+        "Error message should explain the issue. Got: {error_msg}"
     );
 }


### PR DESCRIPTION
…, and add neuron data structures and FFI functions. Implement debug logging for Parquet file operations and improve record discovery data handling with neuron data integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds precomputed neuron-data recording, new FFI and JSON APIs to record/read Parquet discovery records, plus safety/debug improvements, tests, and docs; bumps version.
> 
> - **Core/Recording**:
>   - Accepts precomputed `neuron_data` in `TrainingRecord` via new `NeuronData`; records only non-input, existing neurons; validates/deduplicates `record_indices`; guards `obs_index` conversion.
>   - Splits API: `record_discovery_internal` (Rust) and FFI entry `record_discovery`.
> - **Parquet I/O**:
>   - Add `read_records_from_parquet` to filter by `neuron_uuid` and preserve `obs_index`.
>   - New JSON API `read_discovery_records` and FFI `read_discovery_records_ffi`; add `free_discovery_result`.
> - **FFI/Safety & Debug**:
>   - Safe C-string handling with JSON error responses; UTF-8-safe truncation helper `truncate_utf8_safe`; structured debug logs.
> - **Tests**:
>   - Extensive unit/integration tests for recording with `neuron_data`, index handling, Parquet readback, UTF-8 truncation, and error JSON escaping.
> - **Docs & Config**:
>   - README strengthens code-quality requirements and clarifies cross-neuron alignment by `obs_index`.
>   - Bump `Cargo.toml` to `0.1.10`; add `parquet`, `arrow`, and `tempfile` dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296853fda85005ed8b6e4a0bbb803fdc458fd44d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->