### PR TITLE
fixed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.36"
+version = "0.1.37"
 edition = "2021"
 
 [lib]

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -180,8 +180,10 @@ ensure_lib_built() {
   >&2 echo "Building ${PKG} v${DESIRED}"
   cargo build --release --lib >&2
 
+  # Verify build succeeded - target library must exist
+  [[ -f "$target_lib" ]] || { >&2 echo "Build failed: expected library not found at $target_lib"; exit 1; }
+
   # Sign the target binary for macOS (required for Deno FFI to load it without SIGKILL)
-  # This must be done before copying so that binary comparisons work correctly
   if [[ "$(uname -s)" == "Darwin" ]]; then
     >&2 echo "Signing ${lib_file} for macOS compatibility"
     codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$target_lib" >&2 2>/dev/null || true
@@ -192,9 +194,11 @@ ensure_lib_built() {
   mkdir -p "$HOME/.cargo/lib" >&2
   cp "$target_lib" "$lib_path" >&2
 
-  echo "$DESIRED" > "$version_marker"
+  # Verify copy succeeded - installed library must exist
+  [[ -f "$lib_path" ]] || { >&2 echo "Installation failed: expected library not found at $lib_path"; exit 1; }
 
-  [[ -f "$lib_path" ]] || { >&2 echo "Expected library not found at $lib_path"; exit 1; }
+  # Only write version marker after successful build, signing, and installation
+  echo "$DESIRED" > "$version_marker"
 
   # IMPORTANT: stdout must contain ONLY the path (no extra text)
   echo "$lib_path"

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -167,14 +167,6 @@ ensure_lib_built() {
   fi
 
   if [[ "$needs_rebuild" == "false" ]]; then
-    # Compare installed and target binaries; rebuild/copy if they differ
-    if [[ -f "$target_lib" ]] && ! cmp -s "$target_lib" "$lib_path"; then
-      needs_rebuild=true
-      rebuild_reason="Installed library differs from freshly built artifact"
-    fi
-  fi
-
-  if [[ "$needs_rebuild" == "false" ]]; then
     echo "$lib_path"
     return 0
   fi
@@ -188,16 +180,17 @@ ensure_lib_built() {
   >&2 echo "Building ${PKG} v${DESIRED}"
   cargo build --release --lib >&2
 
+  # Sign the target binary for macOS (required for Deno FFI to load it without SIGKILL)
+  # This must be done before copying so that binary comparisons work correctly
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    >&2 echo "Signing ${lib_file} for macOS compatibility"
+    codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$target_lib" >&2 2>/dev/null || true
+  fi
+
   # Copy to cargo lib directory
   >&2 echo "Installing ${lib_file} → ${lib_path}"
   mkdir -p "$HOME/.cargo/lib" >&2
   cp "$target_lib" "$lib_path" >&2
-
-  # Re-sign the library for macOS (required for Deno FFI to load it without SIGKILL)
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    >&2 echo "Re-signing ${lib_file} for macOS compatibility"
-    codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$lib_path" >&2 2>/dev/null || true
-  fi
 
   echo "$DESIRED" > "$version_marker"
 

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -193,6 +193,12 @@ ensure_lib_built() {
   mkdir -p "$HOME/.cargo/lib" >&2
   cp "$target_lib" "$lib_path" >&2
 
+  # Re-sign the library for macOS (required for Deno FFI to load it without SIGKILL)
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    >&2 echo "Re-signing ${lib_file} for macOS compatibility"
+    codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$lib_path" >&2 2>/dev/null || true
+  fi
+
   echo "$DESIRED" > "$version_marker"
 
   [[ -f "$lib_path" ]] || { >&2 echo "Expected library not found at $lib_path"; exit 1; }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Harden the build/install script with validations and macOS signing, and bump the crate version to 0.1.39.
> 
> - **Build/CI**:
>   - Harden `scripts/runlib.sh` flow:
>     - Add post-build check for `target/release/<lib>` existence.
>     - Sign built library on macOS for FFI compatibility.
>     - Verify copy to `~/.cargo/lib` succeeded before proceeding.
>     - Write version marker only after successful build/sign/install.
>     - Remove installed-vs-target binary comparison step.
> - **Versioning**:
>   - Bump `Cargo.toml` `version` to `0.1.39`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 706e73ba469152538b2793b469103e7ce4802239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->