### PR TITLE
Update version to 0.1.132 and enhance impact calculation with squash-…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.131"
+version = "0.1.132"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -587,6 +587,29 @@ A's contribution to B = |w| / total_inbound_to_B × B's_impact
 
 This is **recursive** - if B has 100 inputs, A only contributes 1/100th of B's signal.
 
+#### Squash-aware impact calculation (v0.1.132)
+
+**ENHANCEMENT**: The impact calculation is now **squash-aware**. Different squash
+functions use different impact formulas to avoid underestimating impact.
+
+| Squash Category | Functions | Impact Formula | Rationale |
+|-----------------|-----------|----------------|-----------|
+| **Linear** | IDENTITY, TANH, LOGISTIC, etc. | `\|w\| / total_inbound × child` | Sum of weighted inputs |
+| **Threshold** | STEP, BIPOLAR | `child_impact` (full, not normalised) | Any synapse can flip output |
+| **Selection** | MINIMUM, MAXIMUM, IF | `child_impact / N` (equal probability) | Only one synapse "wins" |
+
+**Why this matters**:
+
+- **STEP/BIPOLAR**: A tiny weight (1e-8) feeding into a STEP neuron could flip the
+  output from 0→1 if the neuron is near its threshold. The old sum-based formula
+  would calculate impact ≈ 0, but the actual effect could be 1.0!
+
+- **MINIMUM/MAXIMUM**: The old formula gave large weights high impact in MINIMUM
+  (~90%), but small weights are actually more likely to win! The new formula gives
+  each synapse equal probability (1/N).
+
+For detailed explanation with diagrams, see [Impact Calculation](docs/IMPACT_CALCULATION.md).
+
 **Example**: Output has 107 incoming synapses with total |weight| = 343.
 A neuron with weight 3.0 to output contributes: `3.0 / 343 ≈ 0.9%` of output.
 
@@ -758,6 +781,12 @@ whether discovery should be enabled:
   `analysis_deadline_ms` is not provided. If a timeout is explicitly provided
   but is less than 3 seconds or greater than 1 hour, it will be clamped to the
   10-minute default with a warning message.
+
+## Additional documentation
+
+- [Impact Calculation](docs/IMPACT_CALCULATION.md) - Detailed explanation of how
+  neuron impact is calculated, including special handling for threshold (STEP/BIPOLAR)
+  and selection (MINIMUM/MAXIMUM) squash functions.
 
 ## Existing reference material
 

--- a/docs/IMPACT_CALCULATION.md
+++ b/docs/IMPACT_CALCULATION.md
@@ -1,0 +1,456 @@
+# 🧠 Neuron Impact Calculation
+
+This document explains how neuron impact is calculated in NEAT-AI-Discovery. Impact
+is a crucial metric that determines:
+
+1. 🎯 **Focus neuron ranking**: Higher impact neurons are prioritised for discovery
+2. 🗑️ **Removal candidate detection**: Low impact neurons can be safely removed
+3. 📉 **Hidden neuron prediction discounting**: Impact affects confidence in predictions
+
+## Table of Contents
+
+- [What is Impact?](#what-is-impact)
+- [Basic Impact Calculation](#basic-impact-calculation)
+- [Visual Examples](#visual-examples)
+- [Special Squash Function Handling](#special-squash-function-handling)
+  - [STEP and BIPOLAR (Threshold Functions)](#step-and-bipolar-threshold-functions)
+  - [MINIMUM and MAXIMUM (Selection Functions)](#minimum-and-maximum-selection-functions)
+- [Activation-Weighted Impact](#activation-weighted-impact)
+- [Implementation Status](#implementation-status-v01132)
+- [Future Improvements](#future-improvements)
+
+---
+
+## ⚡ What is Impact?
+
+**Impact** measures how much a neuron's activation affects the creature's final output
+(and hence its score). The formula captures:
+
+$$\text{impact} = \text{how much does changing this neuron's activation change the output?}$$
+
+For **output neurons**, impact = 1.0 (they directly determine the score).
+
+For **hidden neurons**, impact depends on:
+1. The weights of synapses connecting them to outputs (directly or indirectly)
+2. The squash functions of neurons they connect through
+3. Their activation patterns
+
+---
+
+## 📊 Basic Impact Calculation
+
+The current implementation uses a **normalised path weight** approach:
+
+$$\text{impact}(n) = \sum_{\text{synapses}} \frac{|w|}{T} \times \text{impact}(\text{child})$$
+
+Where:
+- $w$ = the synapse weight from this neuron to its child
+- $T$ = `total_inbound` = sum of |weights| of all synapses going INTO the child
+- $\text{impact}(\text{child})$ = recursively computed impact of the child neuron 🔄
+- Output neurons have `impact = 1.0`
+
+### Example: Simple Chain
+
+```
+    ┌─────────┐    w=0.5     ┌─────────┐    w=1.0     ┌──────────┐
+    │ input-0 │─────────────▶│ hidden-1│─────────────▶│ output-0 │
+    └─────────┘              └─────────┘              └──────────┘
+         │                        │                        │
+   (not computed)            impact=1.0              impact=1.0
+                            (1.0/1.0 × 1.0)
+```
+
+- **output-0** 🎯: impact = 1.0 (it's an output)
+- **hidden-1** 🧠: impact = |1.0| / 1.0 × 1.0 = 1.0 (only synapse to output, 100% contribution)
+- **input-0**: Not computed (input neurons are observation sources, not selectable for discovery)
+  - *If we did calculate it*: |0.5| / 0.5 × 1.0 = 1.0 (only synapse to hidden-1, 100% contribution)
+
+### Example: Branching Network
+
+```
+                          ┌─────────┐
+                    w=0.3 │ hidden-1│─────────┐
+                 ┌───────▶└─────────┘         │w=0.3
+    ┌─────────┐  │                            │
+    │ input-0 │──┤                            ▼
+    └─────────┘  │                       ┌──────────┐
+                 │              w=0.7    │ output-0 │ impact=1.0
+                 └─────────────────────▶│          │ total_inbound=1.0
+                                        └──────────┘
+
+hidden-1 impact = |0.3| / 1.0 × 1.0 = 0.3
+
+When both hidden-1 and input-0 connect to output-0:
+
+    ┌─────────┐
+    │ input-0 │──┬───────────────────────────────────────┐
+    └─────────┘  │                                       │w=0.7
+                 │w=1.0   ┌─────────┐      w=0.3         ▼
+                 └───────▶│ hidden-1│───────────────▶┌──────────┐
+                          └─────────┘                │ output-0 │
+                                                     └──────────┘
+                                                total_inbound = 1.0
+
+hidden-1 impact = |0.3| / |0.3+0.7| × 1.0 = 0.3
+```
+
+---
+
+## 📈 Visual Examples
+
+### Example 1: Multiple Outputs (Cumulative Impact) ➕
+
+When a neuron connects to multiple outputs, its impact is the **SUM** of all paths:
+
+```
+                               ┌──────────┐
+                         w=1.0 │ output-0 │ impact=1.0
+                    ┌─────────▶└──────────┘
+    ┌─────────┐     │
+    │   hub   │─────┤
+    └─────────┘     │
+                    │    w=1.0 ┌──────────┐
+                    └─────────▶│ output-1 │ impact=1.0
+                               └──────────┘
+
+hub impact = (1.0/1.0 × 1.0) + (1.0/1.0 × 1.0) = 2.0
+```
+
+⚡⚡ This reflects that removing 'hub' affects TWO outputs!
+
+### Example 2: Deep Network with Dilution 📉
+
+Impact dilutes as you go deeper into the network:
+
+```
+    ┌─────────┐  w=1.0  ┌─────────┐  w=1.0  ┌─────────┐  w=1.0  ┌──────────┐
+    │ input-0 │────────▶│ layer-1 │────────▶│ layer-2 │────────▶│ output-0 │
+    └─────────┘         └─────────┘         └─────────┘         └──────────┘
+                             │                  │                    │
+                        impact=1.0          impact=1.0           impact=1.0
+
+    But if layer-2 has many inputs:
+
+    ┌─────────┐  w=1.0  ┌─────────┐  w=0.01  ┌─────────┐  w=1.0  ┌──────────┐
+    │ input-0 │────────▶│ layer-1 │─────────▶│ layer-2 │────────▶│ output-0 │
+    └─────────┘         └─────────┘          └─────────┘         └──────────┘
+                             │     (99 other │     │                  │
+                             │     synapses) │     │                  │
+                        impact=0.01      total=1.0 │             impact=1.0
+                    (0.01/1.0 × 1.0)         impact=1.0
+```
+
+---
+
+## ⚙️ Special Squash Function Handling
+
+The impact calculation is **squash-aware** to handle special activation functions correctly.
+
+### 🎚️ STEP and BIPOLAR (Threshold Functions)
+
+**STEP** and **BIPOLAR** are threshold (binary) functions:
+
+```
+STEP(x):                          BIPOLAR(x):
+    output                            output
+       │                                 │
+     1 ├────────────                   1 ├────────────
+       │            │                    │            │
+       │            │                    │            │
+       ├────────────┴─────▶ x     -1 ├───┘            │
+     0 │                             └────────────────┴─────▶ x
+       │                                           threshold=0
+```
+
+#### ⚠️ The Problem
+
+With threshold functions, **tiny signals can have HUGE effects**:
+
+```
+    ┌──────────┐  w=0.000_001  ┌──────────┐  w=0.000_002  ┌─────────────┐
+    │ hidden-a │──────────────▶│ hidden-b │──────────────▶│ STEP/BIPOLAR│
+    └──────────┘               └──────────┘               │  output-0   │
+    activation=0.000_001                                  └─────────────┘
+
+    OLD impact calculation:
+    contribution = 0.000_001 × 0.000_002 ≈ 0 (negligible!)
+
+    BUT ACTUAL EFFECT:
+    If hidden-b's input sum is at -0.000_001 (just below threshold 0):
+    - Before: output = 0 (or -1 for BIPOLAR)
+    - After adding synapse: input = -0.000_001 + 0.000_001×0.000_002 ≈ 0
+    - After: Could flip to output = 1!
+
+    Impact on score: Δoutput = 1.0 (or 2.0 for BIPOLAR -1→1)
+    Calculated impact: ≈ 0
+```
+
+🚨 **ERROR: Off by ~1,000,000x**
+
+#### ✅ Implemented Solution (v0.1.132+)
+
+For neurons feeding into STEP/BIPOLAR targets, **don't normalise by total_inbound**.
+Each synapse is treated as potentially decisive:
+
+$$\text{contribution} = \text{child\_impact}$$
+
+**Rationale:**
+- Any synapse crossing the threshold causes full output change 🔀
+- Without activation data, we can't know which synapses are "close" to threshold
+- Conservative: won't underestimate impact (may overestimate)
+- Better for removal candidate detection (won't incorrectly flag as "safe to remove") ✅
+
+#### 🔮 Future Enhancement
+
+With activation data, we could compute the actual threshold-crossing probability:
+
+$$\text{threshold\_impact} = P(\text{crossing}) \times \Delta\text{output}$$
+
+Where:
+- $P(\text{crossing})$ = fraction of samples where synapse pushes target across threshold 🎲
+- $\Delta\text{output}$ = 1.0 for STEP, 2.0 for BIPOLAR
+
+### 🏆 MINIMUM and MAXIMUM (Selection Functions)
+
+**MINIMUM** and **MAXIMUM** are selection functions - they don't sum inputs, they
+select one:
+
+```
+MINIMUM:                              MAXIMUM:
+┌────────────────┐                   ┌────────────────┐
+│   synapse-1 ───┤                   │   synapse-1 ───┤
+│   synapse-2 ───┤───▶ min(all)      │   synapse-2 ───┤───▶ max(all)
+│   synapse-3 ───┤                   │   synapse-3 ───┤
+└────────────────┘                   └────────────────┘
+```
+
+#### ⚠️ The Problem
+
+The old impact calculation assumed **summing** of inputs and normalised by
+total weight:
+
+```
+    Old formula: impact = |weight| / Σ|weights| × child_impact
+
+    For MINIMUM/MAXIMUM, only ONE synapse "wins" at any time.
+    The others contribute NOTHING to the output!
+
+    Example:
+    ┌──────────┐  w=0.1
+    │ hidden-a │────────────┐
+    └──────────┘            │
+                            │
+    ┌──────────┐  w=0.5     ▼
+    │ hidden-b │───────▶┌─────────────┐
+    └──────────┘        │   MINIMUM   │
+                        │   output    │
+    ┌──────────┐  w=10.0│             │
+    │ hidden-c │───────▶└─────────────┘
+    └──────────┘
+
+    OLD calculation (WRONG for MINIMUM):
+    hidden-a impact = 0.1 / (0.1+0.5+10.0) × 1.0 = 0.0094 (~1%)
+    hidden-b impact = 0.5 / 10.6 × 1.0 = 0.047 (~5%)
+    hidden-c impact = 10.0 / 10.6 × 1.0 = 0.94 (~94%)
+
+    ACTUAL behaviour (MINIMUM):
+    If hidden-a×0.1 = 0.01, hidden-b×0.5 = 0.25, hidden-c×10.0 = 5.0:
+    - MINIMUM selects 0.01 (hidden-a's contribution)
+    - Output = 0.01
+    - hidden-a has 100% impact on output!
+    - hidden-b, hidden-c have 0% impact!
+```
+
+🚨 **ERROR: Completely inverted!**
+
+#### ✅ Implemented Solution (v0.1.132+)
+
+For MINIMUM/MAXIMUM targets, use **equal probability** for each synapse:
+
+$$\text{contribution} = \frac{\text{child\_impact}}{N}$$
+
+Where:
+- $N$ = number of incoming synapses to the target
+- Each synapse has $\frac{1}{N}$ probability of "winning" the selection 🎲
+
+**Rationale:**
+- Without activation data, we can't know which synapse wins
+- Equal probability is conservative: won't incorrectly flag neurons as "low impact"
+- MUCH better than old sum-based approach which was completely wrong!
+
+❌ **Old behaviour (BROKEN)**: sum-based normalisation gave large weights ~90% impact
+in MINIMUM, but small weights are more likely to win!
+
+✅ **New behaviour (FIXED)**: all synapses get equal impact (1/N), which is conservative
+but won't incorrectly identify removal candidates.
+
+#### 🔮 Future Enhancement
+
+With activation data, we could compute actual selection probability:
+
+$$\text{selection\_impact} = P(\text{winning}) \times \text{child\_impact}$$
+
+Where:
+- $P(\text{winning})$ = fraction of samples where this synapse has min/max value 🎲
+- For MINIMUM: smaller weighted contributions win more often
+- For MAXIMUM: larger weighted contributions win more often
+
+---
+
+## ⚖️ Activation-Weighted Impact
+
+The final impact metric used for removal candidates is **activation-weighted impact**:
+
+$$\text{activation\_weighted\_impact} = \text{structural\_impact} \times \text{mean\_absolute\_activation}$$
+
+This captures that a neuron with:
+- High structural impact but zero activation → no contribution → can remove 🗑️
+- Low structural impact but huge activation → still contributes → don't remove ⛔
+
+### Example
+
+```
+    ┌─────────────┐  w=0.001  ┌──────────┐
+    │   dormant   │──────────▶│ output-0 │
+    │ activation≈0│           └──────────┘
+    └─────────────┘
+    structural_impact = 0.001
+    mean_activation = 0.0001
+    activation_weighted_impact = 0.001 × 0.0001 = 1e-7
+```
+✅ **REMOVAL CANDIDATE** (💤 dormant neuron)
+
+```
+    ┌────────────────┐  w=0.001  ┌──────────┐
+    │     active     │──────────▶│ output-0 │
+    │ activation≈1e5 │           └──────────┘
+    └────────────────┘
+    structural_impact = 0.001
+    mean_activation = 1e5
+    activation_weighted_impact = 0.001 × 1e5 = 100
+```
+❌ **NOT A REMOVAL CANDIDATE** (⚡ active neuron)
+
+---
+
+## 📋 Implementation Status (v0.1.132+)
+
+The impact calculation is now **squash-aware**. Different squash functions use
+different impact formulas:
+
+| Squash Function | Impact Model | Accuracy | Notes |
+|-----------------|--------------|----------|-------|
+| **IDENTITY** | Linear (normalised) | ✅ Accurate | Mathematically exact |
+| **TANH/LOGISTIC** | Linear (normalised) | ⚠️ Approx | Saturation not modelled |
+| **HARD_TANH** | Linear (normalised) | ⚠️ Approx | Clamping not modelled |
+| **STEP** | Threshold (full impact) | ✅ Conservative | Any synapse can flip output 🎚️ |
+| **BIPOLAR** | Threshold (full impact) | ✅ Conservative | Any synapse can flip output 🎚️ |
+| **MINIMUM** | Selection (1/N each) | ✅ Conservative | Equal probability of winning 🏆 |
+| **MAXIMUM** | Selection (1/N each) | ✅ Conservative | Equal probability of winning 🏆 |
+| **IF** | Selection (1/N each) | ✅ Conservative | Conditional selection |
+| **ReLU** | Linear (normalised) | ⚠️ Approx | Zero region not modelled |
+
+### 🏷️ Squash Categories
+
+The implementation categorises squash functions into three types:
+
+```rust
+enum SquashCategory {
+    Linear,     // IDENTITY, TANH, LOGISTIC, HARD_TANH, ReLU, etc.
+    Threshold,  // STEP, BIPOLAR
+    Selection,  // MINIMUM, MAXIMUM, IF
+}
+```
+
+### 📊 Impact Formulas by Category
+
+**Linear squashes** (default):
+
+$$\text{contribution} = \frac{|w|}{T} \times \text{child\_impact}$$
+
+**Threshold squashes** (STEP/BIPOLAR) 🎚️:
+
+$$\text{contribution} = \text{child\_impact}$$
+
+No normalisation - any synapse can flip output!
+
+**Selection squashes** (MINIMUM/MAXIMUM/IF) 🏆:
+
+$$\text{contribution} = \frac{\text{child\_impact}}{N}$$
+
+Equal probability for N incoming synapses.
+
+---
+
+## 🔮 Future Improvements
+
+### ✅ Completed
+
+- [x] Document the problem (this document)
+- [x] Track squash functions in impact calculation
+- [x] Add squash-aware impact functions
+- [x] STEP/BIPOLAR support (conservative full-impact approach) 🎚️
+- [x] MINIMUM/MAXIMUM support (equal-probability approach) 🏆
+- [x] Integration with removal candidate detection
+- [x] Add tests for new edge cases
+
+### 📋 Future Enhancements
+
+These could further improve accuracy but require activation data:
+
+- [ ] STEP/BIPOLAR: Compute actual threshold-crossing probability from samples 🎲
+- [ ] MINIMUM/MAXIMUM: Compute actual selection probability from samples 🎲
+- [ ] TANH/LOGISTIC: Model saturation using activation values
+- [ ] ReLU: Model zero region using activation values
+
+---
+
+## 💻 Related Code
+
+| File | Function | Purpose |
+|------|----------|---------|
+| `src/focus.rs` | `compute_impacts_internal()` | Core impact calculation 🔄 |
+| `src/focus.rs` | `compute_impact_recursive()` | Recursive path traversal |
+| `src/focus.rs` | `rank_focus_neurons()` | Uses impact for ranking 📊 |
+| `src/analysis.rs` | `compute_impacts_public()` | Public API for analysis |
+| `tests/focus.rs` | Various | Impact calculation tests ✅ |
+
+---
+
+## 📐 Appendix: Mathematical Formulas
+
+### Current Formula (Normalised Path Weight)
+
+$$
+\text{impact}(n) = \begin{cases}
+1.0 & \text{if } n \text{ is output} \\
+\sum_i \frac{|w_i|}{T_i} \times \text{impact}(\text{child}_i) & \text{otherwise}
+\end{cases}
+$$
+
+Where:
+- $w_i$ = weight of synapse from $n$ to $\text{child}_i$
+- $T_i$ = $\sum|w|$ for all synapses INTO $\text{child}_i$
+
+### Squash-Aware Formula
+
+$$
+\text{impact}(n) = \begin{cases}
+1.0 & \text{if } n \text{ is output} \\
+\sum_i f_{\text{squash}}(n, \text{child}_i) & \text{otherwise}
+\end{cases}
+$$
+
+Where $f_{\text{squash}}$ depends on child's squash function:
+
+**Linear** (IDENTITY, etc.):
+
+$$f = \frac{|w|}{T} \times \text{impact}(\text{child})$$
+
+**Threshold** (STEP, BIPOLAR) 🎚️:
+
+$$f = \text{impact}(\text{child})$$
+
+**Selection** (MINIMUM, MAXIMUM) 🏆:
+
+$$f = \frac{\text{impact}(\text{child})}{N}$$

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -174,6 +174,40 @@ fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)
     adjacency
 }
 
+/// Build a map from neuron UUID to squash function name.
+fn build_squash_map(creature: &CreatureJson) -> HashMap<String, String> {
+    creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.squash.to_uppercase()))
+        .collect()
+}
+
+/// Categorise squash functions for impact calculation.
+/// See docs/IMPACT_CALCULATION.md for detailed explanation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SquashCategory {
+    /// Linear or approximately linear (IDENTITY, TANH, etc.)
+    /// Impact = normalised weight fraction
+    Linear,
+    /// Threshold functions (STEP, BIPOLAR)
+    /// Any input could flip the output - don't normalise
+    Threshold,
+    /// Selection functions (MINIMUM, MAXIMUM)
+    /// Only one synapse "wins" - conservative: don't normalise
+    Selection,
+}
+
+impl SquashCategory {
+    fn from_squash(squash: &str) -> Self {
+        match squash.to_uppercase().as_str() {
+            "STEP" | "BIPOLAR" => Self::Threshold,
+            "MINIMUM" | "MAXIMUM" | "IF" => Self::Selection,
+            _ => Self::Linear,
+        }
+    }
+}
+
 // NOTE: build_inbound_weights was removed in v0.1.126 as part of the impact
 // calculation fix. The normalisation it supported was causing massive
 // underestimation of neuron impact (see regression_v0_1_126.rs tests).
@@ -186,12 +220,27 @@ fn compute_impacts(creature: &CreatureJson) -> HashMap<String, f32> {
 /// Computes the structural impact of each neuron on outputs (path weight products).
 /// Output neurons have impact = 1.0, hidden neurons have impact in [0, 1] based on
 /// their weighted paths to outputs.
+///
+/// NOTE: This function is squash-aware. For neurons feeding into STEP/BIPOLAR/MINIMUM/MAXIMUM
+/// targets, the impact calculation uses special handling to avoid underestimation.
+/// See docs/IMPACT_CALCULATION.md for detailed explanation.
 pub fn compute_impacts_public(creature: &CreatureJson) -> HashMap<String, f32> {
     compute_impacts_internal(creature)
 }
 
+/// Context for impact calculation, containing pre-computed lookup tables.
+/// This struct groups related parameters to avoid clippy::too_many_arguments.
+struct ImpactContext {
+    adjacency: HashMap<String, Vec<(String, f32)>>,
+    total_inbound: HashMap<String, f32>,
+    inbound_count: HashMap<String, usize>,
+    squash_map: HashMap<String, String>,
+    outputs: HashSet<String>,
+}
+
 fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
     let adjacency = build_adjacency(creature);
+    let squash_map = build_squash_map(creature);
 
     // Build total inbound |weight| for each neuron (for normalisation)
     let total_inbound: HashMap<String, f32> = {
@@ -202,12 +251,30 @@ fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
         map
     };
 
-    let output_neurons: HashSet<String> = creature
+    // Build inbound synapse count for selection squashes
+    let inbound_count: HashMap<String, usize> = {
+        let mut map: HashMap<String, usize> = HashMap::new();
+        for synapse in &creature.synapses {
+            *map.entry(synapse.to_uuid.clone()).or_insert(0) += 1;
+        }
+        map
+    };
+
+    let outputs: HashSet<String> = creature
         .neurons
         .iter()
         .filter(|n| n.neuron_type == "output")
         .map(|n| n.uuid.clone())
         .collect();
+
+    let ctx = ImpactContext {
+        adjacency,
+        total_inbound,
+        inbound_count,
+        squash_map,
+        outputs,
+    };
+
     let mut cache: HashMap<String, f32> = HashMap::new();
 
     for neuron in &creature.neurons {
@@ -215,14 +282,7 @@ fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
             continue;
         }
         let mut visiting = HashSet::new();
-        compute_impact_recursive(
-            &neuron.uuid,
-            &adjacency,
-            &total_inbound,
-            &output_neurons,
-            &mut cache,
-            &mut visiting,
-        );
+        compute_impact_recursive(&neuron.uuid, &ctx, &mut cache, &mut visiting);
     }
 
     cache
@@ -230,9 +290,7 @@ fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
 
 fn compute_impact_recursive(
     uuid: &str,
-    adjacency: &HashMap<String, Vec<(String, f32)>>,
-    total_inbound: &HashMap<String, f32>,
-    outputs: &HashSet<String>,
+    ctx: &ImpactContext,
     cache: &mut HashMap<String, f32>,
     visiting: &mut HashSet<String>,
 ) -> f32 {
@@ -245,40 +303,79 @@ fn compute_impact_recursive(
         return 0.0;
     }
 
-    let impact = if outputs.contains(uuid) {
+    let impact = if ctx.outputs.contains(uuid) {
         1.0
-    } else if let Some(edges) = adjacency.get(uuid) {
+    } else if let Some(edges) = ctx.adjacency.get(uuid) {
         // Sum across all outgoing edges (neuron may connect to multiple targets)
         let mut total_impact = 0.0;
         for (to_uuid, weight) in edges {
-            let child_impact = compute_impact_recursive(
-                to_uuid,
-                adjacency,
-                total_inbound,
-                outputs,
-                cache,
-                visiting,
-            );
+            let child_impact = compute_impact_recursive(to_uuid, ctx, cache, visiting);
             if child_impact <= 0.0 {
                 continue;
             }
 
-            // NORMALISED impact: what fraction of the target's input does this neuron provide?
-            //
-            // If target has 100 incoming synapses with total |weight| = 343,
-            // and this synapse has |weight| = 3, then this neuron contributes:
-            //   3 / 343 ≈ 0.9% of the target's input
-            //
-            // This is recursive - the fraction propagates through the network.
-            // A neuron 2 hops from output, going through a target with 100 inputs,
-            // has its impact diluted by that factor.
-            let target_total = total_inbound
+            // Get the target neuron's squash category
+            let squash = ctx
+                .squash_map
                 .get(to_uuid)
-                .copied()
-                .unwrap_or(1.0)
-                .max(1e-10);
-            let fraction = weight.abs() / target_total;
-            let contribution = fraction * child_impact;
+                .map(|s| s.as_str())
+                .unwrap_or("IDENTITY");
+            let category = SquashCategory::from_squash(squash);
+
+            let contribution = match category {
+                SquashCategory::Linear => {
+                    // NORMALISED impact: what fraction of the target's input does this neuron provide?
+                    //
+                    // If target has 100 incoming synapses with total |weight| = 343,
+                    // and this synapse has |weight| = 3, then this neuron contributes:
+                    //   3 / 343 ≈ 0.9% of the target's input
+                    //
+                    // This is recursive - the fraction propagates through the network.
+                    // A neuron 2 hops from output, going through a target with 100 inputs,
+                    // has its impact diluted by that factor.
+                    let target_total = ctx
+                        .total_inbound
+                        .get(to_uuid)
+                        .copied()
+                        .unwrap_or(1.0)
+                        .max(1e-10);
+                    let fraction = weight.abs() / target_total;
+                    fraction * child_impact
+                }
+                SquashCategory::Threshold => {
+                    // THRESHOLD impact (STEP/BIPOLAR): Any synapse could flip the output!
+                    //
+                    // For STEP/BIPOLAR neurons, even tiny weights can cause the full output
+                    // swing if they push the neuron across the threshold (0).
+                    //
+                    // Conservative approach: Don't normalise by total_inbound. Instead,
+                    // use the full child_impact as if this synapse alone determines output.
+                    //
+                    // This may overestimate impact, but it's better than underestimating
+                    // (which causes incorrect removal candidates).
+                    //
+                    // See docs/IMPACT_CALCULATION.md for detailed explanation.
+                    child_impact
+                }
+                SquashCategory::Selection => {
+                    // SELECTION impact (MINIMUM/MAXIMUM/IF): Only one synapse "wins"!
+                    //
+                    // For MINIMUM/MAXIMUM neurons, only the min/max synapse contributes to
+                    // the output. The others have zero contribution at any given time.
+                    //
+                    // Without activation data, we can't know which synapse wins. Conservative
+                    // approach: assume each synapse has 1/N probability of winning (where N
+                    // is the number of incoming synapses), giving impact = child_impact / N.
+                    //
+                    // This is better than the sum-based approach which is completely wrong
+                    // (gives high impact to large weights in MINIMUM when they're least
+                    // likely to win).
+                    //
+                    // See docs/IMPACT_CALCULATION.md for detailed explanation.
+                    let count = ctx.inbound_count.get(to_uuid).copied().unwrap_or(1).max(1);
+                    child_impact / count as f32
+                }
+            };
             total_impact += contribution;
         }
         total_impact

--- a/tests/impact_squash.rs
+++ b/tests/impact_squash.rs
@@ -1,0 +1,433 @@
+//! Tests for squash-aware impact calculation.
+//!
+//! These tests verify that impact calculation correctly handles special
+//! squash functions like STEP, BIPOLAR, MINIMUM, and MAXIMUM where the
+//! standard linear model fails.
+//!
+//! See docs/IMPACT_CALCULATION.md for detailed explanation of the issues.
+
+mod common;
+
+use neat_ai_discovery::focus::rank_focus_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Helper to create a creature with specified neurons (including squash) and synapses
+fn create_creature_with_squash(
+    neurons: Vec<(&str, &str, &str)>, // (uuid, type, squash)
+    synapses: Vec<(&str, &str, f32)>, // (from, to, weight)
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t, _)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t, _)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .map(|(uuid, neuron_type, squash)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: neuron_type.to_string(),
+                squash: squash.to_string(),
+                bias: 0.0,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, weight)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Helper to create parquet records for neurons with specified errors and activations
+fn create_records_with_activation(
+    neuron_data: Vec<(&str, f32, f32)>, // (uuid, error, activation)
+) -> Vec<DiscoverRecord> {
+    neuron_data
+        .into_iter()
+        .flat_map(|(uuid, error, activation)| {
+            vec![
+                DiscoverRecord::new(0, uuid.to_string(), Some(0.5), activation, vec![error]),
+                DiscoverRecord::new(1, uuid.to_string(), Some(0.5), activation, vec![error]),
+            ]
+        })
+        .collect()
+}
+
+// =============================================================================
+// STEP/BIPOLAR Tests
+// =============================================================================
+
+/// Test that tiny weights into STEP neurons are not underestimated.
+///
+/// Scenario: A neuron with activation 0.000_001 connects via weight 0.000_002
+/// to a STEP output neuron. The linear formula calculates impact ≈ 0, but if
+/// the STEP neuron is near its threshold, this tiny signal could flip the output.
+///
+/// NOTE: This test currently documents the EXPECTED behaviour. Until we implement
+/// squash-aware impact, it will show the current (incorrect) behaviour.
+#[test]
+fn test_step_neuron_tiny_weight_impact_not_underestimated() {
+    // Network: hidden-a (tiny activation) -> STEP output
+    let creature = create_creature_with_squash(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("hidden-a", "hidden", "IDENTITY"),
+            ("output-0", "output", "STEP"), // STEP activation!
+        ],
+        vec![
+            ("input-0", "hidden-a", 1.0),
+            ("hidden-a", "output-0", 0.000_002), // Tiny weight
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // hidden-a has tiny activation
+    let records = create_records_with_activation(vec![
+        ("hidden-a", 0.1, 0.000_001), // Tiny activation
+        ("output-0", 0.5, 0.5),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    // Find hidden-a's impact
+    let hidden_a = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-a")
+        .expect("hidden-a should be in results");
+
+    // Current behaviour: impact ≈ 0 (linear calculation: 0.000_002 / 0.000_002 * 1.0 = 1.0 actually)
+    // The issue is the activation_weighted_impact which is structural_impact × mean_activation
+    // = 1.0 × 0.000_001 = 0.000_001
+    //
+    // For STEP functions, even this tiny contribution could flip the output if near threshold.
+    // We document the current behaviour and note that this should be improved.
+    println!(
+        "STEP test - hidden-a structural_impact: {}, mean_activation: {}, activation_weighted_impact: {}",
+        hidden_a.impact, hidden_a.mean_activation, hidden_a.activation_weighted_impact
+    );
+
+    // The structural impact should still be ~1.0 (it's the only synapse to output)
+    assert!(
+        hidden_a.impact > 0.5,
+        "Structural impact should reflect connectivity, got {}",
+        hidden_a.impact
+    );
+
+    // Document: For STEP neurons, the activation_weighted_impact is potentially misleading
+    // because threshold crossings aren't accounted for.
+    // This is a known limitation documented in docs/IMPACT_CALCULATION.md
+}
+
+/// Test that BIPOLAR neurons also exhibit the threshold sensitivity issue.
+#[test]
+fn test_bipolar_neuron_threshold_impact() {
+    let creature = create_creature_with_squash(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("hidden-a", "hidden", "IDENTITY"),
+            ("output-0", "output", "BIPOLAR"), // BIPOLAR activation!
+        ],
+        vec![
+            ("input-0", "hidden-a", 1.0),
+            ("hidden-a", "output-0", 0.01), // Small weight
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = create_records_with_activation(vec![
+        ("hidden-a", 0.1, 0.5),
+        ("output-0", 0.5, 1.0), // BIPOLAR output = 1.0 (positive side)
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    let hidden_a = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-a")
+        .expect("hidden-a should be in results");
+
+    println!(
+        "BIPOLAR test - hidden-a structural_impact: {}, activation_weighted_impact: {}",
+        hidden_a.impact, hidden_a.activation_weighted_impact
+    );
+
+    // For BIPOLAR, the output change on threshold crossing is 2.0 (-1 to +1)
+    // This makes accurate impact even more important.
+}
+
+// =============================================================================
+// MINIMUM/MAXIMUM Tests
+// =============================================================================
+
+/// Test that MINIMUM neurons use conservative equal-probability impact.
+///
+/// For MINIMUM/MAXIMUM selection functions, we can't know which synapse "wins"
+/// without activation data. The conservative approach gives each synapse equal
+/// probability (1/N) of winning.
+///
+/// This is a MAJOR improvement over the old sum-based approach which gave large
+/// weights higher impact in MINIMUM - completely wrong since small weights are
+/// more likely to win in MINIMUM!
+#[test]
+fn test_minimum_neuron_selection_impact() {
+    // Network: Three hidden neurons feeding into a MINIMUM output
+    let creature = create_creature_with_squash(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("hidden-small", "hidden", "IDENTITY"),
+            ("hidden-medium", "hidden", "IDENTITY"),
+            ("hidden-large", "hidden", "IDENTITY"),
+            ("output-0", "output", "MINIMUM"), // MINIMUM activation!
+        ],
+        vec![
+            ("input-0", "hidden-small", 1.0),
+            ("input-0", "hidden-medium", 1.0),
+            ("input-0", "hidden-large", 1.0),
+            // Small weight → contributes small value to MINIMUM
+            ("hidden-small", "output-0", 0.1),
+            // Medium weight
+            ("hidden-medium", "output-0", 1.0),
+            // Large weight
+            ("hidden-large", "output-0", 10.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // All have similar positive activations, so:
+    // hidden-small contributes: 0.5 × 0.1 = 0.05 (smallest → WINS in MINIMUM!)
+    // hidden-medium contributes: 0.5 × 1.0 = 0.5
+    // hidden-large contributes: 0.5 × 10.0 = 5.0 (largest → loses)
+    let records = create_records_with_activation(vec![
+        ("hidden-small", 0.1, 0.5),
+        ("hidden-medium", 0.1, 0.5),
+        ("hidden-large", 0.1, 0.5),
+        ("output-0", 0.1, 0.05), // Output = min(0.05, 0.5, 5.0) = 0.05
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    let small = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-small")
+        .expect("hidden-small should be in results");
+    let medium = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-medium")
+        .expect("hidden-medium should be in results");
+    let large = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-large")
+        .expect("hidden-large should be in results");
+
+    println!(
+        "MINIMUM test - small impact: {}, medium impact: {}, large impact: {}",
+        small.impact, medium.impact, large.impact
+    );
+
+    // With the new selection-aware impact calculation, all neurons have equal
+    // probability of "winning" the selection (1/3 each), so equal impact.
+    //
+    // OLD BROKEN behaviour: large.impact = 90%, small.impact = 1%
+    // NEW FIXED behaviour: all have equal impact = 1/3 ≈ 0.33
+    //
+    // This is much better for MINIMUM because it doesn't incorrectly flag
+    // the small-weight neuron as "low impact" when it actually determines
+    // the output in many cases!
+    let epsilon = 0.01;
+    assert!(
+        (small.impact - large.impact).abs() < epsilon,
+        "For MINIMUM, all synapses should have equal structural impact (conservative). \
+         small: {}, large: {} - the OLD behaviour gave large weights ~90% impact!",
+        small.impact,
+        large.impact
+    );
+
+    // All should have ~0.33 impact (1/3 probability each)
+    let expected_impact = 1.0 / 3.0;
+    assert!(
+        (small.impact - expected_impact).abs() < epsilon,
+        "Impact should be ~0.33 (1/3 probability), got {}",
+        small.impact
+    );
+}
+
+/// Test that MAXIMUM neurons use conservative equal-probability impact.
+///
+/// For MAXIMUM/MINIMUM selection functions, we can't know which synapse "wins"
+/// without activation data. The conservative approach gives each synapse equal
+/// probability (1/N) of winning, so all have equal structural impact.
+///
+/// This is better than underestimating (which causes incorrect removal candidates)
+/// even if it doesn't perfectly model which synapse is likely to win.
+#[test]
+fn test_maximum_neuron_selection_impact() {
+    let creature = create_creature_with_squash(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("hidden-small", "hidden", "IDENTITY"),
+            ("hidden-large", "hidden", "IDENTITY"),
+            ("output-0", "output", "MAXIMUM"), // MAXIMUM activation!
+        ],
+        vec![
+            ("input-0", "hidden-small", 1.0),
+            ("input-0", "hidden-large", 1.0),
+            ("hidden-small", "output-0", 0.1),
+            ("hidden-large", "output-0", 10.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // For MAXIMUM: large weight usually wins in practice
+    // But at the structural level (without activations), we use conservative equal probability
+    let records = create_records_with_activation(vec![
+        ("hidden-small", 0.1, 0.5),
+        ("hidden-large", 0.1, 0.5),
+        ("output-0", 0.1, 5.0), // Output = max(0.05, 5.0) = 5.0
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    let small = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-small")
+        .expect("hidden-small should be in results");
+    let large = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-large")
+        .expect("hidden-large should be in results");
+
+    println!(
+        "MAXIMUM test - small impact: {}, large impact: {}",
+        small.impact, large.impact
+    );
+
+    // With the new selection-aware impact calculation, both neurons have equal
+    // probability of "winning" the selection (1/2 each), so equal impact.
+    //
+    // This is more conservative than the old behaviour (which gave large weights
+    // higher impact). The conservative approach is better for removal candidate
+    // detection because it won't incorrectly flag neurons as "low impact" when
+    // they could actually be the winning synapse.
+    //
+    // Impact = child_impact / N = 1.0 / 2 = 0.5 for both
+    let epsilon = 0.01;
+    assert!(
+        (small.impact - large.impact).abs() < epsilon,
+        "For MAXIMUM/MINIMUM, all synapses have equal structural impact (conservative). \
+         small: {}, large: {}",
+        small.impact,
+        large.impact
+    );
+
+    // Both should have ~0.5 impact (1/2 of the output's impact)
+    assert!(
+        (small.impact - 0.5).abs() < epsilon,
+        "Impact should be ~0.5 (1/2 probability), got {}",
+        small.impact
+    );
+}
+
+// =============================================================================
+// Interaction Tests
+// =============================================================================
+
+/// Test removal candidate detection with STEP output.
+///
+/// A hidden neuron feeding into a STEP output might be flagged as "low impact"
+/// by the current calculation but could actually flip the output.
+#[test]
+fn test_removal_candidate_step_output_interaction() {
+    let creature = create_creature_with_squash(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("hidden-critical", "hidden", "IDENTITY"),
+            ("output-0", "output", "STEP"),
+        ],
+        vec![
+            ("input-0", "hidden-critical", 1.0),
+            // Tiny weight that could still flip STEP output
+            ("hidden-critical", "output-0", 1e-8),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // hidden-critical has small activation
+    let records = create_records_with_activation(vec![
+        ("hidden-critical", 0.1, 0.001),
+        ("output-0", 0.5, 1.0),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    // Check if hidden-critical is flagged as a removal candidate
+    let is_removal_candidate = result
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "hidden-critical");
+
+    let hidden = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "hidden-critical")
+        .expect("hidden-critical should be in results");
+
+    println!(
+        "STEP removal test - activation_weighted_impact: {}, is_removal_candidate: {}",
+        hidden.activation_weighted_impact, is_removal_candidate
+    );
+
+    // Document: With tiny weights to STEP outputs, neurons might be incorrectly
+    // flagged as removal candidates because the threshold-crossing effect
+    // is not accounted for.
+}
+
+// =============================================================================
+// Documentation Tests
+// =============================================================================
+
+/// This test documents the current impact calculation behaviour for various squash
+/// functions. It's not meant to pass/fail but to document the current state.
+#[test]
+fn document_squash_function_impact_accuracy() {
+    println!("\n=== IMPACT CALCULATION ACCURACY BY SQUASH FUNCTION ===\n");
+    println!("| Squash      | Current Model | Accuracy   | Notes                          |");
+    println!("|-------------|---------------|------------|--------------------------------|");
+    println!("| IDENTITY    | Linear sum    | ✅ Accurate | Mathematically exact           |");
+    println!("| TANH        | Linear sum    | ⚠️ Approx   | Saturation not modelled        |");
+    println!("| LOGISTIC    | Linear sum    | ⚠️ Approx   | Saturation not modelled        |");
+    println!("| HARD_TANH   | Linear sum    | ⚠️ Approx   | Clamping not modelled          |");
+    println!("| STEP        | Linear sum    | ❌ Wrong    | Threshold crossing ignored     |");
+    println!("| BIPOLAR     | Linear sum    | ❌ Wrong    | Threshold crossing ignored     |");
+    println!("| MINIMUM     | Linear sum    | ❌ Wrong    | Selection not modelled         |");
+    println!("| MAXIMUM     | Linear sum    | ⚠️ Approx   | Works by coincidence           |");
+    println!("| ReLU        | Linear sum    | ⚠️ Approx   | Zero region not modelled       |");
+    println!("\nSee docs/IMPACT_CALCULATION.md for detailed analysis.");
+}


### PR DESCRIPTION
…aware logic

- Bump version in Cargo.toml from 0.1.131 to 0.1.132.
- Update README to introduce the new squash-aware impact calculation, detailing how different squash functions affect impact estimation.
- Implement logic in focus.rs to categorize squash functions and adjust impact calculations accordingly, ensuring accurate contributions from neurons with various activation types.
- Add documentation for the impact calculation methodology, including examples and rationale for the changes.

These enhancements improve the accuracy of neuron impact assessments, contributing to the overall performance of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds squash-aware impact model (Linear/Threshold/Selection) to neuron impact calculation, updates docs, adds tests, and bumps version to 0.1.132.
> 
> - **Focus/Impact Calculation**:
>   - Introduces squash-aware impact logic in `src/focus.rs`:
>     - Categorises squashes via `SquashCategory` and `build_squash_map()`.
>     - Linear: `|w|/total_inbound × child_impact`; Threshold (STEP/BIPOLAR): `child_impact`; Selection (MINIMUM/MAXIMUM/IF): `child_impact / N`.
>     - Refactors with `ImpactContext` and inbound synapse counts; updates recursion to use categories.
> - **Documentation**:
>   - Adds `docs/IMPACT_CALCULATION.md` detailing formulas, categories, and rationale.
>   - Updates `README.md` with squash-aware impact section and link to docs.
> - **Tests**:
>   - Adds `tests/impact_squash.rs` covering STEP, BIPOLAR, MINIMUM, MAXIMUM, and removal interaction cases.
> - **Version**:
>   - Bumps `Cargo.toml` version to `0.1.132`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f401793e106c0f27e54ecf11313ca59e593cd3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->