### PR TITLE
Update version to 0.1.122 and refine activation function handling in …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.120"
+version = "0.1.122"
 edition = "2021"
 
 [lib]

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4102,17 +4102,27 @@ fn leaky_relu(x: f32) -> f32 {
 
 /// Get the activation function for a given squash name.
 /// Returns None for activations that are approximately linear and don't need simulation.
+///
+/// v0.1.121: Added ELU, SELU, GELU, Softplus to improve prediction accuracy
+/// for these commonly-used non-linear activations.
 #[inline]
 fn get_target_activation_fn(squash: &str) -> Option<fn(f32) -> f32> {
     match squash {
+        // Saturating activations - simulation critical near boundaries
         "HARD_TANH" => Some(hard_tanh),
-        "ReLU" => Some(relu),
-        "LeakyReLU" => Some(leaky_relu),
         "TANH" => Some(|x: f32| x.tanh()),
         "LOGISTIC" => Some(logistic_activation),
-        "BIPOLAR" => Some(bipolar_activation),
         "CLIPPED" => Some(clipped_activation),
-        // IDENTITY, INVERSE, etc. are linear - no simulation needed
+        "BIPOLAR" => Some(bipolar_activation),
+        // ReLU family - simulation important for threshold behaviour
+        "ReLU" => Some(relu),
+        "LeakyReLU" => Some(leaky_relu),
+        // Smooth non-linear activations - simulation improves accuracy (v0.1.121)
+        "ELU" => Some(elu_activation),
+        "SELU" => Some(selu_activation),
+        "GELU" => Some(gelu_activation),
+        "Softplus" => Some(softplus_activation),
+        // IDENTITY, INVERSE are linear - no simulation needed
         _ => None,
     }
 }
@@ -4805,32 +4815,20 @@ fn evaluate_activation_candidate(
                         target_squash,
                     );
 
-                    // CRITICAL FIX: Recompute optimal weight WITH the bias included.
-                    // The initial weight_candidates were computed WITHOUT bias, so they're
-                    // wrong when bias significantly changes the activation pattern.
-                    // Now recompute the weight that optimises error reduction for this bias.
-                    let mut sum_activation_sq_with_bias = 0.0f32;
-                    let mut sum_error_activation_with_bias = 0.0f32;
-                    for sample in samples.iter() {
-                        let pre_activation = incoming_weight * sample.activation + bias;
-                        let output = (spec.activation)(pre_activation);
-                        if output.is_finite() {
-                            sum_activation_sq_with_bias += output * output;
-                            sum_error_activation_with_bias += output * sample.avg_error;
-                        }
-                    }
-                    let recomputed_weight = if sum_activation_sq_with_bias > EPSILON {
-                        (sum_error_activation_with_bias / sum_activation_sq_with_bias)
-                            .clamp(-10.0, 10.0)
-                    } else {
-                        clamped_weight
-                    };
+                    // v0.1.122: When target simulation is available, DON'T recompute weight
+                    // using VALUE domain optimization. The candidate weights are already
+                    // scaled versions of linear optimal. Recomputing in VALUE domain can
+                    // overshoot near saturation, leading to worse ACTIVATION domain results.
+                    // Instead, let the ACTIVATION domain evaluation pick the best candidate.
+                    //
+                    // We DO recompute to account for bias changing the activation pattern,
+                    // but only when we don't have target simulation (linear approximation).
 
                     // Single pass for improvement and count with target simulation
                     let (improvement, improved, _) = compute_activation_improvement_and_count(
                         samples,
                         incoming_weight,
-                        recomputed_weight,
+                        clamped_weight, // Use candidate weight directly, not recomputed
                         bias,
                         spec.activation,
                         baseline_sq,
@@ -4839,7 +4837,7 @@ fn evaluate_activation_candidate(
 
                     if improvement > best_improvement {
                         best_improvement = improvement;
-                        best_weight = recomputed_weight;
+                        best_weight = clamped_weight; // Use candidate weight directly
                         best_bias = bias;
                         best_improved_count = improved;
                     }


### PR DESCRIPTION
…analysis.rs

- Bump version in Cargo.toml from 0.1.120 to 0.1.122.
- Enhance the get_target_activation_fn function to include additional non-linear activation functions (ELU, SELU, GELU, Softplus) for improved prediction accuracy.
- Modify weight computation logic in evaluate_activation_candidate to avoid unnecessary recomputation when target simulation is available, ensuring better performance and accuracy in activation evaluations.

These changes enhance the flexibility and reliability of the activation function simulations, contributing to improved overall analysis framework performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ELU/SELU/GELU/Softplus to `get_target_activation_fn` and avoids outgoing-weight recomputation when target simulation is available, plus bumps crate version to 0.1.122.
> 
> - **Analysis (activation handling)**:
>   - Extend `get_target_activation_fn` to support `ELU`, `SELU`, `GELU`, and `Softplus` for target activation simulation.
> - **Activation candidate evaluation**:
>   - In `evaluate_activation_candidate`, when target simulation is available, stop recomputing outgoing weight in the value domain; use candidate `clamped_weight` and let activation-domain evaluation select the best. Retain recomputation only for non-simulation (linear) cases.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.122`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c282ecee885a0a851af1c7ee7142a6fd59f50a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->