### PR TITLE
Fix4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 
 [lib]

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -1,7 +1,7 @@
 //! Parquet file format handling for discovery records
 
 use anyhow::{Context, Result};
-use arrow::array::{Float32Array, LargeStringArray, ListArray, UInt32Array};
+use arrow::array::{Float32Array, ListArray, StringArray, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
@@ -15,7 +15,7 @@ use crate::types::DiscoverRecord;
 pub fn create_schema() -> Schema {
     Schema::new(vec![
         Field::new("obs_index", DataType::UInt32, false),
-        Field::new("neuron_uuid", DataType::LargeUtf8, false),
+        Field::new("neuron_uuid", DataType::Utf8, false),
         Field::new("value", DataType::Float32, true), // nullable
         Field::new("activation", DataType::Float32, false),
         Field::new(
@@ -39,7 +39,6 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     let props = WriterProperties::builder().build();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
         .context("Failed to create ArrowWriter")?;
-
     // Prepare arrays
     let obs_indices: Vec<u32> = records.iter().map(|r| r.obs_index).collect();
     let neuron_uuids: Vec<String> = records.iter().map(|r| r.neuron_uuid.clone()).collect();
@@ -65,7 +64,7 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     }
 
     let obs_index_array = Arc::new(UInt32Array::from(obs_indices));
-    let neuron_uuid_array = Arc::new(LargeStringArray::from(neuron_uuids));
+    let neuron_uuid_array = Arc::new(StringArray::from(neuron_uuids));
     let value_array = Arc::new(Float32Array::from(values));
     let activation_array = Arc::new(Float32Array::from(activations));
 
@@ -93,12 +92,51 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
     )
     .context("Failed to create RecordBatch")?;
 
-    writer
-        .write(&batch)
-        .context("Failed to write RecordBatch")?;
+    if let Err(err) = writer.write(&batch) {
+        let err_msg = err.to_string();
+        if err_msg.contains("Invalid string length") {
+            if let Some((longest_uuid, longest_len)) = records
+                .iter()
+                .map(|r| (r.neuron_uuid.as_str(), r.neuron_uuid.len()))
+                .max_by_key(|(_, len)| *len)
+            {
+                let preview = truncate_utf8(longest_uuid, 120);
+                return Err(anyhow::anyhow!(
+                    "Failed to write discovery data because Arrow rejected a neuron UUID length. Longest observed UUID was \"{preview}\" ({longest_len} bytes). Original error: {err_msg}"
+                ));
+            }
+            return Err(anyhow::anyhow!(
+                "Failed to write discovery data because Arrow reported an invalid string length. Original error: {err_msg}"
+            ));
+        } else {
+            return Err(err).context("Failed to write RecordBatch");
+        }
+    }
     writer.close().context("Failed to close Parquet writer")?;
 
     Ok(())
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+
+    if max_bytes == 0 {
+        return "...".to_string();
+    }
+
+    let mut end = max_bytes.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    if end == 0 {
+        return "...".to_string();
+    }
+
+    let slice = &value[..end];
+    format!("{slice}...")
 }
 
 /// Merge multiple discovery parquet files into a single Parquet file.
@@ -147,7 +185,7 @@ pub fn read_records_from_parquet(
     file_path: &str,
     neuron_uuid: &str,
 ) -> Result<Vec<DiscoverRecord>> {
-    use arrow::array::{Array, Float32Array, LargeStringArray, ListArray, UInt32Array};
+    use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
 
@@ -173,7 +211,7 @@ pub fn read_records_from_parquet(
         let neuron_uuid_col = batch
             .column(1)
             .as_any()
-            .downcast_ref::<LargeStringArray>()
+            .downcast_ref::<StringArray>()
             .context("Failed to cast neuron_uuid column")?;
         let value_col = batch
             .column(2)
@@ -246,12 +284,12 @@ mod tests {
     }
 
     #[test]
-    fn test_create_schema_uses_large_utf8_for_neuron_uuid() {
+    fn test_create_schema_uses_utf8_for_neuron_uuid() {
         let schema = create_schema();
         assert_eq!(
             schema.field(1).data_type(),
-            &DataType::LargeUtf8,
-            "Neuron UUID column should use LargeUtf8 to support large datasets"
+            &DataType::Utf8,
+            "Neuron UUID column should use Utf8 to ensure Parquet compatibility"
         );
     }
 

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 
 use crate::types::DiscoverRecord;
 
+const MAX_NEURON_UUID_TOTAL_BYTES: usize = i32::MAX as usize;
+
 /// Parquet schema for discovery records
 pub fn create_schema() -> Schema {
     Schema::new(vec![
@@ -28,8 +30,63 @@ pub fn create_schema() -> Schema {
 
 /// Write discovery records to a Parquet file
 pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> Result<()> {
+    write_records_to_parquet_with_limit(file_path, records, MAX_NEURON_UUID_TOTAL_BYTES)
+}
+
+fn write_records_to_parquet_with_limit(
+    file_path: &str,
+    records: &[DiscoverRecord],
+    max_uuid_bytes: usize,
+) -> Result<()> {
     if records.is_empty() {
         return Err(anyhow::anyhow!("No records to write"));
+    }
+
+    if records.len() > i32::MAX as usize {
+        return Err(anyhow::anyhow!(
+            "Neuron UUID count ({}) exceeds maximum supported row count ({}) for Arrow StringArray offsets",
+            records.len(),
+            i32::MAX,
+        ));
+    }
+
+    let mut total_uuid_bytes: usize = 0;
+    let mut longest_uuid: Option<&str> = None;
+    let mut longest_len: usize = 0;
+
+    for record in records {
+        let uuid = record.neuron_uuid.as_str();
+        let len = uuid.len();
+        total_uuid_bytes = total_uuid_bytes.checked_add(len).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Combined neuron UUID byte length overflowed usize while validating Arrow StringArray offsets"
+            )
+        })?;
+
+        if len > longest_len {
+            longest_len = len;
+            longest_uuid = Some(uuid);
+        }
+    }
+
+    if total_uuid_bytes > max_uuid_bytes {
+        let (preview, preview_len) = if let Some(uuid) = longest_uuid {
+            (Some(truncate_utf8(uuid, 120)), longest_len)
+        } else {
+            (None, 0)
+        };
+
+        let mut message = format!(
+            "Total neuron UUID byte length ({total_uuid_bytes}) exceeds maximum allowed ({max_uuid_bytes}) for Arrow StringArray offsets"
+        );
+
+        if let Some(preview_value) = preview {
+            message.push_str(&format!(
+                r#". Longest UUID observed was "{preview_value}" ({preview_len} bytes)"#
+            ));
+        }
+
+        return Err(anyhow::anyhow!(message));
     }
 
     let schema = Arc::new(create_schema());
@@ -102,7 +159,7 @@ pub fn write_records_to_parquet(file_path: &str, records: &[DiscoverRecord]) -> 
             {
                 let preview = truncate_utf8(longest_uuid, 120);
                 return Err(anyhow::anyhow!(
-                    "Failed to write discovery data because Arrow rejected a neuron UUID length. Longest observed UUID was \"{preview}\" ({longest_len} bytes). Original error: {err_msg}"
+                    r#"Failed to write discovery data because Arrow rejected a neuron UUID length. Longest observed UUID was "{preview}" ({longest_len} bytes). Original error: {err_msg}"#
                 ));
             }
             return Err(anyhow::anyhow!(
@@ -390,6 +447,23 @@ mod tests {
 
         let result = write_records_to_parquet(file_path, &records);
         assert!(result.is_ok(), "Validation should allow valid error counts");
+    }
+
+    #[test]
+    fn test_write_records_validates_neuron_uuid_total_bytes_overflow() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let file_path = temp_file.path().to_str().unwrap();
+
+        let records = vec![
+            DiscoverRecord::new(0, "hidden-0000".to_string(), Some(0.5), 0.7, vec![0.1]),
+            DiscoverRecord::new(1, "hidden-1111".to_string(), Some(0.6), 0.8, vec![0.2]),
+        ];
+
+        let result = write_records_to_parquet_with_limit(file_path, &records, 16);
+        assert!(
+            result.is_err(),
+            "Expected error when total neuron UUID byte length exceeds configured limit"
+        );
     }
 
     #[test]

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use arrow::array::{Float32Array, ListArray, StringArray, UInt32Array};
-use arrow::array::{Float32Array, ListArray, StringArray, UInt32Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
@@ -122,7 +121,6 @@ fn write_records_to_parquet_with_limit(
     }
 
     let obs_index_array = Arc::new(UInt32Array::from(obs_indices));
-    let neuron_uuid_array = Arc::new(StringArray::from(neuron_uuids));
     let neuron_uuid_array = Arc::new(StringArray::from(neuron_uuids));
     let value_array = Arc::new(Float32Array::from(values));
     let activation_array = Arc::new(Float32Array::from(activations));

--- a/src/record.rs
+++ b/src/record.rs
@@ -60,15 +60,13 @@ pub fn record_discovery_data(input: &RecordDiscoveryInput) -> Result<RecordResul
         for &idx in record_indices {
             if !seen.insert(idx) {
                 return Err(anyhow::anyhow!(
-                    "Record index {} is duplicated in record_indices. Discovery recording requires unique indices.",
-                    idx
+                    "Record index {idx} is duplicated in record_indices. Discovery recording requires unique indices."
                 ));
             }
             let obs_index_u32 = u32::try_from(idx).map_err(|_| {
                 anyhow::anyhow!(
-                    "Record index {} exceeds maximum supported size ({})",
-                    idx,
-                    u32::MAX
+                    "Record index {idx} exceeds maximum supported size ({max})",
+                    max = u32::MAX
                 )
             })?;
             indices.push(obs_index_u32);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add validations for total `neuron_uuid` bytes and row count when writing Parquet, refactor writer to support limits, and add a targeted test with clearer errors.
> 
> - **Parquet writing**:
>   - Add pre-write validations in `write_records_to_parquet_with_limit` for `neuron_uuid` total byte size and record count against `i32::MAX`.
>   - Refactor `write_records_to_parquet` to delegate to new `write_records_to_parquet_with_limit` with `MAX_NEURON_UUID_TOTAL_BYTES`.
>   - Improve error reporting with longest UUID preview and clearer messages.
> - **Tests**:
>   - Add `test_write_records_validates_neuron_uuid_total_bytes_overflow` to assert byte-limit validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 785af6e2112b41b18b42cf36fd8ccd99e2b459a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->