### PR TITLE
Update version to 0.1.158 and refine GPU batch size handling in analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.157"
+version = "0.1.158"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1156,16 +1156,16 @@ The library adapts to your machine's capabilities:
 | System Memory | Memory Tier | Work Queue | Batch Size Adjustment |
 |---------------|-------------|------------|----------------------|
 | < 8GB available | Low | 4 | Reduced to 256 |
-| 8-16GB available | Standard | 8 | GPU tier default |
+| 8-16GB available | Standard | 8 | Capped at 512 (v0.1.158) |
 | > 16GB available | High | 16 | GPU tier default |
 
 | GPU Type | GPU Tier | Default Batch Size |
 |----------|----------|-------------------|
-| M4, M4 Pro, M4 Max, M4 Ultra | High | 1024 (or 256 if low memory) |
-| M3 Pro, M3 Max, M2 Pro, M2 Max | High | 1024 (or 256 if low memory) |
-| M1, M2, M3 (base) | Standard | 512 (or 256 if low memory) |
-| Discrete GPUs (NVIDIA, AMD) | High | 1024 (or 256 if low memory) |
-| Integrated GPUs (Intel, etc.) | Standard | 512 (or 256 if low memory) |
+| M4, M4 Pro, M4 Max, M4 Ultra | High | 1024 (512 if standard memory, 256 if low) |
+| M3 Pro, M3 Max, M2 Pro, M2 Max | High | 1024 (512 if standard memory, 256 if low) |
+| M1, M2, M3 (base) | Standard | 512 (256 if low memory) |
+| Discrete GPUs (NVIDIA, AMD) | High | 1024 (512 if standard memory, 256 if low) |
+| Integrated GPUs (Intel, etc.) | Standard | 512 (256 if low memory) |
 
 **Why memory matters**: GPU operations require staging buffers in system RAM.
 On memory-constrained systems, smaller batches and fewer in-flight requests

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -519,9 +519,10 @@ fn get_adjusted_batch_size(gpu_tier: GpuPerformanceTier) -> usize {
     };
 
     // Reduce batch size if memory is constrained
+    // Standard memory tier should also reduce batch size to prevent Metal command buffer exhaustion
     match resources.memory_tier {
         MemoryTier::Low => LOW_MEMORY_GPU_BATCH_SIZE.min(base_size),
-        MemoryTier::Standard => base_size,
+        MemoryTier::Standard => DEFAULT_GPU_BATCH_SIZE.min(base_size), // Use 512 max, not 1024
         MemoryTier::High => base_size,
     }
 }
@@ -3737,6 +3738,11 @@ impl GpuAnalyzer {
         let (activation_layout, activation_pipeline) =
             Self::build_activation_pipeline(&device, "activation-pipeline");
         let (bias_layout, bias_pipeline) = Self::build_bias_pipeline(&device, "bias-pipeline");
+
+        // CRITICAL: Warm up the GPU by polling to ensure all pipeline creation work is complete.
+        // On Metal/M4, the GPU can get into a bad state if we start submitting compute work
+        // before shader compilation has finished. This blocking poll ensures the GPU is ready.
+        device.poll(wgpu::Maintain::Wait);
 
         Ok(Self {
             device: Some(device),


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.157 to 0.1.158.
- Update README to clarify batch size limits for standard memory tier, capping it at 512.
- Enhance batch size adjustment logic in `get_adjusted_batch_size` to prevent Metal command buffer exhaustion on standard memory systems.
- Add critical GPU polling to ensure readiness before submitting compute work, improving stability on Metal.

These changes enhance GPU processing efficiency and provide clearer guidance on memory tier configurations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps GPU batch size at 512 for standard-memory systems, adds a blocking GPU poll after pipeline creation for Metal stability, updates README tables, and bumps version to 0.1.158.
> 
> - **GPU/Analysis**:
>   - `src/analysis.rs`: In `get_adjusted_batch_size`, `MemoryTier::Standard` now uses `DEFAULT_GPU_BATCH_SIZE.min(base_size)` (cap 512).
>   - After pipeline creation, call `device.poll(wgpu::Maintain::Wait)` to ensure GPU readiness on Metal/M4 before submitting compute work.
> - **Docs**:
>   - `README.md`: Clarify standard-memory batch cap (512) and refine GPU batch size table/notes.
> - **Version**:
>   - `Cargo.toml`: Bump to `0.1.158`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7694e9bcfd7f95c7f980254c4054fb604233f88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->