### PR TITLE
Update version to 0.1.148 and fix impact calculation logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.147"
+version = "0.1.148"
 edition = "2021"
 
 [lib]

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -549,7 +549,6 @@ pub fn compute_impacts_public(creature: &CreatureJson) -> HashMap<String, f32> {
 /// This struct groups related parameters to avoid clippy::too_many_arguments.
 struct ImpactContext {
     adjacency: HashMap<String, Vec<(String, f32)>>,
-    total_inbound: HashMap<String, f32>,
     inbound_count: HashMap<String, usize>,
     squash_map: HashMap<String, String>,
     outputs: HashSet<String>,
@@ -582,16 +581,7 @@ fn compute_impacts_internal_with_stats(
     let adjacency = build_adjacency(creature);
     let squash_map = build_squash_map(creature);
 
-    // Build total inbound |weight| for each neuron (for normalisation)
-    let total_inbound: HashMap<String, f32> = {
-        let mut map: HashMap<String, f32> = HashMap::new();
-        for synapse in &creature.synapses {
-            *map.entry(synapse.to_uuid.clone()).or_insert(0.0) += synapse.weight.abs();
-        }
-        map
-    };
-
-    // Build inbound synapse count for selection squashes
+    // Build inbound synapse count for selection squashes (MIN/MAX/IF neurons)
     let inbound_count: HashMap<String, usize> = {
         let mut map: HashMap<String, usize> = HashMap::new();
         for synapse in &creature.synapses {
@@ -612,7 +602,6 @@ fn compute_impacts_internal_with_stats(
 
     let ctx = ImpactContext {
         adjacency,
-        total_inbound,
         inbound_count,
         squash_map,
         outputs,
@@ -687,23 +676,25 @@ fn compute_impact_recursive(
 
             let contribution = match category {
                 SquashCategory::Linear => {
-                    // NORMALISED impact: what fraction of the target's input does this neuron provide?
+                    // ABSOLUTE impact: what is the actual contribution magnitude?
                     //
-                    // If target has 100 incoming synapses with total |weight| = 343,
-                    // and this synapse has |weight| = 3, then this neuron contributes:
-                    //   3 / 343 ≈ 0.9% of the target's input
+                    // v0.1.145: CRITICAL FIX - normalisation was causing massive underestimation.
                     //
-                    // This is recursive - the fraction propagates through the network.
-                    // A neuron 2 hops from output, going through a target with 100 inputs,
-                    // has its impact diluted by that factor.
-                    let target_total = ctx
-                        .total_inbound
-                        .get(to_uuid)
-                        .copied()
-                        .unwrap_or(1.0)
-                        .max(1e-10);
-                    let fraction = weight.abs() / target_total;
-                    fraction * child_impact
+                    // Previously we computed `|weight| / total_inbound × child_impact`, which
+                    // gave "what fraction of inputs is this?" but this is WRONG for removal
+                    // prediction. Production data showed impact underestimated by up to
+                    // 145 BILLION times (calculated 1e-12, actual 20% error increase).
+                    //
+                    // The correct formula for removal impact is:
+                    //   impact = |weight| × child_impact
+                    //
+                    // This gives the actual magnitude of change when the neuron is removed.
+                    // Values are no longer bounded to [0,1] but that's fine - we only care
+                    // about relative ordering for removal candidates.
+                    //
+                    // The old normalisation made sense for "blame assignment" but not for
+                    // predicting what happens when a neuron is removed from the network.
+                    weight.abs() * child_impact
                 }
                 SquashCategory::Threshold => {
                     // THRESHOLD impact (STEP/BIPOLAR): Any synapse could flip the output!
@@ -878,7 +869,7 @@ pub fn rank_focus_neurons(
     // Identify removal candidates: neurons with activation_weighted_impact < costOfGrowth.
     //
     // activation_weighted_impact = structural_impact × mean_activation
-    // where structural_impact = NORMALISED impact through the network
+    // where structural_impact = ABSOLUTE impact through the network (v0.1.145 fix)
     //
     // Neurons with impact below costOfGrowth are net negative - removing them
     // reduces complexity more than it affects error.
@@ -886,7 +877,11 @@ pub fn rank_focus_neurons(
     // We provide complexity savings info for each neuron based on NEAT-AI's formula:
     //   savings = growthCost × (1 + (N + M) / 10)
     // where N = incoming synapses, M = outgoing synapses
-    const COST_OF_GROWTH: f32 = 1e-7;
+    //
+    // v0.1.145: Changed from 1e-7 to 0.01 to match TypeScript default.
+    // The old 1e-7 was calibrated for NORMALISED impacts which massively
+    // underestimated actual impact (by up to 145 billion times in production).
+    const COST_OF_GROWTH: f32 = 0.01;
 
     // Return ALL neurons with impact below costOfGrowth as removal candidates
     let mut removal_candidates: Vec<RemovalCandidate> = neurons

--- a/tests/impact_calculation_production.rs
+++ b/tests/impact_calculation_production.rs
@@ -1,0 +1,386 @@
+//! Production-based impact calculation tests (Dec 2024)
+//!
+//! These tests are derived from actual production failures where impact was
+//! massively underestimated, causing neurons to be incorrectly marked as
+//! "low impact" when removing them actually increased error by up to 20%.
+//!
+//! ## Production Failure Pattern
+//!
+//! | Calculated Impact | Actual Error Increase | Underestimation |
+//! |-------------------|----------------------|-----------------|
+//! | 1.39e-12          | 20% (0.2)            | 145 billion x   |
+//! | 4.94e-13          | 0.0054% (5.4e-5)     | 100 million x   |
+//! | 1.87e-10          | 0.44% (4.4e-3)       | 24 million x    |
+//!
+//! ## Root Cause (v0.1.145 fix)
+//!
+//! The old normalised impact calculation:
+//!   impact = |weight| / total_inbound × child_impact
+//!
+//! Was fundamentally wrong for removal prediction. It answered "what share of
+//! blame?" not "what happens when removed?"
+//!
+//! The fix uses absolute impact:
+//!   impact = |weight| × child_impact
+
+mod common;
+
+use neat_ai_discovery::focus::{compute_impacts_public, rank_focus_neurons};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Create a synapse helper for cleaner test setup
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Create a hidden neuron helper
+fn hidden(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Create an output neuron helper
+fn output(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "output".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Production pattern: Hidden neuron with many incoming synapses and small weight to output.
+///
+/// In production, neurons like this were marked as "low impact" (1e-13) when
+/// removing them actually increased error by 0.005%. The old normalised
+/// calculation diluted impact by the number of incoming synapses.
+#[test]
+fn test_many_inputs_small_output_weight_has_reasonable_impact() {
+    // Pattern from production failure:
+    // - 16 incoming synapses to hidden neuron
+    // - 1 outgoing synapse with weight 0.037
+    // - Old calculation gave impact ~4.94e-13
+    // - Actual removal impact was ~5.4e-5 (100 million x underestimate)
+    let creature = CreatureJson {
+        input: 16,
+        output: 1,
+        neurons: vec![hidden("target", "IDENTITY"), output("output-0", "IDENTITY")],
+        synapses: {
+            let mut synapses = Vec::new();
+            // 16 incoming synapses (like production)
+            for i in 0..16 {
+                synapses.push(synapse(&format!("input-{i}"), "target", 1.0));
+            }
+            // Small weight to output
+            synapses.push(synapse("target", "output-0", 0.037));
+            synapses
+        },
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let target_impact = *impacts.get("target").unwrap_or(&0.0);
+
+    // With absolute impact: 0.037 × 1.0 = 0.037
+    // Must be >> 1e-10 (the old underestimate)
+    assert!(
+        target_impact > 0.01,
+        "Target impact should be ~0.037 (absolute weight), got {target_impact:.2e}. \
+         Old normalised calculation would give ~1e-13 which was wrong."
+    );
+}
+
+/// Production pattern: Deep network with multiple intermediate layers.
+///
+/// The old normalised calculation multiplied fractions at each layer,
+/// causing exponential underestimation. A neuron 3 hops from output
+/// with 20 synapses at each layer would have impact diluted by:
+///   1/20 × 1/20 × 1/20 = 1/8000
+#[test]
+fn test_deep_network_impact_not_exponentially_diluted() {
+    // 3-layer network: candidate → hidden1 → hidden2 → output
+    // Each layer has multiple inputs that would dilute normalised impact
+    let creature = CreatureJson {
+        input: 10,
+        output: 1,
+        neurons: vec![
+            hidden("candidate", "IDENTITY"),
+            hidden("hidden1", "IDENTITY"),
+            hidden("hidden2", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: {
+            let mut synapses = vec![
+                synapse("input-0", "candidate", 1.0),
+                synapse("candidate", "hidden1", 0.5),
+                synapse("hidden1", "hidden2", 0.5),
+                synapse("hidden2", "output-0", 0.5),
+            ];
+            // Add "diluting" synapses at each layer
+            for i in 1..10 {
+                synapses.push(synapse(&format!("input-{i}"), "hidden1", 0.5));
+            }
+            for i in 1..10 {
+                synapses.push(synapse(&format!("input-{i}"), "hidden2", 0.5));
+            }
+            synapses
+        },
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let candidate_impact = *impacts.get("candidate").unwrap_or(&0.0);
+
+    // Absolute impact through the path:
+    // candidate → hidden1: 0.5
+    // hidden1 → hidden2: 0.5
+    // hidden2 → output: 0.5
+    // Total: 0.5 × 0.5 × 0.5 = 0.125
+    //
+    // Old normalised would give:
+    // (0.5/5) × (0.5/5) × (0.5) = 0.01 × 0.01 × 0.5 = 0.00005
+    assert!(
+        candidate_impact > 0.05,
+        "Deep network impact should be ~0.125 (weight product), got {candidate_impact:.4}. \
+         Old normalised calculation would exponentially dilute this."
+    );
+}
+
+/// Production pattern: Intermediate neuron with 322 inputs.
+///
+/// From actual production failure:
+/// - Candidate had 1 outgoing synapse (weight 0.037) to intermediate
+/// - Intermediate had 322 incoming synapses and connected to output
+/// - Old calculation: 0.037/322 ≈ 0.0001 × downstream = ~1e-10
+/// - Actual impact was much higher
+#[test]
+fn test_hub_neuron_with_many_inputs_doesnt_zero_upstream_impact() {
+    let creature = CreatureJson {
+        input: 100,
+        output: 1,
+        neurons: vec![
+            hidden("upstream", "IDENTITY"),
+            hidden("hub", "IDENTITY"), // Like the 322-input neuron in production
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: {
+            let mut synapses = vec![
+                synapse("input-0", "upstream", 1.0),
+                synapse("upstream", "hub", 0.5),
+                synapse("hub", "output-0", 1.0),
+            ];
+            // Add 99 more inputs to hub (total 100 including upstream)
+            for i in 1..100 {
+                synapses.push(synapse(&format!("input-{i}"), "hub", 0.5));
+            }
+            synapses
+        },
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let upstream_impact = *impacts.get("upstream").unwrap_or(&0.0);
+
+    // Absolute: upstream → hub (0.5) × hub → output (1.0) = 0.5
+    // Old normalised: 0.5/50 × 1.0 = 0.01 (50x underestimate!)
+    assert!(
+        upstream_impact > 0.3,
+        "Upstream impact should be ~0.5 (absolute path weight), got {upstream_impact:.4}. \
+         The 100 other inputs to hub shouldn't dilute this."
+    );
+}
+
+/// Verify that neurons with genuinely negligible weights have low impact.
+///
+/// The fix to absolute impact shouldn't make all impacts large. A neuron
+/// with weight 1e-8 to output should still have negligible impact.
+#[test]
+fn test_truly_negligible_weight_has_low_impact() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            hidden("negligible", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "negligible", 1.0),
+            synapse("negligible", "output-0", 1e-8),
+            synapse("input-0", "output-0", 1.0),
+        ],
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let impact = *impacts.get("negligible").unwrap_or(&0.0);
+
+    // Absolute: 1e-8 × 1.0 = 1e-8 (genuinely small)
+    assert!(
+        impact < 1e-6,
+        "Neuron with 1e-8 weight should have small impact, got {impact:.2e}"
+    );
+    assert!(impact > 1e-10, "Impact shouldn't be zero, got {impact:.2e}");
+}
+
+/// Test that impact is correctly shared when neuron connects to multiple outputs.
+///
+/// If a neuron connects to 2 outputs with weight 1.0 each, it should have
+/// impact ~2.0 (sum of paths), not diluted.
+#[test]
+fn test_multiple_output_connections_sum_impact() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 2,
+        neurons: vec![
+            hidden("multi-output", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+            output("output-1", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "multi-output", 1.0),
+            synapse("multi-output", "output-0", 1.0),
+            synapse("multi-output", "output-1", 1.0),
+        ],
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let impact = *impacts.get("multi-output").unwrap_or(&0.0);
+
+    // Should sum: 1.0 + 1.0 = 2.0
+    assert!(
+        (impact - 2.0).abs() < 0.01,
+        "Multi-output neuron should have summed impact ~2.0, got {impact}"
+    );
+}
+
+/// Test with actual activation data - the mean_activation should correctly
+/// scale the structural impact for removal candidate detection.
+#[test]
+fn test_activation_weighted_impact_with_recorded_activations() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![hidden("tested", "IDENTITY"), output("output-0", "IDENTITY")],
+        synapses: vec![
+            synapse("input-0", "tested", 1.0),
+            synapse("tested", "output-0", 0.1), // Small but not negligible
+        ],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Records with various activations
+    let records = vec![
+        DiscoverRecord::new(0, "tested".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(1, "tested".to_string(), Some(0.3), 0.3, vec![0.1]),
+        DiscoverRecord::new(2, "tested".to_string(), Some(0.7), 0.7, vec![0.1]),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    let neuron = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "tested")
+        .expect("tested should be in results");
+
+    // structural_impact = 0.1 (weight to output)
+    // mean_activation ≈ 0.5 (average of 0.5, 0.3, 0.7)
+    // activation_weighted_impact ≈ 0.1 × 0.5 = 0.05
+    assert!(
+        neuron.impact > 0.05,
+        "Structural impact should be ~0.1, got {:.4}",
+        neuron.impact
+    );
+    assert!(
+        neuron.mean_activation > 0.3 && neuron.mean_activation < 0.7,
+        "Mean activation should be ~0.5, got {:.4}",
+        neuron.mean_activation
+    );
+}
+
+/// Test STEP/BIPOLAR neurons use full child_impact (threshold category).
+///
+/// For threshold functions, any synapse could flip the output, so we don't
+/// normalise by total_inbound.
+#[test]
+fn test_step_neuron_uses_full_impact_not_normalised() {
+    let creature = CreatureJson {
+        input: 10,
+        output: 1,
+        neurons: vec![
+            hidden("upstream", "IDENTITY"),
+            hidden("step-gate", "STEP"), // Threshold activation
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: {
+            let mut synapses = vec![
+                synapse("input-0", "upstream", 1.0),
+                synapse("upstream", "step-gate", 0.1), // Small weight
+                synapse("step-gate", "output-0", 1.0),
+            ];
+            // Add other inputs to step-gate
+            for i in 1..10 {
+                synapses.push(synapse(&format!("input-{i}"), "step-gate", 1.0));
+            }
+            synapses
+        },
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let upstream_impact = *impacts.get("upstream").unwrap_or(&0.0);
+
+    // For STEP targets, we use full child_impact (not normalised)
+    // upstream → step-gate uses child_impact = 1.0 (step-gate → output)
+    // So upstream impact should be ~1.0, not 0.1/10 × 1.0 = 0.01
+    assert!(
+        upstream_impact > 0.5,
+        "Upstream to STEP neuron should have high impact (threshold category), got {upstream_impact:.4}"
+    );
+}
+
+/// Test MINIMUM/MAXIMUM neurons use selection-based impact.
+///
+/// Only one synapse "wins" at any time, so impact should be probability-weighted.
+#[test]
+fn test_minimum_neuron_uses_selection_based_impact() {
+    let creature = CreatureJson {
+        input: 3,
+        output: 1,
+        neurons: vec![
+            hidden("always-wins", "IDENTITY"),
+            hidden("min-gate", "MINIMUM"),
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "always-wins", 1.0),
+            synapse("always-wins", "min-gate", 1.0),
+            synapse("input-1", "min-gate", 1.0),
+            synapse("input-2", "min-gate", 1.0),
+            synapse("min-gate", "output-0", 1.0),
+        ],
+    };
+
+    let impacts = compute_impacts_public(&creature);
+    let impact = *impacts.get("always-wins").unwrap_or(&0.0);
+
+    // Without activation data, MINIMUM uses equal probability: 1/3
+    // So impact ≈ 1/3 × 1.0 = 0.33
+    assert!(
+        impact > 0.2 && impact < 0.5,
+        "MINIMUM selection impact should be ~0.33 (1/3 probability), got {impact:.4}"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -401,19 +401,24 @@ fn test_impact_calculation_with_multiple_incoming_connections() {
         .as_f64()
         .expect("impact should be a number") as f32;
 
-    // With NORMALISED impact: |weight| / total_inbound × downstream_impact
-    // Output has 2 incoming synapses: weight 10 + weight 5 = total 15
-    // - hidden-a: 10/15 × 1.0 = 0.667 (67% of output's input)
-    // - hidden-b: 5/15 × 1.0 = 0.333 (33% of output's input)
+    // v0.1.145: Changed to ABSOLUTE impact: |weight| × downstream_impact
     //
-    // This is CORRECT: if we remove hidden-a, output loses 67% of its input, not 1000%!
+    // The old normalised approach (|weight| / total_inbound) was fundamentally wrong
+    // for removal prediction. It caused impacts to be underestimated by up to
+    // 145 billion times in production (calculated 1e-12, actual 20% error increase).
+    //
+    // With absolute impact:
+    // - hidden-a: 10 × 1.0 = 10.0 (removing loses 10 units of contribution)
+    // - hidden-b: 5 × 1.0 = 5.0 (removing loses 5 units of contribution)
+    //
+    // The ratio should still be 2:1 (proportional to weights)
     assert!(
-        (impact_a - 0.667).abs() < 0.01,
-        "hidden-a impact should be ~0.667 (10/15 of output's input), got {impact_a}",
+        (impact_a - 10.0).abs() < 0.01,
+        "hidden-a impact should be 10.0 (weight × downstream), got {impact_a}",
     );
     assert!(
-        (impact_b - 0.333).abs() < 0.01,
-        "hidden-b impact should be ~0.333 (5/15 of output's input), got {impact_b}",
+        (impact_b - 5.0).abs() < 0.01,
+        "hidden-b impact should be 5.0 (weight × downstream), got {impact_b}",
     );
 
     // The ratio of impacts should still be 2:1 (proportional to weights)

--- a/tests/regression_v0_1_126.rs
+++ b/tests/regression_v0_1_126.rs
@@ -1,34 +1,45 @@
-//! REGRESSION TESTS for impact calculation
+//! REGRESSION TESTS for impact calculation (v0.1.126 → v0.1.145)
 //!
-//! These tests verify that impact is correctly NORMALISED by total inbound weight.
+//! ## History:
 //!
-//! ## Key insight:
+//! v0.1.126 introduced NORMALISED impact calculation:
+//!   impact = |weight| / total_inbound × downstream_impact
 //!
-//! If an output neuron has 100 incoming synapses with total |weight| = 343,
-//! and one neuron contributes weight 3.0, that neuron provides:
-//!   3.0 / 343 ≈ 0.9% of the output's input
+//! This was WRONG. Production data (Dec 2024) showed impacts underestimated
+//! by up to 145 BILLION times:
+//!   - Calculated: 1.39e-12
+//!   - Actual: -20% error increase (0.2)
 //!
-//! Removing that neuron reduces output by ~0.9%, not 300%!
+//! v0.1.145 fixes this with ABSOLUTE impact:
+//!   impact = |weight| × downstream_impact
 //!
-//! This normalisation is recursive through the network.
+//! ## Why normalisation was wrong:
+//!
+//! When you remove a neuron, the network doesn't "redistribute" its inputs.
+//! If a neuron contributes 3 units to an output with total input 100:
+//!   - Normalised said: "removing loses 3% of output" (impact 0.03)
+//!   - Reality: "removing loses 3 units of contribution" (impact 3.0)
+//!
+//! The normalised approach answered "what share of blame?" not "what happens
+//! when removed?" - a fundamentally different question.
 
 mod common;
 
 use neat_ai_discovery::focus::compute_impacts_public;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 
-/// Test: Impact is normalised by total inbound weight.
+/// Test: Impact is ABSOLUTE (weight × downstream_impact), not normalised.
 ///
-/// When a target has multiple inputs, each input's impact is proportional
-/// to its share of the total input, not its absolute weight.
+/// v0.1.145: This test was updated to verify the fix. Previously it tested
+/// normalised impact which caused massive underestimation in production.
 #[test]
-fn test_impact_normalised_by_total_inbound() {
+fn test_impact_is_absolute_not_normalised() {
     // Network:
     //   candidate → output (weight 3.0)
     //   other inputs → output (total weight 97.0)
     //
-    // candidate provides 3/100 = 3% of output's input
-    // So candidate's impact should be ~0.03, not 3.0
+    // With ABSOLUTE impact: candidate impact = 3.0 × 1.0 = 3.0
+    // (The old normalised approach gave 0.03, which was wrong)
     let creature = CreatureJson {
         input: 10,
         output: 1,
@@ -62,7 +73,7 @@ fn test_impact_normalised_by_total_inbound() {
                     synapse_type: None,
                 },
             ];
-            // Add 97 units of weight from other inputs
+            // Add 97 units of weight from other inputs (shouldn't affect candidate's impact)
             for i in 1..10 {
                 synapses.push(SynapseJson {
                     from_uuid: format!("input-{i}"),
@@ -78,24 +89,23 @@ fn test_impact_normalised_by_total_inbound() {
     let impacts = compute_impacts_public(&creature);
     let candidate_impact = *impacts.get("candidate").unwrap_or(&0.0);
 
-    // Total inbound to output = 3.0 + 97.0 = 100.0
-    // candidate's share = 3.0 / 100.0 = 0.03 (3%)
+    // ABSOLUTE impact: weight × downstream = 3.0 × 1.0 = 3.0
+    // (Other inputs don't dilute this - they're independent contributions)
     assert!(
-        (candidate_impact - 0.03).abs() < 0.005,
-        "candidate impact should be ~0.03 (3% of output's input), got {candidate_impact}"
+        (candidate_impact - 3.0).abs() < 0.01,
+        "candidate impact should be 3.0 (absolute weight × downstream), got {candidate_impact}"
     );
 }
 
-/// Test: Deep network impact accumulates normalisation at each step.
+/// Test: Deep network impact multiplies weights (not fractions).
 #[test]
-fn test_deep_network_normalised_impact() {
+fn test_deep_network_absolute_impact() {
     // Network:
-    //   candidate → hidden (weight 1.0, hidden has total inbound 10)
-    //   hidden → output (weight 2.0, output has total inbound 4)
+    //   candidate → hidden (weight 1.0)
+    //   hidden → output (weight 2.0)
     //
-    // candidate's share of hidden = 1/10 = 10%
-    // hidden's share of output = 2/4 = 50%
-    // candidate's impact = 0.1 × 0.5 = 0.05 (5%)
+    // With ABSOLUTE impact: candidate = 1.0 × 2.0 = 2.0
+    // (The old normalised approach gave 0.05, which was wrong)
     let creature = CreatureJson {
         input: 10,
         output: 1,
@@ -127,14 +137,14 @@ fn test_deep_network_normalised_impact() {
                     weight: 1.0,
                     synapse_type: None,
                 },
-                // candidate → hidden (1.0 out of total 10)
+                // candidate → hidden (1.0)
                 SynapseJson {
                     from_uuid: "candidate".to_string(),
                     to_uuid: "hidden".to_string(),
                     weight: 1.0,
                     synapse_type: None,
                 },
-                // hidden → output (2.0 out of total 4)
+                // hidden → output (2.0)
                 SynapseJson {
                     from_uuid: "hidden".to_string(),
                     to_uuid: "output-0".to_string(),
@@ -142,7 +152,7 @@ fn test_deep_network_normalised_impact() {
                     synapse_type: None,
                 },
             ];
-            // Add 9 more units to hidden (total inbound = 10)
+            // Add other synapses (shouldn't affect candidate's impact)
             for i in 1..10 {
                 synapses.push(SynapseJson {
                     from_uuid: format!("input-{i}"),
@@ -151,7 +161,6 @@ fn test_deep_network_normalised_impact() {
                     synapse_type: None,
                 });
             }
-            // Add 2 more units to output (total inbound = 4)
             synapses.push(SynapseJson {
                 from_uuid: "input-1".to_string(),
                 to_uuid: "output-0".to_string(),
@@ -165,20 +174,17 @@ fn test_deep_network_normalised_impact() {
     let impacts = compute_impacts_public(&creature);
     let candidate_impact = *impacts.get("candidate").unwrap_or(&0.0);
 
-    // candidate → hidden: 1/10 = 0.1
-    // hidden → output: 2/4 = 0.5
-    // combined: 0.1 × 0.5 = 0.05
+    // ABSOLUTE: candidate → hidden (1.0) × hidden → output (2.0) = 2.0
     assert!(
-        (candidate_impact - 0.05).abs() < 0.01,
-        "candidate impact should be ~0.05 (10% × 50%), got {candidate_impact}"
+        (candidate_impact - 2.0).abs() < 0.01,
+        "candidate impact should be 2.0 (1.0 × 2.0), got {candidate_impact}"
     );
 }
 
-/// Test: Negligible weight neuron has negligible normalised impact.
+/// Test: Negligible weight neuron has negligible absolute impact.
 #[test]
 fn test_negligible_weight_has_negligible_impact() {
-    // A neuron with weight 1e-8 to output (which has total inbound ~1.0)
-    // should have impact ~1e-8
+    // A neuron with weight 1e-8 to output should have impact ~1e-8
     let creature = CreatureJson {
         input: 1,
         output: 1,
@@ -203,13 +209,14 @@ fn test_negligible_weight_has_negligible_impact() {
                 weight: 1.0,
                 synapse_type: None,
             },
+            // Very small weight to output
             SynapseJson {
                 from_uuid: "negligible".to_string(),
                 to_uuid: "output-0".to_string(),
                 weight: 1e-8,
                 synapse_type: None,
             },
-            // Add another input so total isn't just the negligible one
+            // Normal weight direct connection
             SynapseJson {
                 from_uuid: "input-0".to_string(),
                 to_uuid: "output-0".to_string(),
@@ -220,12 +227,12 @@ fn test_negligible_weight_has_negligible_impact() {
     };
 
     let impacts = compute_impacts_public(&creature);
-    let negligible_impact = *impacts.get("negligible").unwrap_or(&0.0);
+    let impact = *impacts.get("negligible").unwrap_or(&0.0);
 
-    // Total inbound to output = 1e-8 + 1.0 ≈ 1.0
-    // negligible's share ≈ 1e-8 / 1.0 = 1e-8
+    // With absolute impact: 1e-8 × 1.0 = 1e-8
+    // The direct connection doesn't affect this neuron's impact
     assert!(
-        negligible_impact < 1e-6 && negligible_impact > 0.0,
-        "negligible neuron should have tiny impact, got {negligible_impact}"
+        impact < 1e-6 && impact > 1e-10,
+        "negligible neuron impact should be ~1e-8, got {impact}"
     );
 }

--- a/tests/regression_v0_1_127.rs
+++ b/tests/regression_v0_1_127.rs
@@ -41,8 +41,9 @@ use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 use tempfile::NamedTempFile;
 
-/// Default growth cost matching NEAT-AI's typical value
-const COST_OF_GROWTH: f32 = 1e-7;
+/// Default growth cost matching NEAT-AI's typical value (0.01 per TypeScript default)
+/// v0.1.145: Changed from 1e-7 to 0.01 to match TypeScript and work with absolute impacts.
+const COST_OF_GROWTH: f32 = 0.01;
 
 /// Test the removal savings calculation matches NEAT-AI's Score.ts formula.
 ///
@@ -362,47 +363,47 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     );
 
     // Verify the savings match the NEAT-AI formula: growthCost × (1 + totalSynapses/10)
-    let expected_few_savings = COST_OF_GROWTH * (1.0 + 2.0 / 10.0); // 1.2e-7
-    let expected_many_savings = COST_OF_GROWTH * (1.0 + 5.0 / 10.0); // 1.5e-7
+    // v0.1.145: COST_OF_GROWTH changed from 1e-7 to 0.01 to match TypeScript
+    let expected_few_savings = COST_OF_GROWTH * (1.0 + 2.0 / 10.0); // 0.012
+    let expected_many_savings = COST_OF_GROWTH * (1.0 + 5.0 / 10.0); // 0.015
 
     assert!(
-        (few_candidate.removal_savings - expected_few_savings).abs() < 1e-15,
+        (few_candidate.removal_savings - expected_few_savings).abs() < 1e-6,
         "few-synapses savings should be {:.2e}, got {:.2e}",
         expected_few_savings,
         few_candidate.removal_savings
     );
     assert!(
-        (many_candidate.removal_savings - expected_many_savings).abs() < 1e-15,
+        (many_candidate.removal_savings - expected_many_savings).abs() < 1e-6,
         "many-synapses savings should be {:.2e}, got {:.2e}",
         expected_many_savings,
         many_candidate.removal_savings
     );
 }
 
-/// REGRESSION TEST: Threshold must use costOfGrowth (1e-7).
+/// REGRESSION TEST: Threshold must use costOfGrowth (0.01 per TypeScript).
+///
+/// v0.1.145: costOfGrowth changed from 1e-7 to 0.01 to match TypeScript
+/// and work with absolute (non-normalised) impacts.
 ///
 /// Neurons are removal candidates when:
-///   activation_weighted_impact < costOfGrowth (1e-7)
+///   activation_weighted_impact < costOfGrowth (0.01)
 ///
 /// This test creates a neuron with impact ABOVE costOfGrowth that should NOT
 /// be a removal candidate.
 #[test]
 fn regression_threshold_uses_cost_of_growth() {
-    // Create a neuron with activation_weighted_impact = 1e-3 (0.1%)
-    // This is:
-    //   - LARGER than costOfGrowth (1e-7) - should NOT be a candidate
-    //
-    // With normalised impact:
-    //   total_inbound to output = 1e-2 + 1.0 = 1.02
-    //   structural_impact = 1e-2 / 1.02 × 1.0 ≈ 0.0098 (0.98%)
-    //   mean_activation = 0.1
-    //   activation_weighted_impact ≈ 0.0098 × 0.1 = 9.8e-4 >> 1e-7
+    // Create a neuron with significant weight to output
+    // With ABSOLUTE impact (v0.1.145):
+    //   structural_impact = 0.5 × 1.0 = 0.5 (weight × downstream)
+    //   mean_activation = 0.5
+    //   activation_weighted_impact = 0.5 × 0.5 = 0.25 >> 0.01
     let creature = CreatureJson {
         input: 1,
         output: 1,
         neurons: vec![
             NeuronJson {
-                uuid: "moderate-impact".to_string(),
+                uuid: "high-impact".to_string(),
                 neuron_type: "hidden".to_string(),
                 squash: "IDENTITY".to_string(),
                 bias: 0.0,
@@ -417,22 +418,15 @@ fn regression_threshold_uses_cost_of_growth() {
         synapses: vec![
             SynapseJson {
                 from_uuid: "input-0".to_string(),
-                to_uuid: "moderate-impact".to_string(),
-                weight: 0.5,
-                synapse_type: None,
-            },
-            // Hidden → output with small weight
-            SynapseJson {
-                from_uuid: "moderate-impact".to_string(),
-                to_uuid: "output-0".to_string(),
-                weight: 1e-2,
-                synapse_type: None,
-            },
-            // Direct input → output (dominates inbound)
-            SynapseJson {
-                from_uuid: "input-0".to_string(),
-                to_uuid: "output-0".to_string(),
+                to_uuid: "high-impact".to_string(),
                 weight: 1.0,
+                synapse_type: None,
+            },
+            // Hidden → output with moderate weight
+            SynapseJson {
+                from_uuid: "high-impact".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.5,
                 synapse_type: None,
             },
         ],
@@ -441,10 +435,10 @@ fn regression_threshold_uses_cost_of_growth() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    // Records with mean_activation = 0.1
+    // Records with mean_activation = 0.5
     let records = vec![
-        DiscoverRecord::new(0, "moderate-impact".to_string(), Some(0.1), 0.1, vec![0.1]),
-        DiscoverRecord::new(1, "moderate-impact".to_string(), Some(0.1), 0.1, vec![0.1]),
+        DiscoverRecord::new(0, "high-impact".to_string(), Some(0.5), 0.5, vec![0.1]),
+        DiscoverRecord::new(1, "high-impact".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(0, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
         DiscoverRecord::new(1, "output-0".to_string(), Some(0.5), 0.5, vec![0.1]),
     ];
@@ -456,30 +450,29 @@ fn regression_threshold_uses_cost_of_growth() {
     let neuron = result
         .neurons
         .iter()
-        .find(|n| n.neuron_uuid == "moderate-impact")
-        .expect("moderate-impact should be in ranked neurons");
+        .find(|n| n.neuron_uuid == "high-impact")
+        .expect("high-impact should be in ranked neurons");
 
-    // Verify impact is above costOfGrowth
-    let cost_of_growth: f32 = 1e-7;
+    // Verify impact is above costOfGrowth (0.01)
     assert!(
-        neuron.activation_weighted_impact > cost_of_growth,
+        neuron.activation_weighted_impact > COST_OF_GROWTH,
         "activation_weighted_impact ({:.2e}) should be LARGER than costOfGrowth ({:.0e})",
         neuron.activation_weighted_impact,
-        cost_of_growth
+        COST_OF_GROWTH
     );
 
     // Should NOT be a removal candidate (impact > costOfGrowth)
     let candidate = result
         .removal_candidates
         .iter()
-        .find(|c| c.neuron_uuid == "moderate-impact");
+        .find(|c| c.neuron_uuid == "high-impact");
 
     assert!(
         candidate.is_none(),
         "Neuron with activation_weighted_impact ({:.2e}) > costOfGrowth ({:.0e}) should NOT \
          be a removal candidate. Found candidates: {:?}",
         neuron.activation_weighted_impact,
-        cost_of_growth,
+        COST_OF_GROWTH,
         result
             .removal_candidates
             .iter()


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.147 to 0.1.148.
- Refactor impact calculation in `focus.rs` to use absolute impact instead of normalised impact, correcting significant underestimations observed in production.
- Update tests to reflect changes in impact calculation, ensuring accuracy in removal candidate evaluations based on the new absolute impact logic.

These changes enhance the reliability of impact assessments and improve the overall performance of the analysis framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches impact calculation to absolute weights, adds selection-probability handling, raises removal threshold to 0.01, and updates/expands tests; bumps version to 0.1.148.
> 
> - **Core (impact calculation in `src/focus.rs`)**:
>   - Replace normalised impact with ABSOLUTE propagation (`|weight| × child_impact`); remove `total_inbound` usage.
>   - Add activation-based selection probabilities for `MINIMUM`/`MAXIMUM`/`IF` via `compute_selection_stats`; fall back to equal probability.
>   - Sum contributions across multiple outputs; keep threshold squashes using full `child_impact`.
>   - Update removal logic: `activation_weighted_impact = impact × mean_activation`; set `COST_OF_GROWTH` to `0.01`; include synapse-based `removal_savings` in reasons.
> - **Tests**:
>   - Add `tests/impact_calculation_production.rs` covering production underestimation patterns and deep networks.
>   - Update `tests/regression_v0_1_126.rs` and `tests/regression_v0_1_127.rs` to absolute impacts and new threshold; relax tolerances where needed.
>   - Adjust `tests/integration.rs` expectations to absolute impacts and cumulative multi-output impact.
> - **Meta**:
>   - Bump version in `Cargo.toml` to `0.1.148`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 672001203c72d34d53f95ca0bb84a5887234335a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->