### PR TITLE
Update version to 0.1.35 and enhance analysis structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 
 [lib]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4590,51 +4590,60 @@ mod tests_synapses {
         // Test case: samples with substantial activation but negligible error (below EPSILON)
         // CPU computes activation_sq_sum and error_activation_sum when activation > epsilon
         // GPU should match this behavior (fixed in shader)
-        
+
         let samples = vec![
             HelpfulSample {
-                activation: 1.0,  // Substantial activation
-                avg_error: 1e-9,  // Negligible error (below EPSILON = 1e-8)
+                activation: 1.0, // Substantial activation
+                avg_error: 1e-9, // Negligible error (below EPSILON = 1e-8)
             },
             HelpfulSample {
-                activation: -2.0,  // Substantial activation
-                avg_error: 0.0,    // Zero error
+                activation: -2.0, // Substantial activation
+                avg_error: 0.0,   // Zero error
             },
             HelpfulSample {
-                activation: 3.0,   // Substantial activation
-                avg_error: -1e-9,  // Negligible error (below EPSILON)
+                activation: 3.0,  // Substantial activation
+                avg_error: -1e-9, // Negligible error (below EPSILON)
             },
         ];
 
         let cpu_stats = cpu_helpful_stats(&samples);
-        
+
         // CPU computes activation stats even when error is negligible or zero
         // activation_sq_sum = 1.0^2 + (-2.0)^2 + 3.0^2 = 1 + 4 + 9 = 14.0
         assert!((cpu_stats.activation_sq_sum - 14.0).abs() < 1e-6,
             "CPU should compute activation_sq_sum when activation > epsilon, even if error <= epsilon");
-        
+
         // error_activation_sum should be computed (even if very small)
         // For sample 1: 1.0 * 1e-9 = 1e-9
         // For sample 2: -2.0 * 0.0 = 0.0
         // For sample 3: 3.0 * (-1e-9) = -3e-9
         // Total: -2e-9
-        assert!(cpu_stats.error_activation_sum.abs() < 1e-6,
-            "error_activation_sum should be computed (very small but non-zero)");
-        
+        assert!(
+            cpu_stats.error_activation_sum.abs() < 1e-6,
+            "error_activation_sum should be computed (very small but non-zero)"
+        );
+
         // Now test GPU (if available) - should match CPU after fix
         let analyzer = GpuAnalyzer::new(false);
         if let Ok(analyzer) = analyzer {
             if analyzer.gpu_used() {
-                let gpu_stats = analyzer.evaluate_helpful(&samples)
+                let gpu_stats = analyzer
+                    .evaluate_helpful(&samples)
                     .expect("GPU evaluation should succeed");
-                
+
                 // GPU should match CPU behavior after fix
-                assert!((gpu_stats.activation_sq_sum - cpu_stats.activation_sq_sum).abs() < 1e-6,
-                    "GPU activation_sq_sum should match CPU: CPU={}, GPU={}", 
-                    cpu_stats.activation_sq_sum, gpu_stats.activation_sq_sum);
-                assert!((gpu_stats.error_activation_sum - cpu_stats.error_activation_sum).abs() < 1e-6,
-                    "GPU error_activation_sum should match CPU: CPU={}, GPU={}", 
-                    cpu_stats.error_activation_sum, gpu_stats.error_activation_sum);
+                assert!(
+                    (gpu_stats.activation_sq_sum - cpu_stats.activation_sq_sum).abs() < 1e-6,
+                    "GPU activation_sq_sum should match CPU: CPU={}, GPU={}",
+                    cpu_stats.activation_sq_sum,
+                    gpu_stats.activation_sq_sum
+                );
+                assert!(
+                    (gpu_stats.error_activation_sum - cpu_stats.error_activation_sum).abs() < 1e-6,
+                    "GPU error_activation_sum should match CPU: CPU={}, GPU={}",
+                    cpu_stats.error_activation_sum,
+                    gpu_stats.error_activation_sum
+                );
             }
         }
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1054,8 +1054,12 @@ struct HelpfulContribution {
     negative_improvement: f32,
     positive_activation: f32,
     negative_activation: f32,
+    error_squared: f32,
+    activation_squared: f32,
+    error_activation: f32,
     pad0: f32,
     pad1: f32,
+    pad2: f32,
 }
 
 #[repr(C)]
@@ -1093,6 +1097,9 @@ struct HelpfulStats {
     negative_improvement_sum: f32,
     positive_activation_sum: f32,
     negative_activation_sum: f32,
+    error_sq_sum: f32,
+    activation_sq_sum: f32,
+    error_activation_sum: f32,
 }
 
 #[derive(Clone, Copy)]
@@ -1489,22 +1496,32 @@ fn cpu_helpful_stats(samples: &[HelpfulSample]) -> HelpfulStats {
     let mut stats = HelpfulStats::default();
 
     for sample in samples {
-        if sample.activation.abs() <= EPSILON || sample.avg_error.abs() <= EPSILON {
+        if sample.activation.abs() <= EPSILON && sample.avg_error.abs() <= EPSILON {
             continue;
         }
 
-        let required_sign = -sample.avg_error.signum() * sample.activation.signum();
-        let improvement = sample.avg_error.abs();
-        let activation_mag = sample.activation.abs();
+        // Always accumulate error stats if there is any error, even if activation is small
+        if sample.avg_error.abs() > EPSILON {
+            stats.error_sq_sum += sample.avg_error * sample.avg_error;
+        }
 
-        if required_sign > 0.0 {
-            stats.positive_count += 1;
-            stats.positive_improvement_sum += improvement;
-            stats.positive_activation_sum += activation_mag;
-        } else if required_sign < 0.0 {
-            stats.negative_count += 1;
-            stats.negative_improvement_sum += improvement;
-            stats.negative_activation_sum += activation_mag;
+        if sample.activation.abs() > EPSILON {
+            stats.activation_sq_sum += sample.activation * sample.activation;
+            stats.error_activation_sum += sample.avg_error * sample.activation;
+
+            let required_sign = -sample.avg_error.signum() * sample.activation.signum();
+            let improvement = sample.avg_error.abs();
+            let activation_mag = sample.activation.abs();
+
+            if required_sign > 0.0 {
+                stats.positive_count += 1;
+                stats.positive_improvement_sum += improvement;
+                stats.positive_activation_sum += activation_mag;
+            } else if required_sign < 0.0 {
+                stats.negative_count += 1;
+                stats.negative_improvement_sum += improvement;
+                stats.negative_activation_sum += activation_mag;
+            }
         }
     }
 
@@ -2016,6 +2033,9 @@ impl GpuAnalyzer {
             stats.negative_improvement_sum += contribution.negative_improvement;
             stats.positive_activation_sum += contribution.positive_activation;
             stats.negative_activation_sum += contribution.negative_activation;
+            stats.error_sq_sum += contribution.error_squared;
+            stats.activation_sq_sum += contribution.activation_squared;
+            stats.error_activation_sum += contribution.error_activation;
         }
 
         drop(data);
@@ -2395,6 +2415,9 @@ impl GpuAnalyzer {
                     stats.negative_improvement_sum += contribution.negative_improvement;
                     stats.positive_activation_sum += contribution.positive_activation;
                     stats.negative_activation_sum += contribution.negative_activation;
+                    stats.error_sq_sum += contribution.error_squared;
+                    stats.activation_sq_sum += contribution.activation_squared;
+                    stats.error_activation_sum += contribution.error_activation;
                 }
 
                 drop(data);
@@ -3379,8 +3402,14 @@ fn analyze_synapses_with_cache(
             weight = weight.clamp(-1.0, 1.0);
         }
 
-        let expected_improvement_percentage =
-            (improved_count as f32 - worsen_count as f32) / total_count as f32;
+        let improvement_magnitude =
+            2.0 * weight * stats.error_activation_sum - weight * weight * stats.activation_sq_sum;
+
+        let expected_improvement_percentage = if stats.error_sq_sum > EPSILON {
+            improvement_magnitude / stats.error_sq_sum
+        } else {
+            0.0
+        };
 
         if expected_improvement_percentage <= threshold {
             diagnostics.record_below_threshold(
@@ -4503,5 +4532,56 @@ mod tests_synapses {
             message.contains("GPU"),
             "Expected GPU related error message, got: {message}"
         );
+    }
+
+    #[test]
+    fn test_divergence_between_count_and_magnitude() {
+        // This test reproduces the scenario where a high percentage of samples improve (count),
+        // but one large failure causes the net error reduction (magnitude) to be negative.
+        // Old Logic would report positive improvement (e.g. > 80%)
+        // New Logic should report negative improvement (e.g. < 0%)
+
+        let mut samples = Vec::new();
+
+        // 10 samples that improve slightly
+        for _ in 0..10 {
+            samples.push(HelpfulSample {
+                activation: 0.1,
+                avg_error: 0.1,
+            });
+        }
+
+        // 1 sample that worsens drastically
+        // Activation -10.0. Error 10.0.
+        samples.push(HelpfulSample {
+            activation: -10.0,
+            avg_error: 10.0,
+        });
+
+        let stats = cpu_helpful_stats(&samples);
+
+        // Check stats calculation
+        assert_eq!(stats.negative_count, 10);
+        assert_eq!(stats.positive_count, 1);
+
+        let positive_is_better = stats.positive_count >= stats.negative_count;
+        assert!(!positive_is_better);
+
+        let weight = 1.0;
+
+        let improvement_magnitude =
+            2.0 * weight * stats.error_activation_sum - weight * weight * stats.activation_sq_sum;
+
+        assert!((stats.error_activation_sum - (-99.9)).abs() < 1e-4);
+        assert!((stats.activation_sq_sum - 100.1).abs() < 1e-4);
+
+        assert!(improvement_magnitude < -200.0);
+
+        let expected_improvement_percentage = improvement_magnitude / stats.error_sq_sum;
+
+        assert!((stats.error_sq_sum - 100.1).abs() < 1e-4);
+        assert!(expected_improvement_percentage < -2.0); // Should be around -3.0 (-300%)
+
+        println!("Expected improvement (Magnitude): {expected_improvement_percentage}");
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4584,4 +4584,58 @@ mod tests_synapses {
 
         println!("Expected improvement (Magnitude): {expected_improvement_percentage}");
     }
+
+    #[test]
+    fn test_cpu_gpu_divergence_activation_without_error() {
+        // Test case: samples with substantial activation but negligible error (below EPSILON)
+        // CPU computes activation_sq_sum and error_activation_sum when activation > epsilon
+        // GPU should match this behavior (fixed in shader)
+        
+        let samples = vec![
+            HelpfulSample {
+                activation: 1.0,  // Substantial activation
+                avg_error: 1e-9,  // Negligible error (below EPSILON = 1e-8)
+            },
+            HelpfulSample {
+                activation: -2.0,  // Substantial activation
+                avg_error: 0.0,    // Zero error
+            },
+            HelpfulSample {
+                activation: 3.0,   // Substantial activation
+                avg_error: -1e-9,  // Negligible error (below EPSILON)
+            },
+        ];
+
+        let cpu_stats = cpu_helpful_stats(&samples);
+        
+        // CPU computes activation stats even when error is negligible or zero
+        // activation_sq_sum = 1.0^2 + (-2.0)^2 + 3.0^2 = 1 + 4 + 9 = 14.0
+        assert!((cpu_stats.activation_sq_sum - 14.0).abs() < 1e-6,
+            "CPU should compute activation_sq_sum when activation > epsilon, even if error <= epsilon");
+        
+        // error_activation_sum should be computed (even if very small)
+        // For sample 1: 1.0 * 1e-9 = 1e-9
+        // For sample 2: -2.0 * 0.0 = 0.0
+        // For sample 3: 3.0 * (-1e-9) = -3e-9
+        // Total: -2e-9
+        assert!(cpu_stats.error_activation_sum.abs() < 1e-6,
+            "error_activation_sum should be computed (very small but non-zero)");
+        
+        // Now test GPU (if available) - should match CPU after fix
+        let analyzer = GpuAnalyzer::new(false);
+        if let Ok(analyzer) = analyzer {
+            if analyzer.gpu_used() {
+                let gpu_stats = analyzer.evaluate_helpful(&samples)
+                    .expect("GPU evaluation should succeed");
+                
+                // GPU should match CPU behavior after fix
+                assert!((gpu_stats.activation_sq_sum - cpu_stats.activation_sq_sum).abs() < 1e-6,
+                    "GPU activation_sq_sum should match CPU: CPU={}, GPU={}", 
+                    cpu_stats.activation_sq_sum, gpu_stats.activation_sq_sum);
+                assert!((gpu_stats.error_activation_sum - cpu_stats.error_activation_sum).abs() < 1e-6,
+                    "GPU error_activation_sum should match CPU: CPU={}, GPU={}", 
+                    cpu_stats.error_activation_sum, gpu_stats.error_activation_sum);
+            }
+        }
+    }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1509,18 +1509,21 @@ fn cpu_helpful_stats(samples: &[HelpfulSample]) -> HelpfulStats {
             stats.activation_sq_sum += sample.activation * sample.activation;
             stats.error_activation_sum += sample.avg_error * sample.activation;
 
-            let required_sign = -sample.avg_error.signum() * sample.activation.signum();
-            let improvement = sample.avg_error.abs();
-            let activation_mag = sample.activation.abs();
+            // Positive/negative counts are only computed when BOTH activation AND error exceed epsilon
+            if sample.avg_error.abs() > EPSILON {
+                let required_sign = -sample.avg_error.signum() * sample.activation.signum();
+                let improvement = sample.avg_error.abs();
+                let activation_mag = sample.activation.abs();
 
-            if required_sign > 0.0 {
-                stats.positive_count += 1;
-                stats.positive_improvement_sum += improvement;
-                stats.positive_activation_sum += activation_mag;
-            } else if required_sign < 0.0 {
-                stats.negative_count += 1;
-                stats.negative_improvement_sum += improvement;
-                stats.negative_activation_sum += activation_mag;
+                if required_sign > 0.0 {
+                    stats.positive_count += 1;
+                    stats.positive_improvement_sum += improvement;
+                    stats.positive_activation_sum += activation_mag;
+                } else if required_sign < 0.0 {
+                    stats.negative_count += 1;
+                    stats.negative_improvement_sum += improvement;
+                    stats.negative_activation_sum += activation_mag;
+                }
             }
         }
     }
@@ -4643,6 +4646,67 @@ mod tests_synapses {
                     "GPU error_activation_sum should match CPU: CPU={}, GPU={}",
                     cpu_stats.error_activation_sum,
                     gpu_stats.error_activation_sum
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_cpu_gpu_positive_negative_count_divergence() {
+        // Test case: samples with substantial activation but negligible error (below EPSILON)
+        // Both CPU and GPU should NOT compute positive/negative counts when error <= epsilon,
+        // even if activation > epsilon. This matches the GPU shader behavior.
+
+        let samples = vec![
+            HelpfulSample {
+                activation: 1.0, // Substantial activation
+                avg_error: 1e-9, // Negligible error (below EPSILON = 1e-8)
+            },
+            HelpfulSample {
+                activation: -2.0, // Substantial activation
+                avg_error: 0.0,   // Zero error
+            },
+            HelpfulSample {
+                activation: 3.0,  // Substantial activation
+                avg_error: -1e-9, // Negligible error (below EPSILON)
+            },
+        ];
+
+        let cpu_stats = cpu_helpful_stats(&samples);
+
+        // CPU should NOT compute positive/negative counts when error <= epsilon
+        // even though activation > epsilon
+        assert_eq!(cpu_stats.positive_count, 0,
+            "CPU should not compute positive_count when error <= epsilon, even if activation > epsilon");
+        assert_eq!(cpu_stats.negative_count, 0,
+            "CPU should not compute negative_count when error <= epsilon, even if activation > epsilon");
+        assert_eq!(
+            cpu_stats.positive_improvement_sum, 0.0,
+            "CPU should not compute positive_improvement_sum when error <= epsilon"
+        );
+        assert_eq!(
+            cpu_stats.negative_improvement_sum, 0.0,
+            "CPU should not compute negative_improvement_sum when error <= epsilon"
+        );
+
+        // Now test GPU (if available) - should match CPU
+        let analyzer = GpuAnalyzer::new(false);
+        if let Ok(analyzer) = analyzer {
+            if analyzer.gpu_used() {
+                let gpu_stats = analyzer
+                    .evaluate_helpful(&samples)
+                    .expect("GPU evaluation should succeed");
+
+                // GPU should match CPU behavior
+                assert_eq!(
+                    gpu_stats.positive_count, cpu_stats.positive_count,
+                    "GPU positive_count should match CPU: CPU={}, GPU={}",
+                    cpu_stats.positive_count, gpu_stats.positive_count
+                );
+                assert_eq!(
+                    gpu_stats.negative_count, cpu_stats.negative_count,
+                    "GPU negative_count should match CPU: CPU={}, GPU={}",
+                    cpu_stats.negative_count, gpu_stats.negative_count
                 );
             }
         }

--- a/src/shaders/helpful.wgsl
+++ b/src/shaders/helpful.wgsl
@@ -10,8 +10,12 @@ struct HelpfulContribution {
     negative_improvement: f32,
     positive_activation: f32,
     negative_activation: f32,
+    error_squared: f32,
+    activation_squared: f32,
+    error_activation: f32,
     pad0: f32,
     pad1: f32,
+    pad2: f32,
 };
 
 struct HelpfulUniforms {
@@ -52,12 +56,21 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     contribution.negative_improvement = 0.0;
     contribution.positive_activation = 0.0;
     contribution.negative_activation = 0.0;
+    contribution.error_squared = 0.0;
+    contribution.activation_squared = 0.0;
+    contribution.error_activation = 0.0;
     contribution.pad0 = 0.0;
     contribution.pad1 = 0.0;
+    contribution.pad2 = 0.0;
 
     if (abs(sample.activation) > uniforms.epsilon && abs(sample.avg_error) > uniforms.epsilon) {
         let required_sign = -sign_nonzero(sample.avg_error) * sign_nonzero(sample.activation);
         let improvement = abs(sample.avg_error);
+        
+        contribution.error_squared = sample.avg_error * sample.avg_error;
+        contribution.activation_squared = sample.activation * sample.activation;
+        contribution.error_activation = sample.avg_error * sample.activation;
+
         if (required_sign > 0.0) {
             contribution.positive_flag = 1u;
             contribution.positive_improvement = improvement;
@@ -67,8 +80,10 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
             contribution.negative_improvement = improvement;
             contribution.negative_activation = abs(sample.activation);
         }
+    } else if (abs(sample.avg_error) > uniforms.epsilon) {
+        // Even if activation is zero, we should count the error for total baseline error
+        contribution.error_squared = sample.avg_error * sample.avg_error;
     }
 
     contributions[idx] = contribution;
 }
-

--- a/src/shaders/helpful.wgsl
+++ b/src/shaders/helpful.wgsl
@@ -63,26 +63,33 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     contribution.pad1 = 0.0;
     contribution.pad2 = 0.0;
 
-    if (abs(sample.activation) > uniforms.epsilon && abs(sample.avg_error) > uniforms.epsilon) {
-        let required_sign = -sign_nonzero(sample.avg_error) * sign_nonzero(sample.activation);
-        let improvement = abs(sample.avg_error);
-        
+    // Always accumulate error stats if there is any error, even if activation is small
+    if (abs(sample.avg_error) > uniforms.epsilon) {
         contribution.error_squared = sample.avg_error * sample.avg_error;
+    }
+
+    // Always accumulate activation stats if there is any activation, even if error is small
+    // This matches CPU behavior: activation_sq_sum and error_activation_sum are computed
+    // when activation > epsilon, regardless of error magnitude
+    if (abs(sample.activation) > uniforms.epsilon) {
         contribution.activation_squared = sample.activation * sample.activation;
         contribution.error_activation = sample.avg_error * sample.activation;
 
-        if (required_sign > 0.0) {
-            contribution.positive_flag = 1u;
-            contribution.positive_improvement = improvement;
-            contribution.positive_activation = abs(sample.activation);
-        } else if (required_sign < 0.0) {
-            contribution.negative_flag = 1u;
-            contribution.negative_improvement = improvement;
-            contribution.negative_activation = abs(sample.activation);
+        // Positive/negative counts are only computed when BOTH activation AND error exceed epsilon
+        if (abs(sample.avg_error) > uniforms.epsilon) {
+            let required_sign = -sign_nonzero(sample.avg_error) * sign_nonzero(sample.activation);
+            let improvement = abs(sample.avg_error);
+
+            if (required_sign > 0.0) {
+                contribution.positive_flag = 1u;
+                contribution.positive_improvement = improvement;
+                contribution.positive_activation = abs(sample.activation);
+            } else if (required_sign < 0.0) {
+                contribution.negative_flag = 1u;
+                contribution.negative_improvement = improvement;
+                contribution.negative_activation = abs(sample.activation);
+            }
         }
-    } else if (abs(sample.avg_error) > uniforms.epsilon) {
-        // Even if activation is zero, we should count the error for total baseline error
-        contribution.error_squared = sample.avg_error * sample.avg_error;
     }
 
     contributions[idx] = contribution;


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.34 to 0.1.35.
- Add new fields for error statistics in `HelpfulContribution` and `HelpfulStats` structures to improve analysis capabilities.
- Refactor `cpu_helpful_stats` function to accumulate error statistics more effectively.
- Update WGSL shader to include new error-related calculations for contributions.
- Introduce a new test to validate the divergence between count and magnitude in analysis results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add error/activation squared and cross metrics to helpful analysis, switch expected improvement to magnitude-based, align WGSL shader with CPU logic, and add tests; bump to 0.1.35.
> 
> - **Analysis (Rust)**:
>   - Extend `HelpfulContribution` and `HelpfulStats` with `error_squared`, `activation_squared`, and `error_activation` fields; accumulate corresponding sums in GPU/CPU paths.
>   - Refactor `cpu_helpful_stats`: accumulate error and activation stats independently; only count positive/negative when both activation and error exceed `EPSILON`.
>   - Change expected improvement in `analyze_synapses_with_cache` to magnitude-based using `2*w*sum(ea) - w^2*sum(aa)` normalized by `error_sq_sum`.
> - **GPU Shader** (`src/shaders/helpful.wgsl`):
>   - Add new contribution fields and compute `error_squared`, `activation_squared`, and `error_activation`.
>   - Mirror CPU thresholds: always accumulate error/activation stats; count pos/neg only when both exceed `epsilon`.
> - **GPU Pipeline**:
>   - Read and sum new fields in `evaluate_helpful` and batched variant; keep CPU fallback logic.
> - **Tests**:
>   - Add tests covering count vs magnitude divergence and CPU/GPU parity for activation-without-error and pos/neg counts gating.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.35`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b4b8159b231178cdb8b85f13087fdbd3ae19727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->