### PR TITLE
Update version to 0.1.46 and enhance impact calculation normalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.45"
+version = "0.1.46"
 edition = "2021"
 
 [lib]

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -61,8 +61,21 @@ fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)
     adjacency
 }
 
+/// Build a map of total incoming absolute weights for each neuron.
+/// This is used to normalize connection contributions when calculating impact.
+fn build_inbound_weights(creature: &CreatureJson) -> HashMap<String, f32> {
+    let mut inbound_weights: HashMap<String, f32> = HashMap::new();
+    for synapse in &creature.synapses {
+        *inbound_weights
+            .entry(synapse.to_uuid.clone())
+            .or_insert(0.0) += synapse.weight.abs();
+    }
+    inbound_weights
+}
+
 fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
     let adjacency = build_adjacency(creature);
+    let inbound_weights = build_inbound_weights(creature);
     let output_neurons: HashSet<String> = creature
         .neurons
         .iter()
@@ -79,6 +92,7 @@ fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
         compute_impact_recursive(
             &neuron.uuid,
             &adjacency,
+            &inbound_weights,
             &output_neurons,
             &mut cache,
             &mut visiting,
@@ -91,6 +105,7 @@ fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
 fn compute_impact_recursive(
     uuid: &str,
     adjacency: &HashMap<String, Vec<(String, f32)>>,
+    inbound_weights: &HashMap<String, f32>,
     outputs: &HashSet<String>,
     cache: &mut HashMap<String, f32>,
     visiting: &mut HashSet<String>,
@@ -109,12 +124,29 @@ fn compute_impact_recursive(
     } else if let Some(edges) = adjacency.get(uuid) {
         let mut max_value = 0.0;
         for (to_uuid, weight) in edges {
-            let child_impact =
-                compute_impact_recursive(to_uuid, adjacency, outputs, cache, visiting);
+            let child_impact = compute_impact_recursive(
+                to_uuid,
+                adjacency,
+                inbound_weights,
+                outputs,
+                cache,
+                visiting,
+            );
             if child_impact <= 0.0 {
                 continue;
             }
-            let contribution = (weight.abs() * child_impact).min(child_impact);
+
+            // Normalize contribution by the total incoming weight to the target neuron
+            // This ensures that impact is properly diluted across multiple paths
+            let total_inbound = inbound_weights.get(to_uuid).copied().unwrap_or(0.0);
+            let normalized_weight = if total_inbound > 1e-9 {
+                weight.abs() / total_inbound
+            } else {
+                // If total inbound weight is near zero, treat all connections equally
+                0.0
+            };
+
+            let contribution = normalized_weight * child_impact;
             if contribution > max_value {
                 max_value = contribution;
             }

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -136,13 +136,16 @@ fn compute_impact_recursive(
                 continue;
             }
 
-            // Normalize contribution by the total incoming weight to the target neuron
-            // This ensures that impact is properly diluted across multiple paths
+            // Normalise contribution by the total incoming weight to the target neuron.
+            // This ensures that impact is properly shared across multiple paths and that
+            // connections with genuinely zero total inbound weight (all weights zero)
+            // do not contribute spurious impact.
             let total_inbound = inbound_weights.get(to_uuid).copied().unwrap_or(0.0);
-            let normalized_weight = if total_inbound > 1e-9 {
+            let normalized_weight = if total_inbound > 0.0 {
                 weight.abs() / total_inbound
             } else {
-                // If total inbound weight is near zero, treat all connections equally
+                // If there is no effective inbound signal (all weights zero), treat the
+                // connection as having no impact to avoid division-by-zero artefacts.
                 0.0
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub struct RecordDiscoveryInput {
 }
 
 /// JSON representation of Creature
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CreatureJson {
     pub neurons: Vec<NeuronJson>,
     pub synapses: Vec<SynapseJson>,
@@ -36,7 +36,7 @@ pub struct CreatureJson {
     pub output: usize,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NeuronJson {
     pub uuid: String,
     #[serde(rename = "type")]
@@ -45,7 +45,7 @@ pub struct NeuronJson {
     pub bias: f32,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SynapseJson {
     pub from_uuid: String,
     pub to_uuid: String,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use neat_ai_discovery::record_discovery_internal;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 use tempfile::TempDir;
 
 #[test]
@@ -165,5 +166,160 @@ fn test_record_discovery_returns_json_error_on_failure() {
             || error_msg.contains("No discovery records")
             || error_msg.contains("No pre-computed neuron_data"),
         "Error message should explain the issue. Got: {error_msg}"
+    );
+}
+
+#[test]
+fn test_impact_calculation_with_multiple_incoming_connections() {
+    // Test that impact is properly normalized when a neuron has multiple incoming connections
+    // This tests the fix for the bug where impact was using absolute weights instead of normalized shares
+
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-1".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-a".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-b".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-a".to_string(),
+                weight: 1.0,
+            },
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "hidden-b".to_string(),
+                weight: 1.0,
+            },
+            // Both hidden neurons connect to output with different weights
+            // Total incoming weight to output-0 = 10.0 + 5.0 = 15.0
+            SynapseJson {
+                from_uuid: "hidden-a".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 10.0,
+            },
+            SynapseJson {
+                from_uuid: "hidden-b".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 5.0,
+            },
+        ],
+        input: 2,
+        output: 1,
+    };
+
+    // Create a temporary parquet file with some data
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Write minimal data to the parquet file
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": [{
+            "input": [0.1, 0.2],
+            "output": [0.5],
+            "neuron_data": [
+                {"neuron_uuid": "hidden-a", "activation": 0.5, "value": 0.5, "errors": [0.1]},
+                {"neuron_uuid": "hidden-b", "activation": 0.5, "value": 0.5, "errors": [0.1]},
+                {"neuron_uuid": "output-0", "activation": 0.5, "value": 0.5, "errors": [0.2]}
+            ]
+        }],
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    // Create the parquet file
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data"
+    );
+
+    // Get the actual parquet file path
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    // Now test impact calculation using the public API
+    use neat_ai_discovery::rank_focus_neurons_internal;
+    let rank_input = serde_json::json!({
+        "parquetFile": parquet_file.to_str().unwrap(),
+        "creature": creature,
+        "maxResults": 10
+    })
+    .to_string();
+
+    let result_json = rank_focus_neurons_internal(&rank_input).unwrap();
+    let result: serde_json::Value = serde_json::from_str(&result_json).unwrap();
+
+    if result["success"] != true {
+        panic!(
+            "Rank focus neurons failed: {}",
+            result["error"].as_str().unwrap_or("unknown error")
+        );
+    }
+    let neurons = result["neurons"]
+        .as_array()
+        .expect("neurons should be an array");
+
+    // Find the impacts for our test neurons
+    let hidden_a = neurons
+        .iter()
+        .find(|n| n["neuronUuid"] == "hidden-a")
+        .expect("hidden-a should be in results");
+    let hidden_b = neurons
+        .iter()
+        .find(|n| n["neuronUuid"] == "hidden-b")
+        .expect("hidden-b should be in results");
+
+    let impact_a = hidden_a["impact"]
+        .as_f64()
+        .expect("impact should be a number") as f32;
+    let impact_b = hidden_b["impact"]
+        .as_f64()
+        .expect("impact should be a number") as f32;
+
+    // hidden-a has weight 10.0 to output-0, total incoming is 15.0, so impact should be 10.0/15.0 = 0.6667
+    // hidden-b has weight 5.0 to output-0, total incoming is 15.0, so impact should be 5.0/15.0 = 0.3333
+    assert!(
+        (impact_a - 0.6667).abs() < 0.01,
+        "hidden-a impact should be ~0.667, got {impact_a}",
+    );
+    assert!(
+        (impact_b - 0.3333).abs() < 0.01,
+        "hidden-b impact should be ~0.333, got {impact_b}",
+    );
+
+    // Also verify that hidden-a has about 2x the impact of hidden-b (since it has 2x the weight)
+    assert!(
+        (impact_a / impact_b - 2.0).abs() < 0.1,
+        "hidden-a should have ~2x impact of hidden-b, got ratio {}",
+        impact_a / impact_b
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,6 +170,102 @@ fn test_record_discovery_returns_json_error_on_failure() {
 }
 
 #[test]
+fn test_impact_with_very_small_incoming_weight_is_not_zeroed() {
+    // Test that impact is not forced to zero when the only path to an output
+    // uses a very small but non-zero weight (regression around near-zero totals)
+
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![SynapseJson {
+            from_uuid: "hidden-1".to_string(),
+            to_uuid: "output-0".to_string(),
+            // Very small but non-zero weight so the total inbound is below
+            // any practical threshold, but still represents a valid path.
+            weight: 1e-12,
+        }],
+        input: 0,
+        output: 1,
+    };
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Write minimal data to the parquet file
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": [{
+            "input": [],
+            "output": [0.5],
+            "neuron_data": [
+                {"neuron_uuid": "hidden-1", "activation": 0.5, "value": 0.5, "errors": [0.1]},
+                {"neuron_uuid": "output-0", "activation": 0.5, "value": 0.5, "errors": [0.2]}
+            ]
+        }],
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data"
+    );
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    use neat_ai_discovery::rank_focus_neurons_internal;
+    let rank_input = serde_json::json!({
+        "parquetFile": parquet_file.to_str().unwrap(),
+        "creature": creature,
+        "maxResults": 10
+    })
+    .to_string();
+
+    let result_json = rank_focus_neurons_internal(&rank_input).unwrap();
+    let result: serde_json::Value = serde_json::from_str(&result_json).unwrap();
+
+    if result["success"] != true {
+        panic!(
+            "Rank focus neurons failed: {}",
+            result["error"].as_str().unwrap_or("unknown error")
+        );
+    }
+
+    let neurons = result["neurons"]
+        .as_array()
+        .expect("neurons should be an array");
+    let hidden_1 = neurons
+        .iter()
+        .find(|n| n["neuronUuid"] == "hidden-1")
+        .expect("hidden-1 should be in results");
+
+    let impact = hidden_1["impact"]
+        .as_f64()
+        .expect("impact should be a number") as f32;
+
+    // With a single non-zero connection to an output, impact should be close to 1.0,
+    // not forced to zero just because the weight is very small.
+    assert!(
+        impact > 0.5,
+        "hidden-1 impact should be significant for the only path to an output, got {impact}",
+    );
+}
+
+#[test]
 fn test_impact_calculation_with_multiple_incoming_connections() {
     // Test that impact is properly normalized when a neuron has multiple incoming connections
     // This tests the fix for the bug where impact was using absolute weights instead of normalized shares


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.45 to 0.1.46.
- Introduce a new function `build_inbound_weights` to calculate total incoming absolute weights for each neuron, improving the accuracy of impact calculations.
- Modify `compute_impacts` and `compute_impact_recursive` to utilize normalized weights for contributions, ensuring proper dilution of impact across multiple paths.
- Add a new test to validate the impact calculation with multiple incoming connections, confirming that impacts are correctly normalized based on total incoming weights.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize neuron impact by inbound weight shares, ensure tiny-weight paths retain impact, add tests, derive Serialize for JSON types, and bump version to 0.1.46.
> 
> - **Impact calculation (focus)**:
>   - Add `build_inbound_weights` to sum absolute inbound weights per neuron.
>   - Update `compute_impacts`/`compute_impact_recursive` to use normalized contributions (`|w| / total_inbound`) and handle zero-inbound safely.
> - **Serialization**:
>   - Derive `Serialize` for `CreatureJson`, `NeuronJson`, and `SynapseJson` in `src/lib.rs`.
> - **Tests**:
>   - Add integration tests validating normalization across multiple incoming connections and that very small non-zero weights still yield significant impact.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.46`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad8c4d50194dedc3f6cb6131e90f1fa16cffc991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->