### PR TITLE
Update version to 0.1.157 and enhance GPU timeout handling in analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.156"
+version = "0.1.157"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1115,13 +1115,20 @@ whether discovery should be enabled:
 - **Deadlock or stuck process**: If the process appears stuck (0% CPU/GPU), see the
   [Debugging Deadlocks](#debugging-deadlocks) section below.
 - **GPU timeout errors**: The library includes automatic timeout protection for GPU
-  operations (default: 60 seconds per operation). If the GPU becomes unresponsive,
-  you'll see an error like:
+  operations. If the GPU becomes unresponsive, you'll see an error like:
   
   ```
   GPU helpful batch evaluation timed out after 60s. The GPU may be unresponsive.
   Consider reducing batch size or restarting.
   ```
+  
+  **Two-tier timeout architecture** (v0.1.156):
+  - **Buffer mapping timeout**: 55 seconds - allows GPU operations to timeout internally
+  - **Queue timeout**: 60 seconds - ensures the work queue doesn't block forever
+  - **Shutdown timeout**: 12 seconds max (2s send + 10s exit wait) - prevents hung cleanup
+  
+  This layered approach ensures the GPU thread always has time to detect timeouts and
+  return errors before the queue gives up, preventing deadlocks when the GPU driver hangs.
   
   **Causes and solutions:**
   - **GPU driver hang**: Restart the process. If persistent, restart the machine.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -76,11 +76,18 @@ const MINIMUM_TOTAL_MEMORY_GB: f64 = 4.0;
 /// If less than 2GB is available, discovery is disabled to prevent hangs.
 const MINIMUM_AVAILABLE_MEMORY_GB: f64 = 2.0;
 
-/// Timeout for individual GPU operations (in seconds).
-/// If a GPU operation takes longer than this, we assume the GPU is stuck
-/// and return an error rather than hanging forever. This allows recovery
-/// on unattended machines.
-const GPU_OPERATION_TIMEOUT_SECS: u64 = 60;
+/// Timeout (seconds) for the GPU work queue waiting for a response from the GPU thread.
+/// This is the OUTER timeout - if the GPU thread doesn't respond within this time,
+/// the queue gives up and returns an error.
+const GPU_QUEUE_TIMEOUT_SECS: u64 = 60;
+
+/// Timeout (seconds) for individual GPU buffer mapping operations.
+/// This MUST be shorter than GPU_QUEUE_TIMEOUT_SECS to avoid a race condition:
+/// if both timeouts are the same, the queue might timeout before the GPU thread
+/// has a chance to return its own timeout error, leaving the thread stuck.
+/// By making this 5 seconds shorter, the GPU thread has time to detect the timeout,
+/// build an error response, and send it back before the queue gives up.
+const GPU_BUFFER_MAP_TIMEOUT_SECS: u64 = 55;
 
 /// Timeout for GPU thread initialisation (in seconds).
 /// GPU device creation should be fast; if it takes longer, something is wrong.
@@ -3365,11 +3372,11 @@ impl GpuWorkQueue {
             .map_err(|_| anyhow!("GPU work queue channel closed"))?;
 
         // Wait for the response with timeout
-        let timeout = Duration::from_secs(GPU_OPERATION_TIMEOUT_SECS);
+        let timeout = Duration::from_secs(GPU_QUEUE_TIMEOUT_SECS);
         match response_rx.recv_timeout(timeout) {
             Ok(result) => result,
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => Err(anyhow!(
-                "GPU helpful batch evaluation timed out after {GPU_OPERATION_TIMEOUT_SECS}s. \
+                "GPU helpful batch evaluation timed out after {GPU_QUEUE_TIMEOUT_SECS}s. \
                      The GPU may be unresponsive. Consider reducing batch size or restarting."
             )),
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
@@ -3396,11 +3403,11 @@ impl GpuWorkQueue {
             })
             .map_err(|_| anyhow!("GPU work queue channel closed"))?;
 
-        let timeout = Duration::from_secs(GPU_OPERATION_TIMEOUT_SECS);
+        let timeout = Duration::from_secs(GPU_QUEUE_TIMEOUT_SECS);
         match response_rx.recv_timeout(timeout) {
             Ok(result) => result,
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => Err(anyhow!(
-                "GPU harmful batch evaluation timed out after {GPU_OPERATION_TIMEOUT_SECS}s. \
+                "GPU harmful batch evaluation timed out after {GPU_QUEUE_TIMEOUT_SECS}s. \
                      The GPU may be unresponsive. Consider reducing batch size or restarting."
             )),
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
@@ -3434,11 +3441,11 @@ impl GpuWorkQueue {
             })
             .map_err(|_| anyhow!("GPU work queue channel closed"))?;
 
-        let timeout = Duration::from_secs(GPU_OPERATION_TIMEOUT_SECS);
+        let timeout = Duration::from_secs(GPU_QUEUE_TIMEOUT_SECS);
         match response_rx.recv_timeout(timeout) {
             Ok(result) => result,
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => Err(anyhow!(
-                "GPU ReLU evaluation timed out after {GPU_OPERATION_TIMEOUT_SECS}s. \
+                "GPU ReLU evaluation timed out after {GPU_QUEUE_TIMEOUT_SECS}s. \
                      The GPU may be unresponsive. Consider reducing batch size or restarting."
             )),
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
@@ -3472,11 +3479,11 @@ impl GpuWorkQueue {
             })
             .map_err(|_| anyhow!("GPU work queue channel closed"))?;
 
-        let timeout = Duration::from_secs(GPU_OPERATION_TIMEOUT_SECS);
+        let timeout = Duration::from_secs(GPU_QUEUE_TIMEOUT_SECS);
         match response_rx.recv_timeout(timeout) {
             Ok(result) => result,
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => Err(anyhow!(
-                "GPU activation evaluation timed out after {GPU_OPERATION_TIMEOUT_SECS}s. \
+                "GPU activation evaluation timed out after {GPU_QUEUE_TIMEOUT_SECS}s. \
                      The GPU may be unresponsive. Consider reducing batch size or restarting."
             )),
             Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
@@ -4233,7 +4240,7 @@ impl GpuAnalyzer {
             }
 
             // Event-driven wait: poll non-blocking, check all callback channels
-            wait_for_buffer_maps_batch(device, &map_receivers, GPU_OPERATION_TIMEOUT_SECS)
+            wait_for_buffer_maps_batch(device, &map_receivers, GPU_BUFFER_MAP_TIMEOUT_SECS)
                 .context("Harmful batch buffer mapping failed")?;
 
             // Process results - maintain order with empty flags
@@ -4398,7 +4405,7 @@ impl GpuAnalyzer {
         });
 
         // Event-driven wait: poll non-blocking, check callback channel
-        wait_for_buffer_map(device, &receiver, GPU_OPERATION_TIMEOUT_SECS)
+        wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("ReLU buffer mapping failed")?;
 
         let data = buffer_slice.get_mapped_range();
@@ -4570,7 +4577,7 @@ impl GpuAnalyzer {
         });
 
         // Event-driven wait: poll non-blocking, check callback channel
-        wait_for_buffer_map(device, &receiver, GPU_OPERATION_TIMEOUT_SECS)
+        wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("Activation buffer mapping failed")?;
 
         let data = buffer_slice.get_mapped_range();
@@ -4756,7 +4763,7 @@ impl GpuAnalyzer {
         });
 
         // Event-driven wait: poll non-blocking, check callback channel
-        wait_for_buffer_map(device, &receiver, GPU_OPERATION_TIMEOUT_SECS)
+        wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("Bias buffer mapping failed")?;
 
         let data = buffer_slice.get_mapped_range();
@@ -4947,7 +4954,7 @@ impl GpuAnalyzer {
             }
 
             // Event-driven wait: poll non-blocking, check all callback channels
-            wait_for_buffer_maps_batch(device, &map_receivers, GPU_OPERATION_TIMEOUT_SECS)
+            wait_for_buffer_maps_batch(device, &map_receivers, GPU_BUFFER_MAP_TIMEOUT_SECS)
                 .context("Helpful batch buffer mapping failed")?;
 
             // Now read all the mapped data (buffers are already mapped)


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.156 to 0.1.157.
- Refactor GPU operation timeout constants to improve clarity and prevent race conditions.
- Introduce a two-tier timeout architecture for GPU operations, ensuring better error handling and preventing deadlocks.
- Update README to reflect the new timeout architecture and its benefits for GPU operations.

These changes enhance the robustness of GPU processing and improve user guidance on timeout handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split GPU timeouts into queue (60s) and buffer-map (55s), updated analysis code and README accordingly, and bumped version to 0.1.157.
> 
> - **Analysis (GPU timeouts)**:
>   - Introduce `GPU_QUEUE_TIMEOUT_SECS=60` and `GPU_BUFFER_MAP_TIMEOUT_SECS=55`.
>   - Replace queue wait timeouts to use `GPU_QUEUE_TIMEOUT_SECS` with updated error messages.
>   - Use `GPU_BUFFER_MAP_TIMEOUT_SECS` for `wait_for_buffer_map(s)_batch` calls.
> - **Docs**:
>   - Update README GPU timeout section to describe two-tier timeout architecture and remove fixed 60s-per-op phrasing.
> - **Version**:
>   - Bump `Cargo.toml` version to `0.1.157`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aea2e765216e2ae403abfffbe82d80c06da6529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->