### PR TITLE
Update version to 0.1.153 and refine signal handling and backtrace ca…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.152"
+version = "0.1.153"
 edition = "2021"
 
 [lib]
@@ -22,8 +22,7 @@ once_cell = "1.19"
 
 crossbeam-channel = "0.5"  # Efficient multi-producer work queues for GPU thread
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }  # Deadlock detection
-backtrace = "0.3"  # Thread backtraces for debugging
-signal-hook = "0.3"  # Signal handling (SIGQUIT for thread dumps)
+signal-hook = "0.3"  # Signal handling (SIGUSR1 for thread dumps)
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,23 @@ the same functional behavior.
    - Ensure code formatting and quality standards are maintained
    - **Never commit code without running `./quality.sh` first**
 
+3. **Dependency License Requirements**: All dependencies must be Apache-2.0 compatible
+   - **Allowed licenses**: Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, ISC, Zlib, Unlicense
+   - **Not allowed**: GPL, LGPL, AGPL, MPL (copyleft licenses)
+   - **Prefer built-in**: Use Rust standard library features over external crates when possible
+   - **Check before adding**: Run `cargo license` to verify new dependencies
+   - **CI enforcement**: Pull requests are checked by dependency review workflow
+   
+   Current dependencies and their licenses:
+   | Crate | License | Purpose |
+   |-------|---------|---------|
+   | serde | MIT/Apache-2.0 | JSON serialisation |
+   | parquet/arrow | Apache-2.0 | Data storage |
+   | wgpu | MIT/Apache-2.0 | GPU compute |
+   | rayon | MIT/Apache-2.0 | Parallelism |
+   | parking_lot | MIT/Apache-2.0 | Deadlock detection |
+   | signal-hook | MIT/Apache-2.0 | Signal handling |
+
 ### Prerequisites
 
 **User-installable (automatically handled by `runlib.sh`):**

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -149,11 +149,11 @@ fn install_signal_handler() {
 
 /// Dump backtraces of all threads to stderr.
 ///
-/// This is called when SIGQUIT (kill -3) is received.
+/// This is called when SIGUSR1 (kill -USR1) is received.
 /// Unlike Java, Rust doesn't have built-in thread enumeration, so we print
 /// the current thread's backtrace plus any deadlock information.
 fn dump_all_threads() {
-    use backtrace::Backtrace;
+    use std::backtrace::Backtrace;
 
     let timestamp = chrono_lite_timestamp();
 
@@ -167,9 +167,9 @@ fn dump_all_threads() {
     eprintln!("Name: {:?}", current.name().unwrap_or("<unnamed>"));
     eprintln!("ID: {:?}", current.id());
 
-    // Capture backtrace of current thread
-    let bt = Backtrace::new();
-    eprintln!("Backtrace:\n{bt:?}");
+    // Capture backtrace of current thread (force capture)
+    let bt = Backtrace::force_capture();
+    eprintln!("Backtrace:\n{bt}");
     eprintln!();
 
     // Check for any deadlocked threads (this gives us visibility into blocked threads)


### PR DESCRIPTION
…pture

- Bump version in Cargo.toml from 0.1.152 to 0.1.153.
- Update signal handling to use SIGUSR1 for thread dumps instead of SIGQUIT.
- Change backtrace capture method to force capture for improved debugging accuracy.
- Enhance README with new dependency license requirements and current dependencies table.

These changes improve debugging capabilities and ensure compliance with dependency licensing standards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches thread dumps to SIGUSR1 with std::backtrace force-capture, documents dependency license policy, and bumps version to 0.1.153.
> 
> - **Debugging**:
>   - Signal handler now listens for `SIGUSR1` (was `SIGQUIT`) to trigger thread dumps.
>   - Use `std::backtrace::Backtrace::force_capture()` and print formatted backtrace in `src/debug.rs`.
> - **Docs**:
>   - Add dependency license requirements and a current dependencies table in `README.md`.
> - **Dependencies/Build**:
>   - Remove `backtrace` crate usage; rely on standard library backtrace.
>   - Keep `signal-hook` for `SIGUSR1` handling; clarify usage in `Cargo.toml`.
>   - Bump crate version in `Cargo.toml` to `0.1.153`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eecc8af26f569ea5aa7adc39021cf4b1c2fc80c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->