### PR TITLE
fix: implement saturation detection for add-neuron candidates (Issue …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.166"
+version = "0.1.167"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -459,6 +459,44 @@ This means the issue is in **sample collection or interpretation**, not the form
 making the neuron behave like a constant. This appears "optimal" on small samples but fails to generalise.
 See `tests/fixed_vs_optimised_params.rs` for investigation tests.
 
+#### Saturation detection for add-neuron candidates (v0.1.167, Issue #123)
+
+**CRITICAL FIX**: Candidates with saturated neurons are now detected and rejected before being
+returned. This prevents massive prediction failures where expected improvement is orders of
+magnitude higher than actual improvement.
+
+**The problem** (Issue #123):
+- Expected error reduction: 4.67%
+- Actual error reduction: ~0% (2.5×10⁻¹⁴)
+- This is a 12 orders of magnitude prediction error!
+
+**Root cause**: When bias is large relative to the input range, the neuron saturates and outputs
+nearly-constant values regardless of input:
+
+| Activation | Bias | Input Range | Output Range | Status |
+|------------|------|-------------|--------------|--------|
+| SOFTSIGN | 5.0 | [-1, 1] | [0.78, 0.85] | **Saturated** ❌ |
+| TANH | 10.0 | [-1, 1] | [0.9999, 1.0] | **Saturated** ❌ |
+| TANH | 1.0 | [-1, 1] | [-0.76, 0.96] | Normal ✓ |
+
+A constant-output neuron **cannot** reduce error correlation - it just adds a fixed offset.
+The prediction model incorrectly assumes output varies with input.
+
+**The fix**: Before returning a candidate, the library now checks if:
+1. The INPUT activations have variance (source data varies)
+2. The OUTPUT would have variance (neuron not saturated)
+
+If input varies but output doesn't, the candidate is rejected. This is implemented via
+`has_sufficient_output_variance()` with threshold `MIN_NEURON_OUTPUT_STD_DEV = 0.01`.
+
+**Note**: If the input itself is constant (all samples have same source activation), the
+candidate is NOT rejected - constant output is expected and predictions remain valid.
+
+**Tests added**:
+- `test_saturation_detection_rejects_constant_output`: SOFTSIGN with bias=5 rejected
+- `test_saturation_detection_tanh_large_bias`: TANH with bias=10 rejected
+- `test_saturation_detection_allows_constant_input`: Constant input not incorrectly rejected
+
 #### Root cause identified: Sample representativeness (v0.1.142)
 
 **CRITICAL FINDING**: Synthetic integration tests (`tests/prediction_validation.rs`) have
@@ -1051,6 +1089,41 @@ const expectedChange = candidate.expectedErrorReduction;
 // WRONG: Don't use neuron error as the prediction!
 // const expectedChange = candidate.totalError;  // BUG!
 ```
+
+#### Field naming and percentage calculations (Issue #124)
+
+**IMPORTANT**: Rust returns two types of improvement/error metrics with different semantics:
+
+| Field | Type | Value Range | To Display as % |
+|-------|------|-------------|-----------------|
+| `expectedImprovementPercentage` | **Ratio** | 0.0 - 1.0 | `value × 100` |
+| `expectedErrorReduction` | **Absolute** | Any positive | `(value / originalError) × 100` |
+
+**`expectedImprovementPercentage`** is already a ratio (decimal percentage):
+- Value `0.07` means 7% improvement
+- Calculated as `(baseline_error - new_error) / baseline_error`
+- **To display**: multiply by 100 → `0.07 × 100 = 7%`
+
+**`expectedErrorReduction`** is an **absolute value**, NOT a ratio:
+- Value `0.0656` is a raw error delta, not a percentage
+- **WRONG**: `0.0656 × 100 = 6.56%` ❌ (this is meaningless)
+- **CORRECT**: `(0.0656 / 0.5827) × 100 = 11.26%` ✓ (reduction as percentage of original error)
+
+TypeScript should NOT create `*Pct` fields by simply multiplying by 100:
+```typescript
+// WRONG: Multiplying absolute value by 100 is not a valid percentage
+const expectedErrorReductionPct = expectedErrorReduction * 100;  // BUG!
+
+// CORRECT: Use expectedImprovementPercentage directly (it's already a ratio)
+const improvementPercent = candidate.expectedImprovementPercentage * 100;
+
+// CORRECT: If you need error reduction as %, divide by original error first
+const errorReductionPercent = (expectedErrorReduction / originalError) * 100;
+```
+
+**Recommendation**: Use `expectedImprovementPercentage` for all percentage displays.
+The `expectedErrorReduction` field is provided for reference but should not be
+converted to a percentage by simple multiplication.
 
 ## Verifying the installation
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -26,6 +26,21 @@ const EPSILON: f32 = 1e-8;
 const WORKGROUP_SIZE: u32 = 256;
 const MIN_NEURON_SAMPLE_COUNT: usize = 10;
 
+/// Minimum variance of new neuron output across samples.
+///
+/// Issue #123: When bias is too large relative to the input range, the neuron becomes
+/// saturated and outputs nearly-constant values regardless of input. For example:
+/// - SOFTSIGN(5 + 0.35×x) ≈ 0.83 for all typical x values
+/// - TANH(10 + x) ≈ 1.0 for all x > -9
+///
+/// A constant-output neuron CANNOT reduce error correlation - it just adds a fixed offset.
+/// The prediction model incorrectly assumes the output varies with input, leading to
+/// massive prediction failures (e.g., predicting 4.67% improvement when actual is ~0%).
+///
+/// This threshold rejects candidates where the output standard deviation is below 0.01,
+/// meaning the neuron produces nearly identical output across all samples.
+const MIN_NEURON_OUTPUT_STD_DEV: f32 = 0.01;
+
 /// Maximum absolute value for outgoing weights in add-neuron candidates.
 ///
 /// Based on analysis of successful discoveries vs failures:
@@ -45,6 +60,79 @@ const MAX_OUTGOING_WEIGHT: f32 = 0.1;
 #[inline]
 fn is_threshold_activation(squash: &str) -> bool {
     matches!(squash.to_uppercase().as_str(), "STEP" | "BIPOLAR")
+}
+
+/// Check if a new neuron would be saturated (producing nearly-constant output).
+///
+/// Issue #123: Neurons with large bias values relative to typical inputs become saturated
+/// and output nearly the same value regardless of input. This causes massive prediction
+/// failures because the linear error model assumes output varies with input.
+///
+/// Returns `true` if the neuron is NOT saturated (output has sufficient variance).
+/// Returns `false` if the neuron IS saturated (should be rejected).
+///
+/// IMPORTANT: We only reject when INPUT has variance but OUTPUT doesn't. If input is
+/// already constant (low variance), then constant output is expected and predictions
+/// will still be valid.
+///
+/// # Arguments
+/// * `samples` - The samples to evaluate
+/// * `incoming_weight` - Weight from source to new neuron
+/// * `bias` - Bias of the new neuron
+/// * `activation_fn` - Activation function of the new neuron
+fn has_sufficient_output_variance(
+    samples: &[HelpfulSample],
+    incoming_weight: f32,
+    bias: f32,
+    activation_fn: fn(f32) -> f32,
+) -> bool {
+    if samples.len() < 2 {
+        return false;
+    }
+
+    // Compute mean and variance of both input and output
+    let mut input_sum = 0.0f64;
+    let mut input_sum_sq = 0.0f64;
+    let mut output_sum = 0.0f64;
+    let mut output_sum_sq = 0.0f64;
+    let mut count = 0u32;
+
+    for sample in samples {
+        let input = sample.activation;
+        let pre_activation = incoming_weight * input + bias;
+        let output = activation_fn(pre_activation);
+        if output.is_finite() && input.is_finite() {
+            input_sum += input as f64;
+            input_sum_sq += (input as f64) * (input as f64);
+            output_sum += output as f64;
+            output_sum_sq += (output as f64) * (output as f64);
+            count += 1;
+        }
+    }
+
+    if count < 2 {
+        return false;
+    }
+
+    let n = count as f64;
+
+    // Calculate input variance
+    let input_mean = input_sum / n;
+    let input_variance = (input_sum_sq / n) - (input_mean * input_mean);
+    let input_std_dev = input_variance.max(0.0).sqrt() as f32;
+
+    // Calculate output variance
+    let output_mean = output_sum / n;
+    let output_variance = (output_sum_sq / n) - (output_mean * output_mean);
+    let output_std_dev = output_variance.max(0.0).sqrt() as f32;
+
+    // If input already has low variance, constant output is expected - allow it
+    if input_std_dev < MIN_NEURON_OUTPUT_STD_DEV {
+        return true;
+    }
+
+    // If input has variance but output doesn't, the neuron is saturated - reject
+    output_std_dev >= MIN_NEURON_OUTPUT_STD_DEV
 }
 
 /// Default GPU batch size for GPU operations.
@@ -6225,6 +6313,19 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
                 target_squash,
             );
 
+            // Issue #123: Check for saturation - reject if neuron output is nearly constant.
+            // Large bias values (e.g., 5.0 for SOFTSIGN) can cause the neuron to saturate,
+            // producing nearly identical output regardless of input. Such neurons cannot
+            // reduce error correlation and lead to massive prediction failures.
+            if !has_sufficient_output_variance(
+                all_samples,
+                incoming_weight,
+                optimal_bias,
+                spec.activation,
+            ) {
+                continue;
+            }
+
             // CRITICAL: Evaluate NET improvement across ALL samples
             // This ensures the candidate helps the target subset more than it hurts the other
             let (net_improvement, improved_count, total_count) =
@@ -6590,6 +6691,19 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             // They must be checked BEFORE setting fallback_candidate to prevent
             // invalid candidates from being returned through the fallback path.
             // =================================================================
+
+            // Issue #123: Check for saturation - reject if neuron output is nearly constant.
+            // Large bias values (e.g., 5.0 for SOFTSIGN) can cause the neuron to saturate,
+            // producing nearly identical output regardless of input. Such neurons cannot
+            // reduce error correlation and lead to massive prediction failures.
+            if !has_sufficient_output_variance(
+                samples,
+                incoming_weight,
+                optimal_bias,
+                spec.activation,
+            ) {
+                continue;
+            }
 
             // Require minimum ABSOLUTE error reduction, not just percentage.
             // A 1% improvement on baseline_sq=0.0001 is only 0.000001 absolute reduction,
@@ -8057,6 +8171,136 @@ Pages speculative:                        12345.
         assert!(names.contains(&"ReLU6"), "ReLU6 should be included");
         // Total count
         assert_eq!(names.len(), 19, "Should have 19 activation specs");
+    }
+
+    // ==================== Saturation Detection Tests (Issue #123) ====================
+
+    /// Test that has_sufficient_output_variance detects saturated neurons.
+    /// Issue #123: Large bias values cause neurons to output nearly-constant values,
+    /// leading to massive prediction failures (e.g., predicting 4.67% when actual is ~0%).
+    #[test]
+    fn test_saturation_detection_rejects_constant_output() {
+        // Create samples with typical activation range [-1, 1]
+        let samples: Vec<HelpfulSample> = (-10..=10)
+            .map(|i| HelpfulSample {
+                activation: i as f32 / 10.0,
+                avg_error: 0.1,
+                target_value: None,
+                target_activation: None,
+            })
+            .collect();
+
+        // SOFTSIGN with bias=5 and incoming=0.35 (from issue #123)
+        // Output ≈ (5 + 0.35×x) / (1 + |5 + 0.35×x|) ≈ 0.83 for all x
+        let saturated = !has_sufficient_output_variance(
+            &samples,
+            0.35, // incoming_weight
+            5.0,  // bias (too large!)
+            softsign_activation,
+        );
+        assert!(
+            saturated,
+            "SOFTSIGN with bias=5 should be detected as saturated (constant output)"
+        );
+
+        // SOFTSIGN with bias=0 should NOT be saturated
+        let not_saturated = has_sufficient_output_variance(
+            &samples,
+            1.0, // incoming_weight
+            0.0, // bias
+            softsign_activation,
+        );
+        assert!(
+            not_saturated,
+            "SOFTSIGN with bias=0 should NOT be saturated"
+        );
+    }
+
+    /// Test that TANH with large bias is detected as saturated.
+    #[test]
+    fn test_saturation_detection_tanh_large_bias() {
+        let samples: Vec<HelpfulSample> = (-10..=10)
+            .map(|i| HelpfulSample {
+                activation: i as f32 / 10.0,
+                avg_error: 0.1,
+                target_value: None,
+                target_activation: None,
+            })
+            .collect();
+
+        // TANH with bias=10 is heavily saturated (output ≈ 1.0 for all inputs)
+        let saturated = !has_sufficient_output_variance(
+            &samples,
+            1.0,  // incoming_weight
+            10.0, // bias (way too large!)
+            |x| x.tanh(),
+        );
+        assert!(
+            saturated,
+            "TANH with bias=10 should be detected as saturated"
+        );
+
+        // TANH with moderate bias=1 should still have variance
+        let not_saturated = has_sufficient_output_variance(
+            &samples,
+            1.0, // incoming_weight
+            1.0, // bias (reasonable)
+            |x| x.tanh(),
+        );
+        assert!(
+            not_saturated,
+            "TANH with bias=1 should NOT be saturated - still has output variance"
+        );
+    }
+
+    /// Test that ReLU is not incorrectly flagged as saturated.
+    /// ReLU naturally has "half" of samples at 0, but the other half varies.
+    #[test]
+    fn test_saturation_detection_relu_not_false_positive() {
+        let samples: Vec<HelpfulSample> = (-10..=10)
+            .map(|i| HelpfulSample {
+                activation: i as f32 / 10.0,
+                avg_error: 0.1,
+                target_value: None,
+                target_activation: None,
+            })
+            .collect();
+
+        // ReLU with bias=0 should NOT be flagged as saturated
+        // Half the outputs are 0, but the other half varies from 0 to 1
+        let not_saturated = has_sufficient_output_variance(&samples, 1.0, 0.0, |x| x.max(0.0));
+        assert!(
+            not_saturated,
+            "ReLU with bias=0 should NOT be flagged as saturated"
+        );
+    }
+
+    /// Test that constant input samples are NOT incorrectly rejected.
+    /// If input is constant, output will be constant too, but predictions are still valid.
+    #[test]
+    fn test_saturation_detection_allows_constant_input() {
+        // All samples have the same input activation (constant input)
+        let samples: Vec<HelpfulSample> = (0..20)
+            .map(|_| HelpfulSample {
+                activation: -1.0, // Constant input
+                avg_error: 0.3,
+                target_value: None,
+                target_activation: None,
+            })
+            .collect();
+
+        // Even with large bias, constant input should be allowed
+        // because predictions are still valid when input doesn't vary
+        let should_allow = has_sufficient_output_variance(
+            &samples,
+            1.0,
+            5.0, // Large bias, but input is constant so it's OK
+            |x| x.tanh(),
+        );
+        assert!(
+            should_allow,
+            "Constant input samples should NOT be rejected - predictions are valid"
+        );
     }
 }
 


### PR DESCRIPTION
…#123)

This critical fix introduces a mechanism to detect and reject candidates with saturated neurons before they are returned, preventing significant prediction failures. The root cause was identified as large bias values relative to input ranges, leading to nearly-constant outputs that do not contribute to error reduction.

- Added `has_sufficient_output_variance()` to check for output variance before accepting candidates.
- Updated relevant functions to incorporate saturation checks.
- Enhanced README to document the saturation detection logic and its implications.
- Added tests to ensure correct rejection of saturated candidates and validation of expected behavior.

These changes improve the reliability of predictions and enhance the overall functionality of the system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects and filters saturated add‑neuron candidates using an output variance threshold, updates docs, and adds targeted tests.
> 
> - **Analysis (core)**:
>   - Add `MIN_NEURON_OUTPUT_STD_DEV = 0.01` and `has_sufficient_output_variance()` to detect saturation (constant outputs).
>   - Integrate saturation check in add‑neuron evaluation paths to skip candidates when input varies but output does not.
> - **Tests**:
>   - Add saturation detection tests: `test_saturation_detection_rejects_constant_output`, `test_saturation_detection_tanh_large_bias`, `test_saturation_detection_relu_not_false_positive`, `test_saturation_detection_allows_constant_input`.
> - **Docs**:
>   - Update `README.md` with saturation detection details and guidance on `expectedImprovementPercentage` vs `expectedErrorReduction` percentage handling.
> - **Version**:
>   - Bump `Cargo.toml` to `0.1.167`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 996c4ff7d7e202bb5898e72b1bbd07e63b9d30a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->