### PR TITLE
Update version to 0.1.28 and add focus neuron ranking functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 
 [lib]
@@ -16,6 +16,7 @@ arrow = { version = "57.0", default-features = false }  # Arrow arrays for Parqu
 wgpu = "0.19"
 pollster = "0.3"
 bytemuck = { version = "1.14", features = ["derive"] }
+rayon = "1.8"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -1,0 +1,213 @@
+use crate::parquet_format::read_records_from_parquet;
+use crate::types::DiscoverRecord;
+use crate::{CreatureJson, NeuronJson};
+use anyhow::{Context, Result};
+use rayon::prelude::*;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+#[derive(Debug)]
+pub struct RankedNeuron {
+    pub neuron_uuid: String,
+    pub total_error: f32,
+    pub impact: f32,
+}
+
+#[derive(Debug)]
+pub struct RankFocusStats {
+    pub neurons: Vec<RankedNeuron>,
+    pub max_output_error: f32,
+    pub processed_neurons: usize,
+    pub total_neurons: usize,
+    pub duration_ms: u128,
+}
+
+fn is_selectable_type(neuron_type: &str) -> bool {
+    neuron_type != "input" && neuron_type != "constant"
+}
+
+fn average_absolute_error(parquet_file: &str, neuron_uuid: &str) -> Result<f32> {
+    let records: Vec<DiscoverRecord> = read_records_from_parquet(parquet_file, neuron_uuid)
+        .with_context(|| format!("Failed to read discovery records for neuron {neuron_uuid}"))?;
+
+    let mut sum = 0.0f32;
+    let mut count: u32 = 0;
+
+    for record in records {
+        for err in record.errors {
+            if err.is_finite() {
+                sum += err.abs();
+                count += 1;
+            }
+        }
+    }
+
+    if count == 0 {
+        Ok(0.0)
+    } else {
+        Ok(sum / count as f32)
+    }
+}
+
+fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)>> {
+    let mut adjacency: HashMap<String, Vec<(String, f32)>> = HashMap::new();
+    for synapse in &creature.synapses {
+        adjacency
+            .entry(synapse.from_uuid.clone())
+            .or_default()
+            .push((synapse.to_uuid.clone(), synapse.weight));
+    }
+    adjacency
+}
+
+fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
+    let adjacency = build_adjacency(creature);
+    let output_neurons: HashSet<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .collect();
+    let mut cache: HashMap<String, f32> = HashMap::new();
+
+    for neuron in &creature.neurons {
+        if !is_selectable_type(&neuron.neuron_type) {
+            continue;
+        }
+        let mut visiting = HashSet::new();
+        compute_impact_recursive(
+            &neuron.uuid,
+            &adjacency,
+            &output_neurons,
+            &mut cache,
+            &mut visiting,
+        );
+    }
+
+    cache
+}
+
+fn compute_impact_recursive(
+    uuid: &str,
+    adjacency: &HashMap<String, Vec<(String, f32)>>,
+    outputs: &HashSet<String>,
+    cache: &mut HashMap<String, f32>,
+    visiting: &mut HashSet<String>,
+) -> f32 {
+    if let Some(value) = cache.get(uuid) {
+        return *value;
+    }
+
+    if !visiting.insert(uuid.to_string()) {
+        // Cycle detected; treat as zero contribution
+        return 0.0;
+    }
+
+    let impact = if outputs.contains(uuid) {
+        1.0
+    } else if let Some(edges) = adjacency.get(uuid) {
+        let mut max_value = 0.0;
+        for (to_uuid, weight) in edges {
+            let child_impact =
+                compute_impact_recursive(to_uuid, adjacency, outputs, cache, visiting);
+            if child_impact <= 0.0 {
+                continue;
+            }
+            let contribution = (weight.abs() * child_impact).min(child_impact);
+            if contribution > max_value {
+                max_value = contribution;
+            }
+        }
+        max_value
+    } else {
+        0.0
+    };
+
+    visiting.remove(uuid);
+    cache.insert(uuid.to_string(), impact);
+    impact
+}
+
+pub fn rank_focus_neurons(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+) -> Result<RankFocusStats> {
+    let start = Instant::now();
+    let selectable: Vec<&NeuronJson> = creature
+        .neurons
+        .iter()
+        .filter(|neuron| is_selectable_type(&neuron.neuron_type))
+        .collect();
+    let total_neurons = selectable.len();
+
+    if total_neurons == 0 {
+        return Ok(RankFocusStats {
+            neurons: Vec::new(),
+            max_output_error: 0.0,
+            processed_neurons: 0,
+            total_neurons: 0,
+            duration_ms: start.elapsed().as_millis(),
+        });
+    }
+
+    let output_neurons: Vec<&NeuronJson> = creature
+        .neurons
+        .iter()
+        .filter(|neuron| neuron.neuron_type == "output")
+        .collect();
+
+    let max_output_error = if output_neurons.is_empty() {
+        0.0
+    } else {
+        output_neurons
+            .par_iter()
+            .map(|neuron| average_absolute_error(parquet_file, &neuron.uuid))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .fold(0.0, f32::max)
+    };
+
+    let impact_map = compute_impacts(creature);
+
+    let mut neurons = selectable
+        .par_iter()
+        .map(|neuron| -> Result<RankedNeuron> {
+            let avg_error = average_absolute_error(parquet_file, &neuron.uuid)?;
+            let impact = *impact_map.get(&neuron.uuid).unwrap_or(&0.0);
+            let total_error = if max_output_error > 0.0 {
+                avg_error.min(max_output_error)
+            } else {
+                avg_error
+            };
+            Ok(RankedNeuron {
+                neuron_uuid: neuron.uuid.clone(),
+                total_error,
+                impact,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    neurons.sort_by(|a, b| {
+        b.total_error
+            .partial_cmp(&a.total_error)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| b.impact.partial_cmp(&a.impact).unwrap_or(Ordering::Equal))
+            .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
+    });
+
+    if let Some(limit) = max_results {
+        if neurons.len() > limit {
+            neurons.truncate(limit);
+        }
+    }
+
+    Ok(RankFocusStats {
+        neurons,
+        max_output_error,
+        processed_neurons: total_neurons,
+        total_neurons,
+        duration_ms: start.elapsed().as_millis(),
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! beneficial new synapses/neurons that would reduce error.
 
 pub mod analysis;
+pub mod focus;
 pub mod parquet_format;
 pub mod record;
 pub mod types;
@@ -161,6 +162,41 @@ pub struct AnalyzeNeuronsOutput {
     pub helpful_neurons: Option<Vec<CandidateNeuronJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostics: Option<Vec<NeuronDiagnosticJson>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RankFocusNeuronsInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    #[serde(default)]
+    pub max_results: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RankedNeuronJson {
+    pub neuron_uuid: String,
+    pub total_error: f32,
+    pub impact: f32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RankFocusNeuronsOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub neurons: Option<Vec<RankedNeuronJson>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_error: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processed_neurons: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_neurons: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -457,6 +493,60 @@ pub fn merge_discovery_parquet_internal(input_json: &str) -> Result<String> {
     }
 }
 
+pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
+    let input: RankFocusNeuronsInput = match serde_json::from_str(input_json) {
+        Ok(value) => value,
+        Err(e) => {
+            let output = RankFocusNeuronsOutput {
+                success: false,
+                neurons: None,
+                max_output_error: None,
+                processed_neurons: None,
+                total_neurons: None,
+                duration_ms: None,
+                error: Some(format!("Failed to parse input JSON: {e}")),
+            };
+            return Ok(serde_json::to_string(&output)?);
+        }
+    };
+
+    match focus::rank_focus_neurons(&input.parquet_file, &input.creature, input.max_results) {
+        Ok(stats) => {
+            let neurons: Vec<RankedNeuronJson> = stats
+                .neurons
+                .into_iter()
+                .map(|neuron| RankedNeuronJson {
+                    neuron_uuid: neuron.neuron_uuid,
+                    total_error: neuron.total_error,
+                    impact: neuron.impact,
+                })
+                .collect();
+            let output = RankFocusNeuronsOutput {
+                success: true,
+                neurons: Some(neurons),
+                max_output_error: Some(stats.max_output_error),
+                processed_neurons: Some(stats.processed_neurons),
+                total_neurons: Some(stats.total_neurons),
+                duration_ms: Some(stats.duration_ms.min(u64::MAX as u128) as u64),
+                error: None,
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+        Err(e) => {
+            let output = RankFocusNeuronsOutput {
+                success: false,
+                neurons: None,
+                max_output_error: None,
+                processed_neurons: None,
+                total_neurons: None,
+                duration_ms: None,
+                error: Some(e.to_string()),
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+    }
+}
+
 /// FFI export for recording discovery data
 ///
 /// # Safety
@@ -544,6 +634,52 @@ pub extern "C" fn merge_discovery_parquet(
             };
             serde_json::to_string(&output).unwrap_or_else(|_| {
                 r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+            })
+        }
+    };
+
+    match CString::new(result) {
+        Ok(c_string) => c_string.into_raw(),
+        Err(_) => {
+            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+            CString::new(error).unwrap().into_raw()
+        }
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+
+    let input_str = unsafe {
+        if input_json.is_null() {
+            let error = r#"{"success":false,"error":"Null input pointer"}"#;
+            return CString::new(error).unwrap().into_raw();
+        }
+        match CStr::from_ptr(input_json).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+        }
+    };
+
+    let result = match rank_focus_neurons_internal(input_str) {
+        Ok(json) => json,
+        Err(e) => {
+            let output = RankFocusNeuronsOutput {
+                success: false,
+                neurons: None,
+                max_output_error: None,
+                processed_neurons: None,
+                total_neurons: None,
+                duration_ms: None,
+                error: Some(e.to_string()),
+            };
+            serde_json::to_string(&output).unwrap_or_else(|_| {
+                r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
             })
         }
     };


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.27 to 0.1.28.
- Introduce new module `focus` and implement `rank_focus_neurons_internal` function for ranking neurons based on focus criteria.
- Add new data structures for input and output of the ranking function, including `RankFocusNeuronsInput` and `RankFocusNeuronsOutput`.
- Implement FFI export for `rank_focus_neurons` to allow external calls with error handling for input validation.
- Enhance the library's capabilities for neuron analysis by integrating focus ranking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new parallelized focus-neuron ranking feature with JSON/FFI bindings and adds rayon, alongside a version bump.
> 
> - **Focus Ranking**:
>   - Add `focus` module with `rank_focus_neurons` to compute per-neuron average absolute error from Parquet and graph-based impact, then sort/truncate results; returns `RankFocusStats`.
>   - Parallelize error aggregation and ranking using `rayon`.
> - **API/FFI**:
>   - Add `RankFocusNeuronsInput`, `RankedNeuronJson`, and `RankFocusNeuronsOutput` in `src/lib.rs`.
>   - Implement `rank_focus_neurons_internal` and export `extern "C" rank_focus_neurons`.
>   - Expose module via `pub mod focus`.
> - **Dependencies/Version**:
>   - Bump crate version `0.1.27` -> `0.1.28`.
>   - Add dependency `rayon = "1.8"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11b62fb0fecbd8232e141d68b58df70efa91a45a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->