### PR TITLE
Update version to 0.1.57 and enhance analysis timeout handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.56"
+version = "0.1.57"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ whether discovery should be enabled:
 - **Empty Parquet output**: Confirm the caller supplies the sampled discovery
   dataset and that each record bundles observations, activations, and errors for
   the same training index.
+- **XDG_RUNTIME_DIR warnings on Linux**: The library automatically sets
+  `XDG_RUNTIME_DIR` to a temporary directory if it's not already set. This is
+  required by wgpu (WebGPU) on Linux systems using Wayland. The warnings are
+  harmless and the library handles this automatically. On macOS, this variable
+  is not needed.
+- **Out of memory errors**: If the Deno process is killed due to memory
+  exhaustion, increase the `--max-old-space-size` flag. For example:
+  `--v8-flags=--max-old-space-size=16384` for 16GB. The Rust library itself is
+  memory-efficient and streams data from Parquet files, but the TypeScript
+  controller may need more memory for large datasets.
+- **Analysis timeout**: The analysis phase has a default 10-minute timeout when
+  `analysis_deadline_ms` is not provided. If a timeout is explicitly provided
+  but is less than 3 seconds or greater than 1 hour, it will be clamped to the
+  10-minute default with a warning message.
 
 ## Existing reference material
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -27,7 +27,12 @@ fn build_deadline(deadline_ms: Option<u64>) -> Option<SystemTime> {
     // The calling code (TypeScript) calculates this as Date.now() + duration, but we want to treat
     // it as a duration to avoid issues with clock skew and to match the expected semantics.
     // If the calling code passes an absolute timestamp, we need to convert it to a relative duration.
-    deadline_ms.and_then(|target_ms| {
+    // If None is passed, apply default 10 minute timeout to prevent runaway analysis.
+    const DEFAULT_DURATION_MS: u64 = 600_000; // 10 minutes (10 * 60 * 1000)
+
+    let target_ms = deadline_ms.unwrap_or(DEFAULT_DURATION_MS);
+
+    Some(target_ms).and_then(|target_ms| {
         // Heuristic: if the value is less than year 2000 in milliseconds (946684800000),
         // treat it as a relative duration. Otherwise, it's likely an absolute timestamp
         // from the calling code, so convert it to a relative duration.
@@ -57,7 +62,7 @@ fn build_deadline(deadline_ms: Option<u64>) -> Option<SystemTime> {
         // If invalid, default to 10 minutes (expected typical value)
         const MIN_DURATION_MS: u64 = 3_000; // 3 seconds
         const MAX_DURATION_MS: u64 = 3_600_000; // 1 hour (60 * 60 * 1000)
-        const DEFAULT_DURATION_MS: u64 = 600_000; // 10 minutes (10 * 60 * 1000)
+        // Note: DEFAULT_DURATION_MS is defined at function scope above
 
         let validated_ms = if relative_ms < MIN_DURATION_MS {
             eprintln!(
@@ -2080,6 +2085,20 @@ impl GpuAnalyzer {
     /// falling back to CPU – if the adapter or device cannot be created, the
     /// probe reports `false`.
     pub fn gpu_is_available() -> bool {
+        // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
+        #[cfg(target_os = "linux")]
+        {
+            use std::env;
+            if env::var("XDG_RUNTIME_DIR").is_err() {
+                if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
+                    let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
+                    if std::fs::create_dir_all(&runtime_dir).is_ok() {
+                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                    }
+                }
+            }
+        }
+
         let instance = wgpu::Instance::default();
         #[cfg(test)]
         let adapter = if should_force_failure() {
@@ -2116,6 +2135,25 @@ impl GpuAnalyzer {
     }
 
     fn new() -> Result<Self> {
+        // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
+        // This prevents "error: XDG_RUNTIME_DIR not set in the environment" warnings
+        #[cfg(target_os = "linux")]
+        {
+            use std::env;
+            if env::var("XDG_RUNTIME_DIR").is_err() {
+                // Create a temporary runtime directory if XDG_RUNTIME_DIR is not set
+                if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
+                    let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
+                    if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
+                        eprintln!("[NEAT-AI-Discovery] Warning: Failed to create XDG_RUNTIME_DIR at {:?}: {}", runtime_dir, e);
+                    } else {
+                        // Set the environment variable for this process
+                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                    }
+                }
+            }
+        }
+
         let instance = wgpu::Instance::default();
         #[cfg(test)]
         let adapter = if should_force_failure() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Defaults analysis timeout to 10 minutes (with bounds/clamping) and auto-sets XDG_RUNTIME_DIR on Linux for wgpu; updates troubleshooting docs.
> 
> - **Rust (analysis)**:
>   - Apply a default 10-minute analysis deadline when `analysis_deadline_ms` is `None`; validate/clamp out-of-range values with warnings.
>   - On Linux, set `XDG_RUNTIME_DIR` to a temp path if missing in `GpuAnalyzer::gpu_is_available()` and `new()` to satisfy wgpu.
> - **Docs**:
>   - Add troubleshooting notes for `XDG_RUNTIME_DIR` auto-setup on Linux, Deno memory tuning, and analysis timeout default/clamping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e99cffd23eb4b3a05c1c5bd685f00c012ade1a37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->