### PR TITLE
Update version to 0.1.128 and refine neuron removal criteria

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.127"
+version = "0.1.128"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -564,26 +564,29 @@ const complexityPenalty = hiddenNeuronCount * growthCost +
 savings = growthCost × (1 + (N + M) / 10)
 ```
 
-**The fix**: The threshold is calculated as `savings × SCALE_FACTOR` where
-SCALE_FACTOR=100 accounts for uncertainty in the impact calculation:
+**The fix**: A neuron is a removal candidate when its contribution to output
+is less than the complexity savings from removing it:
 
-| Synapses (in + out) | Savings | Threshold (×100) |
-|---------------------|---------|------------------|
-| 0 | `1.0e-7` | `1.0e-5` |
-| 2 | `1.2e-7` | `1.2e-5` |
-| 5 | `1.5e-7` | `1.5e-5` |
-| 10 | `2.0e-7` | `2.0e-5` |
-| 20 | `3.0e-7` | `3.0e-5` |
+```
+activation_weighted_impact < savings
+```
 
-**Why the scale factor?** The impact calculation `structural_impact × mean_activation`
-is an approximation that doesn't capture:
-1. Correlation between neuron activation and error (may be positive or negative)
-2. Partial cancellation when multiple paths exist
-3. Saturation effects in downstream squash functions
+Where:
+- `activation_weighted_impact = structural_impact × mean_activation`
+  (the neuron's contribution to output, diluted by distance from output)
+- `savings = growthCost × (1 + (N + M) / 10)`
+  (from NEAT-AI's Score.ts complexity formula)
 
-The scale factor finds meaningful candidates while maintaining the synapse-based
-relationship: neurons with more synapses get a higher threshold because removing
-them saves more complexity.
+| Synapses (in + out) | Savings |
+|---------------------|---------|
+| 0 | `1.0e-7` |
+| 2 | `1.2e-7` |
+| 5 | `1.5e-7` |
+| 10 | `2.0e-7` |
+| 20 | `3.0e-7` |
+
+This is the mathematically correct criterion: if a neuron's effect on output is
+smaller than the complexity cost of keeping it, removing improves the score.
 
 **Removal candidate JSON response** now includes:
 - `incomingSynapses` / `outgoingSynapses`: synapse counts used in calculation

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -392,46 +392,49 @@ pub fn rank_focus_neurons(
             .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
     });
 
-    // Identify removal candidates: neurons where the contribution is small enough
-    // that removing saves more complexity than it hurts accuracy.
+    // Identify removal candidates: neurons where the contribution to output is less
+    // than the complexity savings from removing them.
     //
     // Based on NEAT-AI's Score.ts formula:
+    //   score = error + complexityPenalty
     //   complexityPenalty = hiddenNeuronCount × growthCost +
     //                       synapseCount × growthCost / 10 +
     //                       penalty × growthCost / 100
     //
-    // So removing a neuron with N incoming and M outgoing synapses saves:
+    // Removing a neuron with N incoming and M outgoing synapses saves:
     //   savings = growthCost × (1 + (N + M) / 10)
     //
-    // THRESHOLD SCALING: The raw savings value (1e-7 range) is too conservative
-    // because our impact calculation has inherent uncertainty. The impact formula
-    // `structural_impact × mean_activation` is an approximation - it assumes:
-    // - The neuron's activation is always in the same direction relative to error
-    // - The path weights capture the full effect on output
+    // A neuron is a removal candidate when:
+    //   activation_weighted_impact < savings
     //
-    // In practice, a neuron with activation_weighted_impact up to ~100× the savings
-    // may still be safe to remove because:
-    // 1. The actual contribution depends on correlation with error (not captured)
-    // 2. Multiple paths may partially cancel each other
-    // 3. The activation may be in a saturated region of downstream squash functions
+    // Where activation_weighted_impact = structural_impact × mean_activation
+    // represents the neuron's contribution to output (diluted by distance from output).
     //
-    // The scale factor is calibrated to find candidates while maintaining a good
-    // success rate. With scale=100, the threshold for a neuron with 2 synapses is:
-    //   1.2e-7 × 100 = 1.2e-5 (0.0012% contribution)
-    //
-    // This maintains the synapse-based relationship (more synapses = higher threshold)
-    // while finding meaningful candidates.
+    // This is the mathematically correct criterion: if the neuron's effect on output
+    // is smaller than the complexity cost of keeping it, removing improves score.
     const COST_OF_GROWTH: f32 = 1e-7;
-    const SCALE_FACTOR: f32 = 100.0;
+
+    // Track statistics for verbose logging
+    let mut min_impact: f32 = f32::MAX;
+    let mut max_impact: f32 = f32::MIN;
+    let mut min_impact_uuid = String::new();
 
     let mut removal_candidates: Vec<RemovalCandidate> = neurons
         .iter()
         .filter_map(|n| {
             let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
             let savings = calculate_removal_savings(incoming, outgoing, COST_OF_GROWTH);
-            let threshold = savings * SCALE_FACTOR;
 
-            if n.activation_weighted_impact < threshold {
+            // Track min/max for verbose logging
+            if n.activation_weighted_impact < min_impact {
+                min_impact = n.activation_weighted_impact;
+                min_impact_uuid = n.neuron_uuid.clone();
+            }
+            if n.activation_weighted_impact > max_impact {
+                max_impact = n.activation_weighted_impact;
+            }
+
+            if n.activation_weighted_impact < savings {
                 Some(RemovalCandidate {
                     neuron_uuid: n.neuron_uuid.clone(),
                     total_error: n.total_error,
@@ -442,8 +445,8 @@ pub fn rank_focus_neurons(
                     outgoing_synapses: outgoing,
                     removal_savings: savings,
                     reason: format!(
-                        "Activation-weighted impact ({:.2e}) < threshold ({:.2e}) from {} synapses - removal likely improves score",
-                        n.activation_weighted_impact, threshold, incoming + outgoing
+                        "Activation-weighted impact ({:.2e}) < removal savings ({:.2e}) for {} synapses - removal improves score",
+                        n.activation_weighted_impact, savings, incoming + outgoing
                     ),
                 })
             } else {
@@ -451,6 +454,22 @@ pub fn rank_focus_neurons(
             }
         })
         .collect();
+
+    // Verbose logging to help debug removal candidate detection
+    if std::env::var("NEAT_AI_DISCOVERY_VERBOSE").is_ok() && !neurons.is_empty() {
+        let typical_savings = COST_OF_GROWTH * 1.5; // ~15 synapses
+        eprintln!(
+            "[NEAT-AI-Discovery][verbose] Removal candidate check: {} neurons, impact range [{:.2e}, {:.2e}], \
+             typical savings threshold {:.2e}, found {} candidates. Lowest impact: {} ({:.2e})",
+            neurons.len(),
+            min_impact,
+            max_impact,
+            typical_savings,
+            removal_candidates.len(),
+            min_impact_uuid,
+            min_impact
+        );
+    }
 
     // Sort by (impact - savings) ascending: most beneficial removals first
     // Lower values = bigger gap between savings and impact = safer to remove

--- a/tests/focus.rs
+++ b/tests/focus.rs
@@ -553,20 +553,25 @@ fn test_negligible_impact_neurons_are_removal_candidates_regardless_of_error() {
 
 #[test]
 fn test_activation_weighted_impact_prevents_false_removal_candidates() {
-    // Scenario: A neuron with low STRUCTURAL impact but HIGH activation should NOT be
+    // Scenario: A neuron with moderate STRUCTURAL impact and HIGH activation should NOT be
     // a removal candidate because actual_contribution ≈ weight × activation.
     //
-    // This test prevents regression on the bug where neurons with tiny weights but
-    // massive activations were incorrectly flagged for removal.
+    // This test verifies that activation-weighted impact (not just structural impact)
+    // determines removal candidates.
     //
-    // Network: input-0 -> high-activation (tiny weight 1e-9) -> output-0
+    // Network: input-0 -> high-activation -> output-0
     //
     // high-activation has:
-    // - Structural impact: 1e-9 (below costOfGrowth 1e-7)
-    // - Mean activation: 1e6 (very high!)
-    // - Activation-weighted impact: 1e-9 × 1e6 = 1e-3 (ABOVE costOfGrowth)
+    // - Structural impact: 1e-6 (small weight to output)
+    // - Mean activation: 1e5 (very high!)
+    // - Activation-weighted impact: 1e-6 × 1e5 = 0.1 (10% - well above threshold)
     //
-    // So it should NOT be a removal candidate.
+    // With SCALE_FACTOR=1e5, threshold for 1 synapse = 1.1e-7 × 1e5 = 0.011 (1.1%)
+    // 10% > 1.1%, so it should NOT be a removal candidate.
+    //
+    // low-activation has same weight but tiny activation:
+    // - Activation-weighted impact: 1e-6 × 1e-9 = 1e-15 (way below threshold)
+    // So it SHOULD be a removal candidate.
     let creature = create_creature(
         vec![
             ("input-0", "input"),
@@ -577,20 +582,20 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         vec![
             ("input-0", "high-activation", 1.0),
             ("input-0", "low-activation", 1.0),
-            // Both have tiny structural paths to output
-            ("high-activation", "output-0", 1e-9),
-            ("low-activation", "output-0", 1e-9),
+            // Both have small structural paths to output
+            ("high-activation", "output-0", 1e-6),
+            ("low-activation", "output-0", 1e-6),
         ],
     );
 
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    // high-activation: tiny structural impact BUT massive activation → NOT removal candidate
-    // low-activation: tiny structural impact AND tiny activation → IS removal candidate
+    // high-activation: small structural impact BUT massive activation → NOT removal candidate
+    // low-activation: small structural impact AND tiny activation → IS removal candidate
     let records = create_records_with_activation(vec![
-        ("high-activation", 0.1, 1e6), // High activation → not safe to remove
-        ("low-activation", 0.1, 1e-9), // Low activation → safe to remove
+        ("high-activation", 0.1, 1e5), // High activation → contribution 10% → not safe to remove
+        ("low-activation", 0.1, 1e-9), // Low activation → contribution ~0% → safe to remove
         ("output-0", 0.5, 0.5),
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
@@ -604,13 +609,14 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         .find(|n| n.neuron_uuid == "high-activation")
         .expect("high-activation should be in results");
     assert!(
-        high_act.mean_activation > 1e5,
+        high_act.mean_activation > 1e4,
         "high-activation should have high mean_activation, got {}",
         high_act.mean_activation
     );
+    // Activation-weighted impact should be ~0.1 (10%)
     assert!(
-        high_act.activation_weighted_impact > 1e-7,
-        "high-activation should have activation_weighted_impact > costOfGrowth, got {}",
+        high_act.activation_weighted_impact > 0.01,
+        "high-activation should have activation_weighted_impact > 1% (threshold), got {}",
         high_act.activation_weighted_impact
     );
 
@@ -621,7 +627,7 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         .find(|c| c.neuron_uuid == "high-activation");
     assert!(
         high_act_removal.is_none(),
-        "high-activation should NOT be a removal candidate because activation-weighted impact ({}) > costOfGrowth",
+        "high-activation should NOT be a removal candidate because activation-weighted impact ({:.4}) > threshold (~1%)",
         high_act.activation_weighted_impact
     );
 
@@ -637,8 +643,8 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         low_act.mean_activation
     );
     assert!(
-        low_act.activation_weighted_impact < 1e-7,
-        "low-activation should have activation_weighted_impact < costOfGrowth, got {}",
+        low_act.activation_weighted_impact < 1e-10,
+        "low-activation should have activation_weighted_impact << threshold, got {}",
         low_act.activation_weighted_impact
     );
 
@@ -649,7 +655,7 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         .find(|c| c.neuron_uuid == "low-activation");
     assert!(
         low_act_removal.is_some(),
-        "low-activation SHOULD be a removal candidate because activation-weighted impact ({}) < costOfGrowth. \
+        "low-activation SHOULD be a removal candidate because activation-weighted impact ({:.2e}) << threshold. \
          Removal candidates: {:?}",
         low_act.activation_weighted_impact,
         result.removal_candidates.iter().map(|c| &c.neuron_uuid).collect::<Vec<_>>()

--- a/tests/regression_v0_1_126.rs
+++ b/tests/regression_v0_1_126.rs
@@ -238,17 +238,19 @@ fn regression_many_competing_inputs_must_not_suppress_impact() {
     );
 }
 
-/// REGRESSION TEST: Removal candidates must be found for neurons with low contribution.
+/// REGRESSION TEST: Removal candidates must be found for neurons with negligible contribution.
 ///
-/// The dynamic threshold is based on NEAT-AI's Score.ts formula with a scale factor:
-///   savings = growthCost × (1 + (incoming + outgoing) / 10)
-///   threshold = savings × SCALE_FACTOR (currently 100)
+/// A neuron is a removal candidate when its contribution to output is less than the
+/// complexity savings from removing it:
+///
+///   activation_weighted_impact < savings
+///
+/// Where savings = growthCost × (1 + (incoming + outgoing) / 10)
 ///
 /// For a neuron with 1 outgoing synapse:
 ///   savings = 1e-7 × (1 + 1/10) = 1.1e-7
-///   threshold = 1.1e-7 × 100 = 1.1e-5
 ///
-/// Removal candidate when: activation_weighted_impact < threshold
+/// Removal candidate when: activation_weighted_impact < 1.1e-7
 #[test]
 fn regression_removal_candidates_found_for_negligible_neurons() {
     use neat_ai_discovery::focus::rank_focus_neurons;
@@ -256,24 +258,23 @@ fn regression_removal_candidates_found_for_negligible_neurons() {
     use neat_ai_discovery::types::DiscoverRecord;
     use tempfile::NamedTempFile;
 
-    // Network with a neuron that has small weights:
-    //   low-impact → output-0 (weight 1e-5)
+    // Network with a neuron that has TRULY negligible weights:
+    //   negligible → output-0 (weight 1e-8)
     //
-    // Structural impact = 1e-5 × 1.0 = 1e-5
+    // Structural impact = 1e-8 × 1.0 = 1e-8
     // With mean_activation = 0.5:
-    //   activation_weighted_impact = 1e-5 × 0.5 = 5e-6
+    //   activation_weighted_impact = 1e-8 × 0.5 = 5e-9
     //
     // Synapse count: 0 incoming, 1 outgoing
     // Removal savings = 1e-7 × (1 + 1/10) = 1.1e-7
-    // Threshold = 1.1e-7 × 100 = 1.1e-5
     //
-    // 5e-6 < 1.1e-5 ✓ (should be a removal candidate)
+    // 5e-9 < 1.1e-7 ✓ (contribution < savings, so removal improves score)
     let creature = CreatureJson {
         input: 1,
         output: 1,
         neurons: vec![
             NeuronJson {
-                uuid: "low-impact".to_string(),
+                uuid: "negligible".to_string(),
                 neuron_type: "hidden".to_string(),
                 squash: "IDENTITY".to_string(),
                 bias: 0.0,
@@ -286,9 +287,9 @@ fn regression_removal_candidates_found_for_negligible_neurons() {
             },
         ],
         synapses: vec![SynapseJson {
-            from_uuid: "low-impact".to_string(),
+            from_uuid: "negligible".to_string(),
             to_uuid: "output-0".to_string(),
-            weight: 1e-5, // Small weight - 0.001% contribution
+            weight: 1e-8, // Truly negligible weight
         }],
     };
 
@@ -297,8 +298,8 @@ fn regression_removal_candidates_found_for_negligible_neurons() {
 
     // Create records with typical activation (0.5)
     let records = vec![
-        DiscoverRecord::new(0, "low-impact".to_string(), Some(0.5), 0.5, vec![0.1]),
-        DiscoverRecord::new(1, "low-impact".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(0, "negligible".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(1, "negligible".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
     ];
@@ -307,58 +308,58 @@ fn regression_removal_candidates_found_for_negligible_neurons() {
     let result = rank_focus_neurons(file_path, &creature, None).unwrap();
 
     // Verify the impact calculation is correct (absolute weights)
-    let low_impact_neuron = result
+    let negligible_neuron = result
         .neurons
         .iter()
-        .find(|n| n.neuron_uuid == "low-impact")
-        .expect("low-impact neuron should be in results");
+        .find(|n| n.neuron_uuid == "negligible")
+        .expect("negligible neuron should be in results");
 
     assert!(
-        (low_impact_neuron.impact - 1e-5).abs() < 1e-6,
-        "Impact should be ~1e-5 (absolute weight), got {}",
-        low_impact_neuron.impact
+        (negligible_neuron.impact - 1e-8).abs() < 1e-9,
+        "Impact should be ~1e-8 (absolute weight), got {}",
+        negligible_neuron.impact
     );
 
-    // Verify activation_weighted_impact = impact × activation = 1e-5 × 0.5 = 5e-6
+    // Verify activation_weighted_impact = impact × activation = 1e-8 × 0.5 = 5e-9
     assert!(
-        (low_impact_neuron.activation_weighted_impact - 5e-6).abs() < 1e-6,
-        "activation_weighted_impact should be ~5e-6, got {}",
-        low_impact_neuron.activation_weighted_impact
+        (negligible_neuron.activation_weighted_impact - 5e-9).abs() < 1e-9,
+        "activation_weighted_impact should be ~5e-9, got {}",
+        negligible_neuron.activation_weighted_impact
     );
 
     // CRITICAL: This neuron should be a removal candidate.
     //
-    // Dynamic threshold (v0.1.127):
+    // Clean criterion (no scale factor):
     //   - 0 incoming synapses, 1 outgoing synapse
     //   - savings = 1e-7 × (1 + 1/10) = 1.1e-7
-    //   - threshold = 1.1e-7 × 100 = 1.1e-5
-    //   - activation_weighted_impact = 5e-6 < 1.1e-5 ✓
+    //   - activation_weighted_impact = 5e-9 < 1.1e-7 ✓
+    //   - Contribution is smaller than complexity cost, so removal improves score
     let removal = result
         .removal_candidates
         .iter()
-        .find(|c| c.neuron_uuid == "low-impact");
+        .find(|c| c.neuron_uuid == "negligible");
 
     assert!(
         removal.is_some(),
         "\n\n\
         ╔══════════════════════════════════════════════════════════════════════════════════╗\n\
-        ║  REGRESSION: No removal candidates found for neuron with low contribution!        ║\n\
+        ║  REGRESSION: No removal candidates found for neuron with negligible contribution! ║\n\
         ╠══════════════════════════════════════════════════════════════════════════════════╣\n\
-        ║  Neuron 'low-impact' has:                                                         \n\
+        ║  Neuron 'negligible' has:                                                         \n\
         ║    - structural_impact = {:.2e}                                                   \n\
         ║    - mean_activation = {:.2}                                                      \n\
         ║    - activation_weighted_impact = {:.2e}                                          \n\
         ║                                                                                   ║\n\
-        ║  Dynamic threshold (0 in + 1 out synapse):                                        ║\n\
+        ║  Clean criterion (0 in + 1 out synapse):                                          ║\n\
         ║    savings = 1e-7 × 1.1 = 1.1e-7                                                  ║\n\
-        ║    threshold = savings × 100 = 1.1e-5                                             ║\n\
-        ║    activation_weighted_impact (5e-6) < threshold (1.1e-5) should pass             ║\n\
+        ║    activation_weighted_impact ({:.2e}) < savings (1.1e-7) should pass             ║\n\
         ║                                                                                   ║\n\
         ║  Found {} removal candidates: {:?}                                                \n\
         ╚══════════════════════════════════════════════════════════════════════════════════╝\n\n",
-        low_impact_neuron.impact,
-        low_impact_neuron.mean_activation,
-        low_impact_neuron.activation_weighted_impact,
+        negligible_neuron.impact,
+        negligible_neuron.mean_activation,
+        negligible_neuron.activation_weighted_impact,
+        negligible_neuron.activation_weighted_impact,
         result.removal_candidates.len(),
         result
             .removal_candidates

--- a/tests/regression_v0_1_127.rs
+++ b/tests/regression_v0_1_127.rs
@@ -106,23 +106,22 @@ fn test_more_synapses_means_higher_threshold() {
     );
 }
 
-/// REGRESSION TEST: Removal candidates must use dynamic threshold based on synapse count.
+/// REGRESSION TEST: Removal candidates must use dynamic savings based on synapse count.
 ///
-/// A neuron with many synapses saves more complexity when removed, so it can have
-/// higher activation_weighted_impact and still be a valid removal candidate.
+/// A neuron with many synapses saves more complexity when removed.
+/// The criterion is: activation_weighted_impact < savings (no scale factor).
 #[test]
 fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     // Network with two neurons having different synapse counts:
     //
-    // few-synapses: 1 incoming, 1 outgoing
-    //   input-0 -> few-synapses -> output-0
+    // few-synapses: 1 incoming, 1 outgoing (2 total)
     //   savings = growthCost × (1 + 2/10) = 1.2e-7
-    //   threshold = 1.2e-7 × 100 = 1.2e-5
     //
-    // many-synapses: 3 incoming, 2 outgoing
-    //   input-0, input-1, input-2 -> many-synapses -> output-0, output-1
+    // many-synapses: 3 incoming, 2 outgoing (5 total)
     //   savings = growthCost × (1 + 5/10) = 1.5e-7
-    //   threshold = 1.5e-7 × 100 = 1.5e-5
+    //
+    // To be a removal candidate: activation_weighted_impact < savings
+    // Using tiny weights (1e-8) so both neurons qualify as candidates.
     let creature = CreatureJson {
         input: 3,
         output: 2,
@@ -157,38 +156,38 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
             SynapseJson {
                 from_uuid: "input-0".to_string(),
                 to_uuid: "few-synapses".to_string(),
-                weight: 1e-6, // Very small weight
+                weight: 1e-8, // Tiny weight so contribution < savings
             },
             SynapseJson {
                 from_uuid: "few-synapses".to_string(),
                 to_uuid: "output-0".to_string(),
-                weight: 1e-6, // Very small weight
+                weight: 1e-8,
             },
             // many-synapses: 3 in, 2 out
             SynapseJson {
                 from_uuid: "input-0".to_string(),
                 to_uuid: "many-synapses".to_string(),
-                weight: 1e-6,
+                weight: 1e-8,
             },
             SynapseJson {
                 from_uuid: "input-1".to_string(),
                 to_uuid: "many-synapses".to_string(),
-                weight: 1e-6,
+                weight: 1e-8,
             },
             SynapseJson {
                 from_uuid: "input-2".to_string(),
                 to_uuid: "many-synapses".to_string(),
-                weight: 1e-6,
+                weight: 1e-8,
             },
             SynapseJson {
                 from_uuid: "many-synapses".to_string(),
                 to_uuid: "output-0".to_string(),
-                weight: 1e-6,
+                weight: 1e-8,
             },
             SynapseJson {
                 from_uuid: "many-synapses".to_string(),
                 to_uuid: "output-1".to_string(),
-                weight: 1e-6,
+                weight: 1e-8,
             },
         ],
     };
@@ -256,9 +255,9 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
         ║    - impact = {:.2e}                                                              \n\
         ║    - activation_weighted_impact = {:.2e}                                          \n\
         ║                                                                                   ║\n\
-        ║  Dynamic threshold (1 in + 1 out = 2 synapses):                                   ║\n\
+        ║  Criterion (1 in + 1 out = 2 synapses):                                           ║\n\
         ║    savings = 1e-7 × 1.2 = 1.2e-7                                                  ║\n\
-        ║    threshold = savings × 100 = 1.2e-5                                             ║\n\
+        ║    activation_weighted_impact < savings should pass                               ║\n\
         ║                                                                                   ║\n\
         ║  Found {} candidates: {:?}                                                        \n\
         ╚══════════════════════════════════════════════════════════════════════════════════╝\n\n",
@@ -282,9 +281,9 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
         ║    - impact = {:.2e}                                                              \n\
         ║    - activation_weighted_impact = {:.2e}                                          \n\
         ║                                                                                   ║\n\
-        ║  Dynamic threshold (3 in + 2 out = 5 synapses):                                   ║\n\
+        ║  Criterion (3 in + 2 out = 5 synapses):                                           ║\n\
         ║    savings = 1e-7 × 1.5 = 1.5e-7                                                  ║\n\
-        ║    threshold = savings × 100 = 1.5e-5                                             ║\n\
+        ║    activation_weighted_impact < savings should pass                               ║\n\
         ║                                                                                   ║\n\
         ║  Found {} candidates: {:?}                                                        \n\
         ╚══════════════════════════════════════════════════════════════════════════════════╝\n\n",


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.127 to 0.1.128.
- Update README to clarify the new criterion for identifying neuron removal candidates based on activation-weighted impact compared to complexity savings.
- Modify the focus.rs logic to implement the refined removal candidate detection, ensuring that neurons are only flagged for removal when their contribution to output is less than the savings from their removal.
- Enhance regression tests to validate the new removal criteria and ensure accurate identification of neurons with negligible contributions.

These changes improve the accuracy of neuron removal decisions, enhancing the overall performance of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch neuron removal detection to `activation_weighted_impact < savings` (no scale factor), add verbose logging, update tests/docs, and bump to 0.1.128.
> 
> - **Focus/removal logic**:
>   - Replace threshold with direct comparison: `activation_weighted_impact < savings` using `calculate_removal_savings()`; remove scale factor and update candidate reason text.
>   - Add verbose logging of impact range and candidate counts when `NEAT_AI_DISCOVERY_VERBOSE=1`.
> - **Tests**:
>   - Update/regression tests to validate savings-based criterion, dynamic synapse-based savings, and activation-weighted impact behavior; adjust weights/names and assertions accordingly.
>   - Ensure removal candidates include correct synapse counts and `removal_savings`, and verify sorting.
> - **Docs**:
>   - README clarifies the mathematically correct removal criterion and provides savings table (no scale factor).
> - **Version**:
>   - Bump `Cargo.toml` to `0.1.128`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc6051f7aba956b789c5b15fb0f39f790987f622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->