### PR TITLE
Update version to 0.1.53 and enhance diagnostic logging in analysis m…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.52"
+version = "0.1.53"
 edition = "2021"
 
 [lib]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -511,12 +511,19 @@ impl TargetDiagnostics {
             }
 
             if entry.total_eligible_sources == 0 {
-                // Note: Detailed diagnostics are already logged above during analysis
-                // This is just a summary for the log output
+                // Log detailed diagnostics here since they may not be visible from parallel processing
+                // or may not have been logged if the target wasn't found in the order map
                 eprintln!(
                     "[NEAT-AI-Discovery][verbose] Target {} had no eligible upstream neurons to evaluate. \
-                    See detailed diagnostics above for explanation.",
-                    entry.target_uuid
+                    Target record count: {}, input neuron count: {}, already connected: {}, record load failures: {}. \
+                    This typically occurs when: (1) the target is an input/constant neuron (no upstream sources), \
+                    (2) all upstream neurons are constants (filtered out), (3) the target has an invalid index, \
+                    or (4) the target was not found in the creature neuron order map.",
+                    entry.target_uuid,
+                    entry.target_record_count,
+                    entry.input_neuron_count,
+                    entry.already_connected_count,
+                    entry.record_load_failures
                 );
                 continue;
             }
@@ -4839,6 +4846,22 @@ fn analyze_synapses_with_cache(
                         .lock()
                         .expect("Mutex poisoned: diagnostics")
                         .set_total_eligible_sources(target_uuid, 0);
+                    // Log detailed diagnostics for this case
+                    let input_count = input_neuron_uuids_arc.len();
+                    let target_neuron_type = neuron_type_map_arc.get(target_uuid.as_str());
+                    let target_in_creature = neuron_type_map_arc.contains_key(target_uuid.as_str());
+                    eprintln!(
+                        "[NEAT-AI-Discovery] Target {} has no eligible upstream neurons to evaluate. \
+                        Target not found in creature neuron order map. \
+                        Target neuron type: {:?}, target in creature.neurons: {}, \
+                        creature.input: {}, total ordered neurons: {}. \
+                        This indicates the neuron may not exist in the creature definition or has an invalid configuration.",
+                        target_uuid,
+                        target_neuron_type,
+                        target_in_creature,
+                        input_count,
+                        ordered_neurons_arc.len()
+                    );
                     if verbose_enabled() {
                         eprintln!(
                             "[NEAT-AI-Discovery][verbose] Target {target_uuid} not found in creature neuron order map (neuron may not exist in creature definition)."


### PR DESCRIPTION
…odule

- Bump version in Cargo.toml from 0.1.52 to 0.1.53.
- Improve logging in `TargetDiagnostics` to provide detailed diagnostics when no eligible upstream neurons are found, including counts of target records, input neurons, and connection statuses.
- Add comprehensive logging for cases where targets are not found in the creature neuron order map, enhancing clarity on potential configuration issues.

These changes improve the diagnostic capabilities of the analysis framework, providing clearer insights into neuron connectivity and evaluation outcomes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds detailed diagnostic logging when targets have no eligible upstream neurons or are missing from the order map, and bumps the crate version to 0.1.53.
> 
> - **Analysis diagnostics**:
>   - **No eligible sources**: `TargetDiagnostics.emit_logs` now logs detailed context (`target_record_count`, `input_neuron_count`, `already_connected_count`, `record_load_failures`) and typical causes when `total_eligible_sources == 0`.
>   - **Target missing in order map**: In `analyze_synapses_with_cache`, when a target UUID isn’t in the order map, set `total_eligible_sources` to `0` and log comprehensive context (target neuron type, whether present in `creature.neurons`, `creature.input` count, total ordered neurons) plus a verbose note.
>   - **Zero-eligible edge case**: Adds explicit, always-on explanations and bug hints for scenarios where eligible sources should exist but none are found (counts before filtering, constants filtered, input vs hidden/output cases).
> - **Version**: Bump `Cargo.toml` version `0.1.52` → `0.1.53`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7916da56011f991cf7f2dc2d07c3161854e1d4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->