### PR TITLE
fix: correct expected error reduction calculation for removal candida…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.160"
+version = "0.1.162"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -965,6 +965,45 @@ const creatureLevelImprovement = candidate.expectedImprovementPercentage;
 // Don't multiply by getNeuronShare() or any other impact factor!
 ```
 
+#### Removal candidate expected error reduction fix (v0.1.162)
+
+**CRITICAL BUG FIX (Issue #117)**: The `expectedErrorReduction` for removal candidates was
+completely wrong. It was showing the **neuron's error** instead of the **creature's expected
+error change** from removing the neuron.
+
+| Field | Old (WRONG) | New (CORRECT) |
+|-------|-------------|---------------|
+| `expectedErrorReduction` | Neuron's `totalError` | `activationWeightedImpact` |
+| Example value | 27% (neuron's error) | 0.000001% (actual impact) |
+| Actual error change | ~0% | ~0% |
+
+**The bug**: TypeScript was using `totalError` (the neuron's average error from recorded
+samples) as the expected error reduction for the creature. This led to predictions like
+"removing this neuron will reduce error by 27%" when the actual reduction was ~0%.
+
+**The fix**: A new `expectedErrorReduction` field is now provided that reflects the
+**actual expected creature-level error change**. For removal candidates (low-impact neurons),
+this is approximately equal to `activationWeightedImpact` - the actual contribution the
+neuron makes to the output.
+
+**Why this makes sense**: Removal candidates have low `activationWeightedImpact` by definition
+(that's why they're candidates for removal). Removing them changes the creature's error by
+approximately this small amount. The neuron's own error (`totalError`) is irrelevant because
+the neuron doesn't significantly affect the output.
+
+**Removal candidate JSON response** now includes:
+- `expectedErrorReduction`: The creature-level expected error change (based on impact)
+- `totalError`: The neuron's error (for reference, but NOT for prediction)
+
+**TypeScript should use `expectedErrorReduction`** for predictions:
+```typescript
+// CORRECT: Use the impact-based prediction
+const expectedChange = candidate.expectedErrorReduction;
+
+// WRONG: Don't use neuron error as the prediction!
+// const expectedChange = candidate.totalError;  // BUG!
+```
+
 ## Verifying the installation
 
 Use the NEAT-AI helper script after copying the library:

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -52,6 +52,11 @@ pub struct RemovalCandidate {
     pub outgoing_synapses: usize,
     /// The complexity savings from removing this neuron (based on NEAT-AI Score.ts formula)
     pub removal_savings: f32,
+    /// Expected creature-level error reduction from removing this neuron.
+    /// This is based on activation_weighted_impact, NOT the neuron's error.
+    /// Issue #117: Previously, total_error was incorrectly used as expected error reduction,
+    /// leading to predictions like 27% when actual reduction was ~0%.
+    pub expected_error_reduction: f32,
     pub reason: String,
 }
 
@@ -891,6 +896,14 @@ pub fn rank_focus_neurons(
             let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
             let savings = calculate_removal_savings(incoming, outgoing, COST_OF_GROWTH);
 
+            // Issue #117: expected_error_reduction should be based on activation_weighted_impact,
+            // NOT total_error. The activation_weighted_impact represents the actual contribution
+            // this neuron makes to the output. Removing it changes error by approximately this amount.
+            //
+            // Previously, total_error (neuron's average error) was incorrectly used, leading to
+            // predictions like 27% when actual reduction was ~0% (for low-impact neurons).
+            let expected_error_reduction = n.activation_weighted_impact;
+
             RemovalCandidate {
                 neuron_uuid: n.neuron_uuid.clone(),
                 total_error: n.total_error,
@@ -900,6 +913,7 @@ pub fn rank_focus_neurons(
                 incoming_synapses: incoming,
                 outgoing_synapses: outgoing,
                 removal_savings: savings,
+                expected_error_reduction,
                 reason: format!(
                     "Impact {:.2e} < costOfGrowth ({:.0e}), {} synapses, saves {:.2e}",
                     n.activation_weighted_impact,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,10 @@ pub struct RemovalCandidateJson {
     pub outgoing_synapses: usize,
     /// The complexity savings from removing this neuron (based on NEAT-AI Score.ts formula)
     pub removal_savings: f32,
+    /// Expected creature-level error reduction from removing this neuron.
+    /// Issue #117: This is based on activation_weighted_impact, NOT total_error.
+    /// For low-impact removal candidates, this will be very small (as it should be).
+    pub expected_error_reduction: f32,
     /// Explains why removal improves score
     pub reason: String,
 }
@@ -790,6 +794,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                     incoming_synapses: c.incoming_synapses,
                     outgoing_synapses: c.outgoing_synapses,
                     removal_savings: c.removal_savings,
+                    expected_error_reduction: c.expected_error_reduction,
                     reason: c.reason,
                 })
                 .collect();

--- a/tests/focus.rs
+++ b/tests/focus.rs
@@ -1099,3 +1099,111 @@ fn test_cumulative_impact_mixed_direct_and_indirect_paths() {
         hub.impact
     );
 }
+
+/// Issue #117: expected_error_reduction should reflect the creature's expected error change,
+/// NOT the neuron's error. For removal candidates, this should be based on activation_weighted_impact.
+///
+/// The bug was that `total_error` (the neuron's average error) was being used as
+/// `expectedErrorReduction` on the TypeScript side, leading to predictions like 27%
+/// when the actual error change was ~0%.
+///
+/// The fix is to provide `expected_error_reduction` that reflects the ACTUAL expected
+/// creature-level error change from removing the neuron. For removal candidates (low-impact
+/// neurons), this should be very small - approximately equal to activation_weighted_impact.
+#[test]
+fn test_removal_candidate_expected_error_reduction_is_impact_based_not_neuron_error() {
+    // Scenario: A neuron with HIGH error (0.27 normalised) but NEGLIGIBLE impact (1e-8).
+    // The bug would predict 27% error reduction, but actual reduction is ~1e-8 (0.000001%).
+    //
+    // Network: input-0 -> negligible -> output-0 (tiny weights)
+    //          input-0 -> output-0 (direct, large weight)
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("negligible", "hidden"), // Negligible impact due to tiny weights
+            ("output-0", "output"),
+        ],
+        vec![
+            // Negligible neuron has tiny weights
+            ("input-0", "negligible", 1e-6),
+            ("negligible", "output-0", 1e-6),
+            // Direct path dominates
+            ("input-0", "output-0", 1.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Negligible neuron has HIGH error (0.27 or 27% when normalised)
+    // but tiny activation-weighted impact
+    let records = create_records_with_activation(vec![
+        ("negligible", 0.27, 0.5), // High error, moderate activation -> still tiny impact
+        ("output-0", 0.5, 0.8),    // Normal error for output
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+
+    // The negligible neuron should be a removal candidate
+    let negligible_removal = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "negligible");
+    assert!(
+        negligible_removal.is_some(),
+        "Negligible neuron should be a removal candidate. All candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| &c.neuron_uuid)
+            .collect::<Vec<_>>()
+    );
+
+    let candidate = negligible_removal.unwrap();
+
+    // CRITICAL: The expected_error_reduction should be tiny (based on impact),
+    // NOT the neuron's error (0.27).
+    //
+    // activation_weighted_impact = structural_impact × mean_activation
+    // structural_impact ≈ 1e-6 × 1e-6 = 1e-12 (tiny!)
+    // mean_activation = 0.5
+    // activation_weighted_impact ≈ 5e-13
+    //
+    // The expected_error_reduction should be approximately activation_weighted_impact
+    // (the actual contribution being removed).
+    assert!(
+        candidate.expected_error_reduction < 0.01, // Less than 1%
+        "expected_error_reduction should be tiny (based on impact), not the neuron's error (0.27). \
+         Got: {:.6} ({:.4}%). Neuron error was: {:.2}. Impact: {:.2e}. \
+         Bug #117: This would have been ~0.27 (27%) if using neuron error!",
+        candidate.expected_error_reduction,
+        candidate.expected_error_reduction * 100.0,
+        candidate.total_error,
+        candidate.activation_weighted_impact
+    );
+
+    // The expected_error_reduction should be in the same order of magnitude as impact
+    // (within 10x) since removing a low-impact neuron has minimal effect on error.
+    let impact_ratio = if candidate.activation_weighted_impact > 1e-10 {
+        candidate.expected_error_reduction / candidate.activation_weighted_impact
+    } else {
+        // For extremely tiny impacts, just verify it's also tiny
+        1.0
+    };
+    assert!(
+        impact_ratio < 100.0,
+        "expected_error_reduction ({:.2e}) should be within ~100x of activation_weighted_impact ({:.2e}). \
+         Ratio: {:.1}x. Bug #117: This ratio would be ~billions if using neuron error!",
+        candidate.expected_error_reduction,
+        candidate.activation_weighted_impact,
+        impact_ratio
+    );
+
+    // Verify total_error is high (this is what was incorrectly used before)
+    assert!(
+        candidate.total_error > 0.1,
+        "Neuron should have high error (0.27), got {:.4}",
+        candidate.total_error
+    );
+}


### PR DESCRIPTION
…tes (v0.1.162)

This update addresses a critical bug (Issue #117) where the `expectedErrorReduction` for removal candidates was incorrectly calculated using the neuron's total error instead of the actual expected creature-level error change. The new implementation uses `activationWeightedImpact` to provide accurate predictions, ensuring that the expected error reduction reflects the true impact of removing low-impact neurons.

- Updated `RemovalCandidate` struct to include the correct `expected_error_reduction` field.
- Adjusted relevant functions to compute the expected error reduction based on the correct criteria.
- Enhanced README to document the changes and clarify the expected behavior.
- Added tests to verify the accuracy of the new expected error reduction calculations.

This fix improves the reliability of predictions related to neuron removal and enhances the overall functionality of the system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects removal candidate expected error reduction to use activation-weighted impact, exposes it in JSON, updates docs/tests, and bumps version to 0.1.162.
> 
> - **Backend (focus/removal)**:
>   - Add `expected_error_reduction` to `RemovalCandidate` computed from `activation_weighted_impact` (replacing neuron `total_error` usage).
>   - Populate and include `expected_error_reduction` when building removal candidates.
> - **Public API/Serialization**:
>   - Extend `RemovalCandidateJson` with `expected_error_reduction` and wire through in `rank_focus_neurons_internal` output.
> - **Tests**:
>   - Add regression test ensuring `expected_error_reduction` is impact-based and tiny for negligible-impact neurons.
> - **Docs**:
>   - README: Document bug (Issue #117), the fix, and correct client usage.
> - **Version**:
>   - Bump crate to `0.1.162`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 905b3c3234132e5f3a0323aaa0a85762e9d8f125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->