### PR TITLE
Enhance library handling in runlib.sh for macOS compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.48"
+version = "0.1.49"
 edition = "2021"
 
 [lib]

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -140,11 +140,17 @@ ensure_lib_built() {
   local target_lib="$project_root/target/release/${lib_file}"
   local deps_lib="$project_root/target/release/deps/${lib_file}"
   
-  # Prefer deps version if it exists (it's usually self-contained)
-  # Otherwise use the target/release version
-  if [[ -f "$deps_lib" ]]; then
-    target_lib="$deps_lib"
-  fi
+  # Helper function to find the actual library location
+  # Cargo places cdylib files in target/release/deps/, so check there first
+  _find_target_lib() {
+    if [[ -f "$deps_lib" ]]; then
+      echo "$deps_lib"
+    elif [[ -f "$target_lib" ]]; then
+      echo "$target_lib"
+    else
+      echo ""
+    fi
+  }
 
   # Check if library needs rebuilding based on version only
   local needs_rebuild=false
@@ -166,10 +172,15 @@ ensure_lib_built() {
   fi
 
   if [[ "$needs_rebuild" == "false" ]]; then
-    # Ensure target artifact exists, otherwise trigger a rebuild
-    if [[ ! -f "$target_lib" ]]; then
+    # Ensure target artifact exists in either location, otherwise trigger a rebuild
+    local existing_lib
+    existing_lib="$(_find_target_lib)"
+    if [[ -z "$existing_lib" ]]; then
       needs_rebuild=true
-      rebuild_reason="Target artifact ${target_lib} missing, rebuilding"
+      rebuild_reason="Target artifact missing in both ${target_lib} and ${deps_lib}, rebuilding"
+    else
+      # Update target_lib to point to the actual location for consistency
+      target_lib="$existing_lib"
     fi
   fi
 
@@ -187,8 +198,15 @@ ensure_lib_built() {
   >&2 echo "Building ${PKG} v${DESIRED}"
   cargo build --release --lib >&2
 
-  # Verify build succeeded - target library must exist
-  [[ -f "$target_lib" ]] || { >&2 echo "Build failed: expected library not found at $target_lib"; exit 1; }
+  # Determine the actual library location after build
+  # Cargo places cdylib files in target/release/deps/, so check there first
+  local actual_lib
+  actual_lib="$(_find_target_lib)"
+  if [[ -z "$actual_lib" ]]; then
+    >&2 echo "Build failed: expected library not found in ${target_lib} or ${deps_lib}"
+    exit 1
+  fi
+  target_lib="$actual_lib"
 
   # On macOS, sign the library (required for Deno FFI to load it without SIGKILL)
   if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -138,6 +138,13 @@ ensure_lib_built() {
   local lib_path="$HOME/.cargo/lib/${lib_file}"
   local version_marker="$HOME/.cargo/lib/.${PKG}.version"
   local target_lib="$project_root/target/release/${lib_file}"
+  local deps_lib="$project_root/target/release/deps/${lib_file}"
+  
+  # Prefer deps version if it exists (it's usually self-contained)
+  # Otherwise use the target/release version
+  if [[ -f "$deps_lib" ]]; then
+    target_lib="$deps_lib"
+  fi
 
   # Check if library needs rebuilding based on version only
   local needs_rebuild=false
@@ -183,7 +190,7 @@ ensure_lib_built() {
   # Verify build succeeded - target library must exist
   [[ -f "$target_lib" ]] || { >&2 echo "Build failed: expected library not found at $target_lib"; exit 1; }
 
-  # Sign the target binary for macOS (required for Deno FFI to load it without SIGKILL)
+  # On macOS, sign the library (required for Deno FFI to load it without SIGKILL)
   if [[ "$(uname -s)" == "Darwin" ]]; then
     >&2 echo "Signing ${lib_file} for macOS compatibility"
     codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$target_lib" >&2 2>/dev/null || true
@@ -193,6 +200,18 @@ ensure_lib_built() {
   >&2 echo "Installing ${lib_file} → ${lib_path}"
   mkdir -p "$HOME/.cargo/lib" >&2
   cp "$target_lib" "$lib_path" >&2
+
+  # On macOS, fix install_name and re-sign after copying
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    >&2 echo "Fixing library install_name for macOS"
+    # Fix the install_name to be relative to the library location
+    # This prevents issues when the library is loaded from ~/.cargo/lib/
+    install_name_tool -id "@rpath/${lib_file}" "$lib_path" >&2 2>/dev/null || {
+      >&2 echo "Warning: install_name_tool failed, but continuing..."
+    }
+    # Re-sign after fixing install_name
+    codesign --force --sign - --timestamp=none --preserve-metadata=entitlements "$lib_path" >&2 2>/dev/null || true
+  fi
 
   # Verify copy succeeded - installed library must exist
   [[ -f "$lib_path" ]] || { >&2 echo "Installation failed: expected library not found at $lib_path"; exit 1; }


### PR DESCRIPTION
- Update ensure_lib_built function to prefer the deps version of the library if it exists, improving build efficiency.
- Modify macOS-specific handling to fix the install_name of the library after copying, ensuring correct loading from ~/.cargo/lib/.
- Re-sign the library after fixing install_name to maintain compatibility with Deno FFI.

This update streamlines the library installation process and enhances compatibility on macOS systems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve `ensure_lib_built` to resolve libs from `target/release/deps`, add stricter artifact checks, and adjust macOS install_name/signing; bump version to 0.1.49.
> 
> - **Scripts (`scripts/runlib.sh`)**:
>   - **Library resolution**: Add `_find_target_lib` to prefer `target/release/deps/` over `target/release/`; verify artifact exists pre/post build and set `target_lib` to actual path.
>   - **Build flow**: Improve rebuild checks and error messages when artifacts are missing in both locations.
>   - **macOS handling**: After copying, run `install_name_tool -id "@rpath/<lib>"` and re-sign the installed lib; retain pre-copy signing step.
> - **Versioning**:
>   - Bump crate version in `Cargo.toml` to `0.1.49`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b11d6b46f0e69d66c36a73c01ed38bff9c5a039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->