### PR TITLE
Update version to 0.1.113 and enhance neuron impact calculations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.111"
+version = "0.1.113"
 edition = "2021"
 
 [lib]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -9341,25 +9341,53 @@ mod tests_synapses {
     /// Test that discrete evaluation filters out low-improvement IDENTITY candidates.
     /// IDENTITY neurons with bias=0 are mathematically equivalent to synapses,
     /// and candidates with very low flip rates (<1%) don't reliably improve the model.
+    ///
+    /// The MIN_DISCRETE_IMPROVEMENT threshold (1%) is the key filter being tested here.
+    /// The test creates samples where ALL have error (to pass MIN_NEURON_SAMPLE_COUNT check)
+    /// but only a tiny fraction would actually flip in the helpful direction.
     #[test]
     fn test_discrete_evaluation_filters_low_improvement_identity() {
-        // Create a large sample set where only a tiny fraction would flip.
-        // This simulates the production scenario where 0.01% improvement candidates
-        // are being returned but don't actually help.
+        // Create a sample set where ALL samples have error (passing the sample count check)
+        // but only a tiny fraction (< 1%) would flip helpfully.
+        //
+        // IMPORTANT: Previously this test was broken - it only gave 5 samples non-zero error,
+        // so samples_with_error=5 was less than MIN_NEURON_SAMPLE_COUNT=10, causing all weight
+        // combinations to be skipped. The test passed for the wrong reason.
+        //
+        // Key insight: To make samples truly un-flippable, source_activation must be ZERO.
+        // Any non-zero source activation with any of the tested weight scales (0.1 to 50.0)
+        // could potentially flip the target. With source_activation=0, contribution=0
+        // regardless of weights, so those samples cannot be affected.
         let mut samples = Vec::new();
 
-        // 1000 samples where most DON'T benefit from the new neuron
+        // 1000 samples - ALL have error to pass samples_with_error check
         for i in 0..1000 {
-            // Only ~5 samples (0.5%) have error on the "wrong side" that could flip
-            let should_flip = i < 5;
-            samples.push(DiscreteHelpfulSample {
-                source_activation: if should_flip { 1.0 } else { 0.1 },
-                // Most samples are already on the correct side of threshold
-                target_value: if should_flip { -0.1 } else { 0.5 },
-                target_activation: if should_flip { 0.0 } else { 1.0 },
-                // Error indicates we want to flip the few wrong samples
-                avg_error: if should_flip { 0.5 } else { 0.0 },
-            });
+            // Only ~5 samples (0.5%) can flip helpfully:
+            // These have non-zero source activation
+            let can_flip_to_help = i < 5;
+
+            if can_flip_to_help {
+                // Sample that CAN flip to help:
+                // - source_activation = 1.0 (non-zero, can contribute)
+                // - target_value just below threshold (0)
+                // - error positive (wants output to increase from 0 to 1)
+                samples.push(DiscreteHelpfulSample {
+                    source_activation: 1.0,
+                    target_value: -0.05,    // Just below threshold
+                    target_activation: 0.0, // Currently outputs 0 (STEP)
+                    avg_error: 0.5,         // Wants to output 1, has error
+                });
+            } else {
+                // Sample that CANNOT flip:
+                // - source_activation = 0 (CRITICAL: contribution is always 0)
+                // - Has error but cannot be helped since contribution = weight * 0 = 0
+                samples.push(DiscreteHelpfulSample {
+                    source_activation: 0.0, // Zero! contribution = weight * 0 = 0
+                    target_value: -0.5,     // Below threshold (outputs 0)
+                    target_activation: 0.0, // Currently outputs 0
+                    avg_error: 0.3,         // Has error but source can't help
+                });
+            }
         }
 
         let candidate = evaluate_discrete_candidate(
@@ -9367,16 +9395,71 @@ mod tests_synapses {
             "target-step",
             &samples,
             ThresholdType::Step,
-            0.0, // Even with zero threshold, low flip rate should be filtered
+            0.0, // Zero threshold - MIN_DISCRETE_IMPROVEMENT (1%) should filter
         );
 
         // Should NOT return a candidate because improvement would be <1%
-        // (only 5 flips out of 1000 samples = 0.5% improvement)
+        // samples_with_error = 1000 (all have error)
+        // helpful_flips = 5 (only samples with non-zero source activation)
+        // harmful_flips = 0 (zero-activation samples can't flip either way)
+        // improvement = 5 / 1000 = 0.5% < MIN_DISCRETE_IMPROVEMENT (1%)
         assert!(
             candidate.is_none(),
-            "Should NOT return IDENTITY candidate with <1% improvement. \
+            "Should NOT return IDENTITY candidate with <1% improvement (0.5% in this test). \
              These are equivalent to direct synapses and don't reliably help. \
              Got candidate: {candidate:?}"
+        );
+    }
+
+    /// Complementary test: verify that improvement ABOVE 1% DOES return a candidate.
+    /// This ensures the MIN_DISCRETE_IMPROVEMENT threshold is the actual filter,
+    /// not some other logic (like MIN_NEURON_SAMPLE_COUNT).
+    #[test]
+    fn test_discrete_evaluation_accepts_above_threshold_improvement() {
+        // Same structure as the filter test, but with 2% flippable samples (> 1% threshold)
+        let mut samples = Vec::new();
+
+        for i in 0..1000 {
+            // 20 samples (2%) can flip helpfully - above the 1% threshold
+            let can_flip_to_help = i < 20;
+
+            if can_flip_to_help {
+                samples.push(DiscreteHelpfulSample {
+                    source_activation: 1.0,
+                    target_value: -0.05,
+                    target_activation: 0.0,
+                    avg_error: 0.5,
+                });
+            } else {
+                samples.push(DiscreteHelpfulSample {
+                    source_activation: 0.0, // Cannot contribute
+                    target_value: -0.5,
+                    target_activation: 0.0,
+                    avg_error: 0.3,
+                });
+            }
+        }
+
+        let candidate = evaluate_discrete_candidate(
+            "input-0",
+            "target-step",
+            &samples,
+            ThresholdType::Step,
+            0.0,
+        );
+
+        // SHOULD return a candidate because improvement = 20/1000 = 2% > 1% threshold
+        assert!(
+            candidate.is_some(),
+            "Should return candidate when improvement (2%) exceeds MIN_DISCRETE_IMPROVEMENT (1%)"
+        );
+
+        let c = candidate.unwrap();
+        // Verify the improvement is roughly what we expect (2%)
+        assert!(
+            c.expected_improvement_percentage > 0.015 && c.expected_improvement_percentage < 0.025,
+            "Expected ~2% improvement, got {}%",
+            c.expected_improvement_percentage * 100.0
         );
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5255,7 +5255,17 @@ fn evaluate_discrete_candidate(
                     let net_flips = helpful_flips - harmful_flips;
                     let improvement = net_flips as f32 / samples_with_error as f32;
 
-                    if improvement > best_improvement && helpful_flips > harmful_flips {
+                    // IMPORTANT: Require meaningful improvement (at least 1%) for IDENTITY neurons.
+                    // IDENTITY with bias=0 is mathematically equivalent to a direct synapse:
+                    //   IDENTITY(source × incoming_weight + 0) × outgoing_weight = source × incoming × outgoing
+                    // These candidates should use add-synapse, not add-neuron.
+                    // Additionally, very low flip rates (< 1%) indicate the contribution isn't
+                    // reliably pushing the target across the threshold.
+                    const MIN_DISCRETE_IMPROVEMENT: f32 = 0.01; // 1% minimum
+
+                    if improvement > best_improvement.max(MIN_DISCRETE_IMPROVEMENT)
+                        && helpful_flips > harmful_flips
+                    {
                         best_improvement = improvement;
 
                         // Create target neuron stats from samples
@@ -9326,6 +9336,48 @@ mod tests_synapses {
             "Should have positive improvement"
         );
         assert!(c.improved_count > 0, "Should have some helpful flips");
+    }
+
+    /// Test that discrete evaluation filters out low-improvement IDENTITY candidates.
+    /// IDENTITY neurons with bias=0 are mathematically equivalent to synapses,
+    /// and candidates with very low flip rates (<1%) don't reliably improve the model.
+    #[test]
+    fn test_discrete_evaluation_filters_low_improvement_identity() {
+        // Create a large sample set where only a tiny fraction would flip.
+        // This simulates the production scenario where 0.01% improvement candidates
+        // are being returned but don't actually help.
+        let mut samples = Vec::new();
+
+        // 1000 samples where most DON'T benefit from the new neuron
+        for i in 0..1000 {
+            // Only ~5 samples (0.5%) have error on the "wrong side" that could flip
+            let should_flip = i < 5;
+            samples.push(DiscreteHelpfulSample {
+                source_activation: if should_flip { 1.0 } else { 0.1 },
+                // Most samples are already on the correct side of threshold
+                target_value: if should_flip { -0.1 } else { 0.5 },
+                target_activation: if should_flip { 0.0 } else { 1.0 },
+                // Error indicates we want to flip the few wrong samples
+                avg_error: if should_flip { 0.5 } else { 0.0 },
+            });
+        }
+
+        let candidate = evaluate_discrete_candidate(
+            "input-0",
+            "target-step",
+            &samples,
+            ThresholdType::Step,
+            0.0, // Even with zero threshold, low flip rate should be filtered
+        );
+
+        // Should NOT return a candidate because improvement would be <1%
+        // (only 5 flips out of 1000 samples = 0.5% improvement)
+        assert!(
+            candidate.is_none(),
+            "Should NOT return IDENTITY candidate with <1% improvement. \
+             These are equivalent to direct synapses and don't reliably help. \
+             Got candidate: {candidate:?}"
+        );
     }
 
     /// Test get_bias_values returns log-spaced values for efficient search

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -174,7 +174,13 @@ fn compute_impact_recursive(
     let impact = if outputs.contains(uuid) {
         1.0
     } else if let Some(edges) = adjacency.get(uuid) {
-        let mut max_value = 0.0;
+        // IMPORTANT: Use SUM (not max) to accumulate impact across all outgoing edges.
+        // A neuron connecting to multiple outputs affects ALL of them, so removing it
+        // has a cumulative effect. Using max previously underestimated impact for neurons
+        // with multiple outgoing synapses - e.g. a neuron connecting to 2 outputs directly
+        // would show impact=1.0 (max) instead of impact=2.0 (sum), causing incorrect
+        // "low-impact" classification and failed removal predictions.
+        let mut total_impact = 0.0;
         for (to_uuid, weight) in edges {
             let child_impact = compute_impact_recursive(
                 to_uuid,
@@ -202,11 +208,9 @@ fn compute_impact_recursive(
             };
 
             let contribution = normalized_weight * child_impact;
-            if contribution > max_value {
-                max_value = contribution;
-            }
+            total_impact += contribution;
         }
-        max_value
+        total_impact
     } else {
         0.0
     };
@@ -1164,5 +1168,117 @@ mod tests {
                 // This is the preferred behavior to maintain data integrity
             }
         }
+    }
+
+    #[test]
+    fn test_cumulative_impact_for_multiple_outgoing_synapses() {
+        // Scenario: A hidden neuron connects to MULTIPLE outputs.
+        // The impact should be the SUM of contributions to all outputs, not the MAX.
+        //
+        // Bug discovered: A neuron with 3 outgoing synapses to 2 outputs + 1 hidden
+        // was flagged as "low-impact" (1.07e-13) but removing it caused a score
+        // delta of 6.3e-5 - much higher than predicted.
+        //
+        // Network:
+        //   input-0 -> hub -> output-0 (weight 0.5, normalised contribution = 50%)
+        //            -> hub -> output-1 (weight 0.5, normalised contribution = 50%)
+        //
+        // Expected cumulative impact: 0.5 + 0.5 = 1.0 (affects both outputs equally)
+        // Bug behaviour (max): 0.5 (only considers one output)
+        let creature = create_creature(
+            vec![
+                ("input-0", "input"),
+                ("hub", "hidden"), // Connects to both outputs
+                ("output-0", "output"),
+                ("output-1", "output"),
+            ],
+            vec![
+                ("input-0", "hub", 1.0),
+                // Hub connects to BOTH outputs with equal weight
+                ("hub", "output-0", 0.5), // 100% of output-0's inbound (only connection)
+                ("hub", "output-1", 0.5), // 100% of output-1's inbound (only connection)
+            ],
+        );
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let file_path = temp_file.path().to_str().unwrap();
+
+        let records = create_records(vec![("hub", 0.5), ("output-0", 0.5), ("output-1", 0.5)]);
+        write_records_to_parquet(file_path, &records).unwrap();
+
+        let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+        // Find the hub neuron's impact
+        let hub = result
+            .neurons
+            .iter()
+            .find(|n| n.neuron_uuid == "hub")
+            .expect("Hub neuron should be in results");
+
+        // Hub connects to both outputs at 100% of each output's inbound weight.
+        // Cumulative impact should be: 1.0 + 1.0 = 2.0 (but we cap at sensible values)
+        // At minimum, impact should be > 1.0 because it affects TWO outputs.
+        //
+        // With the bug (using max), impact would be 1.0 (only counting one output).
+        // With the fix (using sum), impact should be 2.0.
+        assert!(
+            hub.impact > 1.0,
+            "Hub neuron connecting to 2 outputs should have cumulative impact > 1.0, got {}. \
+             This indicates the impact calculation is using MAX instead of SUM for multiple outgoing synapses.",
+            hub.impact
+        );
+    }
+
+    #[test]
+    fn test_cumulative_impact_mixed_direct_and_indirect_paths() {
+        // Scenario: A neuron has multiple paths to outputs:
+        // - Direct connection to output-0
+        // - Indirect connection through hidden-2 to output-1
+        //
+        // Both paths should contribute to the cumulative impact.
+        let creature = create_creature(
+            vec![
+                ("input-0", "input"),
+                ("hub", "hidden"),
+                ("hidden-2", "hidden"),
+                ("output-0", "output"),
+                ("output-1", "output"),
+            ],
+            vec![
+                ("input-0", "hub", 1.0),
+                ("hub", "output-0", 1.0),      // Direct to output-0 (100%)
+                ("hub", "hidden-2", 1.0),      // To hidden-2
+                ("hidden-2", "output-1", 1.0), // hidden-2 to output-1 (100%)
+            ],
+        );
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let file_path = temp_file.path().to_str().unwrap();
+
+        let records = create_records(vec![
+            ("hub", 0.5),
+            ("hidden-2", 0.5),
+            ("output-0", 0.5),
+            ("output-1", 0.5),
+        ]);
+        write_records_to_parquet(file_path, &records).unwrap();
+
+        let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+        let hub = result
+            .neurons
+            .iter()
+            .find(|n| n.neuron_uuid == "hub")
+            .expect("Hub neuron should be in results");
+
+        // Hub has:
+        // - Direct path to output-0: impact = 1.0
+        // - Indirect path via hidden-2 to output-1: impact = 1.0 * 1.0 = 1.0
+        // Cumulative impact should be: 1.0 + 1.0 = 2.0
+        assert!(
+            hub.impact > 1.5,
+            "Hub with direct and indirect paths to 2 outputs should have impact > 1.5, got {}",
+            hub.impact
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -629,6 +629,250 @@ fn test_bias_values_are_activation_specific() {
     }
 }
 
+/// Test that impact is cumulative when a neuron connects to MULTIPLE outputs.
+/// This is a regression test for the bug where impact used MAX instead of SUM
+/// for multiple outgoing synapses, causing neurons connected to multiple outputs
+/// to be incorrectly flagged as "low-impact" removal candidates.
+#[test]
+fn test_cumulative_impact_with_multiple_output_connections() {
+    // Create a creature where a hidden neuron connects to TWO outputs
+    // The impact should be the SUM of contributions to both outputs
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hub".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-1".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hub".to_string(),
+                weight: 1.0,
+            },
+            // Hub connects to BOTH outputs - removing it affects BOTH
+            SynapseJson {
+                from_uuid: "hub".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.5, // 100% of output-0's inbound
+            },
+            SynapseJson {
+                from_uuid: "hub".to_string(),
+                to_uuid: "output-1".to_string(),
+                weight: 0.5, // 100% of output-1's inbound
+            },
+        ],
+        input: 1,
+        output: 2,
+    };
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Write discovery data
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": [{
+            "input": [0.5],
+            "output": [0.25, 0.25],
+            "neuron_data": [
+                {"neuron_uuid": "hub", "activation": 0.5, "value": 0.5, "errors": [0.1, 0.1]},
+                {"neuron_uuid": "output-0", "activation": 0.25, "value": 0.25, "errors": [0.1]},
+                {"neuron_uuid": "output-1", "activation": 0.25, "value": 0.25, "errors": [0.1]}
+            ]
+        }],
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data"
+    );
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    use neat_ai_discovery::rank_focus_neurons_internal;
+    let rank_input = serde_json::json!({
+        "parquetFile": parquet_file.to_str().unwrap(),
+        "creature": creature,
+        "maxResults": 10
+    })
+    .to_string();
+
+    let result_json = rank_focus_neurons_internal(&rank_input).unwrap();
+    let result: serde_json::Value = serde_json::from_str(&result_json).unwrap();
+
+    if result["success"] != true {
+        panic!(
+            "Rank focus neurons failed: {}",
+            result["error"].as_str().unwrap_or("unknown error")
+        );
+    }
+
+    let neurons = result["neurons"]
+        .as_array()
+        .expect("neurons should be an array");
+
+    let hub = neurons
+        .iter()
+        .find(|n| n["neuronUuid"] == "hub")
+        .expect("hub should be in results");
+
+    let impact = hub["impact"].as_f64().expect("impact should be a number") as f32;
+
+    // Hub connects to both outputs at 100% each.
+    // With cumulative (sum) impact: 1.0 + 1.0 = 2.0
+    // With the old bug (max): would only be 1.0
+    //
+    // This is critical: a neuron affecting 2 outputs should NOT be flagged as low-impact!
+    assert!(
+        impact > 1.5,
+        "Hub neuron connecting to 2 outputs should have cumulative impact > 1.5, got {impact}. \
+         This indicates the impact calculation is using MAX instead of SUM for multiple outgoing synapses. \
+         Bug: This neuron could be incorrectly flagged as a removal candidate!"
+    );
+
+    // Verify hub is NOT in removal candidates (it should have high impact)
+    // Note: removalCandidates may be null/None if there are no removal candidates
+    let hub_in_removal = result
+        .get("removalCandidates")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().any(|c| c["neuronUuid"] == "hub"))
+        .unwrap_or(false);
+
+    assert!(
+        !hub_in_removal,
+        "Hub neuron with high cumulative impact should NOT be a removal candidate"
+    );
+}
+
+/// Test that add-neuron analysis can find successful candidates when conditions are right.
+/// This is a regression test to verify add-neuron discovery is working correctly.
+#[test]
+fn test_add_neuron_finds_candidates_with_correlated_errors() {
+    skip_without_gpu!();
+    use neat_ai_discovery::AnalyzeNeuronsInput;
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a simple creature with just an output neuron and multiple inputs
+    let creature = CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![], // No existing synapses - add-neuron should find candidates
+        input: 2,
+        output: 1,
+    };
+
+    // Generate training data where input-0 activation CORRELATES with output error
+    // This is the ideal scenario for add-neuron to find a candidate:
+    // - When input-0 is high, error is positive (output should be higher)
+    // - When input-0 is low, error is negative (output should be lower)
+    let mut training_data = Vec::new();
+    for i in 0..50 {
+        let input_0_val = (i as f32 - 25.0) / 25.0; // Range: -1.0 to 1.0
+        let input_1_val = 0.5; // Constant (no correlation)
+
+        // Create correlated error: when input-0 is positive, error is positive
+        // This means a new neuron from input-0 could help reduce error
+        let error = input_0_val * 0.5; // Positive correlation
+
+        training_data.push(serde_json::json!({
+            "input": [input_0_val, input_1_val],
+            "output": [0.0],
+            "neuron_data": [{
+                "neuron_uuid": "output-0",
+                "activation": 0.0,
+                "value": 0.0,
+                "errors": [error]
+            }]
+        }));
+    }
+
+    // Record discovery data
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": training_data,
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data: {:?}",
+        record_output["error"]
+    );
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    // Analyse neurons with a lower threshold to increase chances of success
+    let analyze_input = AnalyzeNeuronsInput {
+        parquet_file: parquet_file.to_str().unwrap().to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.01), // 1% threshold - low to ensure candidates are found
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
+        .expect("Neuron analysis should succeed");
+
+    // With correlated errors and no existing connections, we should find candidates
+    // The input-0 -> ReLU -> output-0 path should show improvement
+    assert!(
+        !result.helpful_neurons.is_empty(),
+        "Add-neuron should find at least one candidate when input activation correlates with output error. \
+         Diagnostics: {:?}",
+        result.no_candidate_reasons
+    );
+
+    // Verify the candidate makes sense
+    let best = &result.helpful_neurons[0];
+    assert!(
+        best.expected_improvement_percentage > 0.0,
+        "Best candidate should show positive improvement, got {}",
+        best.expected_improvement_percentage
+    );
+
+    // The source should be input-0 (the correlated input)
+    assert!(
+        best.source_neuron_uuid == "input-0",
+        "Best candidate should use the correlated source (input-0), got {}",
+        best.source_neuron_uuid
+    );
+}
+
 /// Test that neurons with calculated bias improve error more than bias=0
 #[test]
 fn test_bias_improves_neuron_performance() {


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.111 to 0.1.113.
- Implement cumulative impact calculation for neurons with multiple outgoing synapses, ensuring accurate assessment of their contributions.
- Introduce tests to validate that low-improvement IDENTITY candidates are correctly filtered out, preventing misclassification as viable candidates.
- Enhance diagnostics to ensure neurons affecting multiple outputs are not incorrectly flagged as low-impact.

These changes improve the accuracy and reliability of neuron evaluations, contributing to better performance in the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require ≥1% improvement for discrete IDENTITY candidates and switch impact calculation to cumulative sum across outgoing edges, with accompanying tests and version bump.
> 
> - **Core logic**:
>   - **Discrete candidate filtering**: In `src/analysis.rs` `evaluate_discrete_candidate`, require `≥1%` net improvement for `IDENTITY` (threshold-based) candidates to avoid synapse-equivalent/low-signal neurons.
>   - **Impact calculation**: In `src/focus.rs` `compute_impact_recursive`, change accumulation from `max` to `sum` across outgoing edges, normalizing by inbound totals to reflect cumulative effect on multiple outputs.
> - **Tests**:
>   - Add unit tests in `analysis.rs` to reject low-improvement `IDENTITY` and accept above-threshold cases.
>   - Add unit tests in `focus.rs` for cumulative impact (multiple outputs and mixed direct/indirect paths).
>   - Add integration tests in `tests/integration.rs` for cumulative impact and verifying add-neuron discovery with correlated errors.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.113`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79879b5b4102b64e067f547deb6fe228f299dbd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->