### PR TITLE
Update README.md and runlib.sh to clarify prerequisites and enhance e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ The current DenoJS implementation requires extreme filtering of the training dat
 
 ### Prerequisites
 
-- Rust (latest stable version)
-- Cargo
-- jq (for build scripts)
+**User-installable (automatically handled by `runlib.sh`):**
+- Rust (latest stable version) - automatically installed by `runlib.sh` if missing
+- Cargo - automatically installed by `runlib.sh` if missing
+
+**System packages (must be installed by administrator):**
+- **jq** - must be installed system-wide (required for build scripts)
+- **Build tools (gcc/cc)** - required on Linux systems:
+  - **Ubuntu/Debian**: `sudo apt-get install -y build-essential`
+  - **RHEL/CentOS/Amazon Linux**: `sudo yum groupinstall -y "Development Tools" && sudo yum install -y gcc`
+  - **Fedora**: `sudo dnf groupinstall -y "Development Tools" && sudo dnf install -y gcc`
+- **macOS**: Xcode Command Line Tools (typically already installed, or can be installed via `xcode-select --install` without sudo)
 
 ### Building
 
@@ -81,6 +89,11 @@ The library can be built and installed using the `scripts/runlib.sh` script:
 ```
 
 This will build the library and install it to `~/.cargo/lib/` with version tracking.
+
+**Note:** The script automatically installs Rust and Cargo if missing (no sudo required). However, system packages must be installed by an administrator:
+- **jq** must be installed system-wide
+- **Build tools (gcc/cc)** must be installed on Linux systems (see Prerequisites above)
+- If build tools are missing, the script will display clear error messages with installation instructions for the administrator
 
 ### Testing
 

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -11,6 +11,64 @@ _require_tools() {
     exit 1
   fi
   
+  # On Linux, check for build tools (gcc/cc) needed for Rust compilation
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    if ! command -v cc >/dev/null 2>&1 && ! command -v gcc >/dev/null 2>&1; then
+      echo "ERROR: Build tools (gcc/cc) not found." >&2
+      echo "" >&2
+      echo "An administrator must install the following system packages:" >&2
+      echo "" >&2
+      
+      # Detect package manager and provide installation instructions
+      if command -v apt-get >/dev/null 2>&1; then
+        # Ubuntu/Debian
+        echo "  For Ubuntu/Debian:" >&2
+        echo "    sudo apt-get update" >&2
+        echo "    sudo apt-get install -y build-essential" >&2
+      elif command -v yum >/dev/null 2>&1; then
+        # RHEL/CentOS/Amazon Linux
+        echo "  For RHEL/CentOS/Amazon Linux:" >&2
+        echo "    sudo yum groupinstall -y \"Development Tools\"" >&2
+        echo "    sudo yum install -y gcc" >&2
+      elif command -v dnf >/dev/null 2>&1; then
+        # Fedora
+        echo "  For Fedora:" >&2
+        echo "    sudo dnf groupinstall -y \"Development Tools\"" >&2
+        echo "    sudo dnf install -y gcc" >&2
+      else
+        echo "  Please install gcc and build-essential using your system's package manager." >&2
+      fi
+      echo "" >&2
+      exit 1
+    fi
+  fi
+  
+  # On macOS, check for Xcode Command Line Tools (can be installed without sudo)
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if ! command -v cc >/dev/null 2>&1 && ! command -v gcc >/dev/null 2>&1; then
+      # Check if Xcode Command Line Tools are installed by checking for developer directory
+      if [[ ! -d "/Library/Developer/CommandLineTools" ]] && [[ ! -d "/Applications/Xcode.app/Contents/Developer" ]]; then
+        echo "WARNING: Build tools (gcc/cc) not found on macOS." >&2
+        echo "Attempting to install Xcode Command Line Tools (no sudo required)..." >&2
+        # xcode-select --install returns 0 if it triggers installation dialog, non-zero if already installed
+        if xcode-select --install 2>&1; then
+          echo "Installation dialog triggered. Please follow the prompt to install Xcode Command Line Tools." >&2
+          echo "After installation completes, run this script again." >&2
+          exit 1
+        else
+          # Tools claim to be installed but not found - might be a PATH issue
+          echo "Xcode Command Line Tools may be installed but gcc/cc not found in PATH." >&2
+          echo "Please ensure Xcode Command Line Tools are properly installed and configured." >&2
+          exit 1
+        fi
+      else
+        echo "ERROR: Xcode Command Line Tools appear to be installed but gcc/cc not found in PATH." >&2
+        echo "Please ensure Xcode Command Line Tools are properly configured and PATH is set correctly." >&2
+        exit 1
+      fi
+    fi
+  fi
+  
   # Install Rust (rustup + cargo) if missing
   if ! command -v cargo >/dev/null 2>&1 || ! command -v rustup >/dev/null 2>&1; then
     echo "Installing Rust (rustup + cargo)..." >&2


### PR DESCRIPTION
…rror handling for missing build tools. README now specifies user-installable and system packages, while runlib.sh includes checks and installation instructions for gcc/cc on Linux and Xcode Command Line Tools on macOS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies README prerequisites and updates `runlib.sh` to check for required compilers with OS-specific guidance, including macOS Xcode CLT handling.
> 
> - **Scripts**:
>   - `scripts/runlib.sh`: Add platform-specific checks for build tools (`gcc`/`cc`).
>     - Linux: detect missing compilers and print install instructions for `apt-get`, `yum`, and `dnf`.
>     - macOS: detect missing compilers, trigger `xcode-select --install`, and provide guidance on PATH/configuration.
> - **Docs**:
>   - `README.md`: Clarify prerequisites by separating user-installable (via `runlib.sh`) from system packages; add platform-specific build tool requirements and notes; document that `runlib.sh` auto-installs Rust/Cargo and surfaces clear admin instructions when build tools are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3a2f7b2a828c2d944589b735bd45407e91e1031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->