### PR TITLE
Investigate EGL and DRI permission errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,4 +417,6 @@ jobs:
         check_filenames: true
         check_hidden: true
         skip: "./target,./.git,./tests/data"
+        # renderD is a Linux GPU device node name (/dev/dri/renderD128), not a typo
+        ignore_words_list: renderD
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.67"
+version = "0.1.68"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.67
+version = "0.1.67"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.64"
+version = "0.1.65"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -138,7 +138,18 @@ whether discovery should be enabled:
   ```json
   {
     "success": true,
-    "gpuAvailable": true
+    "gpuAvailable": true,
+    "reason": null
+  }
+  ```
+
+  When GPU is unavailable, the response includes a diagnostic reason:
+
+  ```json
+  {
+    "success": true,
+    "gpuAvailable": false,
+    "reason": "No GPU adapter found. Discovery disabled on this machine..."
   }
   ```
 
@@ -149,6 +160,16 @@ whether discovery should be enabled:
 - When `"gpuAvailable"` is `true`, controllers may safely schedule discovery
   jobs. If a later GPU initialisation error occurs, the Rust side will return
   a structured error and mark the JSON `success` flag as `false`.
+
+#### Platform-specific GPU behaviour
+
+- **macOS**: GPU (Metal) should always be available. If `gpuAvailable` is
+  `false`, this is treated as an error (`success: false`) indicating a system
+  configuration issue that should be investigated.
+- **Linux**: GPU may not be available on headless servers without GPU hardware
+  or without proper permissions to access `/dev/dri` devices. If `gpuAvailable`
+  is `false`, this is **not** an error (`success: true`) - discovery is simply
+  disabled on that machine. This is normal for older headless Linux servers.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,42 @@ whether discovery should be enabled:
   required by wgpu (WebGPU) on Linux systems using Wayland. The warnings are
   harmless and the library handles this automatically. On macOS, this variable
   is not needed.
+- **EGL/DRI permission denied warnings on Linux**: If you see warnings like
+  `libEGL warning: failed to open /dev/dri/renderD128: Permission denied` or
+  similar for `/dev/dri/card0`, the user running the process needs access to
+  the GPU device nodes. These warnings typically appear when wgpu probes for
+  available GPU backends.
+  
+  **Solutions (choose one):**
+  1. **Add user to the render/video groups** (recommended for dedicated GPU
+     access):
+     ```bash
+     sudo usermod -a -G render $USER
+     sudo usermod -a -G video $USER
+     # Log out and back in for group changes to take effect
+     ```
+  2. **Set device permissions** (temporary fix):
+     ```bash
+     sudo chmod 666 /dev/dri/renderD128 /dev/dri/card0
+     ```
+  3. **Suppress warnings** (if wgpu finds an alternative backend and discovery
+     still works): Set `NEAT_AI_DISCOVERY_QUIET_GPU=1` to suppress Mesa/libEGL
+     debug output. This sets `EGL_LOG_LEVEL=fatal` and `MESA_DEBUG=silent`
+     internally before GPU initialisation.
+  
+  **Diagnosing GPU access:**
+  ```bash
+  # Check which groups own the DRI devices
+  ls -la /dev/dri/
+  # Check your current groups
+  groups
+  # Test GPU availability directly
+  vulkaninfo --summary 2>/dev/null || echo "Vulkan not available"
+  ```
+  
+  If the warnings appear but discovery still proceeds successfully (you see
+  "Training ... with N binary file" after the warnings), wgpu has found an
+  alternative GPU backend and the warnings can be safely ignored.
 - **Out of memory errors**: If the Deno process is killed due to memory
   exhaustion, increase the `--max-old-space-size` flag. For example:
   `--v8-flags=--max-old-space-size=16384` for 16GB. The Rust library itself is

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -2039,6 +2039,16 @@ pub struct GpuAnalyzer {
     bias_pipeline: Option<wgpu::ComputePipeline>,
 }
 
+/// Result of GPU availability check with detailed diagnostics.
+pub struct GpuAvailabilityResult {
+    /// Whether a GPU is available for use.
+    pub available: bool,
+    /// Human-readable reason for the availability status.
+    pub reason: Option<String>,
+    /// Whether this is an error condition (true on macOS when GPU unavailable).
+    pub is_error: bool,
+}
+
 impl GpuAnalyzer {
     /// Lightweight probe to determine whether a usable GPU device is available.
     ///
@@ -2046,7 +2056,21 @@ impl GpuAnalyzer {
     /// enable the Rust discovery extension at all. It deliberately avoids
     /// falling back to CPU – if the adapter or device cannot be created, the
     /// probe reports `false`.
+    ///
+    /// Platform-specific behaviour:
+    /// - **macOS**: GPU should always be available (Metal). Missing GPU is an error.
+    /// - **Linux**: GPU may not be available on headless servers without GPU hardware
+    ///   or proper permissions. Missing GPU gracefully disables discovery.
     pub fn gpu_is_available() -> bool {
+        Self::check_gpu_availability().available
+    }
+
+    /// Check GPU availability with detailed diagnostics.
+    ///
+    /// Returns availability status, reason, and whether it's an error condition.
+    /// On macOS, missing GPU is treated as an error (Metal should always work).
+    /// On Linux, missing GPU gracefully disables discovery (common on headless servers).
+    pub fn check_gpu_availability() -> GpuAvailabilityResult {
         // Suppress Mesa/libEGL warnings if requested (must be called before GPU init)
         suppress_mesa_warnings_if_requested();
 
@@ -2075,7 +2099,7 @@ impl GpuAnalyzer {
         }));
 
         let Some(adapter) = adapter else {
-            return false;
+            return Self::no_gpu_result("No GPU adapter found");
         };
 
         let device_result = pollster::block_on(adapter.request_device(
@@ -2087,7 +2111,55 @@ impl GpuAnalyzer {
             None,
         ));
 
-        device_result.is_ok()
+        match device_result {
+            Ok(_) => GpuAvailabilityResult {
+                available: true,
+                reason: None,
+                is_error: false,
+            },
+            Err(e) => Self::no_gpu_result(&format!("GPU device creation failed: {e}")),
+        }
+    }
+
+    /// Create a result for when GPU is not available.
+    /// On macOS this is an error; on Linux it gracefully disables discovery.
+    fn no_gpu_result(reason: &str) -> GpuAvailabilityResult {
+        #[cfg(target_os = "macos")]
+        {
+            // On macOS, Metal should always be available - missing GPU is an error
+            GpuAvailabilityResult {
+                available: false,
+                reason: Some(format!(
+                    "{reason}. On macOS, GPU (Metal) should always be available. \
+                     This may indicate a system configuration issue."
+                )),
+                is_error: true,
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            // On Linux, GPU may not be available on headless servers - gracefully disable
+            GpuAvailabilityResult {
+                available: false,
+                reason: Some(format!(
+                    "{reason}. Discovery disabled on this machine. \
+                     This is normal for headless Linux servers without GPU hardware or \
+                     without proper permissions to access /dev/dri devices."
+                )),
+                is_error: false,
+            }
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            // For other platforms, treat as non-error (graceful disable)
+            GpuAvailabilityResult {
+                available: false,
+                reason: Some(format!("{reason}. Discovery disabled on this platform.")),
+                is_error: false,
+            }
+        }
     }
 
     fn new() -> Result<Self> {

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -163,6 +163,49 @@ fn verbose_enabled() -> bool {
     std::env::var("NEAT_AI_DISCOVERY_VERBOSE").is_ok()
 }
 
+/// Suppress Mesa/libEGL debug warnings on Linux.
+///
+/// When wgpu initialises on Linux, it probes multiple GPU backends (EGL, Vulkan, etc.).
+/// If the user lacks permission to access `/dev/dri/renderD*` or `/dev/dri/card*` devices,
+/// libEGL emits warnings like "failed to open /dev/dri/renderD128: Permission denied".
+///
+/// These warnings are often benign if wgpu finds an alternative backend (e.g., Vulkan via
+/// a different ICD loader). This function suppresses the warnings by setting environment
+/// variables that quiet Mesa's debug output.
+///
+/// Set `NEAT_AI_DISCOVERY_QUIET_GPU=1` to enable suppression.
+#[cfg(target_os = "linux")]
+fn suppress_mesa_warnings_if_requested() {
+    use std::env;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        if env::var("NEAT_AI_DISCOVERY_QUIET_GPU").is_ok() {
+            // Suppress EGL debug messages (these cause "failed to open /dev/dri/..." warnings)
+            if env::var("EGL_LOG_LEVEL").is_err() {
+                // SAFETY: single-threaded at this point (Once guard) and before GPU init
+                unsafe { env::set_var("EGL_LOG_LEVEL", "fatal") };
+            }
+
+            // Suppress Mesa GLSL shader cache warnings
+            if env::var("MESA_GLSL_CACHE_DISABLE").is_err() {
+                unsafe { env::set_var("MESA_GLSL_CACHE_DISABLE", "true") };
+            }
+
+            // Suppress general Mesa debug output
+            if env::var("MESA_DEBUG").is_err() {
+                unsafe { env::set_var("MESA_DEBUG", "silent") };
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "linux"))]
+fn suppress_mesa_warnings_if_requested() {
+    // No-op on non-Linux platforms
+}
+
 pub struct AnalyzeSynapsesResult {
     pub helpful_synapses: Vec<CandidateSynapseJson>,
     pub harmful_synapses: Vec<CandidateSynapseJson>,
@@ -2004,6 +2047,9 @@ impl GpuAnalyzer {
     /// falling back to CPU – if the adapter or device cannot be created, the
     /// probe reports `false`.
     pub fn gpu_is_available() -> bool {
+        // Suppress Mesa/libEGL warnings if requested (must be called before GPU init)
+        suppress_mesa_warnings_if_requested();
+
         // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
         #[cfg(target_os = "linux")]
         {
@@ -2012,7 +2058,10 @@ impl GpuAnalyzer {
                 if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
                     let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
                     if std::fs::create_dir_all(&runtime_dir).is_ok() {
-                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                        // SAFETY: Called before GPU init, single-threaded context
+                        unsafe {
+                            env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                        }
                     }
                 }
             }
@@ -2042,6 +2091,9 @@ impl GpuAnalyzer {
     }
 
     fn new() -> Result<Self> {
+        // Suppress Mesa/libEGL warnings if requested (must be called before GPU init)
+        suppress_mesa_warnings_if_requested();
+
         // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
         // This prevents "error: XDG_RUNTIME_DIR not set in the environment" warnings
         #[cfg(target_os = "linux")]
@@ -2054,8 +2106,10 @@ impl GpuAnalyzer {
                     if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
                         eprintln!("[NEAT-AI-Discovery] Warning: Failed to create XDG_RUNTIME_DIR at {runtime_dir:?}: {e}");
                     } else {
-                        // Set the environment variable for this process
-                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                        // SAFETY: Called before GPU init, single-threaded context
+                        unsafe {
+                            env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                        }
                     }
                 }
             }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -207,6 +207,43 @@ fn suppress_mesa_warnings_if_requested() {
     // No-op on non-Linux platforms
 }
 
+/// Ensure XDG_RUNTIME_DIR is set on Linux (required by wgpu on Wayland).
+///
+/// This function uses `Once` for thread-safe one-time initialisation. It's safe to
+/// call from multiple threads concurrently - only the first call will set the
+/// environment variable, and subsequent calls are no-ops.
+///
+/// Must be called before any GPU initialisation (wgpu Instance creation).
+#[cfg(target_os = "linux")]
+fn ensure_xdg_runtime_dir() {
+    use std::env;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        if env::var("XDG_RUNTIME_DIR").is_err() {
+            // Create a temporary runtime directory if XDG_RUNTIME_DIR is not set
+            if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
+                let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
+                if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
+                    eprintln!("[NEAT-AI-Discovery] Warning: Failed to create XDG_RUNTIME_DIR at {runtime_dir:?}: {e}");
+                } else {
+                    // SAFETY: Inside Once::call_once, so guaranteed single-threaded execution.
+                    // Called before any GPU init.
+                    unsafe {
+                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "linux"))]
+fn ensure_xdg_runtime_dir() {
+    // No-op on non-Linux platforms
+}
+
 pub struct AnalyzeSynapsesResult {
     pub helpful_synapses: Vec<CandidateSynapseJson>,
     pub harmful_synapses: Vec<CandidateSynapseJson>,
@@ -2176,21 +2213,8 @@ impl GpuAnalyzer {
         suppress_mesa_warnings_if_requested();
 
         // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
-        #[cfg(target_os = "linux")]
-        {
-            use std::env;
-            if env::var("XDG_RUNTIME_DIR").is_err() {
-                if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
-                    let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
-                    if std::fs::create_dir_all(&runtime_dir).is_ok() {
-                        // SAFETY: Called before GPU init, single-threaded context
-                        unsafe {
-                            env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
-                        }
-                    }
-                }
-            }
-        }
+        // Uses Once internally for thread-safe one-time initialisation
+        ensure_xdg_runtime_dir();
 
         let instance = wgpu::Instance::default();
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -2268,25 +2292,8 @@ impl GpuAnalyzer {
         suppress_mesa_warnings_if_requested();
 
         // Set XDG_RUNTIME_DIR if not already set (required by wgpu on Linux/Wayland)
-        // This prevents "error: XDG_RUNTIME_DIR not set in the environment" warnings
-        #[cfg(target_os = "linux")]
-        {
-            use std::env;
-            if env::var("XDG_RUNTIME_DIR").is_err() {
-                // Create a temporary runtime directory if XDG_RUNTIME_DIR is not set
-                if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
-                    let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
-                    if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
-                        eprintln!("[NEAT-AI-Discovery] Warning: Failed to create XDG_RUNTIME_DIR at {runtime_dir:?}: {e}");
-                    } else {
-                        // SAFETY: Called before GPU init, single-threaded context
-                        unsafe {
-                            env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
-                        }
-                    }
-                }
-            }
-        }
+        // Uses Once internally for thread-safe one-time initialisation
+        ensure_xdg_runtime_dir();
 
         let instance = wgpu::Instance::default();
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,11 +652,24 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
 }
 
 pub fn check_gpu_available_internal() -> Result<String> {
-    let available = analysis::GpuAnalyzer::gpu_is_available();
-    let output = CheckGpuOutput {
-        success: true,
-        gpu_available: available,
-        error: None,
+    let result = analysis::GpuAnalyzer::check_gpu_availability();
+
+    // On macOS, missing GPU is an error (Metal should always work).
+    // On Linux, missing GPU gracefully disables discovery (common on headless servers).
+    let output = if result.is_error {
+        CheckGpuOutput {
+            success: false,
+            gpu_available: false,
+            reason: result.reason,
+            error: Some("GPU required but not available".to_string()),
+        }
+    } else {
+        CheckGpuOutput {
+            success: true,
+            gpu_available: result.available,
+            reason: result.reason,
+            error: None,
+        }
     };
     Ok(serde_json::to_string(&output)?)
 }
@@ -1048,6 +1061,7 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
                 let output = CheckGpuOutput {
                     success: false,
                     gpu_available: false,
+                    reason: None,
                     error: Some(format!("Failed to probe GPU: {e}")),
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
@@ -1509,12 +1523,25 @@ mod tests {
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("GPU availability output should be valid JSON");
 
-        assert_eq!(value["success"], true);
+        assert!(
+            value["success"].is_boolean(),
+            "success flag should be a boolean"
+        );
         assert!(
             value["gpuAvailable"].is_boolean(),
             "gpuAvailable flag should be a boolean"
         );
-        // error field is optional and may be null or a string; no strict assertion here
+
+        // Platform-specific behaviour:
+        // - On macOS: success=false when GPU unavailable (error condition)
+        // - On Linux: success=true when GPU unavailable (graceful disable)
+        // - reason field provides diagnostic information when GPU is unavailable
+        if !value["gpuAvailable"].as_bool().unwrap_or(false) {
+            assert!(
+                value["reason"].is_string(),
+                "reason should be provided when GPU is unavailable"
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,8 @@ pub struct CheckGpuOutput {
     pub success: bool,
     pub gpu_available: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 


### PR DESCRIPTION
Add environment variable to suppress benign libEGL permission warnings and improve GPU troubleshooting documentation on Linux.

The `libEGL warning: failed to open /dev/dri/renderD128: Permission denied` messages appear on Linux when wgpu probes for GPU backends and the process lacks direct access to DRI device nodes. These are often harmless if wgpu successfully initializes another backend (e.g., Vulkan). This PR provides a `NEAT_AI_DISCOVERY_QUIET_GPU=1` environment variable to suppress these warnings and updates the README with comprehensive troubleshooting steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-6143b087-acdb-4d05-a940-adcbdc4125cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6143b087-acdb-4d05-a940-adcbdc4125cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds detailed GPU availability diagnostics and optional suppression of Linux libEGL warnings, updates JSON/README, and tweaks CI spell-check.
> 
> - **Core (GPU handling)**:
>   - Add `GpuAvailabilityResult` and `GpuAnalyzer::check_gpu_availability()` with platform-specific diagnostics (macOS errors vs Linux graceful disable).
>   - Introduce Linux-only `suppress_mesa_warnings_if_requested()` (via `NEAT_AI_DISCOVERY_QUIET_GPU=1`) and refactor `ensure_xdg_runtime_dir()` with one-time init.
> - **FFI/JSON output**:
>   - `check_gpu_available` now returns `reason` and sets `success` based on platform; update `CheckGpuOutput` and error paths.
>   - Update tests to validate new fields/behavior.
> - **Docs**:
>   - README: document `reason`, platform-specific semantics, Linux DRI/EGL permissions, and how to suppress warnings.
> - **CI**:
>   - Codespell: ignore `renderD` device name.
> - **Version**:
>   - Bump `Cargo.toml` to `0.1.68`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f553c911c53498547aadc58e293985f806ce97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->