### PR TITLE
Implement combined analysis function for neurons and synapses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 
 [lib]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,11 +1,16 @@
 use crate::parquet_format::read_records_from_parquet;
 use crate::types::DiscoverRecord;
-use crate::{AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson, CandidateSynapseJson};
+use crate::{
+    AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson,
+    CandidateSynapseJson,
+};
 use anyhow::{anyhow, Context, Result};
 use bytemuck::{Pod, Zeroable};
 use once_cell::sync::OnceCell;
+use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use rand::{RngCore, SeedableRng};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -14,6 +19,9 @@ use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use wgpu::util::DeviceExt;
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 const EPSILON: f32 = 1e-8;
 const WORKGROUP_SIZE: u32 = 256;
@@ -120,6 +128,60 @@ fn verbose_enabled() -> bool {
     std::env::var("NEAT_AI_DISCOVERY_VERBOSE").is_ok()
 }
 
+fn deterministic_shuffle_seed(label: &str, focus: &[String]) -> Option<u64> {
+    if std::env::var("NEAT_AI_DISCOVERY_DETERMINISTIC").is_ok() {
+        let mut hasher = DefaultHasher::new();
+        label.hash(&mut hasher);
+        focus.hash(&mut hasher);
+        Some(hasher.finish())
+    } else {
+        None
+    }
+}
+
+enum ShuffleRng {
+    Thread(rand::rngs::ThreadRng),
+    Std(Box<StdRng>),
+}
+
+impl RngCore for ShuffleRng {
+    fn next_u32(&mut self) -> u32 {
+        match self {
+            ShuffleRng::Thread(rng) => rng.next_u32(),
+            ShuffleRng::Std(rng) => rng.next_u32(),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        match self {
+            ShuffleRng::Thread(rng) => rng.next_u64(),
+            ShuffleRng::Std(rng) => rng.next_u64(),
+        }
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        match self {
+            ShuffleRng::Thread(rng) => rng.fill_bytes(dest),
+            ShuffleRng::Std(rng) => rng.fill_bytes(dest),
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        match self {
+            ShuffleRng::Thread(rng) => rng.try_fill_bytes(dest),
+            ShuffleRng::Std(rng) => rng.try_fill_bytes(dest),
+        }
+    }
+}
+
+fn build_shuffle_rng(label: &str, focus: &[String]) -> ShuffleRng {
+    if let Some(seed) = deterministic_shuffle_seed(label, focus) {
+        ShuffleRng::Std(Box::new(StdRng::seed_from_u64(seed)))
+    } else {
+        ShuffleRng::Thread(thread_rng())
+    }
+}
+
 #[cfg(test)]
 static FORCE_GPU_ADAPTER_FAILURE: AtomicBool = AtomicBool::new(false);
 
@@ -134,6 +196,11 @@ pub struct AnalyzeNeuronsResult {
     pub helpful_neurons: Vec<CandidateNeuronJson>,
     pub gpu_used: bool,
     pub no_candidate_reasons: Vec<NeuronNoCandidateSummary>,
+}
+
+pub struct AnalyzeAllResult {
+    pub synapse: Option<AnalyzeSynapsesResult>,
+    pub neuron: Option<AnalyzeNeuronsResult>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2780,7 +2847,10 @@ fn evaluate_activation_candidate(
     Ok(best_candidate.or(fallback_candidate))
 }
 
-pub fn analyze_neurons(input: &AnalyzeNeuronsInput) -> Result<AnalyzeNeuronsResult> {
+fn analyze_neurons_with_cache(
+    input: &AnalyzeNeuronsInput,
+    cache: Arc<RecordCache>,
+) -> Result<AnalyzeNeuronsResult> {
     let require_gpu = input.require_gpu.unwrap_or(cfg!(target_os = "macos"));
     let analyzer = GpuAnalyzer::new(require_gpu)?;
 
@@ -2793,13 +2863,12 @@ pub fn analyze_neurons(input: &AnalyzeNeuronsInput) -> Result<AnalyzeNeuronsResu
 
     let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_neurons")?;
 
-    let cache = RecordCache::new(&input.parquet_file);
     let mut helpful_map: HashMap<(String, String, String), CandidateNeuronJson> = HashMap::new();
 
     let mut diagnostics = NeuronDiagnostics::new(&unique_focus);
 
     let deadline = build_deadline(input.analysis_deadline_ms);
-    let mut rng = thread_rng();
+    let mut rng = build_shuffle_rng("analyze_synapses", &input.focus_neurons);
     let mut focus_order = unique_focus.clone();
     focus_order.shuffle(&mut rng);
     let mut analysis_timed_out = false;
@@ -2922,7 +2991,79 @@ pub fn analyze_neurons(input: &AnalyzeNeuronsInput) -> Result<AnalyzeNeuronsResu
     })
 }
 
-pub fn analyze_synapses(input: &AnalyzeSynapsesInput) -> Result<AnalyzeSynapsesResult> {
+pub fn analyze_neurons(input: &AnalyzeNeuronsInput) -> Result<AnalyzeNeuronsResult> {
+    let cache = Arc::new(RecordCache::new(&input.parquet_file));
+    analyze_neurons_with_cache(input, cache)
+}
+
+pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
+    let include_synapse = input.include_synapse_analysis.unwrap_or(true);
+    let include_neuron = input.include_neuron_analysis.unwrap_or(true);
+
+    if !include_synapse && !include_neuron {
+        return Ok(AnalyzeAllResult {
+            synapse: None,
+            neuron: None,
+        });
+    }
+
+    let shared_cache = Arc::new(RecordCache::new(&input.parquet_file));
+
+    let synapse_input = if include_synapse {
+        Some(AnalyzeSynapsesInput {
+            parquet_file: input.parquet_file.clone(),
+            creature: input.creature.clone(),
+            focus_neurons: input.focus_neurons.clone(),
+            improvement_threshold: input.improvement_threshold,
+            max_candidates: input.max_synapse_candidates,
+            require_gpu: input.require_gpu,
+            analysis_deadline_ms: input.analysis_deadline_ms,
+        })
+    } else {
+        None
+    };
+
+    let neuron_input = if include_neuron {
+        Some(AnalyzeNeuronsInput {
+            parquet_file: input.parquet_file.clone(),
+            creature: input.creature.clone(),
+            focus_neurons: input.focus_neurons.clone(),
+            improvement_threshold: input.improvement_threshold,
+            max_candidates: input.max_neuron_candidates,
+            require_gpu: input.require_gpu,
+            analysis_deadline_ms: input.analysis_deadline_ms,
+        })
+    } else {
+        None
+    };
+
+    let (synapse_result, neuron_result) = rayon::join(
+        || -> Result<Option<AnalyzeSynapsesResult>> {
+            if let Some(inner) = synapse_input.clone() {
+                analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache)).map(Some)
+            } else {
+                Ok(None)
+            }
+        },
+        || -> Result<Option<AnalyzeNeuronsResult>> {
+            if let Some(inner) = neuron_input.clone() {
+                analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache)).map(Some)
+            } else {
+                Ok(None)
+            }
+        },
+    );
+
+    Ok(AnalyzeAllResult {
+        synapse: synapse_result?,
+        neuron: neuron_result?,
+    })
+}
+
+fn analyze_synapses_with_cache(
+    input: &AnalyzeSynapsesInput,
+    cache: Arc<RecordCache>,
+) -> Result<AnalyzeSynapsesResult> {
     let require_gpu = input.require_gpu.unwrap_or(cfg!(target_os = "macos"));
     let analyzer = GpuAnalyzer::new(require_gpu)?;
 
@@ -2949,11 +3090,10 @@ pub fn analyze_synapses(input: &AnalyzeSynapsesInput) -> Result<AnalyzeSynapsesR
 
     let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_synapses")?;
 
-    let cache = RecordCache::new(&input.parquet_file);
     let mut diagnostics = TargetDiagnostics::new(&unique_focus);
 
     let deadline = build_deadline(input.analysis_deadline_ms);
-    let mut rng = thread_rng();
+    let mut rng = build_shuffle_rng("analyze_neurons", &input.focus_neurons);
     let mut focus_order = unique_focus.clone();
     focus_order.shuffle(&mut rng);
     let mut analysis_timed_out = false;
@@ -3229,6 +3369,11 @@ pub fn analyze_synapses(input: &AnalyzeSynapsesInput) -> Result<AnalyzeSynapsesR
         gpu_used: analyzer.gpu_used(),
         no_candidate_reasons,
     })
+}
+
+pub fn analyze_synapses(input: &AnalyzeSynapsesInput) -> Result<AnalyzeSynapsesResult> {
+    let cache = Arc::new(RecordCache::new(&input.parquet_file));
+    analyze_synapses_with_cache(input, cache)
 }
 
 #[cfg(test)]
@@ -4044,6 +4189,71 @@ mod tests {
             result.harmful_synapses.is_empty(),
             "Harmful synapses should not be evaluated after the deadline is exceeded"
         );
+    }
+
+    #[test]
+    fn analyze_all_runs_synapse_and_neuron_phases() {
+        let _guard = ForceGpuFailureGuard::new();
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let parquet_path = temp_dir.path().join("records.parquet");
+        let parquet_file = parquet_path
+            .to_str()
+            .expect("Temporary path should be valid UTF-8")
+            .to_string();
+
+        let mut records = Vec::new();
+        for obs_index in 0..(MIN_NEURON_SAMPLE_COUNT as u32 + 1) {
+            records.push(DiscoverRecord::new(
+                obs_index,
+                "input-0".to_string(),
+                Some(0.0),
+                1.0,
+                vec![0.0],
+            ));
+            records.push(DiscoverRecord::new(
+                obs_index,
+                "output-0".to_string(),
+                Some(0.0),
+                0.5,
+                vec![0.2],
+            ));
+        }
+        write_records_to_parquet(&parquet_file, &records)
+            .expect("Failed to write discovery records");
+
+        let creature = CreatureJson {
+            input: 1,
+            output: 1,
+            neurons: vec![NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            }],
+            synapses: vec![SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.4,
+            }],
+        };
+
+        let input = AnalyzeAllInput {
+            parquet_file,
+            creature,
+            focus_neurons: vec!["output-0".to_string()],
+            improvement_threshold: Some(0.05),
+            harmful_threshold: Some(-0.05),
+            max_synapse_candidates: Some(5),
+            max_neuron_candidates: Some(5),
+            require_gpu: Some(false),
+            analysis_deadline_ms: None,
+            include_synapse_analysis: Some(true),
+            include_neuron_analysis: Some(true),
+        };
+
+        let result = analyze_all(&input).expect("Combined analysis should succeed");
+        assert!(result.synapse.is_some(), "Synapse phase should run");
+        assert!(result.neuron.is_some(), "Neuron phase should run");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 /// JSON input for record_discovery function
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct RecordDiscoveryInput {
     pub creature: CreatureJson,
     pub training_data: Vec<TrainingRecord>,
@@ -28,7 +28,7 @@ pub struct RecordDiscoveryInput {
 }
 
 /// JSON representation of Creature
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct CreatureJson {
     pub neurons: Vec<NeuronJson>,
     pub synapses: Vec<SynapseJson>,
@@ -36,7 +36,7 @@ pub struct CreatureJson {
     pub output: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct NeuronJson {
     pub uuid: String,
     #[serde(rename = "type")]
@@ -45,7 +45,7 @@ pub struct NeuronJson {
     pub bias: f32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct SynapseJson {
     pub from_uuid: String,
     pub to_uuid: String,
@@ -53,7 +53,7 @@ pub struct SynapseJson {
 }
 
 /// Pre-computed neuron data for a single neuron
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct NeuronData {
     pub neuron_uuid: String,
     pub activation: f32,
@@ -63,7 +63,7 @@ pub struct NeuronData {
 }
 
 /// Training data record
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct TrainingRecord {
     pub input: Vec<f32>,
     pub output: Vec<f32>,
@@ -83,7 +83,7 @@ pub struct RecordDiscoveryOutput {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeSynapsesInput {
     pub parquet_file: String,
@@ -126,7 +126,7 @@ pub struct AnalyzeSynapsesOutput {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeNeuronsInput {
     pub parquet_file: String,
@@ -166,6 +166,42 @@ pub struct AnalyzeNeuronsOutput {
     pub helpful_neurons: Option<Vec<CandidateNeuronJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostics: Option<Vec<NeuronDiagnosticJson>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzeAllInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    pub focus_neurons: Vec<String>,
+    #[serde(default)]
+    pub improvement_threshold: Option<f32>,
+    #[serde(default)]
+    pub harmful_threshold: Option<f32>,
+    #[serde(default)]
+    pub max_synapse_candidates: Option<usize>,
+    #[serde(default)]
+    pub max_neuron_candidates: Option<usize>,
+    #[serde(default)]
+    pub require_gpu: Option<bool>,
+    #[serde(default)]
+    pub analysis_deadline_ms: Option<u64>,
+    #[serde(default)]
+    pub include_synapse_analysis: Option<bool>,
+    #[serde(default)]
+    pub include_neuron_analysis: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzeAllOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synapse: Option<AnalyzeSynapsesOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub neuron: Option<AnalyzeNeuronsOutput>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -819,6 +855,74 @@ pub extern "C" fn analyze_neurons(input_json: *const std::ffi::c_char) -> *mut s
 
     match CString::new(json) {
         Ok(result) => result.into_raw(),
+        Err(_) => {
+            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+            CString::new(error).unwrap().into_raw()
+        }
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn analyze_all(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+
+    let input_str = unsafe {
+        if input_json.is_null() {
+            let error = r#"{"success":false,"error":"Null input pointer"}"#;
+            return CString::new(error).unwrap().into_raw();
+        }
+        match CStr::from_ptr(input_json).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+        }
+    };
+
+    let output = match serde_json::from_str::<AnalyzeAllInput>(input_str) {
+        Ok(input) => match analysis::analyze_all(&input) {
+            Ok(result) => AnalyzeAllOutput {
+                success: true,
+                synapse: result.synapse.map(|synapse| AnalyzeSynapsesOutput {
+                    success: true,
+                    gpu_used: Some(synapse.gpu_used),
+                    helpful_synapses: Some(synapse.helpful_synapses),
+                    harmful_synapses: Some(synapse.harmful_synapses),
+                    diagnostics: synapse_diagnostics_json(&synapse.no_candidate_reasons),
+                    error: None,
+                }),
+                neuron: result.neuron.map(|neuron| AnalyzeNeuronsOutput {
+                    success: true,
+                    gpu_used: Some(neuron.gpu_used),
+                    helpful_neurons: Some(neuron.helpful_neurons),
+                    diagnostics: neuron_diagnostics_json(&neuron.no_candidate_reasons),
+                    error: None,
+                }),
+                error: None,
+            },
+            Err(e) => AnalyzeAllOutput {
+                success: false,
+                synapse: None,
+                neuron: None,
+                error: Some(e.to_string()),
+            },
+        },
+        Err(e) => AnalyzeAllOutput {
+            success: false,
+            synapse: None,
+            neuron: None,
+            error: Some(e.to_string()),
+        },
+    };
+
+    let result = serde_json::to_string(&output).unwrap_or_else(|_| {
+        r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
+    });
+
+    match CString::new(result) {
+        Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
             CString::new(error).unwrap().into_raw()


### PR DESCRIPTION
- Introduce `analyze_all` function to perform simultaneous analysis of neurons and synapses, allowing for more comprehensive evaluations.
- Create `AnalyzeAllInput` and `AnalyzeAllResult` structures to facilitate input and output handling for the new analysis function.
- Refactor existing `analyze_neurons` and `analyze_synapses` functions to utilize a shared cache, improving efficiency.
- Enhance randomization in analysis order with a deterministic shuffle mechanism based on input parameters.
- Add unit tests to ensure the correctness of the new combined analysis functionality and its integration with existing components.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `analyze_all` to run neuron and synapse analyses in parallel using a shared cache, add deterministic shuffling, expose a new FFI entrypoint, and refactor existing analyses to support caching.
> 
> - **Analysis**:
>   - Add `analyze_all` running synapse and neuron analyses in parallel (`rayon::join`) with a shared `RecordCache`.
>   - Refactor `analyze_synapses`/`analyze_neurons` into `*_with_cache` helpers; public wrappers construct `Arc<RecordCache>`.
> - **Determinism**:
>   - Introduce deterministic shuffle via `NEAT_AI_DISCOVERY_DETERMINISTIC` and seeded `StdRng`; fallback to thread RNG.
> - **API/FFI**:
>   - Add `AnalyzeAllInput`/`AnalyzeAllOutput` types and new `extern "C" analyze_all` function.
>   - Derive `Clone` on input/data structs used across analyses.
> - **Tests**:
>   - Add tests covering combined analysis flow and diagnostics behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e1bca97f8d324db64411822b06b2f616e93652d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->