### PR TITLE
Update version to 0.1.64 and refactor analysis input/output structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.62"
+version = "0.1.64"
 edition = "2021"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,20 +98,6 @@ pub struct RecordDiscoveryOutput {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeSynapsesInput {
-    pub parquet_file: String,
-    pub creature: CreatureJson,
-    pub focus_neurons: Vec<String>,
-    #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
-    pub max_candidates: Option<usize>,
-    #[serde(default)]
-    pub analysis_deadline_ms: Option<u64>,
-}
-
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CandidateSynapseJson {
@@ -138,36 +124,6 @@ pub struct NeuronStatsJson {
     pub activation_max: f32,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeSynapsesOutput {
-    pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gpu_used: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub helpful_synapses: Option<Vec<CandidateSynapseJson>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub harmful_synapses: Option<Vec<CandidateSynapseJson>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub diagnostics: Option<Vec<SynapseDiagnosticJson>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeNeuronsInput {
-    pub parquet_file: String,
-    pub creature: CreatureJson,
-    pub focus_neurons: Vec<String>,
-    #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
-    pub max_candidates: Option<usize>,
-    #[serde(default)]
-    pub analysis_deadline_ms: Option<u64>,
-}
-
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CandidateNeuronJson {
@@ -182,54 +138,6 @@ pub struct CandidateNeuronJson {
     pub total_count: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_neuron_stats: Option<NeuronStatsJson>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeNeuronsOutput {
-    pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gpu_used: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub helpful_neurons: Option<Vec<CandidateNeuronJson>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub diagnostics: Option<Vec<NeuronDiagnosticJson>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeAllInput {
-    pub parquet_file: String,
-    pub creature: CreatureJson,
-    pub focus_neurons: Vec<String>,
-    #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
-    pub harmful_threshold: Option<f32>,
-    #[serde(default)]
-    pub max_synapse_candidates: Option<usize>,
-    #[serde(default)]
-    pub max_neuron_candidates: Option<usize>,
-    #[serde(default)]
-    pub analysis_deadline_ms: Option<u64>,
-    #[serde(default)]
-    pub include_synapse_analysis: Option<bool>,
-    #[serde(default)]
-    pub include_neuron_analysis: Option<bool>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalyzeAllOutput {
-    pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub synapse: Option<AnalyzeSynapsesOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub neuron: Option<AnalyzeNeuronsOutput>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -270,6 +178,59 @@ pub struct AnalyzeParallelOutput {
     pub neuron_gpu_used: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// Internal input structure for synapse analysis (used by analyze_all)
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzeSynapsesInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    pub focus_neurons: Vec<String>,
+    #[serde(default)]
+    pub improvement_threshold: Option<f32>,
+    #[serde(default)]
+    pub max_candidates: Option<usize>,
+    #[serde(default)]
+    pub analysis_deadline_ms: Option<u64>,
+}
+
+/// Internal input structure for neuron analysis (used by analyze_all)
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzeNeuronsInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    pub focus_neurons: Vec<String>,
+    #[serde(default)]
+    pub improvement_threshold: Option<f32>,
+    #[serde(default)]
+    pub max_candidates: Option<usize>,
+    #[serde(default)]
+    pub analysis_deadline_ms: Option<u64>,
+}
+
+/// Internal input structure for combined analysis (used by analyze_parallel)
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyzeAllInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    pub focus_neurons: Vec<String>,
+    #[serde(default)]
+    pub improvement_threshold: Option<f32>,
+    #[serde(default)]
+    pub harmful_threshold: Option<f32>,
+    #[serde(default)]
+    pub max_synapse_candidates: Option<usize>,
+    #[serde(default)]
+    pub max_neuron_candidates: Option<usize>,
+    #[serde(default)]
+    pub analysis_deadline_ms: Option<u64>,
+    #[serde(default)]
+    pub include_synapse_analysis: Option<bool>,
+    #[serde(default)]
+    pub include_neuron_analysis: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -771,45 +732,64 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::{CStr, CString};
+    use std::panic;
 
-    // Read input C string
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        // Read input C string
+        let input_str = unsafe {
+            if input_json.is_null() {
+                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                }
+            }
+        };
+
+        // Call the Rust function with original string
+        match record_discovery_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                // Properly serialize error message to avoid JSON injection issues
+                let output = RecordDiscoveryOutput {
+                    success: false,
+                    temp_dir: None,
+                    file: None,
+                    error: Some(e.to_string()),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    // Fallback if serialization fails (shouldn't happen)
+                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
             }
         }
-    };
+    }));
 
-    // Call the Rust function with original string
-    let result = match record_discovery_internal(input_str) {
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            // Properly serialize error message to avoid JSON injection issues
-            let output = RecordDiscoveryOutput {
-                success: false,
-                temp_dir: None,
-                file: None,
-                error: Some(e.to_string()),
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
             };
-            let error_json = serde_json::to_string(&output).unwrap_or_else(|_| {
-                // Fallback if serialization fails (shouldn't happen)
-                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-            });
-            return CString::new(error_json).unwrap().into_raw();
+            format!(
+                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
     // Return as C string
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
@@ -823,38 +803,58 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
 pub extern "C" fn merge_discovery_parquet(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::{CStr, CString};
+    use std::panic;
 
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                }
+            }
+        };
+
+        match merge_discovery_parquet_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                let output = MergeParquetOutput {
+                    success: false,
+                    output_file: None,
+                    error: Some(e.to_string()),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
             }
         }
-    };
+    }));
 
-    let result = match merge_discovery_parquet_internal(input_str) {
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            let output = MergeParquetOutput {
-                success: false,
-                output_file: None,
-                error: Some(e.to_string()),
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
             };
-            serde_json::to_string(&output).unwrap_or_else(|_| {
-                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-            })
+            format!(
+                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
@@ -866,118 +866,63 @@ pub extern "C" fn merge_discovery_parquet(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::{CStr, CString};
+    use std::panic;
 
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
             }
-        }
-    };
-
-    let result = match rank_focus_neurons_internal(input_str) {
-        Ok(json) => json,
-        Err(e) => {
-            let output = RankFocusNeuronsOutput {
-                success: false,
-                neurons: None,
-                max_output_error: None,
-                processed_neurons: None,
-                total_neurons: None,
-                duration_ms: None,
-                error: Some(e.to_string()),
-            };
-            serde_json::to_string(&output).unwrap_or_else(|_| {
-                r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
-            })
-        }
-    };
-
-    match CString::new(result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
-pub extern "C" fn analyze_synapses(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
-    use std::ffi::{CStr, CString};
-
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                }
             }
-        }
-    };
+        };
 
-    let output = match serde_json::from_str::<AnalyzeSynapsesInput>(input_str) {
-        Ok(input) => {
-            // Log the received timeout value for debugging (note: value may be an absolute timestamp)
-            if let Some(ms) = input.analysis_deadline_ms {
-                eprintln!(
-                    "[NEAT-AI-Discovery] analyze_synapses FFI: Received analysis_deadline_ms={ms}"
-                );
-            }
-            match analysis::analyze_synapses(&input) {
-                Ok(result) => AnalyzeSynapsesOutput {
-                    success: true,
-                    gpu_used: Some(result.gpu_used),
-                    helpful_synapses: Some(result.helpful_synapses),
-                    harmful_synapses: Some(result.harmful_synapses),
-                    diagnostics: synapse_diagnostics_json(&result.no_candidate_reasons),
-                    error: None,
-                },
-                Err(e) => AnalyzeSynapsesOutput {
+        match rank_focus_neurons_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                let output = RankFocusNeuronsOutput {
                     success: false,
-                    gpu_used: None,
-                    helpful_synapses: None,
-                    harmful_synapses: None,
-                    diagnostics: None,
+                    neurons: None,
+                    max_output_error: None,
+                    processed_neurons: None,
+                    total_neurons: None,
+                    duration_ms: None,
                     error: Some(e.to_string()),
-                },
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
+                })
             }
         }
-        Err(e) => AnalyzeSynapsesOutput {
-            success: false,
-            gpu_used: None,
-            helpful_synapses: None,
-            harmful_synapses: None,
-            diagnostics: None,
-            error: Some(format!("Failed to parse input JSON: {e}")),
-        },
-    };
+    }));
 
-    let json = match serde_json::to_string(&output) {
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            let fallback =
-                format!("{{\"success\":false,\"error\":\"Failed to serialize output: {e}\"}}");
-            return CString::new(fallback).unwrap().into_raw();
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            format!(
+                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
-    match CString::new(json) {
-        Ok(result) => result.into_raw(),
+    match CString::new(json_result) {
+        Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
             CString::new(error).unwrap().into_raw()
@@ -988,33 +933,51 @@ pub extern "C" fn analyze_synapses(input_json: *const std::ffi::c_char) -> *mut 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::{CStr, CString};
+    use std::panic;
 
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                }
+            }
+        };
+
+        match analyze_parallel_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                format!("{{\"success\":false,\"error\":\"Failed to serialize output: {e}\"}}")
             }
         }
-    };
+    }));
 
-    let result = match analyze_parallel_internal(input_str) {
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            let fallback =
-                format!("{{\"success\":false,\"error\":\"Failed to serialize output: {e}\"}}");
-            fallback
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            format!(
+                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
@@ -1025,20 +988,41 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
 
 #[no_mangle]
 pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::CString;
+    use std::panic;
 
-    let result = match check_gpu_available_internal() {
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        match check_gpu_available_internal() {
+            Ok(json) => json,
+            Err(e) => {
+                format!(
+                    "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Failed to probe GPU: {e}\"}}"
+                )
+            }
+        }
+    }));
+
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            let fallback = format!(
-                "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Failed to probe GPU: {e}\"}}"
-            );
-            fallback
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            format!(
+                "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"gpuAvailable":false,"error":"Failed to create output string"}"#;
@@ -1056,165 +1040,45 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
 /// The returned pointer must be freed using free_discovery_result
 #[no_mangle]
 pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::CString;
+    use std::panic;
 
-    let result = match get_library_version_internal() {
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        match get_library_version_internal() {
+            Ok(json) => json,
+            Err(e) => {
+                format!(
+                    "{{\"success\":false,\"version\":\"\",\"error\":\"Failed to get version: {e}\"}}"
+                )
+            }
+        }
+    }));
+
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            let fallback = format!(
-                "{{\"success\":false,\"version\":\"\",\"error\":\"Failed to get version: {e}\"}}"
-            );
-            fallback
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            format!(
+                "{{\"success\":false,\"version\":\"\",\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error =
                 r#"{"success":false,"version":"","error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
-pub extern "C" fn analyze_neurons(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
-    use std::ffi::{CStr, CString};
-
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
-            }
-        }
-    };
-
-    let output = match serde_json::from_str::<AnalyzeNeuronsInput>(input_str) {
-        Ok(input) => {
-            // Log the received timeout value for debugging (note: value may be an absolute timestamp)
-            if let Some(ms) = input.analysis_deadline_ms {
-                eprintln!(
-                    "[NEAT-AI-Discovery] analyze_neurons FFI: Received analysis_deadline_ms={ms}"
-                );
-            }
-            match analysis::analyze_neurons(&input) {
-                Ok(result) => AnalyzeNeuronsOutput {
-                    success: true,
-                    gpu_used: Some(result.gpu_used),
-                    helpful_neurons: Some(result.helpful_neurons),
-                    diagnostics: neuron_diagnostics_json(&result.no_candidate_reasons),
-                    error: None,
-                },
-                Err(e) => AnalyzeNeuronsOutput {
-                    success: false,
-                    gpu_used: None,
-                    helpful_neurons: None,
-                    diagnostics: None,
-                    error: Some(e.to_string()),
-                },
-            }
-        }
-        Err(e) => AnalyzeNeuronsOutput {
-            success: false,
-            gpu_used: None,
-            helpful_neurons: None,
-            diagnostics: None,
-            error: Some(format!("Failed to parse input JSON: {e}")),
-        },
-    };
-
-    let json = match serde_json::to_string(&output) {
-        Ok(json) => json,
-        Err(e) => {
-            let fallback =
-                format!("{{\"success\":false,\"error\":\"Failed to serialize output: {e}\"}}");
-            return CString::new(fallback).unwrap().into_raw();
-        }
-    };
-
-    match CString::new(json) {
-        Ok(result) => result.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
-}
-
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
-pub extern "C" fn analyze_all(input_json: *const std::ffi::c_char) -> *mut std::ffi::c_char {
-    log_version_once();
-    use std::ffi::{CStr, CString};
-
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
-            }
-        }
-    };
-
-    let output = match serde_json::from_str::<AnalyzeAllInput>(input_str) {
-        Ok(input) => match analysis::analyze_all(&input) {
-            Ok(result) => AnalyzeAllOutput {
-                success: true,
-                synapse: result.synapse.map(|synapse| AnalyzeSynapsesOutput {
-                    success: true,
-                    gpu_used: Some(synapse.gpu_used),
-                    helpful_synapses: Some(synapse.helpful_synapses),
-                    harmful_synapses: Some(synapse.harmful_synapses),
-                    diagnostics: synapse_diagnostics_json(&synapse.no_candidate_reasons),
-                    error: None,
-                }),
-                neuron: result.neuron.map(|neuron| AnalyzeNeuronsOutput {
-                    success: true,
-                    gpu_used: Some(neuron.gpu_used),
-                    helpful_neurons: Some(neuron.helpful_neurons),
-                    diagnostics: neuron_diagnostics_json(&neuron.no_candidate_reasons),
-                    error: None,
-                }),
-                error: None,
-            },
-            Err(e) => AnalyzeAllOutput {
-                success: false,
-                synapse: None,
-                neuron: None,
-                error: Some(e.to_string()),
-            },
-        },
-        Err(e) => AnalyzeAllOutput {
-            success: false,
-            synapse: None,
-            neuron: None,
-            error: Some(e.to_string()),
-        },
-    };
-
-    let result = serde_json::to_string(&output).unwrap_or_else(|_| {
-        r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
-    });
-
-    match CString::new(result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
             CString::new(error).unwrap().into_raw()
         }
     }
@@ -1316,44 +1180,63 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
 pub extern "C" fn read_discovery_records_ffi(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    log_version_once();
     use std::ffi::{CStr, CString};
+    use std::panic;
 
-    // Read input C string
-    let input_str = unsafe {
-        if input_json.is_null() {
-            let error = r#"{"success":false,"error":"Null input pointer"}"#;
-            return CString::new(error).unwrap().into_raw();
-        }
-        match CStr::from_ptr(input_json).to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                return CString::new(error).unwrap().into_raw();
+    // Catch any panics to prevent unwinding across FFI boundary
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        // Read input C string
+        let input_str = unsafe {
+            if input_json.is_null() {
+                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                }
+            }
+        };
+
+        // Call the Rust function
+        match read_discovery_records(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                // Properly serialize error message to avoid JSON injection issues
+                let output = ReadDiscoveryOutput {
+                    success: false,
+                    records: None,
+                    error: Some(e.to_string()),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    // Fallback if serialization fails (shouldn't happen)
+                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
             }
         }
-    };
+    }));
 
-    // Call the Rust function
-    let result = match read_discovery_records(input_str) {
+    let json_result = match result {
         Ok(json) => json,
-        Err(e) => {
-            // Properly serialize error message to avoid JSON injection issues
-            let output = ReadDiscoveryOutput {
-                success: false,
-                records: None,
-                error: Some(e.to_string()),
+        Err(panic_info) => {
+            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
             };
-            let error_json = serde_json::to_string(&output).unwrap_or_else(|_| {
-                // Fallback if serialization fails (shouldn't happen)
-                r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-            });
-            return CString::new(error_json).unwrap().into_raw();
+            format!(
+                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+                msg.replace('\\', "\\\\").replace('"', "\\\"")
+            )
         }
     };
 
     // Return as C string
-    match CString::new(result) {
+    match CString::new(json_result) {
         Ok(c_string) => c_string.into_raw(),
         Err(_) => {
             let error = r#"{"success":false,"error":"Failed to create output string"}"#;
@@ -1371,11 +1254,17 @@ pub extern "C" fn read_discovery_records_ffi(
 #[no_mangle]
 pub extern "C" fn free_discovery_result(ptr: *mut std::ffi::c_char) {
     use std::ffi::CString;
-    if !ptr.is_null() {
-        unsafe {
-            let _ = CString::from_raw(ptr);
+    use std::panic;
+
+    // Catch any panics to prevent unwinding across FFI boundary
+    // This is unlikely to panic, but we protect it anyway for safety
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        if !ptr.is_null() {
+            unsafe {
+                let _ = CString::from_raw(ptr);
+            }
         }
-    }
+    }));
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,24 +736,27 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
         // Read input C string
         let input_str = unsafe {
             if input_json.is_null() {
-                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
                 }
             }
         };
 
         // Call the Rust function with original string
-        match record_discovery_internal(input_str) {
+        let json_result = match record_discovery_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
@@ -768,34 +771,38 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        // Return as C string - this is also protected by catch_unwind
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    // Return as C string
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -807,22 +814,25 @@ pub extern "C" fn merge_discovery_parquet(
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
         let input_str = unsafe {
             if input_json.is_null() {
-                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
                 }
             }
         };
 
-        match merge_discovery_parquet_internal(input_str) {
+        let json_result = match merge_discovery_parquet_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
                 let output = MergeParquetOutput {
@@ -834,33 +844,37 @@ pub extern "C" fn merge_discovery_parquet(
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -870,22 +884,25 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
         let input_str = unsafe {
             if input_json.is_null() {
-                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
                 }
             }
         };
 
-        match rank_focus_neurons_internal(input_str) {
+        let json_result = match rank_focus_neurons_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
                 let output = RankFocusNeuronsOutput {
@@ -901,33 +918,37 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
                     r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -937,22 +958,25 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
         let input_str = unsafe {
             if input_json.is_null() {
-                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
                 }
             }
         };
 
-        match analyze_parallel_internal(input_str) {
+        let json_result = match analyze_parallel_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
@@ -972,33 +996,37 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 #[no_mangle]
@@ -1007,10 +1035,11 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
-        match check_gpu_available_internal() {
+        let json_result = match check_gpu_available_internal() {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
@@ -1024,33 +1053,37 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
                     r#"{"success":false,"gpuAvailable":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"gpuAvailable":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"gpuAvailable":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"gpuAvailable":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 /// FFI export for querying the library version
@@ -1066,10 +1099,11 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
-        match get_library_version_internal() {
+        let json_result = match get_library_version_internal() {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
@@ -1084,34 +1118,38 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
                         .to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"version\":\"\",\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error =
+                    r#"{"success":false,"version":"","error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error =
-                r#"{"success":false,"version":"","error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"version\":\"\",\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"version":"","error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 /// JSON input for read_discovery_records function
@@ -1214,24 +1252,27 @@ pub extern "C" fn read_discovery_records_ffi(
     use std::panic;
 
     // Catch any panics to prevent unwinding across FFI boundary
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+    // This includes the final CString::new() conversion to catch any panics there
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
         log_version_once();
 
         // Read input C string
         let input_str = unsafe {
             if input_json.is_null() {
-                return r#"{"success":false,"error":"Null input pointer"}"#.to_string();
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    return r#"{"success":false,"error":"Invalid UTF-8 in input"}"#.to_string();
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
                 }
             }
         };
 
         // Call the Rust function
-        match read_discovery_records(input_str) {
+        let json_result = match read_discovery_records(input_str) {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
@@ -1245,34 +1286,38 @@ pub extern "C" fn read_discovery_records_ffi(
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
-        }
-    }));
+        };
 
-    let json_result = match result {
-        Ok(json) => json,
-        Err(panic_info) => {
-            let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            format!(
-                "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-                msg.replace('\\', "\\\\").replace('"', "\\\"")
-            )
+        // Return as C string - this is also protected by catch_unwind
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
         }
-    };
-
-    // Return as C string
-    match CString::new(json_result) {
-        Ok(c_string) => c_string.into_raw(),
-        Err(_) => {
-            let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-            CString::new(error).unwrap().into_raw()
-        }
-    }
+    }))
+    .unwrap_or_else(|panic_info| {
+        // If panic occurred, create a safe error response
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
 }
 
 /// FFI export for freeing memory allocated by read_discovery_records_ffi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -955,7 +955,22 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
         match analyze_parallel_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                format!("{{\"success\":false,\"error\":\"Failed to serialize output: {e}\"}}")
+                // Properly serialize error message to avoid JSON injection issues
+                let output = AnalyzeParallelOutput {
+                    success: false,
+                    helpful_synapses: None,
+                    harmful_synapses: None,
+                    synapse_diagnostics: None,
+                    synapse_gpu_used: None,
+                    helpful_neurons: None,
+                    neuron_diagnostics: None,
+                    neuron_gpu_used: None,
+                    error: Some(format!("Failed to serialize output: {e}")),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    // Fallback if serialization fails (shouldn't happen)
+                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
             }
         }
     }));
@@ -998,9 +1013,16 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
         match check_gpu_available_internal() {
             Ok(json) => json,
             Err(e) => {
-                format!(
-                    "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Failed to probe GPU: {e}\"}}"
-                )
+                // Properly serialize error message to avoid JSON injection issues
+                let output = CheckGpuOutput {
+                    success: false,
+                    gpu_available: false,
+                    error: Some(format!("Failed to probe GPU: {e}")),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    // Fallback if serialization fails (shouldn't happen)
+                    r#"{"success":false,"gpuAvailable":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
             }
         }
     }));
@@ -1050,9 +1072,17 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
         match get_library_version_internal() {
             Ok(json) => json,
             Err(e) => {
-                format!(
-                    "{{\"success\":false,\"version\":\"\",\"error\":\"Failed to get version: {e}\"}}"
-                )
+                // Properly serialize error message to avoid JSON injection issues
+                let output = GetVersionOutput {
+                    success: false,
+                    version: String::new(),
+                    error: Some(format!("Failed to get version: {e}")),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    // Fallback if serialization fails (shouldn't happen)
+                    r#"{"success":false,"version":"","error":"Failed to serialize error message"}"#
+                        .to_string()
+                })
             }
         }
     }));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,3 +11,15 @@ pub fn test_data_dir() -> PathBuf {
     path.push("data");
     path
 }
+
+/// Macro to skip tests that require a GPU when no GPU is available.
+/// Place this at the start of any test that calls GPU-accelerated analysis functions.
+#[macro_export]
+macro_rules! skip_without_gpu {
+    () => {
+        if !neat_ai_discovery::analysis::GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -423,6 +423,7 @@ fn test_impact_calculation_with_multiple_incoming_connections() {
 /// Test that analyze_neurons returns non-zero bias values for neuron candidates
 #[test]
 fn test_analyze_neurons_returns_non_zero_bias() {
+    skip_without_gpu!();
     use neat_ai_discovery::AnalyzeNeuronsInput;
 
     let temp_dir = TempDir::new().unwrap();
@@ -520,6 +521,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
 /// Test that bias values are activation-function-specific
 #[test]
 fn test_bias_values_are_activation_specific() {
+    skip_without_gpu!();
     use neat_ai_discovery::AnalyzeNeuronsInput;
 
     let temp_dir = TempDir::new().unwrap();
@@ -629,6 +631,7 @@ fn test_bias_values_are_activation_specific() {
 /// Test that neurons with calculated bias improve error more than bias=0
 #[test]
 fn test_bias_improves_neuron_performance() {
+    skip_without_gpu!();
     use neat_ai_discovery::AnalyzeNeuronsInput;
 
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.62 to 0.1.64.
- Refactor input and output structures for synapse and neuron analysis, renaming and consolidating several structs for clarity and consistency.
- Introduce panic handling in FFI functions to prevent unwinding across the boundary, improving stability during error conditions.
- Enhance error handling and logging across various analysis functions to provide clearer diagnostics and prevent crashes.

These changes improve the maintainability and robustness of the analysis framework, particularly in handling input and output for FFI interactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates analysis I/O around parallel APIs, adds panic-safe FFI wrappers with consistent JSON errors, introduces a GPU-skip test macro, and bumps to 0.1.64.
> 
> - **Analysis API**:
>   - Consolidates I/O types: introduce `AnalyzeParallelInput`/`AnalyzeParallelOutput`; add internal `AnalyzeSynapsesInput`, `AnalyzeNeuronsInput`, and combined `AnalyzeAllInput`.
>   - Removes older standalone outputs (`AnalyzeSynapsesOutput`, `AnalyzeNeuronsOutput`) and related FFI endpoints.
> - **FFI**:
>   - Wraps exports with `panic::catch_unwind` and consistent JSON error shaping for `record_discovery`, `merge_discovery_parquet`, `rank_focus_neurons`, `analyze_parallel`, `check_gpu_available`, `get_library_version`, `read_discovery_records_ffi`, and `free_discovery_result`.
> - **Tests**:
>   - Adds `skip_without_gpu!` macro and guards GPU-dependent integration tests.
> - **Version**:
>   - Bumps crate to `0.1.64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5a5f9dc825577f60fc46986095eec2a6a0fcb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->