### PR TITLE
Update version to 0.1.129 and refine neuron removal criteria

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.128"
+version = "0.1.129"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -565,10 +565,19 @@ savings = growthCost × (1 + (N + M) / 10)
 ```
 
 **The fix**: A neuron is a removal candidate when its contribution to output
-is less than the complexity savings from removing it:
+is small enough that removing it likely improves score.
+
+**Unit conversion**: `activation_weighted_impact` is in OUTPUT units (contribution
+to output), while `savings` is in SCORE units (error + complexity). For MSE error,
+a contribution `c` to output can increase error by at most `c²`. So:
 
 ```
-activation_weighted_impact < savings
+c² < savings  →  c < sqrt(savings)
+```
+
+A neuron is a removal candidate when:
+```
+activation_weighted_impact < sqrt(savings)
 ```
 
 Where:
@@ -577,16 +586,17 @@ Where:
 - `savings = growthCost × (1 + (N + M) / 10)`
   (from NEAT-AI's Score.ts complexity formula)
 
-| Synapses (in + out) | Savings |
-|---------------------|---------|
-| 0 | `1.0e-7` |
-| 2 | `1.2e-7` |
-| 5 | `1.5e-7` |
-| 10 | `2.0e-7` |
-| 20 | `3.0e-7` |
+| Synapses (in + out) | Savings | Threshold (sqrt) |
+|---------------------|---------|------------------|
+| 0 | `1.0e-7` | `3.2e-4` (0.03%) |
+| 2 | `1.2e-7` | `3.5e-4` (0.035%) |
+| 5 | `1.5e-7` | `3.9e-4` (0.039%) |
+| 10 | `2.0e-7` | `4.5e-4` (0.045%) |
+| 20 | `3.0e-7` | `5.5e-4` (0.055%) |
 
-This is the mathematically correct criterion: if a neuron's effect on output is
-smaller than the complexity cost of keeping it, removing improves the score.
+This catches neurons contributing less than ~0.04% to output, which with MSE error
+would contribute less than `(0.0004)² ≈ 1.6e-7` to error - comparable to the
+complexity savings from removal.
 
 **Removal candidate JSON response** now includes:
 - `incomingSynapses` / `outgoingSynapses`: synapse counts used in calculation

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -392,8 +392,7 @@ pub fn rank_focus_neurons(
             .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
     });
 
-    // Identify removal candidates: neurons where the contribution to output is less
-    // than the complexity savings from removing them.
+    // Identify removal candidates: neurons where removing them likely improves score.
     //
     // Based on NEAT-AI's Score.ts formula:
     //   score = error + complexityPenalty
@@ -404,14 +403,17 @@ pub fn rank_focus_neurons(
     // Removing a neuron with N incoming and M outgoing synapses saves:
     //   savings = growthCost × (1 + (N + M) / 10)
     //
+    // UNIT CONVERSION: activation_weighted_impact is in OUTPUT units (contribution to
+    // output), while savings is in SCORE units (error + complexity). For MSE error,
+    // a contribution `c` to output can increase error by at most `c²`. So:
+    //
+    //   c² < savings  →  c < sqrt(savings)
+    //
     // A neuron is a removal candidate when:
-    //   activation_weighted_impact < savings
+    //   activation_weighted_impact < sqrt(savings)
     //
-    // Where activation_weighted_impact = structural_impact × mean_activation
-    // represents the neuron's contribution to output (diluted by distance from output).
-    //
-    // This is the mathematically correct criterion: if the neuron's effect on output
-    // is smaller than the complexity cost of keeping it, removing improves score.
+    // For savings ≈ 1.5e-7 (typical), threshold = sqrt(1.5e-7) ≈ 4e-4 (0.04%)
+    // This catches neurons contributing less than 0.04% to output.
     const COST_OF_GROWTH: f32 = 1e-7;
 
     // Track statistics for verbose logging
@@ -434,7 +436,10 @@ pub fn rank_focus_neurons(
                 max_impact = n.activation_weighted_impact;
             }
 
-            if n.activation_weighted_impact < savings {
+            // Use sqrt(savings) as threshold to account for MSE error relationship
+            let threshold = savings.sqrt();
+
+            if n.activation_weighted_impact < threshold {
                 Some(RemovalCandidate {
                     neuron_uuid: n.neuron_uuid.clone(),
                     total_error: n.total_error,
@@ -445,8 +450,8 @@ pub fn rank_focus_neurons(
                     outgoing_synapses: outgoing,
                     removal_savings: savings,
                     reason: format!(
-                        "Activation-weighted impact ({:.2e}) < removal savings ({:.2e}) for {} synapses - removal improves score",
-                        n.activation_weighted_impact, savings, incoming + outgoing
+                        "Activation-weighted impact ({:.2e}) < threshold ({:.2e}) for {} synapses - removal likely improves score",
+                        n.activation_weighted_impact, threshold, incoming + outgoing
                     ),
                 })
             } else {
@@ -458,13 +463,15 @@ pub fn rank_focus_neurons(
     // Verbose logging to help debug removal candidate detection
     if std::env::var("NEAT_AI_DISCOVERY_VERBOSE").is_ok() && !neurons.is_empty() {
         let typical_savings = COST_OF_GROWTH * 1.5; // ~15 synapses
+        let typical_threshold = typical_savings.sqrt();
         eprintln!(
             "[NEAT-AI-Discovery][verbose] Removal candidate check: {} neurons, impact range [{:.2e}, {:.2e}], \
-             typical savings threshold {:.2e}, found {} candidates. Lowest impact: {} ({:.2e})",
+             threshold sqrt({:.2e})={:.2e}, found {} candidates. Lowest impact: {} ({:.2e})",
             neurons.len(),
             min_impact,
             max_impact,
             typical_savings,
+            typical_threshold,
             removal_candidates.len(),
             min_impact_uuid,
             min_impact

--- a/tests/regression_v0_1_127.rs
+++ b/tests/regression_v0_1_127.rs
@@ -1,6 +1,6 @@
-//! REGRESSION TESTS for v0.1.127 fixes
+//! REGRESSION TESTS for v0.1.127+ fixes
 //!
-//! These tests catch regressions if the v0.1.127 fixes are accidentally reverted.
+//! These tests catch regressions if the v0.1.127+ fixes are accidentally reverted.
 //! DO NOT DELETE OR COMMENT OUT THESE TESTS - they protect against known bugs.
 //!
 //! ## Fixes covered:
@@ -20,7 +20,15 @@
 //!    savings = growthCost × (1 + (N + M) / 10)
 //!    ```
 //!
-//!    Removal is beneficial when: activation_weighted_impact < savings × SCALE_FACTOR
+//! 2. **Unit conversion via sqrt**: activation_weighted_impact is in OUTPUT units,
+//!    while savings is in SCORE units (error + complexity). For MSE error, a
+//!    contribution c to output increases error by c². So:
+//!
+//!    ```
+//!    c² < savings  →  c < sqrt(savings)
+//!    ```
+//!
+//!    Removal is beneficial when: activation_weighted_impact < sqrt(savings)
 //!
 //! If any of these tests fail after a code change, the fix has regressed.
 
@@ -109,18 +117,20 @@ fn test_more_synapses_means_higher_threshold() {
 /// REGRESSION TEST: Removal candidates must use dynamic savings based on synapse count.
 ///
 /// A neuron with many synapses saves more complexity when removed.
-/// The criterion is: activation_weighted_impact < savings (no scale factor).
+/// The criterion is: activation_weighted_impact < sqrt(savings).
 #[test]
 fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     // Network with two neurons having different synapse counts:
     //
     // few-synapses: 1 incoming, 1 outgoing (2 total)
     //   savings = growthCost × (1 + 2/10) = 1.2e-7
+    //   threshold = sqrt(1.2e-7) ≈ 3.5e-4
     //
     // many-synapses: 3 incoming, 2 outgoing (5 total)
     //   savings = growthCost × (1 + 5/10) = 1.5e-7
+    //   threshold = sqrt(1.5e-7) ≈ 3.9e-4
     //
-    // To be a removal candidate: activation_weighted_impact < savings
+    // To be a removal candidate: activation_weighted_impact < sqrt(savings)
     // Using tiny weights (1e-8) so both neurons qualify as candidates.
     let creature = CreatureJson {
         input: 3,
@@ -345,6 +355,136 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
         "many-synapses savings should be {:.2e}, got {:.2e}",
         expected_many_savings,
         many_candidate.removal_savings
+    );
+}
+
+/// REGRESSION TEST: Threshold must use sqrt(savings) not raw savings.
+///
+/// activation_weighted_impact is in OUTPUT units, savings is in SCORE units.
+/// For MSE error, a contribution c increases error by c². So:
+///   c² < savings  →  c < sqrt(savings)
+///
+/// This test creates a neuron with impact BETWEEN savings and sqrt(savings):
+///   savings = 1.5e-7
+///   sqrt(savings) ≈ 3.9e-4
+///   impact = 1e-5 (between them)
+///
+/// Under old logic (impact < savings): NOT a candidate (1e-5 > 1.5e-7)
+/// Under correct logic (impact < sqrt(savings)): IS a candidate (1e-5 < 3.9e-4)
+#[test]
+fn regression_threshold_must_use_sqrt_savings() {
+    // Create a neuron with activation_weighted_impact = 1e-5
+    // This is:
+    //   - LARGER than savings (1.5e-7) - would NOT be candidate under old raw comparison
+    //   - SMALLER than sqrt(savings) (~3.9e-4) - IS a candidate under sqrt comparison
+    //
+    // We achieve impact ≈ 1e-5 using weight × activation:
+    //   structural_impact ≈ weight = 1e-4 (path to output)
+    //   mean_activation = 0.1
+    //   activation_weighted_impact ≈ 1e-4 × 0.1 = 1e-5
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "between-thresholds".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            // Input → hidden (3 synapses for savings = 1.4e-7)
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "between-thresholds".to_string(),
+                weight: 0.5,
+            },
+            // Hidden → output with small weight for small impact
+            SynapseJson {
+                from_uuid: "between-thresholds".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1e-4, // Small weight → small structural impact
+            },
+            // Direct input → output to ensure output neuron has records
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+            },
+        ],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Records with mean_activation = 0.1 for our target neuron
+    let records = vec![
+        DiscoverRecord::new(
+            0,
+            "between-thresholds".to_string(),
+            Some(0.1), // activation
+            0.1,       // state
+            vec![0.1],
+        ),
+        DiscoverRecord::new(
+            1,
+            "between-thresholds".to_string(),
+            Some(0.1),
+            0.1,
+            vec![0.1],
+        ),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    // Find the neuron in removal candidates
+    let candidate = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "between-thresholds");
+
+    // This neuron MUST be a removal candidate under the sqrt threshold
+    assert!(
+        candidate.is_some(),
+        "Neuron with activation_weighted_impact (~1e-5) should be a removal candidate \
+         because 1e-5 < sqrt(1.4e-7) ≈ 3.7e-4. Found candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| format!("{}: {:.2e}", c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+
+    let candidate = candidate.unwrap();
+
+    // Verify the impact is in the expected range (between savings and sqrt(savings))
+    let savings = candidate.removal_savings;
+    let sqrt_savings = savings.sqrt();
+
+    assert!(
+        candidate.activation_weighted_impact > savings,
+        "activation_weighted_impact ({:.2e}) should be LARGER than raw savings ({:.2e}) - \
+         this test specifically targets the gap between savings and sqrt(savings)",
+        candidate.activation_weighted_impact,
+        savings
+    );
+
+    assert!(
+        candidate.activation_weighted_impact < sqrt_savings,
+        "activation_weighted_impact ({:.2e}) should be SMALLER than sqrt(savings) ({:.2e}) - \
+         this is why it qualifies as a removal candidate",
+        candidate.activation_weighted_impact,
+        sqrt_savings
     );
 }
 


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.128 to 0.1.129.
- Update README to clarify the revised criterion for identifying neuron removal candidates, emphasizing the use of the square root of savings for comparison.
- Modify focus.rs logic to implement the updated removal candidate detection, ensuring neurons are flagged for removal when their contribution to output is less than the square root of the savings from their removal.
- Enhance regression tests to validate the new threshold logic and ensure accurate identification of neurons with minimal contributions.

These changes improve the precision of neuron removal decisions, contributing to the overall performance of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch neuron removal criterion to `activation_weighted_impact < sqrt(savings)`, update README and regression tests, and bump version.
> 
> - **Backend (focus.rs)**:
>   - Change removal threshold to `activation_weighted_impact < sqrt(savings)` (MSE unit conversion) with dynamic synapse-based `savings`.
>   - Add `threshold` in reasoning message and refine verbose log (reports `sqrt(savings)`).
> - **Tests**:
>   - Update `regression_v0_1_127.rs` to validate sqrt-based threshold and dynamic synapse savings.
>   - Add regression test covering impact between `savings` and `sqrt(savings)`.
> - **Docs**:
>   - README clarifies unit conversion and adds threshold table using `sqrt(savings)`.
> - **Version**:
>   - Bump `Cargo.toml` from `0.1.128` to `0.1.129`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fedd0414c5ca60094d83c6ec34dcfd1d01cd811. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->