### PR TITLE
Update version to 0.1.14 and enhance library functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 
 [lib]

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -142,6 +142,7 @@ ensure_lib_built() {
   # Check if library needs rebuilding based on version only
   local needs_rebuild=false
   local rebuild_reason=""
+  local installed_version=""
 
   if [[ ! -f "$lib_path" ]]; then
     needs_rebuild=true
@@ -150,8 +151,6 @@ ensure_lib_built() {
     needs_rebuild=true
     rebuild_reason="Version marker missing for ${PKG}"
   else
-    # Check version from marker file
-    local installed_version
     installed_version="$(cat "$version_marker" 2>/dev/null || echo "")"
     if [[ "$installed_version" != "$DESIRED" ]]; then
       needs_rebuild=true
@@ -160,12 +159,26 @@ ensure_lib_built() {
   fi
 
   if [[ "$needs_rebuild" == "false" ]]; then
-    # Silent when up-to-date - just return the path
+    # Ensure target artifact exists, otherwise trigger a rebuild
+    if [[ ! -f "$target_lib" ]]; then
+      needs_rebuild=true
+      rebuild_reason="Target artifact ${target_lib} missing, rebuilding"
+    fi
+  fi
+
+  if [[ "$needs_rebuild" == "false" ]]; then
+    # Compare installed and target binaries; rebuild/copy if they differ
+    if [[ -f "$target_lib" ]] && ! cmp -s "$target_lib" "$lib_path"; then
+      needs_rebuild=true
+      rebuild_reason="Installed library differs from freshly built artifact"
+    fi
+  fi
+
+  if [[ "$needs_rebuild" == "false" ]]; then
     echo "$lib_path"
     return 0
   fi
 
-  # Show rebuild reason
   >&2 echo "Library crate: $PKG"
   >&2 echo "Library: $lib_file"
   >&2 echo "Version: $DESIRED"
@@ -180,7 +193,6 @@ ensure_lib_built() {
   mkdir -p "$HOME/.cargo/lib" >&2
   cp "$target_lib" "$lib_path" >&2
 
-  # Store version marker for future checks
   echo "$DESIRED" > "$version_marker"
 
   [[ -f "$lib_path" ]] || { >&2 echo "Expected library not found at $lib_path"; exit 1; }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,23 @@ pub struct AnalyzeNeuronsOutput {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeParquetInput {
+    pub output_file: String,
+    pub input_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergeParquetOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// Safely truncate a UTF-8 string at character boundaries
 ///
 /// Returns a string truncated to at most `max_bytes` bytes, ensuring the
@@ -225,6 +242,48 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     };
 
     Ok(serde_json::to_string(&output)?)
+}
+
+pub fn merge_discovery_parquet_internal(input_json: &str) -> Result<String> {
+    let input: MergeParquetInput = match serde_json::from_str(input_json) {
+        Ok(input) => input,
+        Err(e) => {
+            let output = MergeParquetOutput {
+                success: false,
+                output_file: None,
+                error: Some(format!("Failed to parse input JSON: {e}")),
+            };
+            return Ok(serde_json::to_string(&output)?);
+        }
+    };
+
+    if input.input_files.is_empty() {
+        let output = MergeParquetOutput {
+            success: false,
+            output_file: None,
+            error: Some("No discovery parquet files provided for merge".to_string()),
+        };
+        return Ok(serde_json::to_string(&output)?);
+    }
+
+    match parquet_format::merge_parquet_files(&input.output_file, &input.input_files) {
+        Ok(()) => {
+            let output = MergeParquetOutput {
+                success: true,
+                output_file: Some(input.output_file),
+                error: None,
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+        Err(e) => {
+            let output = MergeParquetOutput {
+                success: false,
+                output_file: None,
+                error: Some(e.to_string()),
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+    }
 }
 
 /// FFI export for recording discovery data
@@ -324,6 +383,50 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
     };
 
     // Return as C string
+    match CString::new(result) {
+        Ok(c_string) => c_string.into_raw(),
+        Err(_) => {
+            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+            CString::new(error).unwrap().into_raw()
+        }
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn merge_discovery_parquet(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+
+    let input_str = unsafe {
+        if input_json.is_null() {
+            let error = r#"{"success":false,"error":"Null input pointer"}"#;
+            return CString::new(error).unwrap().into_raw();
+        }
+        match CStr::from_ptr(input_json).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+        }
+    };
+
+    let result = match merge_discovery_parquet_internal(input_str) {
+        Ok(json) => json,
+        Err(e) => {
+            let output = MergeParquetOutput {
+                success: false,
+                output_file: None,
+                error: Some(e.to_string()),
+            };
+            serde_json::to_string(&output).unwrap_or_else(|_| {
+                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+            })
+        }
+    };
+
     match CString::new(result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -101,6 +101,47 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     Ok(())
 }
 
+/// Merge multiple discovery parquet files into a single Parquet file.
+/// Input files are appended in the provided order.
+pub fn merge_parquet_files(output_file: &str, input_files: &[String]) -> Result<()> {
+    if input_files.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No discovery parquet files provided for merge"
+        ));
+    }
+
+    let schema = Arc::new(create_schema());
+    let file = File::create(output_file)
+        .with_context(|| format!("Failed to create merged Parquet file: {output_file}"))?;
+    let props = WriterProperties::builder().build();
+    let mut writer = ArrowWriter::try_new(file, schema, Some(props))
+        .context("Failed to create ArrowWriter for merge")?;
+
+    for input_path in input_files {
+        let input_file = File::open(input_path)
+            .with_context(|| format!("Failed to open discovery Parquet file: {input_path}"))?;
+        let builder =
+            parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(input_file)
+                .with_context(|| format!("Failed to create reader for {input_path}"))?;
+        let reader = builder
+            .build()
+            .with_context(|| format!("Failed to build reader for {input_path}"))?;
+
+        for batch_result in reader {
+            let batch =
+                batch_result.with_context(|| format!("Failed to read batch from {input_path}"))?;
+            writer
+                .write(&batch)
+                .with_context(|| format!("Failed to append batch from {input_path}"))?;
+        }
+    }
+
+    writer
+        .close()
+        .context("Failed to close merged Parquet writer")?;
+    Ok(())
+}
+
 /// Read discovery records from a Parquet file, filtered by neuron UUID
 pub fn read_records_from_parquet(
     file_path: &str,


### PR DESCRIPTION
- Bump version from 0.1.13 to 0.1.14 in Cargo.toml.
- Introduce new structures for merging Parquet files, including MergeParquetInput and MergeParquetOutput.
- Implement merge_discovery_parquet_internal function to handle merging of multiple discovery Parquet files.
- Add merge_parquet_files function in parquet_format.rs to facilitate the merging process.
- Enhance runlib.sh to improve library rebuilding logic and ensure target artifacts are validated before use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Rust+FFI APIs to merge discovery Parquet files and strengthens runlib rebuild checks; bumps crate to 0.1.14.
> 
> - **Library (Rust)**
>   - **Parquet Merge API**:
>     - Add `MergeParquetInput`/`MergeParquetOutput` in `src/lib.rs`.
>     - Implement `merge_discovery_parquet_internal` and FFI export `merge_discovery_parquet`.
>     - Add `parquet_format::merge_parquet_files` to append multiple discovery Parquet files into one.
> - **Build Script** (`scripts/runlib.sh`):
>   - Improve rebuild detection: verify target artifact exists, compare installed vs target with `cmp`, and handle version marker more robustly.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 578fcba6dc591d94052b210c8945c4d377513f6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->