### PR TITLE
Update version to 0.1.131 and refine neuron removal criteria

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.130"
+version = "0.1.131"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -564,8 +564,8 @@ const complexityPenalty = hiddenNeuronCount * growthCost +
 savings = growthCost × (1 + (N + M) / 10)
 ```
 
-**The fix**: Top 10 neurons with lowest impact are returned as removal candidates,
-sorted by `activation_weighted_impact` ascending.
+**The fix**: ALL neurons with `activation_weighted_impact < costOfGrowth` (1e-7) are
+returned as removal candidates, sorted by impact ascending.
 
 ```
 activation_weighted_impact = structural_impact × mean_absolute_activation
@@ -573,7 +573,10 @@ activation_weighted_impact = structural_impact × mean_absolute_activation
 
 Where:
 - `structural_impact` = NORMALISED impact through the network
-- `mean_absolute_activation` = sum(|activation|) / record_count
+- `mean_absolute_activation` = sum(|finite activation|) / finite_record_count
+
+**Note**: Non-finite activation values (NaN, Infinity) are filtered out when computing
+`mean_absolute_activation` to prevent corruption of the removal candidate ranking.
 
 **Normalised impact calculation**:
 
@@ -593,7 +596,7 @@ has a small effect on the downstream signal.
 **Removal candidate JSON response** now includes:
 - `incomingSynapses` / `outgoingSynapses`: synapse counts used in calculation
 - `removalSavings`: the raw savings value from NEAT-AI formula
-- Candidates sorted by benefit (biggest gap between savings and impact first)
+- Candidates sorted by activation_weighted_impact ascending (lowest first = safest to remove)
 
 The `calculate_removal_savings(incoming, outgoing, growth_cost)` function is
 available for use in other analyses and is tested against the NEAT-AI formula.

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -404,22 +404,23 @@ pub fn rank_focus_neurons(
             .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
     });
 
-    // Identify removal candidates: ALL neurons sorted by activation_weighted_impact.
+    // Identify removal candidates: neurons with activation_weighted_impact < costOfGrowth.
     //
     // activation_weighted_impact = structural_impact × mean_activation
-    // where structural_impact = product of |weights| on path(s) to output(s)
+    // where structural_impact = NORMALISED impact through the network
     //
-    // The lowest impact neurons are the best candidates for removal.
-    // NO THRESHOLD FILTERING - let NEAT-AI decide based on cost/benefit analysis.
+    // Neurons with impact below costOfGrowth are net negative - removing them
+    // reduces complexity more than it affects error.
     //
     // We provide complexity savings info for each neuron based on NEAT-AI's formula:
     //   savings = growthCost × (1 + (N + M) / 10)
     // where N = incoming synapses, M = outgoing synapses
     const COST_OF_GROWTH: f32 = 1e-7;
 
-    // Return ALL neurons as potential removal candidates, sorted by impact
+    // Return ALL neurons with impact below costOfGrowth as removal candidates
     let mut removal_candidates: Vec<RemovalCandidate> = neurons
         .iter()
+        .filter(|n| n.activation_weighted_impact < COST_OF_GROWTH)
         .map(|n| {
             let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
             let savings = calculate_removal_savings(incoming, outgoing, COST_OF_GROWTH);
@@ -434,9 +435,11 @@ pub fn rank_focus_neurons(
                 outgoing_synapses: outgoing,
                 removal_savings: savings,
                 reason: format!(
-                    "Impact {:.2e} (structural {:.2e} × activation {:.2e}), {} synapses, saves {:.2e}",
-                    n.activation_weighted_impact, n.impact, n.mean_activation,
-                    incoming + outgoing, savings
+                    "Impact {:.2e} < costOfGrowth ({:.0e}), {} synapses, saves {:.2e}",
+                    n.activation_weighted_impact,
+                    COST_OF_GROWTH,
+                    incoming + outgoing,
+                    savings
                 ),
             }
         })
@@ -448,9 +451,6 @@ pub fn rank_focus_neurons(
             .partial_cmp(&b.activation_weighted_impact)
             .unwrap_or(Ordering::Equal)
     });
-
-    // Return only top 10 candidates (lowest impact = highest chance of success)
-    removal_candidates.truncate(10);
 
     if let Some(limit) = max_results {
         if neurons.len() > limit {

--- a/tests/focus.rs
+++ b/tests/focus.rs
@@ -386,9 +386,9 @@ fn test_disconnected_neurons_are_removal_candidates() {
 }
 
 #[test]
-fn test_high_impact_neurons_sorted_last_in_removal_candidates() {
-    // Scenario: All neurons are returned as removal candidates, but high-impact
-    // neurons should be sorted LAST (lowest impact first).
+fn test_high_impact_neurons_not_returned_as_removal_candidates() {
+    // Scenario: High impact neurons (impact >= costOfGrowth) should NOT be
+    // returned as removal candidates - only neurons below threshold qualify.
     let creature = create_creature(
         vec![
             ("input-0", "input"),
@@ -404,7 +404,7 @@ fn test_high_impact_neurons_sorted_last_in_removal_candidates() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    // Both have high error, but both have high impact
+    // Both have high error, but both have high impact (well above costOfGrowth 1e-7)
     let records = create_records(vec![
         ("hidden-1", 100.0), // Very high error, ~100% impact
         ("output-0", 100.0), // Very high error, 100% impact
@@ -413,27 +413,23 @@ fn test_high_impact_neurons_sorted_last_in_removal_candidates() {
 
     let result = rank_focus_neurons(file_path, &creature, None).unwrap();
 
-    // All neurons returned as candidates, but they have high impact so would be
-    // poor choices for removal. The sorting puts lowest impact first.
+    // High impact neurons should NOT be removal candidates
+    // Both hidden-1 and output-0 have activation_weighted_impact >> 1e-7
     assert!(
-        !result.removal_candidates.is_empty(),
-        "All neurons should be returned as removal candidates"
+        result.removal_candidates.is_empty(),
+        "High impact neurons should NOT be removal candidates. Found: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| (&c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
     );
-
-    // First candidate should have lowest impact
-    let first = &result.removal_candidates[0];
-    for candidate in &result.removal_candidates {
-        assert!(
-            first.activation_weighted_impact <= candidate.activation_weighted_impact,
-            "Candidates should be sorted by impact ascending"
-        );
-    }
 }
 
 #[test]
-fn test_lower_impact_neurons_sorted_before_higher_impact() {
-    // Scenario: All neurons returned as removal candidates, sorted by impact.
-    // Lower impact neurons should appear first (better removal candidates).
+fn test_only_low_impact_neurons_returned_as_removal_candidates() {
+    // Scenario: Only neurons with activation_weighted_impact < costOfGrowth (1e-7)
+    // are returned as removal candidates. High impact neurons are filtered out.
     let creature = create_creature(
         vec![
             ("input-0", "input"),
@@ -452,37 +448,29 @@ fn test_lower_impact_neurons_sorted_before_higher_impact() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
+    // Both neurons have normal activations (0.5), so their activation_weighted_impact
+    // will be structural_impact × 0.5:
+    // - low-impact: 0.05 × 0.5 = 0.025 (>> 1e-7, NOT a candidate)
+    // - connected: 0.95 × 0.5 = 0.475 (>> 1e-7, NOT a candidate)
     let records = create_records(vec![
-        ("low-impact", 0.1), // Low error, ~5% impact
-        ("connected", 10.0), // High error, high impact
-        ("output-0", 5.0),   // Moderate error, 100% impact
+        ("low-impact", 0.1), // Low error, ~5% impact × 0.5 activation = 0.025
+        ("connected", 10.0), // High error, 95% impact × 0.5 activation = 0.475
+        ("output-0", 5.0),   // 100% impact × 0.5 activation = 0.5
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let result = rank_focus_neurons(file_path, &creature, None).unwrap();
 
-    // All neurons returned as candidates
+    // All neurons have impact >> costOfGrowth, so none should be removal candidates
     assert!(
-        !result.removal_candidates.is_empty(),
-        "All neurons should be returned as removal candidates"
+        result.removal_candidates.is_empty(),
+        "Neurons with activation_weighted_impact >> costOfGrowth should NOT be removal candidates. Found: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| (&c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
     );
-
-    // low-impact neuron should be sorted before connected neuron (lower impact first)
-    let low_impact_pos = result
-        .removal_candidates
-        .iter()
-        .position(|c| c.neuron_uuid == "low-impact");
-    let connected_pos = result
-        .removal_candidates
-        .iter()
-        .position(|c| c.neuron_uuid == "connected");
-
-    if let (Some(low_pos), Some(conn_pos)) = (low_impact_pos, connected_pos) {
-        assert!(
-            low_pos < conn_pos,
-            "low-impact neuron (5%) should be sorted before connected neuron (95%)"
-        );
-    }
 }
 
 #[test]
@@ -632,15 +620,15 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         high_act.activation_weighted_impact
     );
 
-    // Both neurons are returned as removal candidates, but high-activation should be
-    // sorted AFTER low-activation because it has higher impact
+    // high-activation should NOT be a removal candidate (impact 0.1 >> 1e-7)
     let high_act_removal = result
         .removal_candidates
         .iter()
         .find(|c| c.neuron_uuid == "high-activation");
     assert!(
-        high_act_removal.is_some(),
-        "high-activation should be in removal candidates (all neurons returned)"
+        high_act_removal.is_none(),
+        "high-activation should NOT be a removal candidate (impact {:.2e} >> costOfGrowth 1e-7)",
+        high_act.activation_weighted_impact
     );
 
     // Verify low-activation neuron has low activation-weighted impact
@@ -660,33 +648,23 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         low_act.activation_weighted_impact
     );
 
-    // low-activation SHOULD be a removal candidate
+    // low-activation SHOULD be a removal candidate (impact 1e-15 << 1e-7)
     let low_act_removal = result
         .removal_candidates
         .iter()
         .find(|c| c.neuron_uuid == "low-activation");
     assert!(
         low_act_removal.is_some(),
-        "low-activation SHOULD be a removal candidate"
+        "low-activation SHOULD be a removal candidate (impact {:.2e} < costOfGrowth 1e-7)",
+        low_act.activation_weighted_impact
     );
 
-    // low-activation should be sorted BEFORE high-activation (lower impact first)
-    let low_pos = result
-        .removal_candidates
-        .iter()
-        .position(|c| c.neuron_uuid == "low-activation");
-    let high_pos = result
-        .removal_candidates
-        .iter()
-        .position(|c| c.neuron_uuid == "high-activation");
-    if let (Some(lp), Some(hp)) = (low_pos, high_pos) {
-        assert!(
-            lp < hp,
-            "low-activation (impact {:.2e}) should be sorted before high-activation (impact {:.2e})",
-            low_act.activation_weighted_impact,
-            high_act.activation_weighted_impact
-        );
-    }
+    // Only low-activation should be in removal candidates
+    assert_eq!(
+        result.removal_candidates.len(),
+        1,
+        "Only low-activation should be a removal candidate"
+    );
 }
 
 #[test]

--- a/tests/regression_v0_1_127.rs
+++ b/tests/regression_v0_1_127.rs
@@ -370,36 +370,30 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     );
 }
 
-/// REGRESSION TEST: Threshold must use savings^0.25 not raw savings.
+/// REGRESSION TEST: Threshold must use costOfGrowth (1e-7).
 ///
-/// activation_weighted_impact is in OUTPUT units, savings is in SCORE units.
-/// We use a fourth root to bridge these units:
-///   threshold = savings^0.25
+/// Neurons are removal candidates when:
+///   activation_weighted_impact < costOfGrowth (1e-7)
 ///
-/// This test creates a neuron with impact BETWEEN savings and savings^0.25:
-///   savings = 1.4e-7 (for 3 synapses)
-///   savings^0.25 ≈ 6.1e-3
-///   impact = 1e-3 (between them)
-///
-/// Under old logic (impact < savings): NOT a candidate (1e-3 > 1.4e-7)
-/// Under correct logic (impact < savings^0.25): IS a candidate (1e-3 < 6.1e-3)
+/// This test creates a neuron with impact ABOVE costOfGrowth that should NOT
+/// be a removal candidate.
 #[test]
-fn regression_threshold_must_use_fourth_root_savings() {
+fn regression_threshold_uses_cost_of_growth() {
     // Create a neuron with activation_weighted_impact = 1e-3 (0.1%)
     // This is:
-    //   - LARGER than savings (1.4e-7) - would NOT be candidate under raw comparison
-    //   - SMALLER than savings^0.25 (~6.1e-3) - IS a candidate under fourth root
+    //   - LARGER than costOfGrowth (1e-7) - should NOT be a candidate
     //
-    // We achieve impact ≈ 1e-3 using weight × activation:
-    //   structural_impact ≈ weight = 1e-2 (path to output)
+    // With normalised impact:
+    //   total_inbound to output = 1e-2 + 1.0 = 1.02
+    //   structural_impact = 1e-2 / 1.02 × 1.0 ≈ 0.0098 (0.98%)
     //   mean_activation = 0.1
-    //   activation_weighted_impact ≈ 1e-2 × 0.1 = 1e-3
+    //   activation_weighted_impact ≈ 0.0098 × 0.1 = 9.8e-4 >> 1e-7
     let creature = CreatureJson {
         input: 1,
         output: 1,
         neurons: vec![
             NeuronJson {
-                uuid: "between-thresholds".to_string(),
+                uuid: "moderate-impact".to_string(),
                 neuron_type: "hidden".to_string(),
                 squash: "IDENTITY".to_string(),
                 bias: 0.0,
@@ -412,19 +406,18 @@ fn regression_threshold_must_use_fourth_root_savings() {
             },
         ],
         synapses: vec![
-            // Input → hidden (3 synapses for savings = 1.4e-7)
             SynapseJson {
                 from_uuid: "input-0".to_string(),
-                to_uuid: "between-thresholds".to_string(),
+                to_uuid: "moderate-impact".to_string(),
                 weight: 0.5,
             },
-            // Hidden → output with moderate weight for ~1e-3 impact
+            // Hidden → output with small weight
             SynapseJson {
-                from_uuid: "between-thresholds".to_string(),
+                from_uuid: "moderate-impact".to_string(),
                 to_uuid: "output-0".to_string(),
-                weight: 1e-2, // structural_impact ≈ 1e-2
+                weight: 1e-2,
             },
-            // Direct input → output to ensure output neuron has records
+            // Direct input → output (dominates inbound)
             SynapseJson {
                 from_uuid: "input-0".to_string(),
                 to_uuid: "output-0".to_string(),
@@ -436,22 +429,10 @@ fn regression_threshold_must_use_fourth_root_savings() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    // Records with mean_activation = 0.1 for our target neuron
+    // Records with mean_activation = 0.1
     let records = vec![
-        DiscoverRecord::new(
-            0,
-            "between-thresholds".to_string(),
-            Some(0.1), // activation
-            0.1,       // state
-            vec![0.1],
-        ),
-        DiscoverRecord::new(
-            1,
-            "between-thresholds".to_string(),
-            Some(0.1),
-            0.1,
-            vec![0.1],
-        ),
+        DiscoverRecord::new(0, "moderate-impact".to_string(), Some(0.1), 0.1, vec![0.1]),
+        DiscoverRecord::new(1, "moderate-impact".to_string(), Some(0.1), 0.1, vec![0.1]),
         DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
     ];
@@ -459,53 +440,57 @@ fn regression_threshold_must_use_fourth_root_savings() {
 
     let result = rank_focus_neurons(file_path, &creature, None).unwrap();
 
-    // Find the neuron in removal candidates
+    // Find the neuron in ranked neurons
+    let neuron = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "moderate-impact")
+        .expect("moderate-impact should be in ranked neurons");
+
+    // Verify impact is above costOfGrowth
+    let cost_of_growth: f32 = 1e-7;
+    assert!(
+        neuron.activation_weighted_impact > cost_of_growth,
+        "activation_weighted_impact ({:.2e}) should be LARGER than costOfGrowth ({:.0e})",
+        neuron.activation_weighted_impact,
+        cost_of_growth
+    );
+
+    // Should NOT be a removal candidate (impact > costOfGrowth)
     let candidate = result
         .removal_candidates
         .iter()
-        .find(|c| c.neuron_uuid == "between-thresholds");
+        .find(|c| c.neuron_uuid == "moderate-impact");
 
-    // This neuron MUST be a removal candidate under the fourth root threshold
     assert!(
-        candidate.is_some(),
-        "Neuron with activation_weighted_impact (~1e-3) should be a removal candidate \
-         because 1e-3 < (1.4e-7)^0.25 ≈ 6.1e-3. Found candidates: {:?}",
+        candidate.is_none(),
+        "Neuron with activation_weighted_impact ({:.2e}) > costOfGrowth ({:.0e}) should NOT \
+         be a removal candidate. Found candidates: {:?}",
+        neuron.activation_weighted_impact,
+        cost_of_growth,
         result
             .removal_candidates
             .iter()
             .map(|c| format!("{}: {:.2e}", c.neuron_uuid, c.activation_weighted_impact))
             .collect::<Vec<_>>()
     );
-
-    let candidate = candidate.unwrap();
-
-    // Verify the impact is in the expected range (between savings and savings^0.25)
-    let savings = candidate.removal_savings;
-    let fourth_root_savings = savings.sqrt().sqrt(); // savings^0.25
-
-    assert!(
-        candidate.activation_weighted_impact > savings,
-        "activation_weighted_impact ({:.2e}) should be LARGER than raw savings ({:.2e}) - \
-         this test specifically targets the gap between savings and savings^0.25",
-        candidate.activation_weighted_impact,
-        savings
-    );
-
-    assert!(
-        candidate.activation_weighted_impact < fourth_root_savings,
-        "activation_weighted_impact ({:.2e}) should be SMALLER than savings^0.25 ({:.2e}) - \
-         this is why it qualifies as a removal candidate",
-        candidate.activation_weighted_impact,
-        fourth_root_savings
-    );
 }
 
 /// Test that the removal reason includes synapse count information.
 #[test]
 fn test_removal_reason_includes_synapse_savings() {
-    // Network with a neuron that should be a removal candidate
+    // Network with a neuron that should be a removal candidate.
+    // To achieve truly negligible impact, we need:
+    //   - Small weight relative to other inputs to output
+    //   - Low activation
+    //
+    // With normalised impact:
+    //   structural_impact = |weight| / total_inbound × downstream_impact
+    //   total_inbound to output = 1e-10 + 10.0 ≈ 10.0
+    //   structural_impact ≈ 1e-10 / 10.0 × 1.0 = 1e-11
+    //   activation_weighted_impact = 1e-11 × 1e-5 = 1e-16 << 1e-7 ✓
     let creature = CreatureJson {
-        input: 1,
+        input: 2,
         output: 1,
         neurons: vec![
             NeuronJson {
@@ -525,12 +510,19 @@ fn test_removal_reason_includes_synapse_savings() {
             SynapseJson {
                 from_uuid: "input-0".to_string(),
                 to_uuid: "negligible".to_string(),
-                weight: 1e-10, // Extremely small
+                weight: 1e-10,
             },
+            // Negligible's synapse to output has tiny weight
             SynapseJson {
                 from_uuid: "negligible".to_string(),
                 to_uuid: "output-0".to_string(),
-                weight: 1e-10, // Extremely small
+                weight: 1e-10,
+            },
+            // Dominant synapse to output (makes negligible's fraction tiny)
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 10.0,
             },
         ],
     };
@@ -538,9 +530,10 @@ fn test_removal_reason_includes_synapse_savings() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
+    // Tiny activation ensures activation_weighted_impact << costOfGrowth
     let records = vec![
-        DiscoverRecord::new(0, "negligible".to_string(), Some(0.5), 0.5, vec![0.1]),
-        DiscoverRecord::new(1, "negligible".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(0, "negligible".to_string(), Some(1e-5), 1e-5, vec![0.1]),
+        DiscoverRecord::new(1, "negligible".to_string(), Some(1e-5), 1e-5, vec![0.1]),
         DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
     ];
@@ -561,7 +554,7 @@ fn test_removal_reason_includes_synapse_savings() {
         result
             .removal_candidates
             .iter()
-            .map(|c| &c.neuron_uuid)
+            .map(|c| format!("{}: {:.2e}", c.neuron_uuid, c.activation_weighted_impact))
             .collect::<Vec<_>>()
     );
 


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.130 to 0.1.131.
- Update README to clarify the new criteria for identifying neuron removal candidates, emphasizing the use of activation-weighted impact compared to a defined cost of growth threshold.
- Modify focus.rs logic to implement the updated removal candidate detection, ensuring neurons are flagged for removal when their activation-weighted impact is below the cost of growth.
- Enhance regression tests to validate the new threshold logic and ensure accurate identification of neurons with minimal contributions.

These changes improve the precision of neuron removal decisions, contributing to the overall performance of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch removal-candidate logic to include only neurons with activation_weighted_impact < costOfGrowth (1e-7), update reason text and tests, and document the criteria in README; bump version to 0.1.131.
> 
> - **Focus (core logic)**:
>   - Filter removal candidates to neurons with `activation_weighted_impact < costOfGrowth` (`1e-7`), instead of returning all neurons.
>   - Keep candidates sorted by `activation_weighted_impact` (ascending); remove previous top-10 truncation.
>   - Update `reason` to include threshold comparison and synapse/savings info.
> - **Docs**:
>   - Clarify removal criteria in `README.md` (use `costOfGrowth` threshold; define `mean_absolute_activation` using finite activations only; state sort order).
> - **Tests**:
>   - Update focus tests to ensure high-impact neurons are excluded and only sub-threshold neurons are candidates; assert sort order and messages.
>   - Revise regression tests to use `costOfGrowth` threshold and verify savings reporting; add scenarios confirming negligible-impact candidates.
> - **Version**:
>   - Bump `Cargo.toml` to `0.1.131`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53894c12c42af7af6232df654af90940acff8274. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->