### PR TITLE
fix: lower minimum available memory from 2GB to 1GB (#115)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.159"
+version = "0.1.160"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ Discovery is automatically disabled on machines that don't meet minimum requirem
 | Requirement | Minimum | Reason |
 |-------------|---------|--------|
 | **Total RAM** | 4 GB | GPU operations require memory for staging buffers |
-| **Available RAM** | 2 GB | Prevents hangs from memory pressure/swap thrashing |
+| **Available RAM** | 1 GB | Prevents hangs from memory pressure/swap thrashing |
 | **GPU** | Metal (macOS) or Vulkan (Linux) | Required for compute shaders |
+
+**Note on macOS memory reporting**: Apple Silicon Macs aggressively cache files in
+memory, so "available" RAM may appear low (e.g., 1-2GB on an 8GB machine). This is
+normal – macOS can quickly reclaim cached memory when needed. The 1GB minimum is
+sufficient for modern Macs with unified memory architecture.
 
 When requirements aren't met, `check_gpu_available()` returns `gpuAvailable: false`
 with a descriptive reason. NEAT-AI's evolution process continues normally - only

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -73,8 +73,11 @@ const STANDARD_MEMORY_THRESHOLD_GB: f64 = 16.0;
 const MINIMUM_TOTAL_MEMORY_GB: f64 = 4.0;
 
 /// Minimum available memory (in GB) required for discovery.
-/// If less than 2GB is available, discovery is disabled to prevent hangs.
-const MINIMUM_AVAILABLE_MEMORY_GB: f64 = 2.0;
+/// If less than 1GB is available, discovery is disabled to prevent hangs.
+/// Note: macOS on Apple Silicon aggressively uses memory for caching, so
+/// "available" memory is often reported low even when plenty can be reclaimed.
+/// 1GB is sufficient since macOS can quickly reclaim cached/inactive pages.
+const MINIMUM_AVAILABLE_MEMORY_GB: f64 = 1.0;
 
 /// Timeout (seconds) for the GPU work queue waiting for a response from the GPU thread.
 /// This is the OUTER timeout - if the GPU thread doesn't respond within this time,


### PR DESCRIPTION
macOS on Apple Silicon aggressively uses memory for caching, so "available" RAM is often reported as low (e.g., 1.3GB on an 8GB M3 MacBook Air) even when plenty can be quickly reclaimed.

The 2GB minimum was too aggressive and disabled discovery on capable machines. 1GB is sufficient since macOS can quickly reclaim cached/inactive pages when needed.

Fixes #115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers discovery’s available RAM requirement from 2GB to 1GB, updates README with macOS memory note, and bumps version.
> 
> - **Analysis/runtime**:
>   - Reduce `MINIMUM_AVAILABLE_MEMORY_GB` from `2.0` to `1.0` in `src/analysis.rs` with notes on macOS memory caching.
> - **Docs**:
>   - Update `README.md` minimum "Available RAM" to `1 GB` and add explanation about Apple Silicon/macOS memory reporting.
> - **Version**:
>   - Bump crate version in `Cargo.toml` to `0.1.160`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaac917aa9f05c8c3d9738900114c3ec24067aa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->