### PR TITLE
Update version to 0.1.124 and enhance hidden neuron analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,383 +1,59 @@
-name: CI/CD Pipeline
+# Continuous Integration workflow for NEAT-AI-Discovery
+#
+# Runs on every push and pull request to main branch.
+# Note: GPU-dependent tests are skipped in CI (no GPU available).
+# Run `./quality.sh` locally with GPU for full test coverage.
+
+name: CI
 
 on:
+  push:
+    branches: [main, master]
   pull_request:
-    branches: [ Develop ]
+    branches: [main, master]
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
-  version-increment:
-    name: Auto-increment Versions
-    runs-on: ubuntu-latest
-    needs: [auto-format]
-    permissions:
-      contents: write
-      pull-requests: write
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Configure Git
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        
-    - name: Pull latest changes
-      run: git pull origin ${{ github.head_ref }}
-        
-    - name: Fetch base branch
-      run: |
-        git fetch origin Develop:Develop || git fetch origin develop:develop || true
-        
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      
-    - name: Install cargo-outdated
-      run: cargo install cargo-outdated
-        
-    - name: Check for source changes and increment version
-      run: |
-        # Determine base branch name (try Develop first, then develop)
-        BASE_BRANCH="Develop"
-        if ! git show-ref --verify --quiet refs/remotes/origin/Develop; then
-          BASE_BRANCH="develop"
-        fi
-        
-        # FIRST: Check if a version increment commit already exists in this PR branch
-        # This is the most reliable way to prevent duplicate increments
-        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
-          # Check if there's already a version increment commit in PR branch that's not in base branch
-          VERSION_COMMIT_COUNT=$(git log --oneline origin/$BASE_BRANCH..HEAD --grep="chore: auto-increment versions for changed projects" | wc -l)
-          if [ "$VERSION_COMMIT_COUNT" -gt 0 ]; then
-            echo "✅ Version increment commit already exists in this PR branch (found $VERSION_COMMIT_COUNT commit(s))"
-            echo "Skipping version increment to avoid duplicate commits"
-            exit 0
-          fi
-        fi
-        
-        # SECOND: Check if version is already different from the base branch
-        # If the version on the PR branch differs from base branch, skip increment (already done)
-        # This prevents duplicate version increments on the same PR
-        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
-          BASE_VERSION=$(git show origin/$BASE_BRANCH:Cargo.toml 2>/dev/null | grep '^version = ' | sed 's/version = "\(.*\)"/\1/' || echo "")
-          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          
-          if [ -n "$BASE_VERSION" ] && [ -n "$CURRENT_VERSION" ]; then
-            echo "Base branch version: $BASE_VERSION"
-            echo "PR branch version: $CURRENT_VERSION"
-            
-            # If versions are different, version has already been incremented for this PR
-            if [ "$CURRENT_VERSION" != "$BASE_VERSION" ]; then
-              echo "✅ Version is already different from base branch ($BASE_VERSION -> $CURRENT_VERSION)"
-              echo "Skipping version increment to avoid duplicate commits"
-              exit 0
-            fi
-          fi
-        fi
-        
-        # Check if there are changes in src directory compared to base branch
-        # This correctly detects changes even if auto-format pushed commits
-        HAS_SRC_CHANGES=false
-        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
-          if ! git diff --quiet origin/$BASE_BRANCH...HEAD -- src/; then
-            HAS_SRC_CHANGES=true
-            echo "Found changes in src directory compared to base branch"
-          else
-            echo "No changes in src directory compared to base branch, skipping version increment"
-            exit 0
-          fi
-        else
-          # Fallback: if base branch not available, check HEAD~1 (original logic)
-          if ! git diff --quiet HEAD~1 HEAD -- src/; then
-            HAS_SRC_CHANGES=true
-            echo "Found changes in src directory"
-          else
-            echo "No changes in src directory, skipping version increment"
-            exit 0
-          fi
-        fi
-        
-        # Get current version from Cargo.toml
-        CURRENT_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-        echo "Current version: $CURRENT_VERSION"
-        
-        # Increment patch version
-        # Normalize version to always have 3 parts (major.minor.patch)
-        # Default missing parts to 0 (e.g., "1.0" becomes "1.0.0")
-        IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-        major=${major:-0}
-        minor=${minor:-0}
-        patch=${patch:-0}
-        NEW_VERSION="$major.$minor.$((patch + 1))"
-        echo "New version: $NEW_VERSION"
-        
-        # Update Cargo.toml with new version (escape regex meta characters in CURRENT_VERSION)
-        # Use a single escape pass to avoid double-escaping backslashes
-        ESCAPED_CURRENT=$(printf '%s' "$CURRENT_VERSION" | sed 's/[\/.^$*+?()[\]{}|]/\\&/g')
-        sed -i.bak "s/^version = \"$ESCAPED_CURRENT\"/version = \"$NEW_VERSION\"/" Cargo.toml
-        rm Cargo.toml.bak
-        
-        echo "✅ Version updated from $CURRENT_VERSION to $NEW_VERSION"
-        
-        cargo update
-        cargo outdated -R || true
-        
-    - name: Check if there are changes
-      id: changes
-      run: |
-        if ! git diff --quiet; then
-          git add -A
-          git commit -m "chore: auto-increment versions for changed projects"
-          git push origin ${{ github.head_ref }}
-        else
-          echo "No version changes to commit"
-        fi
-
   quality:
     name: Quality Checks
-    # GPU tests are skipped automatically when no GPU is available.
-    # Set NEAT_CI_RUNNER to a GPU-enabled runner label for full test coverage.
-    runs-on: 'ubuntu-latest'
-    needs: [version-increment, auto-format]
-    env:
-      RUSTFLAGS: "-D warnings"
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Pull latest changes
-      run: git pull origin ${{ github.head_ref }}
-        
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-        
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-      
-    - name: Check formatting
-      run: cargo fmt --all -- --check
-      
-    - name: Run linter
-      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
-      
-    - name: Check types
-      run: cargo check --all-targets --all-features
-      
-    - name: Build library
-      run: cargo build --lib
-      
-    - name: Run tests
-      run: cargo test --all-targets --all-features --verbose
-
-  security:
-    uses: ./.github/workflows/security.yml
-    with:
-      include-dependency-review: true
-
-  validation:
-    name: Project Validation
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Check for required files
-      run: |
-        echo "🔍 Checking for required project files..."
-        
-        required_files=(
-          "Cargo.toml"
-          "README.md"
-          "LICENSE"
-          "src/lib.rs"
-        )
-        
-        missing_files=()
-        for file in "${required_files[@]}"; do
-          if [ ! -f "$file" ]; then
-            missing_files+=("$file")
-          fi
-        done
-        
-        if [ ${#missing_files[@]} -ne 0 ]; then
-          echo "❌ Missing required files: ${missing_files[*]}"
-          exit 1
-        else
-          echo "✅ All required files present"
-        fi
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Validate Cargo.toml
-      run: |
-        echo "🔍 Validating Cargo.toml..."
-        
-        if ! cargo check --manifest-path Cargo.toml --quiet; then
-          echo "❌ Cargo.toml validation failed"
-          exit 1
-        fi
-        
-        for field in "name" "version" "edition"; do
-          if ! grep -q "$field = " Cargo.toml; then
-            echo "❌ Missing '$field' field in Cargo.toml"
-            exit 1
-          fi
-        done
-        
-        echo "✅ Cargo.toml validation passed"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
-    - name: Check documentation
-      run: |
-        echo "🔍 Checking documentation..."
-        
-        readme_lines=$(wc -l < README.md)
-        if [ "$readme_lines" -lt 10 ]; then
-          echo "❌ README.md seems too short (${readme_lines} lines)"
-          exit 1
-        fi
-        
-        if [ -f "src/lib.rs" ]; then
-          doc_comments=$(grep -c "///" src/lib.rs || echo "0")
-          if [ "$doc_comments" -eq 0 ]; then
-            echo "⚠️  No documentation comments found in src/lib.rs"
-          else
-            echo "✅ Found $doc_comments documentation comments"
-          fi
-        fi
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
-  auto-format:
-    name: Auto-format Code
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
-    - name: Ensure bash scripts are executable
-      run: |
-        echo "🔍 Ensuring all bash scripts are executable..."
-        CHANGED=false
-        while IFS= read -r script; do
-          if [ ! -x "$script" ]; then
-            echo "Making $script executable..."
-            chmod +x "$script"
-            CHANGED=true
-          else
-            echo "✅ $script is already executable"
-          fi
-        done < <(find . -name "*.sh" -not -path "./target/*" -not -path "./.git/*")
-        if [ "$CHANGED" = true ]; then
-          echo "Scripts were made executable"
-        else
-          echo "All scripts are already executable"
-        fi
+      - name: Run clippy linter
+        run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
+      - name: Run type checks
+        run: cargo check --all-targets --all-features
 
-    - name: Format Code
-      run: cargo fmt
+      - name: Run tests (unit + integration)
+        run: cargo test --all-targets --all-features -- --test-threads=1
+        # Note: GPU tests will be skipped (skip_without_gpu! macro)
+        # Full GPU tests require running ./quality.sh locally
 
-    - name: Check for Changes
-      id: check_changes
-      run: |
-        if git diff --quiet; then
-          echo "has_changes=false" >> $GITHUB_OUTPUT
-        else
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Commit Changes
-      if: steps.check_changes.outputs.has_changes == 'true'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git commit -am "chore: apply rustfmt fixes"
-
-    - name: Push Changes
-      if: steps.check_changes.outputs.has_changes == 'true'
-      run: git push origin ${{ github.head_ref }}
-
-  shell-checks:
-    name: Shell Script Quality
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Check bash script syntax
-      run: |
-        echo "🔍 Checking bash script syntax with bash -n..."
-        EXIT_CODE=0
-        while IFS= read -r script; do
-          echo "Checking $script..."
-          if bash -n "$script"; then
-            echo "✅ $script passed syntax check"
-          else
-            echo "❌ $script has syntax errors"
-            EXIT_CODE=1
-          fi
-        done < <(find . -name "*.sh" -not -path "./target/*" -not -path "./.git/*")
-        if [ $EXIT_CODE -eq 0 ]; then
-          echo "✅ All bash scripts passed syntax checks"
-        else
-          echo "❌ Some bash scripts have syntax errors"
-          exit 1
-        fi
-
-  spell-check:
-    name: Spell Check
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Run codespell
-      uses: codespell-project/actions-codespell@v2
-      with:
-        check_filenames: true
-        check_hidden: true
-        skip: "./target,./.git,./tests/data"
-        # renderD is a Linux GPU device node name (/dev/dri/renderD128), not a typo
-        ignore_words_list: renderD
-
+      - name: Build release library
+        run: cargo build --release --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,59 +1,383 @@
-# Continuous Integration workflow for NEAT-AI-Discovery
-#
-# Runs on every push and pull request to main branch.
-# Note: GPU-dependent tests are skipped in CI (no GPU available).
-# Run `./quality.sh` locally with GPU for full test coverage.
-
-name: CI
+name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches: [ Develop ]
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-D warnings"
 
 jobs:
+  version-increment:
+    name: Auto-increment Versions
+    runs-on: ubuntu-latest
+    needs: [auto-format]
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Configure Git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        
+    - name: Pull latest changes
+      run: git pull origin ${{ github.head_ref }}
+        
+    - name: Fetch base branch
+      run: |
+        git fetch origin Develop:Develop || git fetch origin develop:develop || true
+        
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      
+    - name: Install cargo-outdated
+      run: cargo install cargo-outdated
+        
+    - name: Check for source changes and increment version
+      run: |
+        # Determine base branch name (try Develop first, then develop)
+        BASE_BRANCH="Develop"
+        if ! git show-ref --verify --quiet refs/remotes/origin/Develop; then
+          BASE_BRANCH="develop"
+        fi
+        
+        # FIRST: Check if a version increment commit already exists in this PR branch
+        # This is the most reliable way to prevent duplicate increments
+        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
+          # Check if there's already a version increment commit in PR branch that's not in base branch
+          VERSION_COMMIT_COUNT=$(git log --oneline origin/$BASE_BRANCH..HEAD --grep="chore: auto-increment versions for changed projects" | wc -l)
+          if [ "$VERSION_COMMIT_COUNT" -gt 0 ]; then
+            echo "✅ Version increment commit already exists in this PR branch (found $VERSION_COMMIT_COUNT commit(s))"
+            echo "Skipping version increment to avoid duplicate commits"
+            exit 0
+          fi
+        fi
+        
+        # SECOND: Check if version is already different from the base branch
+        # If the version on the PR branch differs from base branch, skip increment (already done)
+        # This prevents duplicate version increments on the same PR
+        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
+          BASE_VERSION=$(git show origin/$BASE_BRANCH:Cargo.toml 2>/dev/null | grep '^version = ' | sed 's/version = "\(.*\)"/\1/' || echo "")
+          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          
+          if [ -n "$BASE_VERSION" ] && [ -n "$CURRENT_VERSION" ]; then
+            echo "Base branch version: $BASE_VERSION"
+            echo "PR branch version: $CURRENT_VERSION"
+            
+            # If versions are different, version has already been incremented for this PR
+            if [ "$CURRENT_VERSION" != "$BASE_VERSION" ]; then
+              echo "✅ Version is already different from base branch ($BASE_VERSION -> $CURRENT_VERSION)"
+              echo "Skipping version increment to avoid duplicate commits"
+              exit 0
+            fi
+          fi
+        fi
+        
+        # Check if there are changes in src directory compared to base branch
+        # This correctly detects changes even if auto-format pushed commits
+        HAS_SRC_CHANGES=false
+        if git show-ref --verify --quiet refs/remotes/origin/$BASE_BRANCH; then
+          if ! git diff --quiet origin/$BASE_BRANCH...HEAD -- src/; then
+            HAS_SRC_CHANGES=true
+            echo "Found changes in src directory compared to base branch"
+          else
+            echo "No changes in src directory compared to base branch, skipping version increment"
+            exit 0
+          fi
+        else
+          # Fallback: if base branch not available, check HEAD~1 (original logic)
+          if ! git diff --quiet HEAD~1 HEAD -- src/; then
+            HAS_SRC_CHANGES=true
+            echo "Found changes in src directory"
+          else
+            echo "No changes in src directory, skipping version increment"
+            exit 0
+          fi
+        fi
+        
+        # Get current version from Cargo.toml
+        CURRENT_VERSION=$(grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+        echo "Current version: $CURRENT_VERSION"
+        
+        # Increment patch version
+        # Normalize version to always have 3 parts (major.minor.patch)
+        # Default missing parts to 0 (e.g., "1.0" becomes "1.0.0")
+        IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+        major=${major:-0}
+        minor=${minor:-0}
+        patch=${patch:-0}
+        NEW_VERSION="$major.$minor.$((patch + 1))"
+        echo "New version: $NEW_VERSION"
+        
+        # Update Cargo.toml with new version (escape regex meta characters in CURRENT_VERSION)
+        # Use a single escape pass to avoid double-escaping backslashes
+        ESCAPED_CURRENT=$(printf '%s' "$CURRENT_VERSION" | sed 's/[\/.^$*+?()[\]{}|]/\\&/g')
+        sed -i.bak "s/^version = \"$ESCAPED_CURRENT\"/version = \"$NEW_VERSION\"/" Cargo.toml
+        rm Cargo.toml.bak
+        
+        echo "✅ Version updated from $CURRENT_VERSION to $NEW_VERSION"
+        
+        cargo update
+        cargo outdated -R || true
+        
+    - name: Check if there are changes
+      id: changes
+      run: |
+        if ! git diff --quiet; then
+          git add -A
+          git commit -m "chore: auto-increment versions for changed projects"
+          git push origin ${{ github.head_ref }}
+        else
+          echo "No version changes to commit"
+        fi
+
   quality:
     name: Quality Checks
-    runs-on: ubuntu-latest
-
+    # GPU tests are skipped automatically when no GPU is available.
+    # Set NEAT_CI_RUNNER to a GPU-enabled runner label for full test coverage.
+    runs-on: 'ubuntu-latest'
+    needs: [version-increment, auto-format]
+    env:
+      RUSTFLAGS: "-D warnings"
+    
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Pull latest changes
+      run: git pull origin ${{ github.head_ref }}
+        
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+        
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+      
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+      
+    - name: Run linter
+      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
+      
+    - name: Check types
+      run: cargo check --all-targets --all-features
+      
+    - name: Build library
+      run: cargo build --lib
+      
+    - name: Run tests
+      run: cargo test --all-targets --all-features --verbose
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+  security:
+    uses: ./.github/workflows/security.yml
+    with:
+      include-dependency-review: true
 
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+  validation:
+    name: Project Validation
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Check for required files
+      run: |
+        echo "🔍 Checking for required project files..."
+        
+        required_files=(
+          "Cargo.toml"
+          "README.md"
+          "LICENSE"
+          "src/lib.rs"
+        )
+        
+        missing_files=()
+        for file in "${required_files[@]}"; do
+          if [ ! -f "$file" ]; then
+            missing_files+=("$file")
+          fi
+        done
+        
+        if [ ${#missing_files[@]} -ne 0 ]; then
+          echo "❌ Missing required files: ${missing_files[*]}"
+          exit 1
+        else
+          echo "✅ All required files present"
+        fi
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+    - name: Validate Cargo.toml
+      run: |
+        echo "🔍 Validating Cargo.toml..."
+        
+        if ! cargo check --manifest-path Cargo.toml --quiet; then
+          echo "❌ Cargo.toml validation failed"
+          exit 1
+        fi
+        
+        for field in "name" "version" "edition"; do
+          if ! grep -q "$field = " Cargo.toml; then
+            echo "❌ Missing '$field' field in Cargo.toml"
+            exit 1
+          fi
+        done
+        
+        echo "✅ Cargo.toml validation passed"
 
-      - name: Run clippy linter
-        run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
+    - name: Check documentation
+      run: |
+        echo "🔍 Checking documentation..."
+        
+        readme_lines=$(wc -l < README.md)
+        if [ "$readme_lines" -lt 10 ]; then
+          echo "❌ README.md seems too short (${readme_lines} lines)"
+          exit 1
+        fi
+        
+        if [ -f "src/lib.rs" ]; then
+          doc_comments=$(grep -c "///" src/lib.rs || echo "0")
+          if [ "$doc_comments" -eq 0 ]; then
+            echo "⚠️  No documentation comments found in src/lib.rs"
+          else
+            echo "✅ Found $doc_comments documentation comments"
+          fi
+        fi
 
-      - name: Run type checks
-        run: cargo check --all-targets --all-features
+  auto-format:
+    name: Auto-format Code
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run tests (unit + integration)
-        run: cargo test --all-targets --all-features -- --test-threads=1
-        # Note: GPU tests will be skipped (skip_without_gpu! macro)
-        # Full GPU tests require running ./quality.sh locally
+    - name: Ensure bash scripts are executable
+      run: |
+        echo "🔍 Ensuring all bash scripts are executable..."
+        CHANGED=false
+        while IFS= read -r script; do
+          if [ ! -x "$script" ]; then
+            echo "Making $script executable..."
+            chmod +x "$script"
+            CHANGED=true
+          else
+            echo "✅ $script is already executable"
+          fi
+        done < <(find . -name "*.sh" -not -path "./target/*" -not -path "./.git/*")
+        if [ "$CHANGED" = true ]; then
+          echo "Scripts were made executable"
+        else
+          echo "All scripts are already executable"
+        fi
 
-      - name: Build release library
-        run: cargo build --release --lib
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+
+    - name: Format Code
+      run: cargo fmt
+
+    - name: Check for Changes
+      id: check_changes
+      run: |
+        if git diff --quiet; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Commit Changes
+      if: steps.check_changes.outputs.has_changes == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git commit -am "chore: apply rustfmt fixes"
+
+    - name: Push Changes
+      if: steps.check_changes.outputs.has_changes == 'true'
+      run: git push origin ${{ github.head_ref }}
+
+  shell-checks:
+    name: Shell Script Quality
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Check bash script syntax
+      run: |
+        echo "🔍 Checking bash script syntax with bash -n..."
+        EXIT_CODE=0
+        while IFS= read -r script; do
+          echo "Checking $script..."
+          if bash -n "$script"; then
+            echo "✅ $script passed syntax check"
+          else
+            echo "❌ $script has syntax errors"
+            EXIT_CODE=1
+          fi
+        done < <(find . -name "*.sh" -not -path "./target/*" -not -path "./.git/*")
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "✅ All bash scripts passed syntax checks"
+        else
+          echo "❌ Some bash scripts have syntax errors"
+          exit 1
+        fi
+
+  spell-check:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Run codespell
+      uses: codespell-project/actions-codespell@v2
+      with:
+        check_filenames: true
+        check_hidden: true
+        skip: "./target,./.git,./tests/data"
+        # renderD is a Linux GPU device node name (/dev/dri/renderD128), not a typo
+        ignore_words_list: renderD
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,9 @@
+# ==============================================================================
+# CRITICAL: Do NOT modify this workflow without explicit approval.
+# This file is essential for PR checks and should match the Develop branch.
+# Restoring from Develop: git checkout Develop -- .github/workflows/ci.yml
+# ==============================================================================
+
 name: CI/CD Pipeline
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.123"
+version = "0.1.124"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.124"
+version = "0.1.125"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -390,6 +390,19 @@ returned. This contradicts the low-confidence fallback fix - if 2% is the
 minimum for reliable predictions, discounted predictions below 2% are equally
 unreliable.
 
+**v0.1.125 FIX**: Focus neurons that have all candidates filtered by impact
+discounting now appear in `no_candidate_reasons` with `ImpactDiscountedBelowThreshold`.
+Previously, these neurons would silently disappear from the response:
+- Candidates were found → `had_candidate = true`
+- Impact discounting reduced improvement below 2%
+- Re-filtering removed all candidates
+- `no_candidate_summaries()` excluded the entry (because `had_candidate == true`)
+- Result: neuron appeared in neither `helpful_neurons` nor `no_candidate_reasons`
+
+Now, after re-filtering, any focus neuron that lost ALL its candidates is marked
+with `impact_discounted_below_threshold = true`, ensuring it appears in the
+diagnostics with an appropriate reason code.
+
 #### All other activations
 
 All other activation functions (including IDENTITY, INVERSE, IF, MAXIMUM,
@@ -482,19 +495,24 @@ now filters out these candidates:
 
 #### Add-neuron target neuron filtering
 
-**Only output neurons are valid targets** for add-neuron analysis. Input and
-hidden neurons are filtered out from the focus list:
+**Output and hidden neurons are valid targets** for add-neuron analysis. Input
+and constant neurons are filtered out from the focus list:
 
 | Neuron Type | Filtered? | Reason | Diagnostic Code |
 |-------------|-----------|--------|-----------------|
 | **output** | No | Direct impact on creature score | (not filtered) |
-| **hidden** | Yes | Backpropagated errors don't reliably predict output error | `hidden_neuron_filtered` |
+| **hidden** | No | Analysed with impact-based discounting (v0.1.123) | (not filtered) |
 | **input** | Yes | Observation sources, not computation nodes | `input_neuron_filtered` |
-| **constant** | Yes | No activation function or error | `hidden_neuron_filtered` |
+| **constant** | Yes | Don't receive inputs - always output fixed value | `constant_neuron_filtered` |
 
 This filtering occurs before analysis begins. The diagnostics response includes
 the appropriate reason code for each filtered neuron, so callers know why a
 focus neuron received no candidates.
+
+**Post-analysis filtering** (v0.1.125): Hidden neurons that have candidates
+found but ALL candidates are filtered by impact discounting (below 2% after
+discount) receive the diagnostic code `impact_discounted_below_threshold`. This
+ensures focus neurons never silently disappear from the response.
 
 If verbose logging is enabled (`NEAT_AI_DISCOVERY_VERBOSE=1`), you'll see
 messages like:

--- a/README.md
+++ b/README.md
@@ -899,16 +899,24 @@ Tests are the specification. Changing them changes what the system promises to d
 
 ### Continuous Integration
 
-GitHub Actions runs quality checks on every push and pull request:
+GitHub Actions runs quality checks on every pull request to `Develop`:
 
 ```yaml
-# .github/workflows/ci.yml
-- cargo fmt --check      # Formatting
-- cargo clippy           # Linting  
-- cargo check            # Type checking
-- cargo test             # Unit + integration tests
-- cargo build --release  # Release build
+# .github/workflows/ci.yml jobs:
+- auto-format          # Applies rustfmt and commits fixes
+- version-increment    # Auto-bumps patch version when src/ changes  
+- quality              # fmt check, clippy, cargo check, tests, build
+- shell-checks         # Validates bash script syntax
+- spell-check          # Runs codespell on codebase
+- validation           # Checks required files and Cargo.toml
+- security             # Runs security audit workflow
 ```
+
+**Test coverage**: The quality job runs `cargo test --all-targets --all-features`
+which includes:
+- Unit tests in `src/` (lib target)
+- Integration tests in `tests/` directory
+- All feature-gated tests
 
 **GPU tests are skipped in CI** (no GPU available). The CI ensures:
 - Code compiles and passes linting
@@ -916,6 +924,12 @@ GitHub Actions runs quality checks on every push and pull request:
 - Public API contract is maintained (integration tests)
 
 For full GPU test coverage, run `./quality.sh` locally before pushing.
+
+**⚠️ CRITICAL: Do NOT modify `.github/workflows/ci.yml` without explicit approval.**
+This workflow is essential for PR checks. If accidentally modified, restore from Develop:
+```bash
+git checkout Develop -- .github/workflows/ci.yml
+```
 
 ## File Format
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ This resolves the production issue where discovery returned many add-neuron
 candidates showing small positive expected improvements, but all resulted in
 actual error increases when applied.
 
-#### Hidden neuron add-neuron analysis (v0.1.123)
+#### Hidden neuron add-neuron analysis (v0.1.123, v0.1.124)
 
 **FEATURE**: Hidden neurons are now valid targets for add-neuron analysis.
 Previously, hidden neurons were filtered out entirely with a 100% failure rate.
@@ -382,6 +382,13 @@ from outputs (low impact).
 The impact score is computed using the existing `compute_impacts()` function
 from the focus module, which calculates normalised path weights through the
 network to all outputs.
+
+**v0.1.124 FIX**: After applying impact discounting, candidates are now
+re-filtered against `MIN_FALLBACK_IMPROVEMENT` (2%). Previously, a hidden neuron
+with 3% raw improvement and 0.3 impact would be discounted to 0.9% but still
+returned. This contradicts the low-confidence fallback fix - if 2% is the
+minimum for reliable predictions, discounted predictions below 2% are equally
+unreliable.
 
 #### All other activations
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,31 @@ This resolves the production issue where discovery returned many add-neuron
 candidates showing small positive expected improvements, but all resulted in
 actual error increases when applied.
 
+#### Hidden neuron add-neuron analysis (v0.1.123)
+
+**FEATURE**: Hidden neurons are now valid targets for add-neuron analysis.
+Previously, hidden neurons were filtered out entirely with a 100% failure rate.
+Investigation revealed this was caused by the same low-confidence fallback
+candidates issue (fixed above).
+
+**How it works**:
+- **Output neurons**: Impact = 1.0 (direct contribution to score). No discount applied.
+- **Hidden neurons**: Impact = path weight product to outputs. Predictions are
+  discounted by impact factor.
+
+For a hidden neuron with impact 0.5:
+- Raw predicted improvement: 10%
+- Discounted improvement: 10% × 0.5 = 5%
+
+This discounting ensures hidden neuron predictions are appropriately penalised
+based on their distance from outputs in the network topology. Hidden neurons
+close to outputs (high impact) have more reliable predictions than those far
+from outputs (low impact).
+
+The impact score is computed using the existing `compute_impacts()` function
+from the focus module, which calculates normalised path weights through the
+network to all outputs.
+
 #### All other activations
 
 All other activation functions (including IDENTITY, INVERSE, IF, MAXIMUM,
@@ -694,6 +719,7 @@ the same functional behavior.
    - Refactor if needed while keeping tests green
    - All new tests should pass after implementation
    - **Always read this README before making any changes**
+   - See [Testing Philosophy](#testing-philosophy) below for test organisation guidelines
 
 2. **Code Quality Enforcement**: **MUST run quality checks after EVERY code change**
    - **CRITICAL**: Execute `./quality.sh` after making ANY code modifications
@@ -746,15 +772,125 @@ This will build the library and install it to `~/.cargo/lib/` with version track
 ### Testing
 
 ```bash
-# Run all tests
+# Run all tests (unit + integration)
 cargo test
 
-# Run unit tests only
+# Run unit tests only (in src/)
 cargo test --lib
 
-# Run integration tests only
+# Run integration tests only (in tests/)
 cargo test --test '*'
+
+# Run specific test file
+cargo test --test integration
+cargo test --test regression_v0_1_123
+cargo test --test weights  # All weight-related tests
+
+# Run tests matching a pattern
+cargo test test_hidden_neuron
 ```
+
+**Note**: GPU-dependent tests include `skip_without_gpu!()` and will be skipped
+automatically on machines without a GPU. Run `./quality.sh` locally with a GPU
+for full test coverage.
+
+### Testing Philosophy
+
+**The quality of tests is what makes a good system.** This project follows these
+testing principles:
+
+#### 1. Test OUTCOMES, not implementation
+
+Tests should verify **what** the system does, not **how** it does it. The same
+test should pass regardless of whether we use GPU, CPU, or TPU internally.
+
+```rust
+// GOOD: Tests the outcome
+#[test]
+fn test_low_impact_neurons_are_detected() {
+    let creature = create_test_creature();
+    let impacts = compute_impacts(&creature);
+    
+    // Verify we detected the expected low-impact neurons
+    assert!(impacts["far-from-output"] < 0.1);
+    assert!(impacts["close-to-output"] > 0.9);
+}
+
+// BAD: Tests implementation details
+#[test]
+fn test_gpu_kernel_computes_impacts() {
+    // Don't test HOW we compute, test WHAT we compute
+}
+```
+
+#### 2. Separate test files organised by feature
+
+Small, focused test files make it **obvious when tests change**:
+- Adding a new test file = good (new coverage)
+- Modifying existing tests = raises questions (why?)
+- Removing tests = requires justification
+
+| Directory | Purpose | Example |
+|-----------|---------|---------|
+| `tests/` | Integration tests for public API | `tests/integration.rs` |
+| `tests/regression_*.rs` | Prevent re-introducing fixed bugs | `tests/regression_v0_1_123.rs` |
+| `tests/<feature>.rs` | Tests grouped by feature/concern | `tests/weights.rs`, `tests/impacts.rs` |
+| `src/*.rs` (`#[cfg(test)]`) | Unit tests for private functions | Only when necessary |
+
+**Prefer separate test files** in `tests/` over inline unit tests:
+- Easier to see what changed in code review
+- Clear separation of concerns
+- Don't need to make APIs public just for testing
+
+#### 3. Don't make APIs public just for testing
+
+If a function is internal, keep it internal. Use integration tests to verify
+behaviour through the public API. Only use inline unit tests (`#[cfg(test)]`
+in `src/`) when you genuinely need to test private implementation details.
+
+#### 4. Group related tests by concern
+
+When investigating an issue (e.g., "something's wrong with weight calculations"),
+you should be able to find all relevant tests in one place:
+
+```
+tests/
+├── common/mod.rs           # Shared test utilities
+├── integration.rs          # General integration tests
+├── regression_v0_1_123.rs  # Regression tests for v0.1.123 fixes
+├── weights.rs              # All weight calculation tests (future)
+├── impacts.rs              # All impact score tests (future)
+└── activations.rs          # All activation function tests (future)
+```
+
+#### 5. Test changes are significant
+
+In code review:
+- **New test file**: Generally good - more coverage
+- **Modified test**: Why? Did requirements change? Was it wrong?
+- **Removed/skipped test**: Red flag - must be justified
+
+Tests are the specification. Changing them changes what the system promises to do.
+
+### Continuous Integration
+
+GitHub Actions runs quality checks on every push and pull request:
+
+```yaml
+# .github/workflows/ci.yml
+- cargo fmt --check      # Formatting
+- cargo clippy           # Linting  
+- cargo check            # Type checking
+- cargo test             # Unit + integration tests
+- cargo build --release  # Release build
+```
+
+**GPU tests are skipped in CI** (no GPU available). The CI ensures:
+- Code compiles and passes linting
+- Non-GPU unit tests pass
+- Public API contract is maintained (integration tests)
+
+For full GPU test coverage, run `./quality.sh` locally before pushing.
 
 ## File Format
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -400,6 +400,15 @@ pub enum NeuronNoCandidateReason {
     /// observation sources, not computation nodes - they have no activation function
     /// or error to reduce.
     InputNeuronFiltered,
+    /// Constant neurons are filtered out from add-neuron analysis because they
+    /// don't receive inputs - they always output a fixed value regardless of
+    /// network state, so adding a connection to them has no effect.
+    ConstantNeuronFiltered,
+    /// Candidates were found but all fell below MIN_FALLBACK_IMPROVEMENT (2%) after
+    /// impact-based discounting for hidden neurons. The raw predictions passed the
+    /// threshold, but after discounting by the neuron's impact score (distance from
+    /// outputs), the discounted predictions were too low to be reliable.
+    ImpactDiscountedBelowThreshold,
 }
 
 #[derive(Debug, Clone)]
@@ -885,6 +894,12 @@ struct NeuronDiagnosticEntry {
     /// Set to true when this neuron was filtered out because it's an input neuron
     /// (input neurons are observation sources, not computation nodes).
     input_filtered: bool,
+    /// Set to true when this neuron was filtered out because it's a constant neuron
+    /// (constant neurons don't receive inputs - they always output a fixed value).
+    constant_filtered: bool,
+    /// Set to true when candidates were found but all fell below MIN_FALLBACK_IMPROVEMENT
+    /// after impact-based discounting. This overrides `had_candidate` for reporting purposes.
+    impact_discounted_below_threshold: bool,
 }
 
 impl NeuronDiagnosticEntry {
@@ -900,6 +915,8 @@ impl NeuronDiagnosticEntry {
             best_rejection: None,
             hidden_filtered: false,
             input_filtered: false,
+            constant_filtered: false,
+            impact_discounted_below_threshold: false,
         }
     }
 
@@ -1010,6 +1027,24 @@ impl NeuronDiagnostics {
         }
     }
 
+    /// Mark a neuron as filtered out because it's a constant neuron.
+    /// Constant neurons don't receive inputs - they always output a fixed value
+    /// regardless of network state, so adding a connection to them has no effect.
+    fn mark_constant_filtered(&mut self, target_uuid: &str) {
+        if let Some(entry) = self.entries.get_mut(target_uuid) {
+            entry.constant_filtered = true;
+        }
+    }
+
+    /// Mark a neuron as having candidates that were all filtered out by impact discounting.
+    /// This is called when a hidden neuron had candidates found, but all fell below
+    /// MIN_FALLBACK_IMPROVEMENT (2%) after applying impact-based discounting.
+    fn mark_impact_discounted_below_threshold(&mut self, target_uuid: &str) {
+        if let Some(entry) = self.entries.get_mut(target_uuid) {
+            entry.impact_discounted_below_threshold = true;
+        }
+    }
+
     fn emit_logs(&self) {
         if !self.log_enabled {
             return;
@@ -1041,6 +1076,17 @@ impl NeuronDiagnostics {
                     "[NEAT-AI-Discovery][verbose] Target {} was filtered out (hidden neuron). \
                     Add-neuron analysis only targets output neurons because hidden neuron error \
                     reduction doesn't reliably translate to creature score improvement.",
+                    entry.target_uuid
+                );
+                continue;
+            }
+
+            // Constant neurons don't receive inputs - they always output a fixed value
+            if entry.constant_filtered {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Target {} was filtered out (constant neuron). \
+                    Constant neurons don't receive inputs - they always output a fixed value \
+                    regardless of network state, so adding a connection to them has no effect.",
                     entry.target_uuid
                 );
                 continue;
@@ -1112,9 +1158,38 @@ impl NeuronDiagnostics {
     fn no_candidate_summaries(&self) -> Vec<NeuronNoCandidateSummary> {
         self.entries
             .values()
-            .filter(|entry| !entry.had_candidate)
+            // Include entries that either:
+            // 1. Never had a candidate (!had_candidate), OR
+            // 2. Had candidates but all were filtered by impact discounting
+            .filter(|entry| !entry.had_candidate || entry.impact_discounted_below_threshold)
             .map(|entry| {
-                // Check pre-analysis filters FIRST - these take precedence over all other reasons.
+                // Check post-analysis filter FIRST - impact discounting takes precedence
+                // because it indicates candidates WERE found but then filtered out.
+                // This ensures neurons don't silently disappear from the response.
+                if entry.impact_discounted_below_threshold {
+                    return NeuronNoCandidateSummary {
+                        target_uuid: entry.target_uuid.clone(),
+                        reason: NeuronNoCandidateReason::ImpactDiscountedBelowThreshold,
+                        evaluated_sources: entry.evaluated_sources,
+                        sources_with_samples: entry.sources_with_samples,
+                        target_record_count: entry.target_record_count,
+                        detail: entry
+                            .best_rejection
+                            .as_ref()
+                            .map(|best| NeuronNoCandidateDetail {
+                                source_uuid: Some(best.source_uuid.clone()),
+                                orientation: best.orientation.map(|name| name.to_string()),
+                                sample_count: Some(best.sample_count),
+                                improved_count: None,
+                                worsened_count: None,
+                                expected_improvement: Some(best.expected_improvement),
+                                threshold: None,
+                                outgoing_weight: None,
+                            }),
+                    };
+                }
+
+                // Check pre-analysis filters NEXT - these take precedence over other reasons.
                 // These neurons are filtered out before analysis even begins, so they won't
                 // have any other diagnostic data (eligible sources, samples, etc.).
 
@@ -1135,6 +1210,18 @@ impl NeuronDiagnostics {
                     return NeuronNoCandidateSummary {
                         target_uuid: entry.target_uuid.clone(),
                         reason: NeuronNoCandidateReason::HiddenNeuronFiltered,
+                        evaluated_sources: 0,
+                        sources_with_samples: 0,
+                        target_record_count: 0,
+                        detail: None,
+                    };
+                }
+
+                // Constant neurons don't receive inputs - they always output a fixed value
+                if entry.constant_filtered {
+                    return NeuronNoCandidateSummary {
+                        target_uuid: entry.target_uuid.clone(),
+                        reason: NeuronNoCandidateReason::ConstantNeuronFiltered,
                         evaluated_sources: 0,
                         sources_with_samples: 0,
                         target_record_count: 0,
@@ -5309,8 +5396,9 @@ fn analyze_neurons_with_cache(
     // Non-output neurons are skipped here but still tracked in diagnostics so the
     // caller knows they were received but filtered out (with the correct reason).
     let original_focus_count = unique_focus.len();
-    let mut skipped_hidden: Vec<String> = Vec::new();
+    let skipped_hidden: Vec<String> = Vec::new();
     let mut skipped_input: Vec<String> = Vec::new();
+    let mut skipped_constant: Vec<String> = Vec::new();
 
     // Randomize the focus neuron order so that repeated runs with timeouts will
     // eventually cover all neurons. Convert to owned strings, shuffle, then use.
@@ -5343,7 +5431,7 @@ fn analyze_neurons_with_cache(
                 }
                 Some("constant") => {
                     // Constant neurons don't receive inputs - filtering them out
-                    skipped_hidden.push((*uuid).clone());
+                    skipped_constant.push((*uuid).clone());
                     None
                 }
                 Some(unknown_type) => {
@@ -5367,36 +5455,34 @@ fn analyze_neurons_with_cache(
         .collect();
 
     // Log when non-output neurons are filtered out
-    let total_skipped = skipped_hidden.len() + skipped_input.len();
+    let total_skipped = skipped_hidden.len() + skipped_input.len() + skipped_constant.len();
     if total_skipped > 0 {
-        if !skipped_input.is_empty() && !skipped_hidden.is_empty() {
-            eprintln!(
-                "[NEAT-AI-Discovery] Filtered {} neuron(s) from add-neuron analysis (only output neurons are valid targets). \
-                Input neurons skipped: {:?}. Hidden neurons skipped: {:?}. Remaining output neurons: {}",
-                total_skipped,
-                skipped_input.iter().take(5).collect::<Vec<_>>(),
-                skipped_hidden.iter().take(5).collect::<Vec<_>>(),
-                focus_order.len()
-            );
-        } else if !skipped_input.is_empty() {
-            eprintln!(
-                "[NEAT-AI-Discovery] Filtered {} input neuron(s) from add-neuron analysis \
-                (input neurons are observation sources, not computation nodes). \
-                Input neurons skipped: {:?}. Remaining output neurons: {}",
-                skipped_input.len(),
-                skipped_input.iter().take(5).collect::<Vec<_>>(),
-                focus_order.len()
-            );
-        } else {
-            eprintln!(
-                "[NEAT-AI-Discovery] Filtered {} hidden neuron(s) from add-neuron analysis \
-                (only output neurons are valid targets). \
-                Hidden neurons skipped: {:?}. Remaining output neurons: {}",
-                skipped_hidden.len(),
-                skipped_hidden.iter().take(5).collect::<Vec<_>>(),
-                focus_order.len()
-            );
+        // Build a summary of skipped neuron types
+        let mut skipped_parts: Vec<String> = Vec::new();
+        if !skipped_input.is_empty() {
+            skipped_parts.push(format!(
+                "Input: {:?}",
+                skipped_input.iter().take(5).collect::<Vec<_>>()
+            ));
         }
+        if !skipped_hidden.is_empty() {
+            skipped_parts.push(format!(
+                "Hidden: {:?}",
+                skipped_hidden.iter().take(5).collect::<Vec<_>>()
+            ));
+        }
+        if !skipped_constant.is_empty() {
+            skipped_parts.push(format!(
+                "Constant: {:?}",
+                skipped_constant.iter().take(5).collect::<Vec<_>>()
+            ));
+        }
+        eprintln!(
+            "[NEAT-AI-Discovery] Filtered {} neuron(s) from add-neuron analysis. {}. Remaining valid targets: {}",
+            total_skipped,
+            skipped_parts.join(". "),
+            focus_order.len()
+        );
     }
 
     // If no output neurons remain after filtering, return early with empty results
@@ -5427,6 +5513,16 @@ fn analyze_neurons_with_cache(
                 detail: None,
             });
         }
+        for uuid in &skipped_constant {
+            no_candidate_reasons.push(NeuronNoCandidateSummary {
+                target_uuid: uuid.clone(),
+                reason: NeuronNoCandidateReason::ConstantNeuronFiltered,
+                evaluated_sources: 0,
+                sources_with_samples: 0,
+                target_record_count: 0,
+                detail: None,
+            });
+        }
         return Ok(AnalyzeNeuronsResult {
             helpful_neurons: Vec::new(),
             gpu_used: true,
@@ -5448,6 +5544,12 @@ fn analyze_neurons_with_cache(
             .lock()
             .expect("Mutex poisoned: diagnostics")
             .mark_hidden_filtered(hidden_uuid);
+    }
+    for constant_uuid in &skipped_constant {
+        diagnostics
+            .lock()
+            .expect("Mutex poisoned: diagnostics")
+            .mark_constant_filtered(constant_uuid);
     }
 
     // Log threshold-crossing neurons for visibility
@@ -5812,7 +5914,7 @@ fn analyze_neurons_with_cache(
         .lock()
         .expect("Mutex poisoned: helpful_map")
         .clone();
-    let diagnostics = diagnostics.lock().expect("Mutex poisoned: diagnostics");
+    let mut diagnostics = diagnostics.lock().expect("Mutex poisoned: diagnostics");
 
     if analysis_timed_out && verbose_enabled() {
         eprintln!("[NEAT-AI-Discovery][verbose] analyse_neurons reached analysis deadline; returning partial results.");
@@ -5894,6 +5996,14 @@ fn analyze_neurons_with_cache(
     // These low predictions are unreliable for the same reason as original fallbacks:
     // the model's error margin (~±0.5%) exceeds the prediction itself.
     const MIN_FALLBACK_IMPROVEMENT: f32 = 0.02; // 2% minimum - same as evaluate_activation_candidate
+
+    // Track which target neurons have candidates BEFORE filtering (v0.1.125 fix)
+    // This allows us to report when neurons lose ALL candidates due to impact discounting.
+    let targets_with_candidates_before: HashSet<String> = helpful_results
+        .iter()
+        .map(|c| c.target_neuron_uuid.clone())
+        .collect();
+
     let pre_filter_count = helpful_results.len();
     helpful_results.retain(|c| c.expected_improvement_percentage >= MIN_FALLBACK_IMPROVEMENT);
     let filtered_count = pre_filter_count - helpful_results.len();
@@ -5903,6 +6013,27 @@ fn analyze_neurons_with_cache(
             {:.0}% MIN_FALLBACK_IMPROVEMENT after impact discounting",
             MIN_FALLBACK_IMPROVEMENT * 100.0
         );
+    }
+
+    // Find target neurons that had candidates but now have NONE after filtering (v0.1.125 fix)
+    // These neurons must appear in no_candidate_reasons, not silently disappear.
+    let targets_with_candidates_after: HashSet<String> = helpful_results
+        .iter()
+        .map(|c| c.target_neuron_uuid.clone())
+        .collect();
+
+    for target_uuid in &targets_with_candidates_before {
+        if !targets_with_candidates_after.contains(target_uuid) {
+            // This target had candidates but all were filtered out by impact discounting
+            diagnostics.mark_impact_discounted_below_threshold(target_uuid);
+            if verbose_enabled() {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Target {} lost ALL candidates after impact \
+                    discounting - will report ImpactDiscountedBelowThreshold",
+                    &target_uuid[..20.min(target_uuid.len())]
+                );
+            }
+        }
     }
 
     helpful_results.sort_by(|a, b| {
@@ -11472,6 +11603,68 @@ mod tests_synapses {
             ),
             "Input neuron should report InputNeuronFiltered, not {:?}",
             input_summary.reason
+        );
+
+        // Find the hidden neuron summary - should still have HiddenNeuronFiltered reason
+        let hidden_summary = summaries
+            .iter()
+            .find(|s| s.target_uuid == "hidden-2")
+            .expect("Should have summary for hidden-2");
+        assert!(
+            matches!(
+                hidden_summary.reason,
+                NeuronNoCandidateReason::HiddenNeuronFiltered
+            ),
+            "Hidden neuron should report HiddenNeuronFiltered, not {:?}",
+            hidden_summary.reason
+        );
+    }
+
+    #[test]
+    fn neuron_diagnostics_reports_constant_neuron_filtered_not_hidden() {
+        // Test that when a constant neuron is in the focus list, it gets
+        // ConstantNeuronFiltered reason (not HiddenNeuronFiltered).
+        //
+        // Bug scenario (v0.1.124): Constant neurons were pushed to skipped_hidden
+        // but reported with HiddenNeuronFiltered reason. This is semantically
+        // incorrect - constant neurons don't receive inputs because they always
+        // output a fixed value, which is different from hidden neurons whose
+        // backpropagated errors don't reliably predict output error.
+        let mut diagnostics =
+            NeuronDiagnostics::new_for_tests(&["output-0", "constant-1", "hidden-2"]);
+
+        // Mark constant-1 as filtered because it's a constant neuron
+        diagnostics.mark_constant_filtered("constant-1");
+
+        // Mark hidden-2 as filtered because it's a hidden neuron
+        diagnostics.mark_hidden_filtered("hidden-2");
+
+        // Simulate output-0 being processed normally but finding no candidate
+        diagnostics.set_target_record_count("output-0", 100);
+        diagnostics.set_total_eligible_sources("output-0", 5);
+        diagnostics.record_candidate_attempt("output-0", false);
+
+        let summaries = diagnostics.no_candidate_summaries();
+
+        // All three should have summaries
+        assert_eq!(
+            summaries.len(),
+            3,
+            "Expected 3 summaries (one for output, one for constant, one for hidden)"
+        );
+
+        // Find the constant neuron summary - should have ConstantNeuronFiltered reason
+        let constant_summary = summaries
+            .iter()
+            .find(|s| s.target_uuid == "constant-1")
+            .expect("Should have summary for constant-1");
+        assert!(
+            matches!(
+                constant_summary.reason,
+                NeuronNoCandidateReason::ConstantNeuronFiltered
+            ),
+            "Constant neuron should report ConstantNeuronFiltered, not {:?}",
+            constant_summary.reason
         );
 
         // Find the hidden neuron summary - should still have HiddenNeuronFiltered reason

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,3 +1,4 @@
+use crate::focus::compute_impacts_public;
 use crate::types::DiscoverRecord;
 use crate::{
     AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson,
@@ -5321,11 +5322,13 @@ fn analyze_neurons_with_cache(
     let mut focus_order: Vec<String> = unique_focus
         .iter()
         .filter_map(|uuid| {
-            // Check neuron type - only allow output neurons for add-neuron analysis
+            // Check neuron type - allow output and hidden neurons for add-neuron analysis
+            // Hidden neurons are analysed with impact-based discounting (v0.1.123)
             let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
             match neuron_type {
-                Some("output") => {
-                    // Output neurons are valid targets - continue processing
+                Some("output") | Some("hidden") => {
+                    // Output and hidden neurons are valid targets
+                    // Hidden neuron predictions will be discounted by impact later
                     if let Some(squash) = neuron_squash_map.get(*uuid) {
                         if is_threshold_activation(squash) {
                             threshold_targets.push((*uuid).clone());
@@ -5338,20 +5341,25 @@ fn analyze_neurons_with_cache(
                     skipped_input.push((*uuid).clone());
                     None
                 }
-                Some(_) => {
-                    // Hidden/constant neurons have backpropagated errors that don't
-                    // reliably translate to output error reduction
+                Some("constant") => {
+                    // Constant neurons don't receive inputs - filtering them out
                     skipped_hidden.push((*uuid).clone());
                     None
                 }
+                Some(unknown_type) => {
+                    // Unknown type - treat as hidden (analysable with discount)
+                    eprintln!(
+                        "[NEAT-AI-Discovery] Warning: Unknown neuron type '{unknown_type}' for UUID '{uuid}'. \
+                        Treating as hidden neuron (will apply impact discount)."
+                    );
+                    Some((*uuid).clone())
+                }
                 None => {
-                    // Unknown UUID - this is likely a bug, but treat as hidden for now
-                    // (this shouldn't happen with proper creature data)
+                    // Unknown UUID - this is likely a bug, skip it
                     eprintln!(
                         "[NEAT-AI-Discovery] Warning: Unknown neuron UUID '{uuid}' in focus list \
-                        (not found in creature). Treating as hidden neuron."
+                        (not found in creature). Skipping."
                     );
-                    skipped_hidden.push((*uuid).clone());
                     None
                 }
             }
@@ -5837,6 +5845,50 @@ fn analyze_neurons_with_cache(
     }
 
     let mut helpful_results: Vec<CandidateNeuronJson> = helpful_map.into_values().collect();
+
+    // Apply impact-based discounting for hidden neurons (v0.1.123)
+    // Hidden neuron errors are backpropagated approximations, so their predictions
+    // are less reliable than output neurons. We discount by their impact score
+    // (path weight product to outputs).
+    let impact_scores = compute_impacts_public(&input.creature);
+    for candidate in &mut helpful_results {
+        let is_hidden = neuron_type_map
+            .get(&candidate.target_neuron_uuid)
+            .map(|t| t != "output")
+            .unwrap_or(true); // Default to true if type unknown (treat as hidden)
+
+        if is_hidden {
+            if let Some(&impact) = impact_scores.get(&candidate.target_neuron_uuid) {
+                let discount = impact.clamp(0.0, 1.0);
+                let original = candidate.expected_improvement_percentage;
+                candidate.expected_improvement_percentage *= discount;
+                if verbose_enabled() {
+                    eprintln!(
+                        "[NEAT-AI-Discovery][verbose] Hidden neuron {} prediction discounted by impact {:.3}: \
+                        {:.4}% -> {:.4}%",
+                        &candidate.target_neuron_uuid[..12.min(candidate.target_neuron_uuid.len())],
+                        discount,
+                        original * 100.0,
+                        candidate.expected_improvement_percentage * 100.0
+                    );
+                }
+            } else {
+                // No impact score means disconnected from outputs - heavy discount
+                let original = candidate.expected_improvement_percentage;
+                candidate.expected_improvement_percentage *= 0.1;
+                if verbose_enabled() {
+                    eprintln!(
+                        "[NEAT-AI-Discovery][verbose] Hidden neuron {} has no impact score (disconnected?). \
+                        Applying 90% discount: {:.4}% -> {:.4}%",
+                        &candidate.target_neuron_uuid[..12.min(candidate.target_neuron_uuid.len())],
+                        original * 100.0,
+                        candidate.expected_improvement_percentage * 100.0
+                    );
+                }
+            }
+        }
+    }
+
     helpful_results.sort_by(|a, b| {
         b.expected_improvement_percentage
             .partial_cmp(&a.expected_improvement_percentage)

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5889,6 +5889,22 @@ fn analyze_neurons_with_cache(
         }
     }
 
+    // Re-filter discounted candidates against MIN_FALLBACK_IMPROVEMENT (v0.1.124)
+    // After impact discounting, hidden neuron candidates may fall below 2%.
+    // These low predictions are unreliable for the same reason as original fallbacks:
+    // the model's error margin (~±0.5%) exceeds the prediction itself.
+    const MIN_FALLBACK_IMPROVEMENT: f32 = 0.02; // 2% minimum - same as evaluate_activation_candidate
+    let pre_filter_count = helpful_results.len();
+    helpful_results.retain(|c| c.expected_improvement_percentage >= MIN_FALLBACK_IMPROVEMENT);
+    let filtered_count = pre_filter_count - helpful_results.len();
+    if filtered_count > 0 && verbose_enabled() {
+        eprintln!(
+            "[NEAT-AI-Discovery][verbose] Filtered {filtered_count} candidate(s) that fell below \
+            {:.0}% MIN_FALLBACK_IMPROVEMENT after impact discounting",
+            MIN_FALLBACK_IMPROVEMENT * 100.0
+        );
+    }
+
     helpful_results.sort_by(|a, b| {
         b.expected_improvement_percentage
             .partial_cmp(&a.expected_improvement_percentage)

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -126,6 +126,18 @@ fn build_inbound_weights(creature: &CreatureJson) -> HashMap<String, f32> {
 }
 
 fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
+    compute_impacts_internal(creature)
+}
+
+/// Public version of compute_impacts for use in add-neuron analysis.
+/// Computes the structural impact of each neuron on outputs (path weight products).
+/// Output neurons have impact = 1.0, hidden neurons have impact in [0, 1] based on
+/// their weighted paths to outputs.
+pub fn compute_impacts_public(creature: &CreatureJson) -> HashMap<String, f32> {
+    compute_impacts_internal(creature)
+}
+
+fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
     let adjacency = build_adjacency(creature);
     let inbound_weights = build_inbound_weights(creature);
     let output_neurons: HashSet<String> = creature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,15 @@ pub enum NeuronDiagnosticReasonJson {
     /// observation sources, not computation nodes - they have no activation function
     /// or error to reduce.
     InputNeuronFiltered,
+    /// Constant neurons are filtered out from add-neuron analysis because they
+    /// don't receive inputs - they always output a fixed value regardless of
+    /// network state, so adding a connection to them has no effect.
+    ConstantNeuronFiltered,
+    /// Candidates were found but all fell below MIN_FALLBACK_IMPROVEMENT (2%) after
+    /// impact-based discounting for hidden neurons. The raw predictions passed the
+    /// threshold, but after discounting by the neuron's impact score (distance from
+    /// outputs), the discounted predictions were too low to be reliable.
+    ImpactDiscountedBelowThreshold,
 }
 
 #[derive(Debug, Serialize)]
@@ -492,6 +501,12 @@ fn neuron_diagnostics_json(
                     }
                     analysis::NeuronNoCandidateReason::InputNeuronFiltered => {
                         NeuronDiagnosticReasonJson::InputNeuronFiltered
+                    }
+                    analysis::NeuronNoCandidateReason::ConstantNeuronFiltered => {
+                        NeuronDiagnosticReasonJson::ConstantNeuronFiltered
+                    }
+                    analysis::NeuronNoCandidateReason::ImpactDiscountedBelowThreshold => {
+                        NeuronDiagnosticReasonJson::ImpactDiscountedBelowThreshold
                     }
                 },
                 evaluated_sources: summary.evaluated_sources,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1074,3 +1074,320 @@ fn test_bias_improves_neuron_performance() {
         }
     }
 }
+
+/// REGRESSION TEST: Hidden neurons must be analysed, not filtered out.
+///
+/// v0.1.123: Previously hidden neurons were filtered entirely with 100% failure rate.
+/// Investigation revealed this was caused by low-confidence fallback candidates.
+/// Now hidden neurons ARE analysed with impact-based discounting.
+///
+/// This test will FAIL if hidden neurons are filtered out instead of analysed.
+#[test]
+fn test_hidden_neurons_are_analysed_not_filtered() {
+    skip_without_gpu!();
+    use neat_ai_discovery::AnalyzeNeuronsInput;
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a creature with: input -> hidden -> output
+    // The hidden neuron connects input to output
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![SynapseJson {
+            from_uuid: "hidden-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0, // Hidden -> Output connection gives hidden-0 impact = 1.0
+        }],
+        input: 2,
+        output: 1,
+    };
+
+    // Generate training data with correlated errors for HIDDEN neuron
+    // This creates a scenario where adding a connection to the hidden neuron could help
+    let mut training_data = Vec::new();
+    for i in 0..50 {
+        let input_0_val = (i as f32 - 25.0) / 25.0; // Range: -1.0 to 1.0
+        let input_1_val = 0.5;
+
+        // Create correlated error at the HIDDEN neuron
+        let hidden_error = input_0_val * 0.5;
+        let hidden_value = input_0_val * 0.3;
+        let hidden_activation = hidden_value.tanh();
+
+        // Output also has error (but we're targeting hidden-0)
+        let output_error = hidden_error * 0.5; // Propagated error
+
+        training_data.push(serde_json::json!({
+            "input": [input_0_val, input_1_val],
+            "output": [0.0],
+            "neuron_data": [
+                {
+                    "neuron_uuid": "hidden-0",
+                    "activation": hidden_activation,
+                    "value": hidden_value,
+                    "errors": [hidden_error]
+                },
+                {
+                    "neuron_uuid": "output-0",
+                    "activation": 0.0,
+                    "value": 0.0,
+                    "errors": [output_error]
+                }
+            ]
+        }));
+    }
+
+    // Record discovery data
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": training_data,
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data: {:?}",
+        record_output["error"]
+    );
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    // CRITICAL: Request analysis with hidden-0 as a focus target
+    let analyze_input = AnalyzeNeuronsInput {
+        parquet_file: parquet_file.to_str().unwrap().to_string(),
+        creature,
+        focus_neurons: vec!["hidden-0".to_string()], // Request hidden neuron analysis
+        improvement_threshold: Some(0.01),
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
+        .expect("Neuron analysis should succeed");
+
+    // REGRESSION CHECK: Hidden neuron should NOT be reported as filtered
+    let hidden_filtered = result.no_candidate_reasons.iter().any(|r| {
+        r.target_uuid == "hidden-0"
+            && matches!(
+                r.reason,
+                neat_ai_discovery::analysis::NeuronNoCandidateReason::HiddenNeuronFiltered
+            )
+    });
+
+    assert!(
+        !hidden_filtered,
+        "REGRESSION: Hidden neuron 'hidden-0' was filtered out instead of being analysed! \
+        Hidden neurons should be analysed with impact-based discounting, not filtered. \
+        Diagnostics: {:?}",
+        result.no_candidate_reasons
+    );
+
+    // If the hidden neuron was analysed but no candidates found, that's OK
+    // The key assertion is that it was NOT filtered
+    eprintln!(
+        "Hidden neuron analysis result: {} candidates found, {} diagnostics",
+        result.helpful_neurons.len(),
+        result.no_candidate_reasons.len()
+    );
+}
+
+/// REGRESSION TEST: Hidden neuron candidates must have discounted predictions.
+///
+/// When a candidate targets a hidden neuron, the expected_improvement_percentage
+/// should be discounted by the hidden neuron's impact score (path to outputs).
+///
+/// Impact is calculated as: (weight to child / total inbound to child) × child_impact
+/// So to get impact < 1.0, we need multiple paths to the output.
+///
+/// This test will FAIL if hidden neuron predictions are not discounted.
+#[test]
+fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
+    skip_without_gpu!();
+    use neat_ai_discovery::AnalyzeNeuronsInput;
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create creature where hidden-0 has impact < 1.0 to output
+    // Two hidden neurons both connect to output, so each has impact ~0.5
+    //
+    //   hidden-0 (weight 1.0) --\
+    //                            --> output-0
+    //   hidden-1 (weight 1.0) --/
+    //
+    // hidden-0 impact = (1.0 / 2.0) × 1.0 = 0.5
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+            },
+            SynapseJson {
+                from_uuid: "hidden-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0, // Total inbound to output = 2.0, so each hidden has impact 0.5
+            },
+        ],
+        input: 2,
+        output: 1,
+    };
+
+    // Generate strongly correlated training data for hidden-0
+    let mut training_data = Vec::new();
+    for i in 0..100 {
+        let input_0_val = (i as f32 - 50.0) / 50.0;
+        let input_1_val = 0.3;
+
+        // Strong correlation at hidden-0
+        let hidden_0_error = input_0_val * 0.8;
+        let hidden_0_value = input_0_val * 0.2;
+
+        // hidden-1 has no correlation (constant)
+        let hidden_1_error = 0.0;
+        let hidden_1_value = 0.5;
+
+        training_data.push(serde_json::json!({
+            "input": [input_0_val, input_1_val],
+            "output": [0.0],
+            "neuron_data": [
+                {
+                    "neuron_uuid": "hidden-0",
+                    "activation": hidden_0_value,
+                    "value": hidden_0_value,
+                    "errors": [hidden_0_error]
+                },
+                {
+                    "neuron_uuid": "hidden-1",
+                    "activation": hidden_1_value,
+                    "value": hidden_1_value,
+                    "errors": [hidden_1_error]
+                },
+                {
+                    "neuron_uuid": "output-0",
+                    "activation": 0.0,
+                    "value": 0.0,
+                    "errors": [hidden_0_error * 0.5]
+                }
+            ]
+        }));
+    }
+
+    // Record discovery data
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": training_data,
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(
+        record_output["success"], true,
+        "Failed to record discovery data: {:?}",
+        record_output["error"]
+    );
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    // Analyse hidden-0 which has impact = 0.5
+    let analyze_input = AnalyzeNeuronsInput {
+        parquet_file: parquet_file.to_str().unwrap().to_string(),
+        creature,
+        focus_neurons: vec!["hidden-0".to_string()],
+        improvement_threshold: Some(0.001), // Very low threshold to get candidates
+        max_candidates: Some(20),
+        analysis_deadline_ms: None,
+    };
+
+    let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
+        .expect("Neuron analysis should succeed");
+
+    // Hidden neuron should be analysed, not filtered
+    let hidden_was_filtered = result.no_candidate_reasons.iter().any(|r| {
+        r.target_uuid == "hidden-0"
+            && matches!(
+                r.reason,
+                neat_ai_discovery::analysis::NeuronNoCandidateReason::HiddenNeuronFiltered
+            )
+    });
+
+    assert!(
+        !hidden_was_filtered,
+        "REGRESSION: Hidden neuron was filtered instead of analysed!"
+    );
+
+    // Find candidates for hidden-0
+    let hidden_candidates: Vec<_> = result
+        .helpful_neurons
+        .iter()
+        .filter(|c| c.target_neuron_uuid == "hidden-0")
+        .collect();
+
+    // If we found hidden candidates, verify their predictions are discounted
+    if !hidden_candidates.is_empty() {
+        for candidate in &hidden_candidates {
+            // With impact = 0.5, predictions should be discounted by 50%
+            // So maximum possible is 50% even if raw prediction was 100%
+            assert!(
+                candidate.expected_improvement_percentage <= 0.5,
+                "Hidden neuron candidate improvement {:.4}% exceeds impact-adjusted maximum of 50%. \
+                Hidden-0 has impact ~0.5, so predictions should be discounted. \
+                This suggests impact discounting is not being applied.",
+                candidate.expected_improvement_percentage * 100.0
+            );
+
+            eprintln!(
+                "Hidden neuron candidate (impact ~0.5): {} -> {} improvement={:.4}%",
+                candidate.source_neuron_uuid,
+                candidate.target_neuron_uuid,
+                candidate.expected_improvement_percentage * 100.0
+            );
+        }
+    } else {
+        // No candidates found - that's OK, the key test is that it wasn't filtered
+        eprintln!(
+            "No candidates found for hidden-0 (this is OK - key test is it wasn't filtered). \
+            Diagnostics: {:?}",
+            result.no_candidate_reasons
+        );
+    }
+}

--- a/tests/regression_v0_1_123.rs
+++ b/tests/regression_v0_1_123.rs
@@ -574,3 +574,226 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         result.helpful_neurons.len()
     );
 }
+
+/// REGRESSION TEST: Impact-discounted neurons must appear in EITHER helpful_neurons OR no_candidate_reasons.
+///
+/// BUG (to be fixed in v0.1.125): When a hidden neuron candidate is found but then filtered out
+/// by impact discounting (falls below 2% after discount), the neuron disappears from BOTH:
+/// - `helpful_neurons` (candidate was removed by re-filtering)
+/// - `no_candidate_reasons` (had_candidate was set to true before filtering)
+///
+/// This causes focus neurons to silently disappear from the response, leaving callers
+/// with no information about neurons they explicitly requested analysis for.
+///
+/// A focus neuron must ALWAYS appear in exactly one of:
+/// 1. `helpful_neurons` (has candidates)
+/// 2. `no_candidate_reasons` (was analysed but has no viable candidates)
+#[test]
+fn regression_impact_discounted_neurons_must_appear_in_response() {
+    skip_without_gpu!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let parquet_file = parquet_path
+        .to_str()
+        .expect("Temporary path should be valid UTF-8")
+        .to_string();
+
+    // Create a creature where hidden-will-be-discounted has VERY LOW impact (0.05).
+    // We'll engineer the data so raw improvement is ~5-15%, but after 0.05 discount
+    // it becomes 0.25-0.75% which falls below MIN_FALLBACK_IMPROVEMENT (2%).
+    //
+    // hidden-will-be-discounted (weight 0.05) --\
+    //                                            --> output-0
+    // hidden-high-impact (weight 0.95) ---------/
+    //
+    // Impact for hidden-will-be-discounted = 0.05 / (0.05 + 0.95) = 0.05
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-will-be-discounted".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-high-impact".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "hidden-will-be-discounted".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.05, // Very low weight = very low impact (0.05)
+            },
+            SynapseJson {
+                from_uuid: "hidden-high-impact".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.95, // High weight = high impact (0.95)
+            },
+        ],
+    };
+
+    // Verify impact scores
+    let impacts = neat_ai_discovery::focus::compute_impacts_public(&creature);
+    let discounted_impact = impacts
+        .get("hidden-will-be-discounted")
+        .copied()
+        .unwrap_or(0.0);
+    eprintln!("hidden-will-be-discounted has impact score: {discounted_impact:.3}");
+    assert!(
+        discounted_impact < 0.1,
+        "Test setup error: hidden-will-be-discounted should have impact < 0.1, got {discounted_impact:.3}"
+    );
+
+    // Create discovery records with VERY WEAK correlation for hidden-will-be-discounted.
+    // We want raw improvement to be ~5-30% so that after 0.05 impact discount
+    // it falls to 0.25-1.5% (below MIN_FALLBACK_IMPROVEMENT of 2%).
+    //
+    // The key is: raw improvement >= 2% (passes initial filter) but
+    // discounted improvement < 2% (gets filtered by re-filtering).
+    //
+    // We use mostly noise with tiny signal to break the correlation.
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        let input_val = (obs_index as f32 - 50.0) / 50.0; // -1.0 to 1.0
+
+        // Heavy noise, tiny signal - produces ~5-30% raw improvement
+        // which becomes 0.25-1.5% after 0.05 impact discount
+        let noise1 = ((obs_index * 17) % 11) as f32 / 5.5 - 1.0; // Pseudo-random -1 to 1
+        let noise2 = ((obs_index * 23) % 7) as f32 / 3.5 - 1.0; // Different noise
+        let hidden_error = input_val * 0.02 + noise1 * 0.3 + noise2 * 0.2;
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_val),
+            input_val,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(0.3),
+            0.3,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-will-be-discounted".to_string(),
+            Some(input_val * 0.2),
+            input_val * 0.2,
+            vec![hidden_error],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-high-impact".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.0], // No error - not our focus
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(input_val * 0.1),
+            input_val * 0.1,
+            vec![hidden_error * 0.1],
+        ));
+    }
+
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write records");
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["hidden-will-be-discounted".to_string()],
+        improvement_threshold: Some(0.01), // Low threshold so raw candidate is found
+        max_candidates: Some(50),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // KEY ASSERTION: The focus neuron must appear in EITHER helpful_neurons OR no_candidate_reasons.
+    // It must NOT silently disappear from the response.
+    let in_helpful = result
+        .helpful_neurons
+        .iter()
+        .any(|c| c.target_neuron_uuid == "hidden-will-be-discounted");
+
+    let in_no_candidate = result
+        .no_candidate_reasons
+        .iter()
+        .any(|r| r.target_uuid == "hidden-will-be-discounted");
+
+    assert!(
+        in_helpful || in_no_candidate,
+        "\n\n\
+        ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+        ║  REGRESSION DETECTED: Focus neuron silently disappeared from response!        ║\n\
+        ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+        ║  'hidden-will-be-discounted' was requested in focus_neurons but appears       ║\n\
+        ║  in NEITHER helpful_neurons NOR no_candidate_reasons.                         ║\n\
+        ║                                                                              ║\n\
+        ║  This happens when:                                                          ║\n\
+        ║  1. A candidate is found → had_candidate = true                              ║\n\
+        ║  2. Impact discounting reduces improvement below 2%                           ║\n\
+        ║  3. Re-filtering removes the candidate                                        ║\n\
+        ║  4. no_candidate_summaries() skips entry (had_candidate == true)              ║\n\
+        ║                                                                              ║\n\
+        ║  Result: Neuron disappears from both lists!                                   ║\n\
+        ║                                                                              ║\n\
+        ║  FIX: After re-filtering, update diagnostics for neurons that lost all        ║\n\
+        ║  candidates to mark them as ImpactDiscountedBelowThreshold.                   ║\n\
+        ║                                                                              ║\n\
+        ║  helpful_neurons: {:?}                                                        \n\
+        ║  no_candidate_reasons: {:?}                                                   \n\
+        ╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+        result
+            .helpful_neurons
+            .iter()
+            .map(|c| &c.target_neuron_uuid)
+            .collect::<Vec<_>>(),
+        result
+            .no_candidate_reasons
+            .iter()
+            .map(|r| &r.target_uuid)
+            .collect::<Vec<_>>()
+    );
+
+    // If it's in no_candidate_reasons, verify the reason is appropriate
+    if in_no_candidate {
+        let reason = result
+            .no_candidate_reasons
+            .iter()
+            .find(|r| r.target_uuid == "hidden-will-be-discounted")
+            .unwrap();
+
+        // It should NOT be HiddenNeuronFiltered (that's a pre-analysis filter)
+        assert!(
+            !matches!(reason.reason, NeuronNoCandidateReason::HiddenNeuronFiltered),
+            "Hidden neuron should have been analysed, not filtered. Got: {:?}",
+            reason.reason
+        );
+
+        eprintln!(
+            "Test passed: hidden-will-be-discounted appears in no_candidate_reasons with reason: {:?}",
+            reason.reason
+        );
+    } else {
+        eprintln!(
+            "Test note: hidden-will-be-discounted appears in helpful_neurons (candidate survived discounting)"
+        );
+    }
+}

--- a/tests/regression_v0_1_123.rs
+++ b/tests/regression_v0_1_123.rs
@@ -1,0 +1,400 @@
+//! REGRESSION TESTS for v0.1.123 fixes
+//!
+//! These tests catch regressions if the v0.1.123 fixes are accidentally reverted.
+//! DO NOT DELETE OR COMMENT OUT THESE TESTS - they protect against known bugs.
+//!
+//! ## Fixes covered:
+//!
+//! 1. **MIN_FALLBACK_IMPROVEMENT (2%)**: Fallback candidates with very low predicted
+//!    improvement (<2%) were causing 100% failure rates because the model's error
+//!    margin (~±0.5%) exceeded the prediction itself.
+//!
+//! 2. **Hidden neuron analysis**: Hidden neurons were filtered out entirely, missing
+//!    valid improvement opportunities. Now they're analysed with impact-based
+//!    discounting.
+//!
+//! If any of these tests fail after a code change, the fix has regressed.
+
+mod common;
+
+use neat_ai_discovery::analysis::{analyze_neurons, NeuronNoCandidateReason};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::TempDir;
+
+/// Skip test if no GPU available (same as other tests)
+macro_rules! skip_without_gpu {
+    () => {
+        if !neat_ai_discovery::analysis::GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: No GPU available");
+            return;
+        }
+    };
+}
+
+/// REGRESSION TEST: Hidden neurons must NOT be filtered from add-neuron analysis.
+///
+/// BUG (fixed in v0.1.123): Hidden neurons were entirely filtered out from
+/// add-neuron analysis due to observed "100% failure rates". This was caused
+/// by the same low-confidence fallback issue. With MIN_FALLBACK_IMPROVEMENT
+/// fixed, hidden neurons can now be analysed with impact-based discounting.
+///
+/// This test verifies that hidden neurons ARE included in analysis.
+/// If this test fails, check that the neuron type filter in
+/// analyze_neurons_with_cache() allows "hidden" neurons through.
+#[test]
+fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
+    skip_without_gpu!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let parquet_file = parquet_path
+        .to_str()
+        .expect("Temporary path should be valid UTF-8")
+        .to_string();
+
+    // Create a creature with BOTH output AND hidden neurons
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            // hidden-0 connects to output-0 with weight 1.0
+            // This gives hidden-0 an impact of 1.0 (direct path to output)
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+            },
+        ],
+    };
+
+    // Create discovery records with correlated errors for both hidden and output
+    let mut records = Vec::new();
+    for obs_index in 0..30u32 {
+        let input_val = (obs_index as f32 - 15.0) / 15.0;
+        let error = input_val * 0.3; // Correlated error
+
+        // Input neuron records
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_val),
+            input_val,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(0.5),
+            0.5,
+            vec![],
+        ));
+
+        // Hidden neuron records (with errors - this is what gets analysed)
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-0".to_string(),
+            Some(input_val * 0.5),
+            (input_val * 0.5_f32).tanh(),
+            vec![error],
+        ));
+
+        // Output neuron records
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(input_val * 0.3),
+            input_val * 0.3,
+            vec![error * 0.5],
+        ));
+    }
+
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write records");
+
+    // Analyse with hidden neuron in focus list
+    let input = AnalyzeNeuronsInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["hidden-0".to_string(), "output-0".to_string()],
+        improvement_threshold: Some(0.01),
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // The key assertion: hidden-0 should NOT have HiddenNeuronFiltered reason
+    let hidden_diagnostic = result
+        .no_candidate_reasons
+        .iter()
+        .find(|d| d.target_uuid == "hidden-0");
+
+    if let Some(diag) = hidden_diagnostic {
+        assert!(
+            !matches!(diag.reason, NeuronNoCandidateReason::HiddenNeuronFiltered),
+            "\n\n\
+            ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+            ║  REGRESSION DETECTED: Hidden neuron filtering has been re-enabled!           ║\n\
+            ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+            ║  Hidden neuron 'hidden-0' was filtered with HiddenNeuronFiltered.            ║\n\
+            ║                                                                              ║\n\
+            ║  This was fixed in v0.1.123. Hidden neurons should be analysed with          ║\n\
+            ║  impact-based discounting, NOT filtered out entirely.                        ║\n\
+            ║                                                                              ║\n\
+            ║  CHECK: analyze_neurons_with_cache() must allow 'hidden' neuron type.        ║\n\
+            ║                                                                              ║\n\
+            ║  Diagnostic: {diag:?}\n\
+            ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
+        );
+    }
+
+    // Hidden-0 either found candidates OR was analysed but found no candidate
+    // (NOT filtered out)
+    let hidden_has_candidates = result
+        .helpful_neurons
+        .iter()
+        .any(|c| c.target_neuron_uuid == "hidden-0");
+
+    let hidden_was_analyzed = hidden_diagnostic
+        .map(|d| !matches!(d.reason, NeuronNoCandidateReason::HiddenNeuronFiltered))
+        .unwrap_or(true); // No diagnostic = was analyzed and found candidates
+
+    assert!(
+        hidden_has_candidates || hidden_was_analyzed,
+        "\n\n\
+        ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+        ║  REGRESSION DETECTED: Hidden neuron appears to be filtered!                  ║\n\
+        ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+        ║  Hidden neuron 'hidden-0' should either:                                     ║\n\
+        ║    - Have candidates returned, OR                                            ║\n\
+        ║    - Have a diagnostic reason OTHER than HiddenNeuronFiltered                ║\n\
+        ║                                                                              ║\n\
+        ║  This was fixed in v0.1.123.                                                 ║\n\
+        ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
+    );
+}
+
+/// REGRESSION TEST: Fallback candidates must meet minimum 2% improvement threshold.
+///
+/// BUG (fixed in v0.1.123): Fallback candidates with very low predicted improvement
+/// (e.g., 0.16%) were returned, but at such low predictions the model's error margin
+/// (~±0.5%) is larger than the prediction itself. This caused actual results to be
+/// NEGATIVE (worse than baseline) while predictions were positive.
+///
+/// This test creates a scenario with weak correlation that would produce low
+/// improvement predictions, and verifies that such weak candidates are NOT returned.
+#[test]
+fn regression_low_improvement_fallback_candidates_must_be_filtered() {
+    skip_without_gpu!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let parquet_file = parquet_path
+        .to_str()
+        .expect("Temporary path should be valid UTF-8")
+        .to_string();
+
+    // Create a simple creature
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![],
+    };
+
+    // Create discovery records with VERY WEAK correlation
+    // This should produce predicted improvements well below 2%
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        let input_val = (obs_index as f32 - 50.0) / 50.0;
+
+        // Very weak correlation: error is mostly noise with tiny signal
+        // This mimics the production scenario where fallback candidates had ~0.16% improvement
+        let noise = ((obs_index * 17) % 11) as f32 / 11.0 - 0.5; // Pseudo-random noise
+        let error = input_val * 0.005 + noise * 0.2; // Very weak signal, lots of noise
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_val),
+            input_val,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(0.5),
+            0.5,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(error),
+            error,
+            vec![error],
+        ));
+    }
+
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write records");
+
+    // Use a very low threshold (1%) - below MIN_FALLBACK_IMPROVEMENT (2%)
+    // If MIN_FALLBACK_IMPROVEMENT is working, weak candidates should still be filtered
+    let input = AnalyzeNeuronsInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.01), // 1% threshold
+        max_candidates: Some(50),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // Check all returned candidates - none should have < 2% improvement
+    for candidate in &result.helpful_neurons {
+        assert!(
+            candidate.expected_improvement_percentage >= 0.02,
+            "\n\n\
+            ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+            ║  REGRESSION DETECTED: Low-confidence fallback candidate returned!            ║\n\
+            ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+            ║  Candidate returned with only {:.2}% expected improvement.                   \n\
+            ║                                                                              ║\n\
+            ║  MIN_FALLBACK_IMPROVEMENT (2%) should have filtered this out.                ║\n\
+            ║  Candidates with < 2% predicted improvement are unreliable because           ║\n\
+            ║  the model's error margin (~±0.5%) exceeds the prediction itself.            ║\n\
+            ║                                                                              ║\n\
+            ║  This was fixed in v0.1.123.                                                 ║\n\
+            ║                                                                              ║\n\
+            ║  CHECK: MIN_FALLBACK_IMPROVEMENT = 0.02 in evaluate_activation_candidate()   ║\n\
+            ║                                                                              ║\n\
+            ║  Candidate: {} -> {} ({})                                                    \n\
+            ╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+            candidate.expected_improvement_percentage * 100.0,
+            candidate.source_neuron_uuid,
+            candidate.target_neuron_uuid,
+            candidate.squash
+        );
+    }
+}
+
+/// REGRESSION TEST: Hidden neuron predictions must be discounted by impact.
+///
+/// This test verifies that hidden neuron predictions are appropriately
+/// discounted based on their impact score (path weight to outputs).
+#[test]
+fn regression_hidden_neuron_predictions_must_be_impact_discounted() {
+    skip_without_gpu!();
+
+    // Verify the impact calculation function exists and works
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-strong".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-weak".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "hidden-strong".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0, // Strong connection
+            },
+            SynapseJson {
+                from_uuid: "hidden-weak".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.1, // Weak connection
+            },
+        ],
+    };
+
+    // Verify impact scores are computed and differ based on connection strength
+    let impacts = neat_ai_discovery::focus::compute_impacts_public(&creature);
+
+    let strong_impact = impacts.get("hidden-strong").copied().unwrap_or(-1.0);
+    let weak_impact = impacts.get("hidden-weak").copied().unwrap_or(-1.0);
+    let output_impact = impacts.get("output-0").copied().unwrap_or(-1.0);
+
+    // Output should have impact = 1.0
+    assert!(
+        (output_impact - 1.0).abs() < 0.01,
+        "\n\n\
+        ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+        ║  REGRESSION DETECTED: Output neuron impact calculation is wrong!             ║\n\
+        ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+        ║  Output neuron should have impact ≈ 1.0, got {output_impact:.3}              \n\
+        ║                                                                              ║\n\
+        ║  CHECK: compute_impacts_public() in focus.rs                                 ║\n\
+        ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
+    );
+
+    // Both hidden neurons should have positive impact
+    assert!(
+        strong_impact > 0.0 && weak_impact > 0.0,
+        "\n\n\
+        ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+        ║  REGRESSION DETECTED: Hidden neuron impact calculation is wrong!             ║\n\
+        ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+        ║  Hidden neurons connected to output should have positive impact.             ║\n\
+        ║  strong_impact = {strong_impact:.3}, weak_impact = {weak_impact:.3}          \n\
+        ║                                                                              ║\n\
+        ║  CHECK: compute_impacts_public() in focus.rs                                 ║\n\
+        ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
+    );
+
+    // Strong connection should have higher impact than weak
+    assert!(
+        strong_impact > weak_impact,
+        "\n\n\
+        ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+        ║  REGRESSION DETECTED: Impact discount not proportional to connection!        ║\n\
+        ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+        ║  hidden-strong (weight=1.0) should have higher impact than                   ║\n\
+        ║  hidden-weak (weight=0.1).                                                   ║\n\
+        ║                                                                              ║\n\
+        ║  strong_impact = {strong_impact:.3}, weak_impact = {weak_impact:.3}          \n\
+        ║                                                                              ║\n\
+        ║  This ensures predictions for hidden neurons far from outputs are            ║\n\
+        ║  appropriately discounted.                                                   ║\n\
+        ║                                                                              ║\n\
+        ║  CHECK: compute_impacts_public() in focus.rs                                 ║\n\
+        ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
+    );
+}

--- a/tests/regression_v0_1_123.rs
+++ b/tests/regression_v0_1_123.rs
@@ -398,3 +398,179 @@ fn regression_hidden_neuron_predictions_must_be_impact_discounted() {
         ╚══════════════════════════════════════════════════════════════════════════════╝\n\n"
     );
 }
+
+/// REGRESSION TEST: Discounted hidden neuron candidates must still meet 2% threshold.
+///
+/// BUG (fixed in v0.1.124): After applying impact-based discounting for hidden neurons,
+/// candidates were not re-filtered against MIN_FALLBACK_IMPROVEMENT (2%). A hidden
+/// neuron with 3% raw improvement and 0.3 impact would be discounted to 0.9%, falling
+/// below the minimum threshold but still returned.
+///
+/// This contradicts the fix for low-confidence fallback candidates - if 2% is the
+/// minimum for reliable predictions, then discounted predictions below 2% are equally
+/// unreliable.
+///
+/// This test creates a hidden neuron with LOW impact that would cause discounting
+/// below 2%, and verifies such candidates are NOT returned.
+#[test]
+fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
+    skip_without_gpu!();
+
+    let temp_dir = TempDir::new().expect("Failed to create temporary directory");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let parquet_file = parquet_path
+        .to_str()
+        .expect("Temporary path should be valid UTF-8")
+        .to_string();
+
+    // Create a creature where hidden-low-impact has LOW impact to output.
+    // Structure: hidden-low-impact (weight 0.1) and hidden-high-impact (weight 0.9) both -> output
+    // hidden-low-impact impact = 0.1 / (0.1 + 0.9) × 1.0 = 0.1
+    //
+    // If analysis produces ~3% raw improvement for hidden-low-impact:
+    // - Raw improvement: 3%
+    // - After 0.1 discount: 0.3%
+    // - This should be filtered (< 2%)
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-low-impact".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-high-impact".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "hidden-low-impact".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.1, // Low weight = low impact
+            },
+            SynapseJson {
+                from_uuid: "hidden-high-impact".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.9, // High weight = high impact
+            },
+        ],
+    };
+
+    // Verify the impact scores first
+    let impacts = neat_ai_discovery::focus::compute_impacts_public(&creature);
+    let low_impact = impacts.get("hidden-low-impact").copied().unwrap_or(0.0);
+    eprintln!("hidden-low-impact has impact score: {low_impact:.3}");
+    assert!(
+        low_impact < 0.2,
+        "Test setup error: hidden-low-impact should have impact < 0.2, got {low_impact:.3}"
+    );
+
+    // Create discovery records with STRONG correlation for hidden-low-impact
+    // This should produce ~3-5% raw improvement prediction (before discount)
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        let input_val = (obs_index as f32 - 50.0) / 50.0; // -1.0 to 1.0
+
+        // Strong linear correlation between input and error at hidden-low-impact
+        let hidden_low_error = input_val * 0.5;
+        let hidden_high_error = 0.0; // No correlation at high-impact hidden
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_val),
+            input_val,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(0.3),
+            0.3,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-low-impact".to_string(),
+            Some(input_val * 0.2),
+            input_val * 0.2,
+            vec![hidden_low_error],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-high-impact".to_string(),
+            Some(0.5),
+            0.5,
+            vec![hidden_high_error],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(input_val * 0.1),
+            input_val * 0.1,
+            vec![hidden_low_error * 0.1], // Small propagated error
+        ));
+    }
+
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write records");
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["hidden-low-impact".to_string()],
+        improvement_threshold: Some(0.01), // 1% threshold (below MIN_FALLBACK_IMPROVEMENT)
+        max_candidates: Some(50),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // KEY ASSERTION: ALL returned candidates must have >= 2% improvement
+    // Even after impact discounting
+    for candidate in &result.helpful_neurons {
+        assert!(
+            candidate.expected_improvement_percentage >= 0.02,
+            "\n\n\
+            ╔══════════════════════════════════════════════════════════════════════════════╗\n\
+            ║  REGRESSION DETECTED: Discounted hidden neuron below MIN_FALLBACK!           ║\n\
+            ╠══════════════════════════════════════════════════════════════════════════════╣\n\
+            ║  Candidate returned with {:.2}% expected improvement (after discount).       \n\
+            ║                                                                              ║\n\
+            ║  This hidden neuron candidate was discounted by impact but NOT re-filtered   ║\n\
+            ║  against MIN_FALLBACK_IMPROVEMENT (2%).                                      ║\n\
+            ║                                                                              ║\n\
+            ║  If 2% is the minimum for reliable predictions, then discounted predictions  ║\n\
+            ║  below 2% are equally unreliable.                                            ║\n\
+            ║                                                                              ║\n\
+            ║  This was fixed in v0.1.124.                                                 ║\n\
+            ║                                                                              ║\n\
+            ║  CHECK: After impact discounting, re-filter against MIN_FALLBACK_IMPROVEMENT ║\n\
+            ║                                                                              ║\n\
+            ║  Candidate: {} -> {} ({})                                                    \n\
+            ║  Target neuron type: hidden (impact: {:.3})                                  \n\
+            ╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+            candidate.expected_improvement_percentage * 100.0,
+            candidate.source_neuron_uuid,
+            candidate.target_neuron_uuid,
+            candidate.squash,
+            low_impact
+        );
+    }
+
+    eprintln!(
+        "Test passed: {} candidates returned, all >= 2% after discounting",
+        result.helpful_neurons.len()
+    );
+}


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.123 to 0.1.124.
- Implement support for analyzing hidden neurons in add-neuron analysis, allowing them to be valid targets with impact-based discounting.
- Introduce a public version of the compute_impacts function for use in neuron analysis.
- Add regression tests to ensure hidden neurons are analyzed correctly and their predictions are discounted based on impact scores.

These changes improve the analysis framework's ability to handle hidden neurons, enhancing overall prediction accuracy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows hidden neurons as add-neuron targets with impact-based discounting and re-filtering, adds new diagnostic reasons, exposes impact API, updates docs/tests, and bumps version to 0.1.125.
> 
> - **Analysis (add-neuron)**:
>   - Hidden neurons are now valid targets; apply impact-based discounting via `focus::compute_impacts_public()`.
>   - Re-filter discounted candidates against `MIN_FALLBACK_IMPROVEMENT` (2%).
>   - Filter `input` and `constant` targets; skip constants explicitly.
> - **Diagnostics**:
>   - New reasons: `ConstantNeuronFiltered`, `ImpactDiscountedBelowThreshold`.
>   - Ensure focus neurons that lose all candidates after discounting appear in `no_candidate_reasons`.
>   - Improved verbose logging and accurate classification for filtered targets.
> - **API**:
>   - Expose `compute_impacts_public()` in `focus` for analysis use.
>   - Map new diagnostics in public JSON types.
> - **Tests/Docs**:
>   - Add extensive regression/integration tests for hidden-neuron analysis, impact discounting, and thresholds.
>   - README expanded (hidden neuron behavior, testing philosophy, CI usage) and test command examples.
> - **Version**:
>   - Bump `Cargo.toml` to `0.1.125`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c76b0affa43991cafaf28d0a9e16d466ee10c82b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->