### PR TITLE
Update version to 0.1.123 and implement fallback candidate improvemen…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.122"
+version = "0.1.123"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -330,6 +330,34 @@ when simulating, VALUE for linear approximation). This is verified by
 - `compute_relu_improvement_and_count`
 - `compute_activation_improvement_and_count`
 
+#### Fallback candidate minimum threshold (v0.1.123)
+
+**BUG FIX**: Add-neuron candidates with very low predicted improvements (e.g., 0.16%)
+were being returned as "fallback candidates" when no candidate passed the standard
+threshold (typically 10%). At such low predicted improvements, the model's error
+margin becomes significant relative to the prediction itself, causing actual results
+to often be **negative** (worse than baseline).
+
+**Example of the issue:**
+- Predicted improvement: +0.16%
+- Model error margin: ±0.5%
+- Possible actual result: -0.34% (making things worse)
+
+**The fix**: Fallback candidates now require a minimum 2% predicted improvement
+(`MIN_FALLBACK_IMPROVEMENT = 0.02`). This filters out unreliable low-confidence
+predictions while still returning useful candidates that don't quite meet the
+standard threshold.
+
+| Candidate Type | Threshold | Purpose |
+|----------------|-----------|---------|
+| **Best candidate** | 10% (configurable) | High-confidence improvements |
+| **Fallback candidate** | 2% (fixed minimum) | Reasonable-confidence when no best found |
+| **Rejected** | < 2% | Too low to be reliable |
+
+This resolves the production issue where discovery returned many add-neuron
+candidates showing small positive expected improvements, but all resulted in
+actual error increases when applied.
+
 #### All other activations
 
 All other activation functions (including IDENTITY, INVERSE, IF, MAXIMUM,

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -4924,9 +4924,21 @@ fn evaluate_activation_candidate(
             }
 
             // =================================================================
-            // FALLBACK CANDIDATE (best seen so far, regardless of threshold)
+            // FALLBACK CANDIDATE (best seen so far, but requires minimum improvement)
             // =================================================================
-            if expected_improvement_percentage > fallback_score {
+            // CRITICAL: Fallback candidates must meet a MINIMUM improvement threshold.
+            // At very low predicted improvements (e.g., 0.16%), the prediction model's
+            // error margin becomes significant. A model error of ±0.5% can turn a
+            // +0.16% prediction into an actual -0.34% result (making things worse).
+            //
+            // We require at least 2% predicted improvement for fallback candidates to
+            // ensure reasonable prediction reliability. This is lower than the typical
+            // 10% threshold for best_candidate, but high enough to filter out noise.
+            const MIN_FALLBACK_IMPROVEMENT: f32 = 0.02; // 2% minimum for fallback
+
+            if expected_improvement_percentage > fallback_score
+                && expected_improvement_percentage >= MIN_FALLBACK_IMPROVEMENT
+            {
                 fallback_score = expected_improvement_percentage;
 
                 let target_stats = NeuronStats::from_samples(samples).map(|s| s.to_json());


### PR DESCRIPTION
…t threshold

- Bump version in Cargo.toml from 0.1.122 to 0.1.123.
- Introduce a minimum predicted improvement threshold of 2% for fallback candidates in the analysis logic to enhance prediction reliability and avoid negative outcomes from low-confidence predictions.
- Update README to document the bug fix and its implications, providing examples and a clear explanation of the new fallback candidate criteria.

These changes address a critical issue where low predicted improvements led to unreliable candidate selections, improving the overall robustness of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a 2% minimum predicted improvement for fallback add‑neuron candidates, updates README, and bumps version to 0.1.123.
> 
> - **Analysis (backend)**:
>   - Require minimum `2%` predicted improvement for fallback add‑neuron candidates via `MIN_FALLBACK_IMPROVEMENT = 0.02` in `src/analysis.rs` (gates `fallback_candidate` updates on this floor).
> - **Docs**:
>   - Document the fallback minimum threshold bug fix with examples and criteria in `README.md`.
> - **Versioning**:
>   - Bump `Cargo.toml` version to `0.1.123`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8910413bfe3ef9da5c6f7bedfd160d93630a8c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->