### PR TITLE
Update version to 0.1.111 and enhance neuron filtering logic in analy…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.109"
+version = "0.1.111"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -251,6 +251,22 @@ now filters out these candidates:
 2. **Bias filtering**: IDENTITY candidates with `|bias| < 0.01` are rejected
 3. **Use synapse analysis**: Direct connections should use `add-synapses`, not `add-neurons`
 
+#### Add-neuron target neuron filtering
+
+**Only output neurons are valid targets** for add-neuron analysis. Input and
+hidden neurons are filtered out from the focus list:
+
+| Neuron Type | Filtered? | Reason | Diagnostic Code |
+|-------------|-----------|--------|-----------------|
+| **output** | No | Direct impact on creature score | (not filtered) |
+| **hidden** | Yes | Backpropagated errors don't reliably predict output error | `hidden_neuron_filtered` |
+| **input** | Yes | Observation sources, not computation nodes | `input_neuron_filtered` |
+| **constant** | Yes | No activation function or error | `hidden_neuron_filtered` |
+
+This filtering occurs before analysis begins. The diagnostics response includes
+the appropriate reason code for each filtered neuron, so callers know why a
+focus neuron received no candidates.
+
 If verbose logging is enabled (`NEAT_AI_DISCOVERY_VERBOSE=1`), you'll see
 messages like:
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,22 @@ The improvement calculation now includes the proposed bias when evaluating neuro
 candidates. This ensures the predicted improvement matches the actual improvement
 when the neuron is applied with its computed bias value.
 
+#### IDENTITY neuron filtering
+
+**IDENTITY neurons with bias ≈ 0 are redundant** because they're mathematically
+equivalent to a direct synapse:
+
+```
+IDENTITY(input × incoming_weight + 0) × outgoing_weight = input × incoming × outgoing
+```
+
+This is just a synapse with `weight = incoming_weight × outgoing_weight`. Discovery
+now filters out these candidates:
+
+1. **Minimum improvement threshold**: IDENTITY requires at least 5% improvement
+2. **Bias filtering**: IDENTITY candidates with `|bias| < 0.01` are rejected
+3. **Use synapse analysis**: Direct connections should use `add-synapses`, not `add-neurons`
+
 If verbose logging is enabled (`NEAT_AI_DISCOVERY_VERBOSE=1`), you'll see
 messages like:
 
@@ -360,11 +376,34 @@ whether discovery should be enabled:
   If the warnings appear but discovery still proceeds successfully (you see
   "Training ... with N binary file" after the warnings), wgpu has found an
   alternative GPU backend and the warnings can be safely ignored.
-- **Out of memory errors**: If the Deno process is killed due to memory
-  exhaustion, increase the `--max-old-space-size` flag. For example:
-  `--v8-flags=--max-old-space-size=16384` for 16GB. The Rust library itself is
-  memory-efficient and streams data from Parquet files, but the TypeScript
-  controller may need more memory for large datasets.
+- **Out of memory errors (exit code 137)**: Exit code 137 indicates the process
+  was killed by the Linux OOM (Out of Memory) killer (128 + SIGKILL). This
+  commonly occurs when `--max-old-space-size` exceeds available system RAM.
+  
+  **For heterogeneous environments** (old Linux servers to new Mac M4 Pro):
+  
+  ```bash
+  # Detect available memory and set V8 heap appropriately
+  # Linux: use 50-75% of available RAM
+  AVAILABLE_MB=$(free -m | awk '/^Mem:/{print int($7 * 0.6)}')
+  # macOS: use 50-75% of available RAM  
+  AVAILABLE_MB=$(vm_stat | awk '/Pages free/{free=$3} /Pages inactive/{inactive=$3} END{print int((free+inactive)*4096/1024/1024*0.6)}')
+  
+  # Set a sensible default if detection fails (2GB works on most machines)
+  HEAP_SIZE=${AVAILABLE_MB:-2048}
+  
+  deno run --v8-flags=--max-old-space-size=${HEAP_SIZE} ...
+  ```
+  
+  **Common scenarios:**
+  - **Large machines** (32GB+ RAM): Use `--max-old-space-size=8192` or higher
+  - **Medium machines** (8-16GB RAM): Use `--max-old-space-size=4096`
+  - **Small/old machines** (4GB or less): Use `--max-old-space-size=2048`
+  
+  **Note:** The Rust library itself is memory-efficient and streams data from
+  Parquet files. The TypeScript/Deno controller typically consumes more memory.
+  Setting `--max-old-space-size` too high on memory-constrained machines causes
+  V8 to allocate beyond available RAM, triggering the OOM killer.
 - **Analysis timeout**: The analysis phase has a default 10-minute timeout when
   `analysis_deadline_ms` is not provided. If a timeout is explicitly provided
   but is less than 3 seconds or greater than 1 hour, it will be clamped to the

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1002,6 +1002,19 @@ impl NeuronDiagnostics {
                 continue;
             }
 
+            // Check hidden_filtered FIRST - this takes precedence over all other reasons.
+            // Hidden neurons are filtered out before analysis even begins, so they won't
+            // have any other diagnostic data (eligible sources, samples, etc.).
+            if entry.hidden_filtered {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Target {} was filtered out (hidden neuron). \
+                    Add-neuron analysis only targets output neurons because hidden neuron error \
+                    reduction doesn't reliably translate to creature score improvement.",
+                    entry.target_uuid
+                );
+                continue;
+            }
+
             // Check for record loading failures (this indicates a bug or data issue)
             if entry.record_load_failures > 0 {
                 eprintln!(

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -395,6 +395,10 @@ pub enum NeuronNoCandidateReason {
     /// Hidden neurons are filtered out from add-neuron analysis because their
     /// backpropagated errors don't reliably translate to output error reduction.
     HiddenNeuronFiltered,
+    /// Input neurons are filtered out from add-neuron analysis because they're
+    /// observation sources, not computation nodes - they have no activation function
+    /// or error to reduce.
+    InputNeuronFiltered,
 }
 
 #[derive(Debug, Clone)]
@@ -877,6 +881,9 @@ struct NeuronDiagnosticEntry {
     /// Set to true when this neuron was filtered out because it's a hidden neuron
     /// (only output neurons are valid targets for add-neuron analysis).
     hidden_filtered: bool,
+    /// Set to true when this neuron was filtered out because it's an input neuron
+    /// (input neurons are observation sources, not computation nodes).
+    input_filtered: bool,
 }
 
 impl NeuronDiagnosticEntry {
@@ -891,6 +898,7 @@ impl NeuronDiagnosticEntry {
             had_candidate: false,
             best_rejection: None,
             hidden_filtered: false,
+            input_filtered: false,
         }
     }
 
@@ -992,6 +1000,15 @@ impl NeuronDiagnostics {
         }
     }
 
+    /// Mark a neuron as filtered out because it's an input neuron.
+    /// Input neurons are observation sources, not computation nodes - they have
+    /// no activation function or error to reduce.
+    fn mark_input_filtered(&mut self, target_uuid: &str) {
+        if let Some(entry) = self.entries.get_mut(target_uuid) {
+            entry.input_filtered = true;
+        }
+    }
+
     fn emit_logs(&self) {
         if !self.log_enabled {
             return;
@@ -1002,9 +1019,22 @@ impl NeuronDiagnostics {
                 continue;
             }
 
-            // Check hidden_filtered FIRST - this takes precedence over all other reasons.
-            // Hidden neurons are filtered out before analysis even begins, so they won't
+            // Check pre-analysis filters FIRST - these take precedence over all other reasons.
+            // These neurons are filtered out before analysis even begins, so they won't
             // have any other diagnostic data (eligible sources, samples, etc.).
+
+            // Input neurons are observation sources, not computation nodes
+            if entry.input_filtered {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Target {} was filtered out (input neuron). \
+                    Input neurons are observation sources, not computation nodes - they have no \
+                    activation function or error to reduce.",
+                    entry.target_uuid
+                );
+                continue;
+            }
+
+            // Hidden neurons have backpropagated errors that don't reliably predict output error
             if entry.hidden_filtered {
                 eprintln!(
                     "[NEAT-AI-Discovery][verbose] Target {} was filtered out (hidden neuron). \
@@ -1083,9 +1113,23 @@ impl NeuronDiagnostics {
             .values()
             .filter(|entry| !entry.had_candidate)
             .map(|entry| {
-                // Check hidden_filtered FIRST - this takes precedence over all other reasons.
-                // Hidden neurons are filtered out before analysis even begins, so they won't
+                // Check pre-analysis filters FIRST - these take precedence over all other reasons.
+                // These neurons are filtered out before analysis even begins, so they won't
                 // have any other diagnostic data (eligible sources, samples, etc.).
+
+                // Input neurons are observation sources, not computation nodes
+                if entry.input_filtered {
+                    return NeuronNoCandidateSummary {
+                        target_uuid: entry.target_uuid.clone(),
+                        reason: NeuronNoCandidateReason::InputNeuronFiltered,
+                        evaluated_sources: 0,
+                        sources_with_samples: 0,
+                        target_record_count: 0,
+                        detail: None,
+                    };
+                }
+
+                // Hidden neurons have backpropagated errors that don't reliably predict output error
                 if entry.hidden_filtered {
                     return NeuronNoCandidateSummary {
                         target_uuid: entry.target_uuid.clone(),
@@ -5264,17 +5308,27 @@ fn analyze_neurons_with_cache(
         .map(|n| (n.uuid.clone(), n.squash.clone()))
         .collect();
 
-    // Build a lookup map for neuron types to filter focus neurons
+    // Build a comprehensive lookup map for ALL neuron UUIDs to their types.
+    // This includes: input neurons (from creature.input count) and all neurons from
+    // creature.neurons (hidden, output, constant). If a UUID is not in this map,
+    // it's an invalid UUID (bug in the caller).
+    //
     // Only output neurons should be targets for add-neuron candidates because:
     // - Output neuron errors directly affect creature score
     // - Hidden neuron errors are backpropagated approximations that don't correlate
     //   reliably with actual output error reduction
-    let neuron_type_map: HashMap<String, String> = input
-        .creature
-        .neurons
-        .iter()
-        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
-        .collect();
+    // - Input neurons are observation sources, not computation nodes
+    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+
+    // Add input neurons (they're not in creature.neurons, only represented by creature.input count)
+    for input_index in 0..input.creature.input {
+        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
+    }
+
+    // Add all neurons from creature.neurons (hidden, output, constant)
+    for neuron in &input.creature.neurons {
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
+    }
 
     // Log creature configuration for debugging data issues
     if verbose_enabled() {
@@ -5364,11 +5418,14 @@ fn analyze_neurons_with_cache(
     // For HIDDEN neurons, the backpropagated error is an approximation that doesn't
     // reliably translate to actual output error reduction - we've observed 100%
     // failure rates when targeting hidden neurons.
+    // For INPUT neurons, they are observation sources, not computation nodes - they
+    // have no activation function or error to reduce.
     //
-    // Hidden neurons are skipped here but still tracked in diagnostics so the caller
-    // knows they were received but filtered out.
+    // Non-output neurons are skipped here but still tracked in diagnostics so the
+    // caller knows they were received but filtered out (with the correct reason).
     let original_focus_count = unique_focus.len();
     let mut skipped_hidden: Vec<String> = Vec::new();
+    let mut skipped_input: Vec<String> = Vec::new();
 
     // Randomize the focus neuron order so that repeated runs with timeouts will
     // eventually cover all neurons. Convert to owned strings, shuffle, then use.
@@ -5382,49 +5439,102 @@ fn analyze_neurons_with_cache(
         .filter_map(|uuid| {
             // Check neuron type - only allow output neurons for add-neuron analysis
             let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
-            if neuron_type != Some("output") {
-                skipped_hidden.push((*uuid).clone());
-                return None;
-            }
-
-            if let Some(squash) = neuron_squash_map.get(*uuid) {
-                if is_threshold_activation(squash) {
-                    threshold_targets.push((*uuid).clone());
+            match neuron_type {
+                Some("output") => {
+                    // Output neurons are valid targets - continue processing
+                    if let Some(squash) = neuron_squash_map.get(*uuid) {
+                        if is_threshold_activation(squash) {
+                            threshold_targets.push((*uuid).clone());
+                        }
+                    }
+                    Some((*uuid).clone())
+                }
+                Some("input") => {
+                    // Input neurons are observation sources, not computation nodes
+                    skipped_input.push((*uuid).clone());
+                    None
+                }
+                Some(_) => {
+                    // Hidden/constant neurons have backpropagated errors that don't
+                    // reliably translate to output error reduction
+                    skipped_hidden.push((*uuid).clone());
+                    None
+                }
+                None => {
+                    // Unknown UUID - this is likely a bug, but treat as hidden for now
+                    // (this shouldn't happen with proper creature data)
+                    eprintln!(
+                        "[NEAT-AI-Discovery] Warning: Unknown neuron UUID '{uuid}' in focus list \
+                        (not found in creature). Treating as hidden neuron."
+                    );
+                    skipped_hidden.push((*uuid).clone());
+                    None
                 }
             }
-            Some((*uuid).clone())
         })
         .collect();
 
-    // Log when hidden neurons are filtered out
-    if !skipped_hidden.is_empty() {
-        eprintln!(
-            "[NEAT-AI-Discovery] Filtered {} hidden neuron(s) from add-neuron analysis (only output neurons are valid targets). \
-            Hidden neurons skipped: {:?}. Remaining output neurons: {}",
-            skipped_hidden.len(),
-            skipped_hidden.iter().take(5).collect::<Vec<_>>(),
-            focus_order.len()
-        );
+    // Log when non-output neurons are filtered out
+    let total_skipped = skipped_hidden.len() + skipped_input.len();
+    if total_skipped > 0 {
+        if !skipped_input.is_empty() && !skipped_hidden.is_empty() {
+            eprintln!(
+                "[NEAT-AI-Discovery] Filtered {} neuron(s) from add-neuron analysis (only output neurons are valid targets). \
+                Input neurons skipped: {:?}. Hidden neurons skipped: {:?}. Remaining output neurons: {}",
+                total_skipped,
+                skipped_input.iter().take(5).collect::<Vec<_>>(),
+                skipped_hidden.iter().take(5).collect::<Vec<_>>(),
+                focus_order.len()
+            );
+        } else if !skipped_input.is_empty() {
+            eprintln!(
+                "[NEAT-AI-Discovery] Filtered {} input neuron(s) from add-neuron analysis \
+                (input neurons are observation sources, not computation nodes). \
+                Input neurons skipped: {:?}. Remaining output neurons: {}",
+                skipped_input.len(),
+                skipped_input.iter().take(5).collect::<Vec<_>>(),
+                focus_order.len()
+            );
+        } else {
+            eprintln!(
+                "[NEAT-AI-Discovery] Filtered {} hidden neuron(s) from add-neuron analysis \
+                (only output neurons are valid targets). \
+                Hidden neurons skipped: {:?}. Remaining output neurons: {}",
+                skipped_hidden.len(),
+                skipped_hidden.iter().take(5).collect::<Vec<_>>(),
+                focus_order.len()
+            );
+        }
     }
 
     // If no output neurons remain after filtering, return early with empty results
     if focus_order.is_empty() {
         eprintln!(
-            "[NEAT-AI-Discovery] No output neurons in focus list ({original_focus_count} hidden neurons filtered out). \
-            Add-neuron candidates can only target output neurons because hidden neuron error reduction \
-            doesn't reliably translate to creature score improvement."
+            "[NEAT-AI-Discovery] No output neurons in focus list ({original_focus_count} non-output neurons filtered out). \
+            Add-neuron candidates can only target output neurons."
         );
-        let no_candidate_reasons: Vec<NeuronNoCandidateSummary> = skipped_hidden
-            .iter()
-            .map(|uuid| NeuronNoCandidateSummary {
+        // Build no_candidate_reasons with correct reason for each neuron type
+        let mut no_candidate_reasons: Vec<NeuronNoCandidateSummary> = Vec::new();
+        for uuid in &skipped_input {
+            no_candidate_reasons.push(NeuronNoCandidateSummary {
+                target_uuid: uuid.clone(),
+                reason: NeuronNoCandidateReason::InputNeuronFiltered,
+                evaluated_sources: 0,
+                sources_with_samples: 0,
+                target_record_count: 0,
+                detail: None,
+            });
+        }
+        for uuid in &skipped_hidden {
+            no_candidate_reasons.push(NeuronNoCandidateSummary {
                 target_uuid: uuid.clone(),
                 reason: NeuronNoCandidateReason::HiddenNeuronFiltered,
                 evaluated_sources: 0,
                 sources_with_samples: 0,
                 target_record_count: 0,
                 detail: None,
-            })
-            .collect();
+            });
+        }
         return Ok(AnalyzeNeuronsResult {
             helpful_neurons: Vec::new(),
             gpu_used: true,
@@ -5432,9 +5542,15 @@ fn analyze_neurons_with_cache(
         });
     }
 
-    // Mark skipped hidden neurons in diagnostics so they appear with the correct reason
-    // (HiddenNeuronFiltered) instead of misleading reasons like NoEligibleSources.
+    // Mark skipped neurons in diagnostics so they appear with the correct reason
+    // instead of misleading reasons like NoEligibleSources.
     // This is the normal flow case where some output neurons exist.
+    for input_uuid in &skipped_input {
+        diagnostics
+            .lock()
+            .expect("Mutex poisoned: diagnostics")
+            .mark_input_filtered(input_uuid);
+    }
     for hidden_uuid in &skipped_hidden {
         diagnostics
             .lock()
@@ -10539,6 +10655,69 @@ mod tests_synapses {
             .expect("Should have summary for hidden-1");
 
         // The hidden neuron should have HiddenNeuronFiltered reason
+        assert!(
+            matches!(
+                hidden_summary.reason,
+                NeuronNoCandidateReason::HiddenNeuronFiltered
+            ),
+            "Hidden neuron should report HiddenNeuronFiltered, not {:?}",
+            hidden_summary.reason
+        );
+    }
+
+    #[test]
+    fn neuron_diagnostics_reports_input_neuron_filtered_not_hidden() {
+        // Test that when an input neuron is in the focus list, it gets
+        // InputNeuronFiltered reason (not HiddenNeuronFiltered).
+        //
+        // Bug scenario: The neuron_type_map was only built from creature.neurons
+        // and didn't include input neurons. When an input neuron (e.g. "input-0")
+        // was in the focus list, neuron_type_map.get() returned None, and
+        // `neuron_type != Some("output")` evaluated to true. The input neuron
+        // was incorrectly added to skipped_hidden and reported with
+        // HiddenNeuronFiltered reason.
+        let mut diagnostics =
+            NeuronDiagnostics::new_for_tests(&["output-0", "input-1", "hidden-2"]);
+
+        // Mark input-1 as filtered because it's an input neuron
+        diagnostics.mark_input_filtered("input-1");
+
+        // Mark hidden-2 as filtered because it's a hidden neuron
+        diagnostics.mark_hidden_filtered("hidden-2");
+
+        // Simulate output-0 being processed normally but finding no candidate
+        diagnostics.set_target_record_count("output-0", 100);
+        diagnostics.set_total_eligible_sources("output-0", 5);
+        diagnostics.record_candidate_attempt("output-0", false);
+
+        let summaries = diagnostics.no_candidate_summaries();
+
+        // All three should have summaries
+        assert_eq!(
+            summaries.len(),
+            3,
+            "Expected 3 summaries (one for output, one for input, one for hidden)"
+        );
+
+        // Find the input neuron summary - should have InputNeuronFiltered reason
+        let input_summary = summaries
+            .iter()
+            .find(|s| s.target_uuid == "input-1")
+            .expect("Should have summary for input-1");
+        assert!(
+            matches!(
+                input_summary.reason,
+                NeuronNoCandidateReason::InputNeuronFiltered
+            ),
+            "Input neuron should report InputNeuronFiltered, not {:?}",
+            input_summary.reason
+        );
+
+        // Find the hidden neuron summary - should still have HiddenNeuronFiltered reason
+        let hidden_summary = summaries
+            .iter()
+            .find(|s| s.target_uuid == "hidden-2")
+            .expect("Should have summary for hidden-2");
         assert!(
             matches!(
                 hidden_summary.reason,

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -392,6 +392,9 @@ pub enum NeuronNoCandidateReason {
     NotEnoughActivations,
     WeightDegenerate,
     BelowThreshold,
+    /// Hidden neurons are filtered out from add-neuron analysis because their
+    /// backpropagated errors don't reliably translate to output error reduction.
+    HiddenNeuronFiltered,
 }
 
 #[derive(Debug, Clone)]
@@ -1932,7 +1935,9 @@ const ACTIVATION_SPECS: [ActivationCandidateSpec; 11] = [
         orientations: &ORIENTATIONS_BIDIRECTIONAL,
         scales: &SCALES_WIDE,
         activation: identity_activation,
-        min_improvement: 0.0,
+        // IDENTITY is just a pass-through - require meaningful improvement to justify
+        // adding a neuron instead of adjusting existing synapse weights
+        min_improvement: 0.05,
     },
     ActivationCandidateSpec {
         name: "BIPOLAR",
@@ -4968,11 +4973,29 @@ fn evaluate_activation_candidate(
                 });
             }
 
-            let improvement_cutoff = threshold.min(spec.min_improvement);
+            // Use the STRICTER threshold (max) to ensure meaningful improvements
+            // If spec requires 5% and caller passes 1%, we require 5%
+            // If spec requires 0% and caller passes 1%, we require 1%
+            let improvement_cutoff = threshold.max(spec.min_improvement);
 
             if expected_improvement_percentage <= improvement_cutoff
                 || final_improved_count < MIN_NEURON_SAMPLE_COUNT as u32
             {
+                continue;
+            }
+
+            // Require minimum ABSOLUTE error reduction, not just percentage.
+            // A 1% improvement on baseline_sq=0.0001 is only 0.000001 absolute reduction,
+            // which won't meaningfully affect the creature's total error.
+            // Minimum absolute improvement = 0.001 (0.1% of typical baseline ~1.0)
+            let absolute_improvement = expected_improvement_percentage * baseline_sq;
+            if absolute_improvement < 0.001 {
+                continue;
+            }
+
+            // IDENTITY with bias ≈ 0 is equivalent to a direct synapse (source × incoming × outgoing)
+            // Filter out these redundant candidates - use synapse analysis for direct connections
+            if spec.name == "IDENTITY" && optimal_bias.abs() < 0.01 {
                 continue;
             }
 
@@ -5188,6 +5211,18 @@ fn analyze_neurons_with_cache(
         .map(|n| (n.uuid.clone(), n.squash.clone()))
         .collect();
 
+    // Build a lookup map for neuron types to filter focus neurons
+    // Only output neurons should be targets for add-neuron candidates because:
+    // - Output neuron errors directly affect creature score
+    // - Hidden neuron errors are backpropagated approximations that don't correlate
+    //   reliably with actual output error reduction
+    let neuron_type_map: HashMap<String, String> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
+        .collect();
+
     // Log creature configuration for debugging data issues
     if verbose_enabled() {
         let non_input_count = input.creature.neurons.len();
@@ -5269,6 +5304,19 @@ fn analyze_neurons_with_cache(
     let gpu_used = true;
     let analysis_timed_out = Arc::new(Mutex::new(false));
 
+    // Filter focus neurons to ONLY output neurons for add-neuron analysis.
+    //
+    // Rationale: Add-neuron candidates predict error reduction at the target neuron.
+    // For OUTPUT neurons, this directly corresponds to creature score improvement.
+    // For HIDDEN neurons, the backpropagated error is an approximation that doesn't
+    // reliably translate to actual output error reduction - we've observed 100%
+    // failure rates when targeting hidden neurons.
+    //
+    // Hidden neurons are skipped here but still tracked in diagnostics so the caller
+    // knows they were received but filtered out.
+    let original_focus_count = unique_focus.len();
+    let mut skipped_hidden: Vec<String> = Vec::new();
+
     // Randomize the focus neuron order so that repeated runs with timeouts will
     // eventually cover all neurons. Convert to owned strings, shuffle, then use.
     //
@@ -5278,15 +5326,58 @@ fn analyze_neurons_with_cache(
     let mut threshold_targets: Vec<String> = Vec::new();
     let mut focus_order: Vec<String> = unique_focus
         .iter()
-        .map(|uuid| {
+        .filter_map(|uuid| {
+            // Check neuron type - only allow output neurons for add-neuron analysis
+            let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
+            if neuron_type != Some("output") {
+                skipped_hidden.push((*uuid).clone());
+                return None;
+            }
+
             if let Some(squash) = neuron_squash_map.get(*uuid) {
                 if is_threshold_activation(squash) {
                     threshold_targets.push((*uuid).clone());
                 }
             }
-            (*uuid).clone()
+            Some((*uuid).clone())
         })
         .collect();
+
+    // Log when hidden neurons are filtered out
+    if !skipped_hidden.is_empty() {
+        eprintln!(
+            "[NEAT-AI-Discovery] Filtered {} hidden neuron(s) from add-neuron analysis (only output neurons are valid targets). \
+            Hidden neurons skipped: {:?}. Remaining output neurons: {}",
+            skipped_hidden.len(),
+            skipped_hidden.iter().take(5).collect::<Vec<_>>(),
+            focus_order.len()
+        );
+    }
+
+    // If no output neurons remain after filtering, return early with empty results
+    if focus_order.is_empty() {
+        eprintln!(
+            "[NEAT-AI-Discovery] No output neurons in focus list ({original_focus_count} hidden neurons filtered out). \
+            Add-neuron candidates can only target output neurons because hidden neuron error reduction \
+            doesn't reliably translate to creature score improvement."
+        );
+        let no_candidate_reasons: Vec<NeuronNoCandidateSummary> = skipped_hidden
+            .iter()
+            .map(|uuid| NeuronNoCandidateSummary {
+                target_uuid: uuid.clone(),
+                reason: NeuronNoCandidateReason::HiddenNeuronFiltered,
+                evaluated_sources: 0,
+                sources_with_samples: 0,
+                target_record_count: 0,
+                detail: None,
+            })
+            .collect();
+        return Ok(AnalyzeNeuronsResult {
+            helpful_neurons: Vec::new(),
+            gpu_used: true,
+            no_candidate_reasons,
+        });
+    }
 
     // Log threshold-crossing neurons for visibility
     if verbose_enabled() && !threshold_targets.is_empty() {

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -874,6 +874,9 @@ struct NeuronDiagnosticEntry {
     sources_with_samples: u32,
     had_candidate: bool,
     best_rejection: Option<NeuronRejectionDetail>,
+    /// Set to true when this neuron was filtered out because it's a hidden neuron
+    /// (only output neurons are valid targets for add-neuron analysis).
+    hidden_filtered: bool,
 }
 
 impl NeuronDiagnosticEntry {
@@ -887,6 +890,7 @@ impl NeuronDiagnosticEntry {
             sources_with_samples: 0,
             had_candidate: false,
             best_rejection: None,
+            hidden_filtered: false,
         }
     }
 
@@ -979,6 +983,15 @@ impl NeuronDiagnostics {
         }
     }
 
+    /// Mark a neuron as filtered out because it's a hidden neuron.
+    /// Hidden neurons are not valid targets for add-neuron analysis because their
+    /// backpropagated errors don't reliably translate to output error reduction.
+    fn mark_hidden_filtered(&mut self, target_uuid: &str) {
+        if let Some(entry) = self.entries.get_mut(target_uuid) {
+            entry.hidden_filtered = true;
+        }
+    }
+
     fn emit_logs(&self) {
         if !self.log_enabled {
             return;
@@ -1057,6 +1070,20 @@ impl NeuronDiagnostics {
             .values()
             .filter(|entry| !entry.had_candidate)
             .map(|entry| {
+                // Check hidden_filtered FIRST - this takes precedence over all other reasons.
+                // Hidden neurons are filtered out before analysis even begins, so they won't
+                // have any other diagnostic data (eligible sources, samples, etc.).
+                if entry.hidden_filtered {
+                    return NeuronNoCandidateSummary {
+                        target_uuid: entry.target_uuid.clone(),
+                        reason: NeuronNoCandidateReason::HiddenNeuronFiltered,
+                        evaluated_sources: 0,
+                        sources_with_samples: 0,
+                        target_record_count: 0,
+                        detail: None,
+                    };
+                }
+
                 // Only report "no eligible sources" if there were genuinely no eligible sources
                 // AND no evaluated candidates. If there were eligible sources but they all failed
                 // to load or had empty records, report that as NoSamples with context.
@@ -4955,6 +4982,31 @@ fn evaluate_activation_candidate(
                 continue;
             }
 
+            // =================================================================
+            // FUNDAMENTAL VALIDITY FILTERS
+            // These filters apply to ALL candidates (both fallback and best).
+            // They must be checked BEFORE setting fallback_candidate to prevent
+            // invalid candidates from being returned through the fallback path.
+            // =================================================================
+
+            // Require minimum ABSOLUTE error reduction, not just percentage.
+            // A 1% improvement on baseline_sq=0.0001 is only 0.000001 absolute reduction,
+            // which won't meaningfully affect the creature's total error.
+            // Minimum absolute improvement = 0.001 (0.1% of typical baseline ~1.0)
+            let absolute_improvement = expected_improvement_percentage * baseline_sq;
+            if absolute_improvement < 0.001 {
+                continue;
+            }
+
+            // IDENTITY with bias ≈ 0 is equivalent to a direct synapse (source × incoming × outgoing)
+            // Filter out these redundant candidates - use synapse analysis for direct connections
+            if spec.name == "IDENTITY" && optimal_bias.abs() < 0.01 {
+                continue;
+            }
+
+            // =================================================================
+            // FALLBACK CANDIDATE (best seen so far, regardless of threshold)
+            // =================================================================
             if expected_improvement_percentage > fallback_score {
                 fallback_score = expected_improvement_percentage;
 
@@ -4973,6 +5025,9 @@ fn evaluate_activation_candidate(
                 });
             }
 
+            // =================================================================
+            // THRESHOLD CHECK (only for best_candidate, not fallback)
+            // =================================================================
             // Use the STRICTER threshold (max) to ensure meaningful improvements
             // If spec requires 5% and caller passes 1%, we require 5%
             // If spec requires 0% and caller passes 1%, we require 1%
@@ -4981,21 +5036,6 @@ fn evaluate_activation_candidate(
             if expected_improvement_percentage <= improvement_cutoff
                 || final_improved_count < MIN_NEURON_SAMPLE_COUNT as u32
             {
-                continue;
-            }
-
-            // Require minimum ABSOLUTE error reduction, not just percentage.
-            // A 1% improvement on baseline_sq=0.0001 is only 0.000001 absolute reduction,
-            // which won't meaningfully affect the creature's total error.
-            // Minimum absolute improvement = 0.001 (0.1% of typical baseline ~1.0)
-            let absolute_improvement = expected_improvement_percentage * baseline_sq;
-            if absolute_improvement < 0.001 {
-                continue;
-            }
-
-            // IDENTITY with bias ≈ 0 is equivalent to a direct synapse (source × incoming × outgoing)
-            // Filter out these redundant candidates - use synapse analysis for direct connections
-            if spec.name == "IDENTITY" && optimal_bias.abs() < 0.01 {
                 continue;
             }
 
@@ -5377,6 +5417,16 @@ fn analyze_neurons_with_cache(
             gpu_used: true,
             no_candidate_reasons,
         });
+    }
+
+    // Mark skipped hidden neurons in diagnostics so they appear with the correct reason
+    // (HiddenNeuronFiltered) instead of misleading reasons like NoEligibleSources.
+    // This is the normal flow case where some output neurons exist.
+    for hidden_uuid in &skipped_hidden {
+        diagnostics
+            .lock()
+            .expect("Mutex poisoned: diagnostics")
+            .mark_hidden_filtered(hidden_uuid);
     }
 
     // Log threshold-crossing neurons for visibility
@@ -10439,6 +10489,50 @@ mod tests_synapses {
         assert!(
             actual_improvement_with_bias > predicted_without_bias + 0.1,
             "Improvement with bias ({actual_improvement_with_bias:.4}) should be significantly higher than without ({predicted_without_bias:.4})"
+        );
+    }
+
+    #[test]
+    fn neuron_diagnostics_reports_hidden_neuron_filtered_in_mixed_focus_list() {
+        // Test that when a focus list contains BOTH output AND hidden neurons,
+        // the hidden neurons get HiddenNeuronFiltered reason (not NoEligibleSources).
+        //
+        // Bug scenario: When focus_order is NOT empty (some output neurons exist),
+        // the skipped_hidden neurons were never merged into diagnostics, so they
+        // appeared with misleading reasons like NoEligibleSources.
+        let mut diagnostics = NeuronDiagnostics::new_for_tests(&["output-0", "hidden-1"]);
+
+        // Mark hidden-1 as filtered (this is what should happen in normal flow)
+        diagnostics.mark_hidden_filtered("hidden-1");
+
+        // Simulate output-0 being processed normally but finding no candidate
+        diagnostics.set_target_record_count("output-0", 100);
+        diagnostics.set_total_eligible_sources("output-0", 5);
+        diagnostics.record_candidate_attempt("output-0", false);
+
+        let summaries = diagnostics.no_candidate_summaries();
+
+        // Both should have summaries
+        assert_eq!(
+            summaries.len(),
+            2,
+            "Expected 2 summaries (one for output, one for hidden)"
+        );
+
+        // Find the hidden neuron summary
+        let hidden_summary = summaries
+            .iter()
+            .find(|s| s.target_uuid == "hidden-1")
+            .expect("Should have summary for hidden-1");
+
+        // The hidden neuron should have HiddenNeuronFiltered reason
+        assert!(
+            matches!(
+                hidden_summary.reason,
+                NeuronNoCandidateReason::HiddenNeuronFiltered
+            ),
+            "Hidden neuron should report HiddenNeuronFiltered, not {:?}",
+            hidden_summary.reason
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,10 @@ pub enum NeuronDiagnosticReasonJson {
     /// Hidden neurons are filtered out from add-neuron analysis because their
     /// backpropagated errors don't reliably translate to output error reduction.
     HiddenNeuronFiltered,
+    /// Input neurons are filtered out from add-neuron analysis because they're
+    /// observation sources, not computation nodes - they have no activation function
+    /// or error to reduce.
+    InputNeuronFiltered,
 }
 
 #[derive(Debug, Serialize)]
@@ -485,6 +489,9 @@ fn neuron_diagnostics_json(
                     }
                     analysis::NeuronNoCandidateReason::HiddenNeuronFiltered => {
                         NeuronDiagnosticReasonJson::HiddenNeuronFiltered
+                    }
+                    analysis::NeuronNoCandidateReason::InputNeuronFiltered => {
+                        NeuronDiagnosticReasonJson::InputNeuronFiltered
                     }
                 },
                 evaluated_sources: summary.evaluated_sources,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,7 @@ pub struct NeuronDiagnosticJson {
     pub detail: Option<NeuronDiagnosticDetailJson>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NeuronDiagnosticReasonJson {
     NoEligibleSources,
@@ -378,6 +378,9 @@ pub enum NeuronDiagnosticReasonJson {
     NotEnoughActivations,
     WeightDegenerate,
     BelowThreshold,
+    /// Hidden neurons are filtered out from add-neuron analysis because their
+    /// backpropagated errors don't reliably translate to output error reduction.
+    HiddenNeuronFiltered,
 }
 
 #[derive(Debug, Serialize)]
@@ -479,6 +482,9 @@ fn neuron_diagnostics_json(
                     }
                     analysis::NeuronNoCandidateReason::BelowThreshold => {
                         NeuronDiagnosticReasonJson::BelowThreshold
+                    }
+                    analysis::NeuronNoCandidateReason::HiddenNeuronFiltered => {
+                        NeuronDiagnosticReasonJson::HiddenNeuronFiltered
                     }
                 },
                 evaluated_sources: summary.evaluated_sources,


### PR DESCRIPTION
…sis.rs

- Bump version in Cargo.toml from 0.1.109 to 0.1.111.
- Implement filtering for IDENTITY neurons with near-zero bias, treating them as redundant and ensuring only meaningful candidates are considered.
- Refine neuron analysis to focus exclusively on output neurons for add-neuron candidates, improving the accuracy of error reduction predictions.
- Introduce detailed logging for filtered hidden neurons to enhance diagnostics and understanding of the analysis process.

These changes significantly improve the efficiency and accuracy of neuron candidate evaluations, contributing to better performance in the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrows add-neuron analysis to output neurons, filters redundant IDENTITY candidates and weak improvements, enhances diagnostics and logging (including new reason codes), updates docs with OOM guidance, and bumps version to 0.1.111.
> 
> - **Analysis/Discovery**:
>   - Filter focus targets to only `output` neurons; build full `neuron_type_map` (incl. inputs); log and return diagnostics for filtered `input`/`hidden` targets.
>   - Candidate filters: require absolute error reduction (`>= 0.001`); reject `IDENTITY` candidates with `|bias| < 0.01`; use stricter threshold `max(caller, spec)`; set `IDENTITY` `min_improvement=0.05`.
>   - Diagnostics: add reasons `hidden_neuron_filtered` and `input_neuron_filtered`; track and emit explicit logs; fix summaries to surface pre-analysis filters first.
>   - Tests: add coverage for new filters/diagnostics and regression cases.
> - **API**:
>   - Expose new `NeuronDiagnosticReasonJson` variants and mapping; derive `Clone` for the enum.
> - **Docs**:
>   - README: add IDENTITY filtering and output-only targeting notes; add detailed OOM (exit 137) guidance.
> - **Version**:
>   - Bump crate to `0.1.111`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfe85b355c5d06bdd6cdeb76d3897c46060fd1a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->