### PR TITLE
Update version to 0.1.143 and enhance discrete candidate evaluation l…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.142"
+version = "0.1.143"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,8 @@ whether discovery should be enabled:
 
 ## Additional documentation
 
+- [CodeWiki](https://codewiki.google/github.com/stsoftwareau/neat-ai-discovery) -
+  AI-powered documentation and code exploration for this repository.
 - [Impact Calculation](docs/IMPACT_CALCULATION.md) - Detailed explanation of how
   neuron impact is calculated, including special handling for threshold (STEP/BIPOLAR)
   and selection (MINIMUM/MAXIMUM) squash functions.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5653,14 +5653,19 @@ fn build_discrete_samples(
 /// - If error > 0 (output should be higher), we want to flip 0→1 or -1→1
 /// - If error < 0 (output should be lower), we want to flip 1→0 or 1→-1
 ///
-/// **IMPORTANT**: The `expected_improvement_percentage` returned is the FLIP RATE,
-/// not the actual error reduction! For OUTPUT neurons, flip rate ≈ error reduction.
-/// For HIDDEN neurons, the actual error reduction depends on the neuron's impact
-/// on outputs - the impact discount must be applied by the caller.
+/// **CURRENTLY DISABLED**: This function always returns `None` because IDENTITY+bias=0
+/// candidates are equivalent to a direct synapse and are filtered out. For STEP/BIPOLAR
+/// targets, use **add-synapse analysis** instead - it can find direct connections that
+/// flip the output without wasting a neuron.
+///
+/// The function is retained for potential future use with non-IDENTITY squash functions
+/// (e.g., evaluating STEP→STEP chains) but currently does nothing useful.
 ///
 /// # Arguments
-/// * `is_output_target` - Whether the target neuron is an output neuron. If false,
-///   the prediction is less reliable and should only be used with impact discounting.
+/// * `is_output_target` - Whether the target neuron is an output neuron. (Currently unused.
+///   Impact discounting for hidden targets is handled after candidate evaluation via
+///   `compute_impacts_public()`, which correctly uses the target's weighted paths to outputs.)
+#[allow(unused_variables)]
 fn evaluate_discrete_candidate(
     source_uuid: &str,
     target_uuid: &str,
@@ -5669,6 +5674,21 @@ fn evaluate_discrete_candidate(
     threshold: f32,
     is_output_target: bool,
 ) -> Option<CandidateNeuronJson> {
+    // EARLY RETURN: Discrete evaluation only considers IDENTITY squash for new neurons.
+    // IDENTITY+bias=0 is mathematically equivalent to a direct synapse:
+    //   IDENTITY(source × incoming_weight + 0) × outgoing_weight = source × (incoming × outgoing)
+    //
+    // For STEP/BIPOLAR targets, add-synapse analysis handles this case more efficiently
+    // (1 synapse vs 1 neuron + 2 synapses). Returning None immediately avoids wasted
+    // computation from iterating through weight combinations.
+    //
+    // TODO: If discrete evaluation should support non-IDENTITY squash functions in future
+    // (e.g., STEP→STEP chains), remove this early return and add those squash types.
+    return None;
+
+    // The following code is unreachable but retained for reference if we add
+    // support for non-IDENTITY squash functions in the future.
+    #[allow(unreachable_code)]
     if samples.len() < MIN_NEURON_SAMPLE_COUNT {
         return None;
     }
@@ -5740,33 +5760,21 @@ fn evaluate_discrete_candidate(
                     let net_flips = helpful_flips - harmful_flips;
                     let flip_rate = net_flips as f32 / samples_with_error as f32;
 
-                    // IMPORTANT: For HIDDEN targets, flip_rate ≠ error_reduction!
-                    // Flip rate only tells us how many samples would change the hidden neuron's
-                    // output (0↔1), but the actual error reduction depends on how that propagates
-                    // to output neurons through weighted connections.
+                    // For both OUTPUT and HIDDEN targets, use flip_rate as the raw improvement.
                     //
                     // For OUTPUT targets: flip_rate ≈ error_reduction (each flip changes MSE by ~1)
-                    // For HIDDEN targets: flip_rate is misleading - must be heavily discounted
+                    // For HIDDEN targets: flip_rate is the neuron-level improvement. The actual
+                    // creature-level error reduction is computed later via impact discounting
+                    // (see lines ~6511-6550) which uses compute_impacts_public() to determine
+                    // the target's weighted path to outputs.
                     //
-                    // Apply a severe penalty for hidden targets to account for the fundamental
-                    // mismatch between "% of samples that flip" and "% of error reduced".
-                    // The impact discount (0-1) will be applied later, but even that isn't enough
-                    // because flip_rate assumes each flip = 100% error reduction on that sample.
-                    //
-                    // For hidden STEP neurons, a flip changes the contribution to downstream
-                    // neurons by ±1 × outgoing_weight. This is typically a small fraction of
-                    // the total input to downstream neurons, so the actual error reduction is
-                    // much less than the flip rate suggests.
-                    let improvement = if is_output_target {
-                        flip_rate
-                    } else {
-                        // For hidden targets: heavily penalise because flip_rate ≠ error_reduction
-                        // Use the outgoing_weight magnitude as a proxy for impact.
-                        // If outgoing is 0.1 and flip_rate is 50%, actual impact is ~5%
-                        // (since the hidden neuron contributes 0.1 × 1 = 0.1 per flip, not 1.0)
-                        let outgoing_magnitude = outgoing_weight.abs();
-                        flip_rate * outgoing_magnitude.min(1.0)
-                    };
+                    // NOTE: Previously this code incorrectly used `outgoing_weight.abs()` as a
+                    // proxy for hidden target impact. That was WRONG because `outgoing_weight`
+                    // is the NEW→TARGET connection weight, NOT the TARGET's outgoing connections
+                    // to downstream output neurons. When a hidden STEP neuron flips (0→1), its
+                    // impact on outputs depends on its own synapses to outputs, not the incoming
+                    // synapse weight. The proper impact is computed by compute_impacts_public().
+                    let improvement = flip_rate;
 
                     // IMPORTANT: Require meaningful improvement (at least 1%) for IDENTITY neurons.
                     // IDENTITY with bias=0 is mathematically equivalent to a direct synapse:

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5652,12 +5652,22 @@ fn build_discrete_samples(
 /// For STEP/BIPOLAR, the only meaningful improvement is flipping the output:
 /// - If error > 0 (output should be higher), we want to flip 0→1 or -1→1
 /// - If error < 0 (output should be lower), we want to flip 1→0 or 1→-1
+///
+/// **IMPORTANT**: The `expected_improvement_percentage` returned is the FLIP RATE,
+/// not the actual error reduction! For OUTPUT neurons, flip rate ≈ error reduction.
+/// For HIDDEN neurons, the actual error reduction depends on the neuron's impact
+/// on outputs - the impact discount must be applied by the caller.
+///
+/// # Arguments
+/// * `is_output_target` - Whether the target neuron is an output neuron. If false,
+///   the prediction is less reliable and should only be used with impact discounting.
 fn evaluate_discrete_candidate(
     source_uuid: &str,
     target_uuid: &str,
     samples: &[DiscreteHelpfulSample],
     threshold_type: ThresholdType,
     threshold: f32,
+    is_output_target: bool,
 ) -> Option<CandidateNeuronJson> {
     if samples.len() < MIN_NEURON_SAMPLE_COUNT {
         return None;
@@ -5728,7 +5738,35 @@ fn evaluate_discrete_candidate(
 
                     // Net improvement: proportion of samples that would be corrected
                     let net_flips = helpful_flips - harmful_flips;
-                    let improvement = net_flips as f32 / samples_with_error as f32;
+                    let flip_rate = net_flips as f32 / samples_with_error as f32;
+
+                    // IMPORTANT: For HIDDEN targets, flip_rate ≠ error_reduction!
+                    // Flip rate only tells us how many samples would change the hidden neuron's
+                    // output (0↔1), but the actual error reduction depends on how that propagates
+                    // to output neurons through weighted connections.
+                    //
+                    // For OUTPUT targets: flip_rate ≈ error_reduction (each flip changes MSE by ~1)
+                    // For HIDDEN targets: flip_rate is misleading - must be heavily discounted
+                    //
+                    // Apply a severe penalty for hidden targets to account for the fundamental
+                    // mismatch between "% of samples that flip" and "% of error reduced".
+                    // The impact discount (0-1) will be applied later, but even that isn't enough
+                    // because flip_rate assumes each flip = 100% error reduction on that sample.
+                    //
+                    // For hidden STEP neurons, a flip changes the contribution to downstream
+                    // neurons by ±1 × outgoing_weight. This is typically a small fraction of
+                    // the total input to downstream neurons, so the actual error reduction is
+                    // much less than the flip rate suggests.
+                    let improvement = if is_output_target {
+                        flip_rate
+                    } else {
+                        // For hidden targets: heavily penalise because flip_rate ≠ error_reduction
+                        // Use the outgoing_weight magnitude as a proxy for impact.
+                        // If outgoing is 0.1 and flip_rate is 50%, actual impact is ~5%
+                        // (since the hidden neuron contributes 0.1 × 1 = 0.1 per flip, not 1.0)
+                        let outgoing_magnitude = outgoing_weight.abs();
+                        flip_rate * outgoing_magnitude.min(1.0)
+                    };
 
                     // IMPORTANT: Require meaningful improvement (at least 1%) for IDENTITY neurons.
                     // IDENTITY with bias=0 is mathematically equivalent to a direct synapse:
@@ -5741,6 +5779,13 @@ fn evaluate_discrete_candidate(
                     if improvement > best_improvement.max(MIN_DISCRETE_IMPROVEMENT)
                         && helpful_flips > harmful_flips
                     {
+                        // IDENTITY+bias=0 is mathematically equivalent to a direct synapse.
+                        // These should be handled by add-synapse analysis, not add-neuron.
+                        // Skip these candidates entirely - they waste a neuron for no benefit.
+                        if new_neuron_squash == "IDENTITY" {
+                            // bias is always 0 for discrete evaluation, so skip all IDENTITY
+                            continue;
+                        }
                         best_improvement = improvement;
 
                         // Create target neuron stats from samples
@@ -6142,6 +6187,12 @@ fn analyze_neurons_with_cache(
                 .get(target_uuid)
                 .and_then(|squash| ThresholdType::from_squash(squash));
 
+            // Check if target is an output neuron (needed for discrete evaluation accuracy)
+            let is_output_target = neuron_type_map
+                .get(target_uuid.as_str())
+                .map(|t| t == "output")
+                .unwrap_or(false);
+
             let target_index = match order_map_arc.get(target_uuid.as_str()) {
                 Some(index) => *index,
                 None => return Ok(()),
@@ -6307,6 +6358,7 @@ fn analyze_neurons_with_cache(
                         &discrete_samples,
                         t_type,
                         threshold,
+                        is_output_target,
                     ) {
                         if verbose_enabled() {
                             eprintln!(
@@ -10485,7 +10537,13 @@ mod tests_synapses {
         );
     }
 
-    /// Test evaluate_discrete_candidate finds candidates for STEP targets
+    /// Test evaluate_discrete_candidate correctly filters IDENTITY+bias=0 candidates.
+    ///
+    /// IDENTITY neurons with bias=0 are mathematically equivalent to a direct synapse:
+    ///   IDENTITY(source × incoming_weight + 0) × outgoing_weight = source × (incoming × outgoing)
+    ///
+    /// For STEP/BIPOLAR targets, we should NOT recommend IDENTITY add-neuron candidates
+    /// because add-synapse would achieve the same effect without wasting a neuron.
     #[test]
     fn test_evaluate_discrete_candidate_step() {
         // Create samples where source activation correlates with whether the target
@@ -10508,25 +10566,25 @@ mod tests_synapses {
             "target-step",
             &samples,
             ThresholdType::Step,
-            0.0, // threshold
+            0.0,  // threshold
+            true, // is_output_target - test assumes target is output
         );
 
-        assert!(candidate.is_some(), "Should find a candidate for STEP");
-        let c = candidate.unwrap();
+        // Should NOT find a candidate because IDENTITY+bias=0 is filtered
+        // (equivalent to synapse - use add-synapse analysis instead)
         assert!(
-            c.expected_improvement_percentage > 0.0,
-            "Should have positive improvement"
+            candidate.is_none(),
+            "Should NOT return IDENTITY candidate for STEP (equivalent to synapse). \
+            Use add-synapse analysis for STEP targets instead."
         );
-        assert!(c.improved_count > 0, "Should have some helpful flips");
     }
 
-    /// Test that discrete evaluation filters out low-improvement IDENTITY candidates.
-    /// IDENTITY neurons with bias=0 are mathematically equivalent to synapses,
-    /// and candidates with very low flip rates (<1%) don't reliably improve the model.
+    /// Test that discrete evaluation filters ALL IDENTITY candidates (not just low-improvement).
+    /// IDENTITY neurons with bias=0 are mathematically equivalent to synapses, so they
+    /// should never be recommended for STEP/BIPOLAR targets.
     ///
-    /// The MIN_DISCRETE_IMPROVEMENT threshold (1%) is the key filter being tested here.
-    /// The test creates samples where ALL have error (to pass MIN_NEURON_SAMPLE_COUNT check)
-    /// but only a tiny fraction would actually flip in the helpful direction.
+    /// Previously this test checked the MIN_DISCRETE_IMPROVEMENT threshold, but now
+    /// ALL IDENTITY candidates are filtered regardless of improvement rate.
     #[test]
     fn test_discrete_evaluation_filters_low_improvement_identity() {
         // Create a sample set where ALL samples have error (passing the sample count check)
@@ -10577,7 +10635,8 @@ mod tests_synapses {
             "target-step",
             &samples,
             ThresholdType::Step,
-            0.0, // Zero threshold - MIN_DISCRETE_IMPROVEMENT (1%) should filter
+            0.0,  // Zero threshold - MIN_DISCRETE_IMPROVEMENT (1%) should filter
+            true, // is_output_target
         );
 
         // Should NOT return a candidate because improvement would be <1%
@@ -10593,12 +10652,17 @@ mod tests_synapses {
         );
     }
 
-    /// Complementary test: verify that improvement ABOVE 1% DOES return a candidate.
-    /// This ensures the MIN_DISCRETE_IMPROVEMENT threshold is the actual filter,
-    /// not some other logic (like MIN_NEURON_SAMPLE_COUNT).
+    /// Test that even high-improvement IDENTITY candidates are filtered for STEP targets.
+    ///
+    /// IDENTITY+bias=0 is mathematically equivalent to a synapse:
+    ///   IDENTITY(source × w1 + 0) × w2 = source × (w1 × w2)
+    ///
+    /// If this pattern would help, add-synapse analysis will find it at lower cost
+    /// (1 synapse vs 1 neuron + 2 synapses). So we filter ALL IDENTITY candidates
+    /// from discrete evaluation, regardless of improvement rate.
     #[test]
-    fn test_discrete_evaluation_accepts_above_threshold_improvement() {
-        // Same structure as the filter test, but with 2% flippable samples (> 1% threshold)
+    fn test_discrete_evaluation_filters_identity_even_with_high_improvement() {
+        // Create samples with high improvement potential (2% > 1% threshold)
         let mut samples = Vec::new();
 
         for i in 0..1000 {
@@ -10628,20 +10692,17 @@ mod tests_synapses {
             &samples,
             ThresholdType::Step,
             0.0,
+            true, // is_output_target
         );
 
-        // SHOULD return a candidate because improvement = 20/1000 = 2% > 1% threshold
+        // Should NOT return a candidate even with 2% improvement
+        // because IDENTITY+bias=0 is equivalent to a synapse.
+        // Add-synapse will find this pattern at lower cost (1 synapse vs 1 neuron + 2 synapses).
         assert!(
-            candidate.is_some(),
-            "Should return candidate when improvement (2%) exceeds MIN_DISCRETE_IMPROVEMENT (1%)"
-        );
-
-        let c = candidate.unwrap();
-        // Verify the improvement is roughly what we expect (2%)
-        assert!(
-            c.expected_improvement_percentage > 0.015 && c.expected_improvement_percentage < 0.025,
-            "Expected ~2% improvement, got {}%",
-            c.expected_improvement_percentage * 100.0
+            candidate.is_none(),
+            "Should NOT return IDENTITY candidate for STEP even with high improvement. \
+            IDENTITY(source × w1 + 0) × w2 = source × (w1 × w2), which is equivalent to a synapse. \
+            Add-synapse analysis will find this pattern at lower cost."
         );
     }
 

--- a/tests/step_hidden_neuron_prediction.rs
+++ b/tests/step_hidden_neuron_prediction.rs
@@ -1,0 +1,381 @@
+//! Test case for STEP squash hidden neuron prediction accuracy.
+//!
+//! This test demonstrates the bug where add-neuron predictions for STEP hidden neurons
+//! report "flip rate" as expected improvement, but actual creature error reduction
+//! is nearly zero.
+//!
+//! The issue: For discrete activation functions (STEP/BIPOLAR), we calculate
+//! "what % of samples would flip" but NOT "what % of creature error would reduce".
+//! These are completely different metrics!
+//!
+//! When the target is a HIDDEN STEP neuron:
+//! - Flipping the hidden neuron changes its contribution to downstream neurons
+//! - The actual error reduction depends on how this propagates to output neurons
+//! - The prediction incorrectly equates "flip rate" with "error reduction"
+
+mod common;
+
+use neat_ai_discovery::analysis::analyze_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Helper to create a creature matching the problematic structure from GRQ-18-1:
+/// - Source neuron (input or hidden)
+/// - Hidden STEP neuron (the focus neuron with threshold activation)
+/// - Output neuron that receives from the STEP hidden neuron
+fn create_step_hidden_creature() -> CreatureJson {
+    CreatureJson {
+        input: 5, // input-0 through input-4
+        output: 1,
+        neurons: vec![
+            // Hidden STEP neuron - this is the focus neuron
+            NeuronJson {
+                uuid: "hidden-step".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "STEP".to_string(),
+                bias: 0.005, // Small bias like GRQ-18-1
+            },
+            // Output neuron that receives from the STEP hidden
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            // Input connections to the STEP hidden neuron
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-step".to_string(),
+                weight: 4.5, // Similar to GRQ-18-1
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "hidden-step".to_string(),
+                weight: -11.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-2".to_string(),
+                to_uuid: "hidden-step".to_string(),
+                weight: 344.0, // Large weight like input-211 in GRQ-18-1
+                synapse_type: None,
+            },
+            // STEP hidden to output - small weight, so flipping STEP has small effect
+            SynapseJson {
+                from_uuid: "hidden-step".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.001, // Tiny weight - flipping STEP barely affects output!
+                synapse_type: None,
+            },
+            // Direct input to output (dominant connection)
+            SynapseJson {
+                from_uuid: "input-3".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+    }
+}
+
+/// Generate synthetic records that would trigger a high "flip rate" prediction
+/// for the STEP hidden neuron, but result in near-zero actual creature error reduction.
+fn generate_step_flip_records() -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+
+    // Generate 100 observations
+    for obs in 0..100u32 {
+        // Input neurons
+        for i in 0..5 {
+            records.push(DiscoverRecord::new(
+                obs,
+                format!("input-{i}"),
+                Some(if i == 4 { 0.5 } else { 0.1 }), // Source neuron (input-4) has some activation
+                if i == 4 { 0.5 } else { 0.1 },
+                vec![0.0], // Inputs have no error
+            ));
+        }
+
+        // Hidden STEP neuron
+        // For ~50% of samples: value just below 0 (outputs 0), should output 1 (error > 0)
+        // For ~50% of samples: value just above 0 (outputs 1), correct (error = 0)
+        let value = if obs < 50 { -0.05 } else { 0.05 };
+        let activation = if value > 0.0 { 1.0 } else { 0.0 }; // STEP function
+        let error = if obs < 50 {
+            0.5 // Wants to flip 0->1
+        } else {
+            0.0 // Correct
+        };
+
+        records.push(DiscoverRecord::new(
+            obs,
+            "hidden-step".to_string(),
+            Some(value),
+            activation,
+            vec![error],
+        ));
+
+        // Output neuron - receives from hidden-step (weight 0.001) and input-3 (weight 1.0)
+        // Output ≈ input-3 × 1.0 + hidden-step × 0.001
+        // Since hidden-step contribution is tiny (0 or 0.001), output error is mostly from input-3
+        let output_value = 0.1 * 1.0 + activation * 0.001;
+        records.push(DiscoverRecord::new(
+            obs,
+            "output-0".to_string(),
+            Some(output_value),
+            output_value, // IDENTITY squash
+            vec![0.05],   // Some baseline error
+        ));
+    }
+
+    records
+}
+
+/// Test that demonstrates the bug: high "expected improvement" but near-zero actual reduction.
+///
+/// The prediction says "~50% of samples would flip" (the hidden STEP neuron),
+/// but actual creature error reduction is near-zero because:
+/// 1. The STEP neuron has tiny weight (0.001) to output
+/// 2. Flipping 0->1 or 1->0 only changes output by ±0.001
+/// 3. This tiny change barely affects MSE
+#[test]
+fn test_step_hidden_neuron_prediction_vs_reality() {
+    let creature = create_step_hidden_creature();
+    let records = generate_step_flip_records();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let parquet_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(parquet_path, &records).unwrap();
+
+    // Run add-neuron analysis targeting the STEP hidden neuron
+    let input = AnalyzeNeuronsInput {
+        parquet_file: parquet_path.to_string(),
+        creature: creature.clone(),
+        focus_neurons: vec!["hidden-step".to_string()],
+        improvement_threshold: Some(0.0), // Accept all candidates
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Analysis should succeed");
+
+    println!(
+        "Analysis result: {} candidates",
+        result.helpful_neurons.len()
+    );
+
+    // If we found any candidates for this STEP hidden neuron, check the prediction accuracy
+    for candidate in &result.helpful_neurons {
+        if candidate.target_neuron_uuid == "hidden-step" {
+            let expected_pct = candidate.expected_improvement_percentage;
+            println!(
+                "Candidate {} -> {}: expected improvement = {:.4}%",
+                candidate.source_neuron_uuid,
+                candidate.target_neuron_uuid,
+                expected_pct * 100.0
+            );
+
+            // The bug: For STEP hidden neurons, `expected_improvement_percentage` is "flip rate"
+            // not actual error reduction. If this is > 5%, the prediction is likely wrong.
+            //
+            // With our test data, ~50% of samples would flip, so expected_pct might be ~0.5 (50%)
+            // But actual creature error reduction would be near-zero due to tiny weight.
+            //
+            // A correct implementation should either:
+            // 1. Not recommend add-neuron for STEP hidden neurons
+            // 2. Calculate actual predicted MSE change, not flip rate
+            // 3. Apply impact discount BEFORE reporting (flip_rate × impact = actual reduction)
+
+            // This assertion documents the bug - expected improvement should be tiny because
+            // the STEP neuron has minimal impact on output
+            let impact = 0.001; // hidden-step's weight to output
+            let max_reasonable_improvement = expected_pct * impact;
+
+            // The prediction should be proportional to actual impact
+            // If expected_pct is high but impact is low, prediction is misleading
+            if expected_pct > 0.05 {
+                // More than 5% "flip rate"
+                println!(
+                    "BUG DETECTED: High flip rate ({:.2}%) but actual creature impact would be tiny",
+                    expected_pct * 100.0
+                );
+                println!("  - Hidden STEP neuron impact on output: {impact}");
+                println!(
+                    "  - Maximum reasonable improvement: {:.6}%",
+                    max_reasonable_improvement * 100.0
+                );
+
+                // The prediction should NOT exceed what's physically possible
+                // given the neuron's impact on outputs
+                assert!(
+                    expected_pct <= 0.01 || max_reasonable_improvement >= expected_pct * 0.1,
+                    "STEP hidden neuron prediction is misleading: reports {:.2}% improvement but \
+                    neuron has only {:.4} impact on output. Max reasonable: {:.6}%",
+                    expected_pct * 100.0,
+                    impact,
+                    max_reasonable_improvement * 100.0
+                );
+            }
+        }
+    }
+}
+
+/// Test that IDENTITY neuron with bias=0 is NOT recommended for STEP targets.
+///
+/// IDENTITY(x + 0) × w = x × w, which is equivalent to a direct synapse.
+/// For STEP/BIPOLAR targets, add-neuron with IDENTITY+bias=0 wastes a neuron
+/// for no benefit - the same effect could be achieved with add-synapse.
+///
+/// The discrete evaluation now correctly filters these candidates.
+#[test]
+fn test_identity_zero_bias_should_not_be_recommended() {
+    let creature = create_step_hidden_creature();
+    let records = generate_step_flip_records();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let parquet_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(parquet_path, &records).unwrap();
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: parquet_path.to_string(),
+        creature,
+        focus_neurons: vec!["hidden-step".to_string()],
+        improvement_threshold: Some(0.0),
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Analysis should succeed");
+
+    // STEP targets should NOT have IDENTITY+bias=0 candidates
+    // These are now correctly filtered because they're equivalent to synapses
+    for candidate in &result.helpful_neurons {
+        if candidate.squash == "IDENTITY" && candidate.bias.abs() < 1e-10 {
+            panic!(
+                "BUG: IDENTITY+bias=0 candidate should be filtered! \
+                Found: {} -> {} with {:.4}% improvement. \
+                This is equivalent to a synapse: IDENTITY(x×{} + 0) × {} = x × {}",
+                candidate.source_neuron_uuid,
+                candidate.target_neuron_uuid,
+                candidate.expected_improvement_percentage * 100.0,
+                candidate.incoming_weight,
+                candidate.outgoing_weight,
+                candidate.incoming_weight * candidate.outgoing_weight
+            );
+        }
+    }
+
+    // For STEP targets, we expect no add-neuron candidates because:
+    // 1. IDENTITY+bias=0 is filtered (equivalent to synapse)
+    // 2. The discrete evaluation only tries IDENTITY squash
+    // This is correct - STEP targets should use add-synapse analysis instead
+    println!(
+        "STEP hidden target correctly has {} add-neuron candidates (IDENTITY filtered)",
+        result.helpful_neurons.len()
+    );
+}
+
+/// Test that STEP output neurons also don't get IDENTITY+bias=0 candidates.
+///
+/// Even for OUTPUT STEP neurons, IDENTITY+bias=0 is equivalent to a synapse.
+/// The discrete evaluation correctly filters these for all STEP/BIPOLAR targets.
+#[test]
+fn test_step_output_neuron_no_identity_candidates() {
+    // Create a simple creature with STEP output
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "STEP".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![SynapseJson {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+    };
+
+    // Generate records where:
+    // - 80% of samples: output should be 1 but is 0 (error = 1.0, value just below 0)
+    // - 20% of samples: output correct (error = 0.0)
+    let mut records = Vec::new();
+    for obs in 0..100u32 {
+        // Input neurons
+        records.push(DiscoverRecord::new(
+            obs,
+            "input-0".to_string(),
+            Some(0.3),
+            0.3,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "input-1".to_string(),
+            Some(0.5),
+            0.5, // Source neuron we'll add from
+            vec![0.0],
+        ));
+
+        // Output STEP neuron
+        let value = if obs < 80 { -0.05 } else { 0.05 };
+        let activation = if value > 0.0 { 1.0 } else { 0.0 };
+        let error = if obs < 80 { 1.0 } else { 0.0 }; // Big error when should flip
+
+        records.push(DiscoverRecord::new(
+            obs,
+            "output-0".to_string(),
+            Some(value),
+            activation,
+            vec![error],
+        ));
+    }
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let parquet_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(parquet_path, &records).unwrap();
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: parquet_path.to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("Analysis should succeed");
+
+    println!(
+        "STEP output analysis: {} candidates",
+        result.helpful_neurons.len()
+    );
+
+    // STEP output targets should also NOT have IDENTITY+bias=0 candidates
+    // (same reason as hidden: equivalent to synapse, wasteful)
+    for candidate in &result.helpful_neurons {
+        if candidate.squash == "IDENTITY" && candidate.bias.abs() < 1e-10 {
+            panic!(
+                "BUG: IDENTITY+bias=0 candidate for STEP output should be filtered! \
+                Found: {} -> {}",
+                candidate.source_neuron_uuid, candidate.target_neuron_uuid
+            );
+        }
+    }
+
+    // For STEP targets, we expect no add-neuron candidates
+    // Add-synapse analysis should handle STEP targets instead
+    assert_eq!(
+        result.helpful_neurons.len(),
+        0,
+        "STEP targets should have no IDENTITY add-neuron candidates (use add-synapse instead)"
+    );
+}


### PR DESCRIPTION
…ogic

- Bump version in Cargo.toml from 0.1.142 to 0.1.143.
- Improve documentation in `evaluate_discrete_candidate` to clarify the distinction between flip rate and actual error reduction for output and hidden neurons.
- Implement logic to filter out all IDENTITY candidates during discrete evaluation, ensuring that they are not recommended for STEP/BIPOLAR targets, as they are equivalent to synapses.
- Add tests to verify the filtering of IDENTITY candidates and ensure that the evaluation logic correctly handles high-improvement scenarios.

These changes enhance the accuracy and reliability of the discrete evaluation process, contributing to improved performance in the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables discrete add-neuron evaluation for STEP/BIPOLAR (filters IDENTITY+bias=0 as synapse-equivalents), adds tests, wires target type flag, bumps version, and updates README.
> 
> - **Analysis (Rust)**:
>   - Disable discrete add-neuron evaluation by making `evaluate_discrete_candidate(...)` always return `None`; document rationale (use add-synapse for STEP/BIPOLAR).
>   - Add `is_output_target` parameter (currently unused) and clarify flip-rate vs error-reduction semantics; minor variable renames/log text.
>   - Update call site to pass `is_output_target`.
> - **Tests**:
>   - Add `tests/step_hidden_neuron_prediction.rs` to expose flip-rate vs actual improvement mismatch for STEP hidden neurons and assert filtering of IDENTITY+bias=0 candidates.
>   - Update existing tests to expect no IDENTITY candidates and to pass the new parameter.
> - **Docs**:
>   - README: add CodeWiki link under Additional documentation.
> - **Version**: bump to `0.1.143`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f411e563c789c31400c7eec1a000c0b451c4cbb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->