### PR TITLE
Update version to 0.1.56 and ensure default Rust toolchain is set in …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.55"
+version = "0.1.56"
 edition = "2021"
 
 [lib]

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -92,6 +92,16 @@ _require_tools() {
     echo "ERROR: rustup installation appears incomplete. Please check Rust installation." >&2
     exit 1
   }
+  
+  # Ensure a default toolchain is set (required for cargo to work)
+  # Check if cargo can run (which requires a default toolchain)
+  if ! cargo --version >/dev/null 2>&1; then
+    echo "No default Rust toolchain configured. Setting default to stable..." >&2
+    rustup default stable >&2 || {
+      echo "ERROR: Failed to set default Rust toolchain. Please run 'rustup default stable' manually." >&2
+      exit 1
+    }
+  fi
 }
 
 # Must be run from the crate dir (where Cargo.toml lives).


### PR DESCRIPTION
…runlib.sh

- Bump version in Cargo.toml from 0.1.55 to 0.1.56.
- Add a check in runlib.sh to ensure a default Rust toolchain is configured, setting it to stable if not, to improve the reliability of the build process.

These changes enhance the setup process for Rust development, ensuring that users have a consistent environment for building the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps crate to 0.1.56 and ensures a default Rust toolchain (stable) is set in the build script.
> 
> - **Build tooling**:
>   - Update `scripts/runlib.sh` to ensure a default Rust toolchain is configured, setting it to `stable` if `cargo --version` fails.
> - **Versioning**:
>   - Bump `Cargo.toml` package version from `0.1.55` to `0.1.56`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f832667d3b6c62cb780a9eaea8b0c8a2f92de9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->