### PR TITLE
chore: update version to 0.2.0 and refactor improvement metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.1.168"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ one group hurts the other equally.
 3. Evaluate NET improvement across ALL samples
 4. Only return candidates where net improvement > 0
 
-**Result**: `expected_improvement_percentage` is now the TRUE net improvement across
+**Result**: The improvement metric is now the TRUE net improvement across
 all samples, not just a subset prediction. Candidates that would hurt one group more
 than they help the other are filtered out automatically.
 
@@ -1023,32 +1023,50 @@ messages like:
 [NEAT-AI-Discovery][verbose] Using threshold-crossing model for 2 STEP/BIPOLAR neurons: [...]
 ```
 
-#### Synapse candidate impact discounting (v0.1.133)
+#### Creature-level metrics (v0.1.169, Issue #128)
 
-**IMPORTANT**: The `expectedImprovementPercentage` field in synapse candidates is now
-**creature-level**, not neuron-level. This makes Rust the **single source of truth**
-for expected improvement calculations.
+**CRITICAL CHANGE**: All discovery candidates now return **creature-level** metrics instead
+of neuron-level percentages. The old `expectedImprovementPercentage` field has been
+**removed** and replaced with clearer creature-level fields.
 
-| Candidate Type | Impact Discounted? | TypeScript Action |
-|----------------|-------------------|-------------------|
-| **Neurons** | ✅ Yes (v0.1.123) | Use value directly |
-| **Synapses** | ✅ Yes (v0.1.133) | Use value directly |
-| **Removal** | ✅ Yes (built-in) | Use value directly |
+**The goal of discovery is to improve the CREATURE'S SCORE.** Every candidate now includes:
+
+| Field | Description | Value Range |
+|-------|-------------|-------------|
+| `targetNeuronImpact` | Impact of target neuron on creature (output=1.0, hidden<1.0) | 0.0 - 1.0 |
+| `expectedCreatureErrorReduction` | Expected reduction in creature's error | 0.0 - 1.0 (ratio) |
+| `expectedCreatureScoreGain` | Expected improvement in creature's score | 0.0 - 1.0 (ratio) |
+
+**Why the change?** The old `expectedImprovementPercentage` was measuring the **target
+neuron's** error reduction, not the **creature's** error reduction. A hidden neuron with
+0.0001 impact and 33% neuron-level improvement would contribute only 0.0033% to the
+creature's score - less than the cost of growth! The new fields make this transparent.
 
 **How it works**:
-- Synapse candidates targeting **output neurons** have impact = 1.0 (no discount)
-- Synapse candidates targeting **hidden neurons** are discounted by the target's impact
-  score (0.0 to 1.0 based on weighted paths to outputs)
+- `targetNeuronImpact` shows the target neuron's weighted path to outputs
+- `expectedCreatureErrorReduction` = neuron-level improvement × targetNeuronImpact
+- `expectedCreatureScoreGain` = expectedCreatureErrorReduction (since score = 1 - error)
 
-**Example**: A synapse candidate improving a hidden neuron by 70% that has impact 0.1:
-- **Old (neuron-level)**: `expectedImprovementPercentage = 0.70` (70%)
-- **New (creature-level)**: `expectedImprovementPercentage = 0.07` (7%)
+**Example**: A candidate improving a hidden neuron's error by 70% where the neuron has impact 0.1:
+```
+targetNeuronImpact: 0.1
+expectedCreatureErrorReduction: 0.07  (70% × 0.1 = 7% creature-level)
+expectedCreatureScoreGain: 0.07
+```
 
-**TypeScript should NOT re-calculate impact**. The returned `expectedImprovementPercentage`
-is the actual expected improvement on the creature's score. Simply use:
+**Candidates are sorted by `expectedCreatureScoreGain`** (highest first), so the best
+candidates for the creature appear at the top.
+
+**TypeScript usage**:
 ```typescript
-const creatureLevelImprovement = candidate.expectedImprovementPercentage;
-// Don't multiply by getNeuronShare() or any other impact factor!
+// Use the creature-level score gain directly
+const creatureLevelImprovement = candidate.expectedCreatureScoreGain;
+
+// The impact is also available for transparency
+console.log(`Target impact: ${candidate.targetNeuronImpact}`);
+
+// Display as percentage
+console.log(`Expected score gain: ${creatureLevelImprovement * 100}%`);
 ```
 
 #### Removal candidate expected error reduction fix (v0.1.162)
@@ -1090,40 +1108,33 @@ const expectedChange = candidate.expectedErrorReduction;
 // const expectedChange = candidate.totalError;  // BUG!
 ```
 
-#### Field naming and percentage calculations (Issue #124)
+#### Field naming and percentage calculations (Issues #124, #128)
 
-**IMPORTANT**: Rust returns two types of improvement/error metrics with different semantics:
+**IMPORTANT**: Rust returns creature-level metrics that are already ratios (0.0 - 1.0).
+Multiply by 100 to display as a percentage.
 
 | Field | Type | Value Range | To Display as % |
 |-------|------|-------------|-----------------|
-| `expectedImprovementPercentage` | **Ratio** | 0.0 - 1.0 | `value × 100` |
-| `expectedErrorReduction` | **Absolute** | Any positive | `(value / originalError) × 100` |
+| `expectedCreatureScoreGain` | **Ratio** | 0.0 - 1.0 | `value × 100` |
+| `expectedCreatureErrorReduction` | **Ratio** | 0.0 - 1.0 | `value × 100` |
+| `targetNeuronImpact` | **Ratio** | 0.0 - 1.0 | `value × 100` |
 
-**`expectedImprovementPercentage`** is already a ratio (decimal percentage):
-- Value `0.07` means 7% improvement
-- Calculated as `(baseline_error - new_error) / baseline_error`
-- **To display**: multiply by 100 → `0.07 × 100 = 7%`
+**These fields are creature-level ratios**, calculated as:
+- `expectedCreatureScoreGain` = (baseline_creature_error - new_creature_error) / baseline_creature_error
+- This accounts for the target neuron's impact on the creature
 
-**`expectedErrorReduction`** is an **absolute value**, NOT a ratio:
-- Value `0.0656` is a raw error delta, not a percentage
-- **WRONG**: `0.0656 × 100 = 6.56%` ❌ (this is meaningless)
-- **CORRECT**: `(0.0656 / 0.5827) × 100 = 11.26%` ✓ (reduction as percentage of original error)
-
-TypeScript should NOT create `*Pct` fields by simply multiplying by 100:
 ```typescript
-// WRONG: Multiplying absolute value by 100 is not a valid percentage
-const expectedErrorReductionPct = expectedErrorReduction * 100;  // BUG!
+// Display as percentage - just multiply by 100
+const scoreGainPercent = candidate.expectedCreatureScoreGain * 100;
+console.log(`Expected score gain: ${scoreGainPercent.toFixed(2)}%`);
 
-// CORRECT: Use expectedImprovementPercentage directly (it's already a ratio)
-const improvementPercent = candidate.expectedImprovementPercentage * 100;
-
-// CORRECT: If you need error reduction as %, divide by original error first
-const errorReductionPercent = (expectedErrorReduction / originalError) * 100;
+// The impact shows how much the target neuron affects the creature
+const targetImpactPercent = candidate.targetNeuronImpact * 100;
+console.log(`Target neuron contributes ${targetImpactPercent.toFixed(1)}% to creature output`);
 ```
 
-**Recommendation**: Use `expectedImprovementPercentage` for all percentage displays.
-The `expectedErrorReduction` field is provided for reference but should not be
-converted to a percentage by simple multiplication.
+**Recommendation**: Use `expectedCreatureScoreGain` for ranking and displaying candidates.
+All fields are already creature-level, so no additional calculations are needed.
 
 ## Verifying the installation
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -2680,6 +2680,8 @@ impl ReluStats {
         let target_stats = NeuronStats::from_samples(original_samples).map(|s| s.to_json());
         let total_count = self.samples.len() as u32;
 
+        // Issue #128: Use creature-level metrics instead of neuron-level percentage.
+        // target_neuron_impact will be updated during impact discounting.
         Some(CandidateNeuronJson {
             source_neuron_uuid: source_uuid.to_string(),
             target_neuron_uuid: target_uuid.to_string(),
@@ -2687,7 +2689,9 @@ impl ReluStats {
             outgoing_weight,
             squash: "ReLU".to_string(),
             bias: optimal_bias,
-            expected_improvement_percentage: expected_improvement,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: expected_improvement,
+            expected_creature_score_gain: expected_improvement,
             improved_count,
             total_count,
             target_neuron_stats: target_stats,
@@ -5514,9 +5518,8 @@ fn upsert_candidate(
 
     match map.entry(key) {
         Entry::Occupied(mut entry) => {
-            if candidate.expected_improvement_percentage
-                > entry.get().expected_improvement_percentage
-            {
+            // Issue #128: Compare by expected creature score gain
+            if candidate.expected_creature_score_gain > entry.get().expected_creature_score_gain {
                 entry.insert(candidate);
             }
         }
@@ -6094,8 +6097,10 @@ fn evaluate_relu_candidates_split<G: GpuEvaluator>(
                 candidate.improved_count = improved;
                 candidate.total_count = total;
 
+                // Issue #128: Update creature-level metrics
                 if net_improvement > best_improvement {
-                    candidate.expected_improvement_percentage = net_improvement;
+                    candidate.expected_creature_error_reduction = net_improvement;
+                    candidate.expected_creature_score_gain = net_improvement;
                     best_improvement = net_improvement;
                     best_candidate = Some(candidate);
                 }
@@ -6136,8 +6141,10 @@ fn evaluate_relu_candidates_split<G: GpuEvaluator>(
                 candidate.improved_count = improved;
                 candidate.total_count = total;
 
+                // Issue #128: Update creature-level metrics
                 if net_improvement > best_improvement {
-                    candidate.expected_improvement_percentage = net_improvement;
+                    candidate.expected_creature_error_reduction = net_improvement;
+                    candidate.expected_creature_score_gain = net_improvement;
                     best_improvement = net_improvement;
                     best_candidate = Some(candidate);
                 }
@@ -6276,6 +6283,7 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
                 best_net_improvement = net_improvement;
 
                 let target_stats = NeuronStats::from_samples(all_samples).map(|s| s.to_json());
+                // Issue #128: Use creature-level metrics
                 best_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
@@ -6283,7 +6291,9 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
-                    expected_improvement_percentage: net_improvement,
+                    target_neuron_impact: 1.0,
+                    expected_creature_error_reduction: net_improvement,
+                    expected_creature_score_gain: net_improvement,
                     improved_count,
                     total_count,
                     target_neuron_stats: target_stats,
@@ -6383,14 +6393,15 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             target_activation_fn,
         )? {
             // Track best and fallback candidates from split evaluation
-            if candidate.expected_improvement_percentage > best_score {
-                best_score = candidate.expected_improvement_percentage;
+            // Issue #128: Use expected_creature_score_gain for comparison
+            if candidate.expected_creature_score_gain > best_score {
+                best_score = candidate.expected_creature_score_gain;
                 best_candidate = Some(candidate.clone());
             }
-            if candidate.expected_improvement_percentage > fallback_score
-                && candidate.expected_improvement_percentage > 0.0
+            if candidate.expected_creature_score_gain > fallback_score
+                && candidate.expected_creature_score_gain > 0.0
             {
-                fallback_score = candidate.expected_improvement_percentage;
+                fallback_score = candidate.expected_creature_score_gain;
                 fallback_candidate = Some(candidate);
             }
         }
@@ -6478,7 +6489,7 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             let (
                 outgoing_weight,
                 optimal_bias,
-                expected_improvement_percentage,
+                neuron_error_improvement, // Issue #128: Renamed - this is neuron-level, not creature-level
                 final_improved_count,
             ) = if target_activation_fn.is_some() {
                 // Weight candidates: base weight and scaled versions
@@ -6626,7 +6637,7 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             // A 1% improvement on baseline_sq=0.0001 is only 0.000001 absolute reduction,
             // which won't meaningfully affect the creature's total error.
             // Minimum absolute improvement = 0.001 (0.1% of typical baseline ~1.0)
-            let absolute_improvement = expected_improvement_percentage * baseline_sq;
+            let absolute_improvement = neuron_error_improvement * baseline_sq;
             if absolute_improvement < 0.001 {
                 continue;
             }
@@ -6644,12 +6655,11 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             // TypeScript will decide if the improvement is worth the cost of growth.
             // We don't apply arbitrary minimum thresholds here - any positive
             // improvement is returned and TypeScript handles candidate selection.
-            if expected_improvement_percentage > fallback_score
-                && expected_improvement_percentage > 0.0
-            {
-                fallback_score = expected_improvement_percentage;
+            if neuron_error_improvement > fallback_score && neuron_error_improvement > 0.0 {
+                fallback_score = neuron_error_improvement;
 
                 let target_stats = NeuronStats::from_samples(samples).map(|s| s.to_json());
+                // Issue #128: Use creature-level metrics (impact discounting applied later)
                 fallback_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
@@ -6657,7 +6667,9 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
-                    expected_improvement_percentage,
+                    target_neuron_impact: 1.0,
+                    expected_creature_error_reduction: neuron_error_improvement,
+                    expected_creature_score_gain: neuron_error_improvement,
                     improved_count: final_improved_count,
                     total_count,
                     target_neuron_stats: target_stats,
@@ -6672,18 +6684,18 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
             // If spec requires 0% and caller passes 1%, we require 1%
             let improvement_cutoff = threshold.max(spec.min_improvement);
 
-            if expected_improvement_percentage <= improvement_cutoff
+            if neuron_error_improvement <= improvement_cutoff
                 || final_improved_count < MIN_NEURON_SAMPLE_COUNT as u32
             {
                 continue;
             }
 
             // Current iteration passed threshold - create best_candidate with current iteration's values
-            if expected_improvement_percentage > best_score {
-                best_score = expected_improvement_percentage;
+            if neuron_error_improvement > best_score {
+                best_score = neuron_error_improvement;
 
                 let target_stats = NeuronStats::from_samples(samples).map(|s| s.to_json());
-                // Use current iteration's values, not fallback candidate's values
+                // Issue #128: Use creature-level metrics (impact discounting applied later)
                 best_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
@@ -6691,9 +6703,11 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
-                    expected_improvement_percentage, // Use current iteration's value
-                    improved_count: final_improved_count, // Use current iteration's value
-                    total_count,                     // Use current iteration's value
+                    target_neuron_impact: 1.0,
+                    expected_creature_error_reduction: neuron_error_improvement,
+                    expected_creature_score_gain: neuron_error_improvement,
+                    improved_count: final_improved_count,
+                    total_count,
                     target_neuron_stats: target_stats,
                 });
             }
@@ -6924,6 +6938,7 @@ fn evaluate_discrete_candidate(
                             NeuronStats::from_samples(&helper_samples).map(|s| s.to_json())
                         };
 
+                        // Issue #128: Use creature-level metrics
                         best_candidate = Some(CandidateNeuronJson {
                             source_neuron_uuid: source_uuid.to_string(),
                             target_neuron_uuid: target_uuid.to_string(),
@@ -6931,7 +6946,9 @@ fn evaluate_discrete_candidate(
                             outgoing_weight,
                             squash: new_neuron_squash.to_string(),
                             bias: 0.0, // IDENTITY doesn't need bias for threshold crossing
-                            expected_improvement_percentage: improvement,
+                            target_neuron_impact: 1.0,
+                            expected_creature_error_reduction: improvement,
+                            expected_creature_score_gain: improvement,
                             improved_count: helpful_flips as u32,
                             total_count,
                             target_neuron_stats: target_stats,
@@ -7513,7 +7530,7 @@ pub(crate) fn analyze_neurons_with_cache(
                                 source.uuid,
                                 target_uuid,
                                 discrete_samples.len(),
-                                candidate.expected_improvement_percentage * 100.0,
+                                candidate.expected_creature_score_gain * 100.0,
                                 candidate.improved_count
                             );
                         }
@@ -7569,7 +7586,7 @@ pub(crate) fn analyze_neurons_with_cache(
                                 "[NEAT-AI-Discovery][verbose] ReLU (push UP) {} -> {}: {:.2}% improvement",
                                 result.source_uuid,
                                 target_uuid,
-                                candidate.expected_improvement_percentage * 100.0
+                                candidate.expected_creature_score_gain * 100.0
                             );
                         }
                         diagnostics
@@ -7586,7 +7603,7 @@ pub(crate) fn analyze_neurons_with_cache(
                                 "[NEAT-AI-Discovery][verbose] ReLU (push DOWN) {} -> {}: {:.2}% improvement",
                                 result.source_uuid,
                                 target_uuid,
-                                candidate.expected_improvement_percentage * 100.0
+                                candidate.expected_creature_score_gain * 100.0
                             );
                         }
                         diagnostics
@@ -7640,10 +7657,9 @@ pub(crate) fn analyze_neurons_with_cache(
 
     let mut helpful_results: Vec<CandidateNeuronJson> = helpful_map.into_values().collect();
 
-    // Apply impact-based discounting for hidden neurons (v0.1.123)
-    // Hidden neuron errors are backpropagated approximations, so their predictions
-    // are less reliable than output neurons. We discount by their impact score
-    // (path weight product to outputs).
+    // Issue #128: Apply impact-based discounting and set creature-level metrics.
+    // Output neurons have impact = 1.0 (no discount).
+    // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
     let impact_scores = compute_impacts_public(&input.creature);
     for candidate in &mut helpful_results {
         let is_hidden = neuron_type_map
@@ -7651,46 +7667,40 @@ pub(crate) fn analyze_neurons_with_cache(
             .map(|t| t != "output")
             .unwrap_or(true); // Default to true if type unknown (treat as hidden)
 
-        if is_hidden {
+        let impact = if is_hidden {
             if let Some(&impact) = impact_scores.get(&candidate.target_neuron_uuid) {
-                let discount = impact.clamp(0.0, 1.0);
-                let original = candidate.expected_improvement_percentage;
-                candidate.expected_improvement_percentage *= discount;
-                if verbose_enabled() {
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Hidden neuron {} prediction discounted by impact {:.3}: \
-                        {:.4}% -> {:.4}%",
-                        &candidate.target_neuron_uuid[..12.min(candidate.target_neuron_uuid.len())],
-                        discount,
-                        original * 100.0,
-                        candidate.expected_improvement_percentage * 100.0
-                    );
-                }
+                impact.clamp(0.0, 1.0)
             } else {
                 // No impact score means disconnected from outputs - heavy discount
-                let original = candidate.expected_improvement_percentage;
-                candidate.expected_improvement_percentage *= 0.1;
-                if verbose_enabled() {
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Hidden neuron {} has no impact score (disconnected?). \
-                        Applying 90% discount: {:.4}% -> {:.4}%",
-                        &candidate.target_neuron_uuid[..12.min(candidate.target_neuron_uuid.len())],
-                        original * 100.0,
-                        candidate.expected_improvement_percentage * 100.0
-                    );
-                }
+                0.1
             }
+        } else {
+            // Output neuron - full impact
+            1.0
+        };
+
+        // Update creature-level metrics
+        candidate.target_neuron_impact = impact;
+        let original = candidate.expected_creature_error_reduction;
+        candidate.expected_creature_error_reduction *= impact;
+        candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
+
+        if verbose_enabled() && is_hidden {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Neuron candidate → {} impact {:.3}: \
+                {:.4}% → {:.4}%",
+                &candidate.target_neuron_uuid[..12.min(candidate.target_neuron_uuid.len())],
+                impact,
+                original * 100.0,
+                candidate.expected_creature_score_gain * 100.0
+            );
         }
     }
 
-    // v0.1.134: No filtering needed after impact discounting.
-    // For valid creatures (validated by TypeScript), all hidden neurons have a path to
-    // outputs, so zero/negative impact is mathematically impossible. TypeScript will
-    // decide if the improvement is worth the cost of growth by measuring actual score.
-
+    // Sort by expected creature score gain (highest first) - Issue #128
     helpful_results.sort_by(|a, b| {
-        b.expected_improvement_percentage
-            .partial_cmp(&a.expected_improvement_percentage)
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
             .unwrap_or(Ordering::Equal)
     });
 
@@ -8727,7 +8737,8 @@ pub(crate) fn analyze_synapses_with_cache(
                     // Falls back to linear model when target_value/target_activation are not recorded.
                     // Both improved_count and worsened_count now use the same CPU-based saturation-aware
                     // methodology for consistency (previously worsened_count came from GPU linear model).
-                    let (expected_improvement_percentage, improved_count, worsened_count) = {
+                    // Issue #128: This is neuron-level improvement - impact discounting converts to creature-level.
+                    let (neuron_error_improvement, improved_count, worsened_count) = {
                         let baseline_error_sq = stats.error_sq_sum;
                         let (improvement, improved, worsened, _) =
                             compute_synapse_improvement_and_count(
@@ -8741,19 +8752,19 @@ pub(crate) fn analyze_synapses_with_cache(
 
                     // Accept all positive improvements as candidates (not just those above threshold)
                     // Only reject if improvement is non-positive (<= 0.0)
-                    if expected_improvement_percentage <= 0.0 {
+                    if neuron_error_improvement <= 0.0 {
                         // Skip non-positive improvements
                         continue;
                     }
 
                     // If positive but below threshold, still accept as candidate but log for diagnostics
-                    if expected_improvement_percentage <= threshold {
+                    if neuron_error_improvement <= threshold {
                         diagnostics_below_threshold.push((
                             work.target_uuid.clone(),
                             work.source_uuid.clone(),
                             ThresholdContext {
                                 sample_count: work.samples.len(),
-                                expected_improvement: expected_improvement_percentage,
+                                expected_improvement: neuron_error_improvement,
                                 threshold,
                                 improved_count,
                                 worsened_count,
@@ -8768,11 +8779,14 @@ pub(crate) fn analyze_synapses_with_cache(
                         .ok()
                         .and_then(|records| NeuronStats::from_records(records.as_ref()))
                         .map(|s| s.to_json());
+                    // Issue #128: Use creature-level metrics (impact discounting applied later)
                     candidates_to_add.push(CandidateSynapseJson {
                         from_neuron_uuid: work.source_uuid.clone(),
                         to_neuron_uuid: work.target_uuid.clone(),
                         weight,
-                        expected_improvement_percentage,
+                        target_neuron_impact: 1.0,
+                        expected_creature_error_reduction: neuron_error_improvement,
+                        expected_creature_score_gain: neuron_error_improvement,
                         improved_count,
                         total_count,
                         target_neuron_stats: target_stats,
@@ -8863,15 +8877,19 @@ pub(crate) fn analyze_synapses_with_cache(
                                 continue;
                             }
 
-                            let expected_improvement_percentage = (stats.harmful_count as f32
+                            // Issue #128: This is neuron-level - impact discounting converts to creature-level
+                            let neuron_error_improvement = (stats.harmful_count as f32
                                 - stats.helpful_count as f32)
                                 / total_count as f32;
 
+                            // Issue #128: Use creature-level metrics (impact discounting applied later)
                             harmful_candidates.push(CandidateSynapseJson {
                                 from_neuron_uuid: work.synapse.from_uuid.clone(),
                                 to_neuron_uuid: work.synapse.to_uuid.clone(),
                                 weight: work.synapse.weight,
-                                expected_improvement_percentage,
+                                target_neuron_impact: 1.0,
+                                expected_creature_error_reduction: neuron_error_improvement,
+                                expected_creature_score_gain: neuron_error_improvement,
                                 improved_count: stats.harmful_count,
                                 total_count,
                                 target_neuron_stats: target_stats.clone(),
@@ -8913,10 +8931,7 @@ pub(crate) fn analyze_synapses_with_cache(
         }
     }
 
-    // Apply impact-based discounting for synapse candidates targeting hidden neurons (v0.1.133)
-    // This makes Rust the single source of truth for creature-level expected improvement.
-    // TypeScript no longer needs to re-calculate impact - just use the returned value directly.
-    //
+    // Issue #128: Apply impact-based discounting and set creature-level metrics.
     // Output neurons have impact = 1.0 (no discount).
     // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
     let impact_scores = compute_impacts_public(&input.creature);
@@ -8927,60 +8942,63 @@ pub(crate) fn analyze_synapses_with_cache(
         .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
         .collect();
 
-    // Discount helpful synapse candidates
+    // Apply impact discounting to helpful synapse candidates
     for candidate in &mut helpful_results {
         let is_hidden = neuron_type_map
             .get(&candidate.to_neuron_uuid)
             .map(|t| t != "output")
             .unwrap_or(true); // Default to hidden if type unknown
 
-        if is_hidden {
+        let impact = if is_hidden {
             if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
-                let discount = impact.clamp(0.0, 1.0);
-                let original = candidate.expected_improvement_percentage;
-                candidate.expected_improvement_percentage *= discount;
-                if verbose_enabled() {
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Synapse candidate → {} discounted by impact {:.3}: \
-                        {:.4}% → {:.4}%",
-                        &candidate.to_neuron_uuid[..12.min(candidate.to_neuron_uuid.len())],
-                        discount,
-                        original * 100.0,
-                        candidate.expected_improvement_percentage * 100.0
-                    );
-                }
+                impact.clamp(0.0, 1.0)
             } else {
                 // No impact score means disconnected from outputs - heavy discount
-                let original = candidate.expected_improvement_percentage;
-                candidate.expected_improvement_percentage *= 0.1;
-                if verbose_enabled() {
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Synapse candidate → {} has no impact score (disconnected?). \
-                        Applying 90% discount: {:.4}% → {:.4}%",
-                        &candidate.to_neuron_uuid[..12.min(candidate.to_neuron_uuid.len())],
-                        original * 100.0,
-                        candidate.expected_improvement_percentage * 100.0
-                    );
-                }
+                0.1
             }
+        } else {
+            // Output neuron - full impact
+            1.0
+        };
+
+        // Update creature-level metrics
+        candidate.target_neuron_impact = impact;
+        let original = candidate.expected_creature_error_reduction;
+        candidate.expected_creature_error_reduction *= impact;
+        candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
+
+        if verbose_enabled() && is_hidden {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Synapse candidate → {} impact {:.3}: \
+                {:.4}% → {:.4}%",
+                &candidate.to_neuron_uuid[..12.min(candidate.to_neuron_uuid.len())],
+                impact,
+                original * 100.0,
+                candidate.expected_creature_score_gain * 100.0
+            );
         }
     }
 
-    // Discount harmful synapse candidates (same logic)
+    // Apply impact discounting to harmful synapse candidates (same logic)
     for candidate in &mut harmful_results {
         let is_hidden = neuron_type_map
             .get(&candidate.to_neuron_uuid)
             .map(|t| t != "output")
             .unwrap_or(true);
 
-        if is_hidden {
+        let impact = if is_hidden {
             if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
-                let discount = impact.clamp(0.0, 1.0);
-                candidate.expected_improvement_percentage *= discount;
+                impact.clamp(0.0, 1.0)
             } else {
-                candidate.expected_improvement_percentage *= 0.1;
+                0.1
             }
-        }
+        } else {
+            1.0
+        };
+
+        candidate.target_neuron_impact = impact;
+        candidate.expected_creature_error_reduction *= impact;
+        candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
     }
 
     // Note: helpful_fallback does NOT need separate discounting here.
@@ -8989,13 +9007,14 @@ pub(crate) fn analyze_synapses_with_cache(
     // empty, the fallback is intentionally not returned (we have better candidates).
 
     helpful_results.sort_by(|a, b| {
-        b.expected_improvement_percentage
-            .partial_cmp(&a.expected_improvement_percentage)
+        // Issue #128: Sort by expected creature score gain (highest first)
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
             .unwrap_or(Ordering::Equal)
     });
     harmful_results.sort_by(|a, b| {
-        b.expected_improvement_percentage
-            .partial_cmp(&a.expected_improvement_percentage)
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
             .unwrap_or(Ordering::Equal)
     });
 
@@ -11579,10 +11598,11 @@ mod tests_synapses {
             }
         } else {
             // We have candidates - verify at least one has positive improvement
+            // Issue #128: Use expected_creature_score_gain (creature-level, not neuron-level)
             let has_positive_improvement = result
                 .helpful_synapses
                 .iter()
-                .any(|synapse| synapse.expected_improvement_percentage > 0.0);
+                .any(|synapse| synapse.expected_creature_score_gain > 0.0);
 
             assert!(
                 has_positive_improvement,
@@ -11653,10 +11673,11 @@ mod tests_synapses {
 
         // Non-positive improvements should be rejected (not appear in helpful_synapses)
         // Even though we now accept positive improvements below threshold, we still reject <= 0.0
+        // Issue #128: Use expected_creature_score_gain (creature-level metric)
         let has_non_positive = result
             .helpful_synapses
             .iter()
-            .any(|synapse| synapse.expected_improvement_percentage <= 0.0);
+            .any(|synapse| synapse.expected_creature_score_gain <= 0.0);
 
         assert!(
             !has_non_positive,
@@ -11727,10 +11748,11 @@ mod tests_synapses {
 
         // Positive improvements above threshold should definitely be accepted
         // This is a regression test to ensure we didn't break existing behavior
+        // Issue #128: Use expected_creature_score_gain (creature-level metric)
         let has_above_threshold = result
             .helpful_synapses
             .iter()
-            .any(|synapse| synapse.expected_improvement_percentage > 0.1);
+            .any(|synapse| synapse.expected_creature_score_gain > 0.1);
 
         // Note: This test may pass even if no candidates are found due to other reasons
         // (e.g., no samples, zero improvement). The key is that if we have candidates,
@@ -11741,7 +11763,7 @@ mod tests_synapses {
                     || result
                         .helpful_synapses
                         .iter()
-                        .any(|s| s.expected_improvement_percentage > 0.0),
+                        .any(|s| s.expected_creature_score_gain > 0.0),
                 "Should have candidates with positive improvement (above or below threshold)"
             );
         }
@@ -12446,6 +12468,7 @@ mod tests_synapses {
             HashMap::new();
 
         // Positive-orientation ReLU candidate
+        // Issue #128: Use creature-level metrics
         let positive_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
@@ -12453,7 +12476,9 @@ mod tests_synapses {
             outgoing_weight: 0.5,
             squash: "ReLU".to_string(),
             bias: 0.0,
-            expected_improvement_percentage: 0.15,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.15,
+            expected_creature_score_gain: 0.15,
             improved_count: 30,
             total_count: 50,
             target_neuron_stats: None,
@@ -12467,7 +12492,9 @@ mod tests_synapses {
             outgoing_weight: 0.4,  // Same outgoing sign
             squash: "ReLU".to_string(),
             bias: 0.0,
-            expected_improvement_percentage: 0.12,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.12,
+            expected_creature_score_gain: 0.12,
             improved_count: 25,
             total_count: 50,
             target_neuron_stats: None,
@@ -12522,6 +12549,7 @@ mod tests_synapses {
 
         // Candidate for positive errors: same source/target, positive outgoing_weight
         // This pushes output UP when source is high
+        // Issue #128: Use creature-level metrics
         let positive_error_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
@@ -12529,7 +12557,9 @@ mod tests_synapses {
             outgoing_weight: 0.5, // POSITIVE: pushes output UP
             squash: "ReLU".to_string(),
             bias: 0.0,
-            expected_improvement_percentage: 0.10,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.10,
+            expected_creature_score_gain: 0.10,
             improved_count: 25,
             total_count: 50,
             target_neuron_stats: None,
@@ -12544,7 +12574,9 @@ mod tests_synapses {
             outgoing_weight: -0.4, // NEGATIVE: pushes output DOWN
             squash: "ReLU".to_string(),
             bias: 0.0,
-            expected_improvement_percentage: 0.08,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.08,
+            expected_creature_score_gain: 0.08,
             improved_count: 20,
             total_count: 50,
             target_neuron_stats: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,15 @@ pub struct CandidateSynapseJson {
     pub from_neuron_uuid: String,
     pub to_neuron_uuid: String,
     pub weight: f32,
-    pub expected_improvement_percentage: f32,
+    /// Impact of the target neuron on the creature's output (0.0 to 1.0).
+    /// Output neurons have impact = 1.0, hidden neurons have discounted impact.
+    pub target_neuron_impact: f32,
+    /// Expected reduction in creature's error from adding this synapse.
+    /// Formula: neuron_error_reduction × target_neuron_impact
+    pub expected_creature_error_reduction: f32,
+    /// Expected improvement in creature's score from adding this synapse.
+    /// Since score = 1 - error, this equals expected_creature_error_reduction.
+    pub expected_creature_score_gain: f32,
     pub improved_count: u32,
     pub total_count: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,7 +152,15 @@ pub struct CandidateNeuronJson {
     pub outgoing_weight: f32,
     pub squash: String,
     pub bias: f32,
-    pub expected_improvement_percentage: f32,
+    /// Impact of the target neuron on the creature's output (0.0 to 1.0).
+    /// Output neurons have impact = 1.0, hidden neurons have discounted impact.
+    pub target_neuron_impact: f32,
+    /// Expected reduction in creature's error from adding this neuron.
+    /// Formula: neuron_error_reduction × target_neuron_impact
+    pub expected_creature_error_reduction: f32,
+    /// Expected improvement in creature's score from adding this neuron.
+    /// Since score = 1 - error, this equals expected_creature_error_reduction.
+    pub expected_creature_score_gain: f32,
     pub improved_count: u32,
     pub total_count: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -371,7 +387,7 @@ pub struct SynapseDiagnosticDetailJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worsened_count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expected_improvement_percentage: Option<f32>,
+    pub expected_creature_error_reduction: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -426,7 +442,7 @@ pub struct NeuronDiagnosticDetailJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worsened_count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub expected_improvement_percentage: Option<f32>,
+    pub expected_creature_error_reduction: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -473,7 +489,7 @@ fn synapse_diagnostics_json(
                         source_record_count: detail.source_record_count,
                         improved_count: detail.improved_count,
                         worsened_count: detail.worsened_count,
-                        expected_improvement_percentage: detail.expected_improvement,
+                        expected_creature_error_reduction: detail.expected_improvement,
                         threshold: detail.threshold,
                         suggested_weight: detail.suggested_weight,
                     }),
@@ -534,7 +550,7 @@ fn neuron_diagnostics_json(
                         sample_count: detail.sample_count,
                         improved_count: detail.improved_count,
                         worsened_count: detail.worsened_count,
-                        expected_improvement_percentage: detail.expected_improvement,
+                        expected_creature_error_reduction: detail.expected_improvement,
                         threshold: detail.threshold,
                         outgoing_weight: detail.outgoing_weight,
                     }),

--- a/tests/creature_level_metrics.rs
+++ b/tests/creature_level_metrics.rs
@@ -1,0 +1,557 @@
+//! Tests for creature-level metrics (Issue #128)
+//!
+//! ## Problem (Issue #128)
+//!
+//! The `expectedImprovementPercentage` field was measuring the TARGET NEURON's error
+//! reduction, not the CREATURE's error reduction. This is meaningless because:
+//!
+//! - A focus neuron with error 0.0003 where we find a candidate reducing error to 0.0002
+//!   shows "33% improvement"
+//! - BUT if that neuron has impact 0.0001 on the creature's error, the actual creature
+//!   improvement is ~0.000033, which may be less than cost of growth!
+//!
+//! ## Solution
+//!
+//! Replace `expectedImprovementPercentage` with creature-level metrics:
+//!
+//! 1. `targetNeuronImpact` - The target neuron's impact on the creature (0.0 to 1.0)
+//! 2. `expectedCreatureErrorReduction` - Expected reduction in creature's error
+//! 3. `expectedCreatureScoreGain` - Expected improvement in creature's score
+//!
+//! All candidates should be sorted by `expectedCreatureScoreGain` (highest first).
+
+mod common;
+
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{analyze_parallel_internal, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Skip test if no GPU available
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+/// Helper to create a synapse
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Helper to create a hidden neuron
+fn hidden(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Helper to create an output neuron
+fn output(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "output".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+// =============================================================================
+// Test: expectedImprovementPercentage field should NOT exist (Issue #128)
+// =============================================================================
+
+/// Issue #128: The `expectedImprovementPercentage` field should be removed from candidates.
+///
+/// This test verifies that the old meaningless field is no longer present in the JSON output.
+#[test]
+fn test_expected_improvement_percentage_field_removed() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records with error so we get candidates
+    let records = vec![
+        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        // Output with error
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+
+    // Verify the old field is NOT present in the JSON
+    assert!(
+        !output_json.contains("expectedImprovementPercentage"),
+        "expectedImprovementPercentage should be removed from JSON output. Found in: {output_json}"
+    );
+}
+
+// =============================================================================
+// Test: New creature-level fields should exist
+// =============================================================================
+
+/// Issue #128: Candidates should include `targetNeuronImpact` field.
+///
+/// This field shows the impact of the target neuron on the creature's output (0.0 to 1.0).
+/// Output neurons have impact = 1.0, hidden neurons have impact < 1.0.
+#[test]
+fn test_target_neuron_impact_field_exists() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = vec![
+        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+
+    // Verify the new field IS present in the JSON
+    assert!(
+        output_json.contains("targetNeuronImpact"),
+        "targetNeuronImpact field should be present in JSON output. Got: {output_json}"
+    );
+}
+
+/// Issue #128: Candidates should include `expectedCreatureErrorReduction` field.
+///
+/// This field shows the expected reduction in the creature's overall error.
+/// Formula: neuron_error_reduction × target_neuron_impact
+#[test]
+fn test_expected_creature_error_reduction_field_exists() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = vec![
+        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+
+    assert!(
+        output_json.contains("expectedCreatureErrorReduction"),
+        "expectedCreatureErrorReduction field should be present in JSON output. Got: {output_json}"
+    );
+}
+
+/// Issue #128: Candidates should include `expectedCreatureScoreGain` field.
+///
+/// This field shows the expected improvement in the creature's score.
+/// Since score = 1 - error, score_gain ≈ error_reduction.
+#[test]
+fn test_expected_creature_score_gain_field_exists() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = vec![
+        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+
+    assert!(
+        output_json.contains("expectedCreatureScoreGain"),
+        "expectedCreatureScoreGain field should be present in JSON output. Got: {output_json}"
+    );
+}
+
+// =============================================================================
+// Test: Output neuron has impact = 1.0
+// =============================================================================
+
+/// Issue #128: Output neurons should have targetNeuronImpact = 1.0
+///
+/// Output neurons directly contribute to the creature's score, so their impact is 1.0.
+#[test]
+fn test_output_neuron_has_impact_one() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = vec![
+        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    // Check synapse candidates (if any)
+    if let Some(synapses) = output["helpfulSynapses"].as_array() {
+        for synapse in synapses {
+            let impact = synapse["targetNeuronImpact"]
+                .as_f64()
+                .expect("targetNeuronImpact should be a number");
+            assert!(
+                (impact - 1.0).abs() < 0.01,
+                "Output neuron should have impact = 1.0, got {impact}"
+            );
+        }
+    }
+
+    // Check neuron candidates (if any)
+    if let Some(neurons) = output["helpfulNeurons"].as_array() {
+        for neuron in neurons {
+            let impact = neuron["targetNeuronImpact"]
+                .as_f64()
+                .expect("targetNeuronImpact should be a number");
+            assert!(
+                (impact - 1.0).abs() < 0.01,
+                "Output neuron should have impact = 1.0, got {impact}"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Test: Hidden neuron has discounted impact
+// =============================================================================
+
+/// Issue #128: Hidden neurons should have targetNeuronImpact < 1.0
+///
+/// Hidden neurons don't directly contribute to the creature's score - their impact
+/// is based on their weighted paths to output neurons.
+#[test]
+fn test_hidden_neuron_has_discounted_impact() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![hidden("hidden-0", "TANH"), output("output-0", "IDENTITY")],
+        synapses: vec![
+            synapse("input-0", "hidden-0", 1.0),
+            synapse("hidden-0", "output-0", 0.5), // 50% weight to output
+        ],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records for all neurons
+    let mut records = Vec::new();
+    for i in 0..10u32 {
+        records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "hidden-0".to_string(),
+            Some(0.46),
+            0.46, // tanh(0.5) ≈ 0.46
+            vec![0.3],
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(0.23),
+            0.23,
+            vec![0.2],
+        ));
+    }
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["hidden-0"],
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    // Check synapse candidates targeting hidden-0
+    if let Some(synapses) = output["helpfulSynapses"].as_array() {
+        for synapse in synapses {
+            if synapse["toNeuronUuid"].as_str() == Some("hidden-0") {
+                let impact = synapse["targetNeuronImpact"]
+                    .as_f64()
+                    .expect("targetNeuronImpact should be a number");
+                assert!(
+                    impact < 1.0,
+                    "Hidden neuron should have impact < 1.0, got {impact}"
+                );
+                assert!(
+                    impact > 0.0,
+                    "Hidden neuron should have impact > 0.0, got {impact}"
+                );
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Test: Candidates sorted by expectedCreatureScoreGain
+// =============================================================================
+
+/// Issue #128: Candidates should be sorted by expectedCreatureScoreGain (highest first).
+///
+/// The goal is to improve the CREATURE's SCORE. Candidates should be sorted by their
+/// expected contribution to that goal.
+#[test]
+fn test_candidates_sorted_by_expected_creature_score_gain() {
+    skip_without_gpu!();
+
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![output("output-0", "IDENTITY")],
+        synapses: vec![],
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records with two inputs having different correlations with error
+    let mut records = Vec::new();
+    for i in 0..20u32 {
+        // input-0: high positive correlation with error
+        records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.8),
+            0.8,
+            vec![],
+        ));
+        // input-1: low correlation with error
+        records.push(DiscoverRecord::new(
+            i,
+            "input-1".to_string(),
+            Some(0.1),
+            0.1,
+            vec![],
+        ));
+        // Output has consistent error
+        records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![0.5],
+        ));
+    }
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input_json = serde_json::json!({
+        "parquetFile": file_path,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+        "maxSynapseCandidates": 10,
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should succeed");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    // Check that synapse candidates are sorted by expectedCreatureScoreGain descending
+    if let Some(synapses) = output["helpfulSynapses"].as_array() {
+        if synapses.len() > 1 {
+            let mut prev_score_gain = f64::INFINITY;
+            for synapse in synapses {
+                let score_gain = synapse["expectedCreatureScoreGain"]
+                    .as_f64()
+                    .expect("expectedCreatureScoreGain should be a number");
+                assert!(
+                    score_gain <= prev_score_gain,
+                    "Candidates should be sorted by expectedCreatureScoreGain descending. \
+                     Got {score_gain} after {prev_score_gain}"
+                );
+                prev_score_gain = score_gain;
+            }
+        }
+    }
+}

--- a/tests/fixed_vs_optimised_params.rs
+++ b/tests/fixed_vs_optimised_params.rs
@@ -161,7 +161,7 @@ fn test_optimised_params_vary_by_sample() {
             .map(|c| {
                 format!(
                     "{}:in={:.2},bias={:.2},exp={:.4}%",
-                    c.squash, c.incoming_weight, c.bias, c.expected_improvement_percentage
+                    c.squash, c.incoming_weight, c.bias, c.expected_creature_score_gain
                 )
             })
             .collect();
@@ -245,7 +245,7 @@ fn test_conservative_params_more_stable_across_samples() {
                 candidate.squash,
                 candidate.incoming_weight,
                 candidate.bias,
-                candidate.expected_improvement_percentage
+                candidate.expected_creature_score_gain
             );
         } else {
             extreme_candidates += 1;
@@ -254,7 +254,7 @@ fn test_conservative_params_more_stable_across_samples() {
                 candidate.squash,
                 candidate.incoming_weight,
                 candidate.bias,
-                candidate.expected_improvement_percentage
+                candidate.expected_creature_score_gain
             );
         }
     }
@@ -470,7 +470,7 @@ fn test_synapse_candidates_no_bias_optimisation() {
             synapse.from_neuron_uuid,
             synapse.to_neuron_uuid,
             synapse.weight,
-            synapse.expected_improvement_percentage * 100.0
+            synapse.expected_creature_score_gain * 100.0
         );
     }
 

--- a/tests/gpu_activation_shaders.rs
+++ b/tests/gpu_activation_shaders.rs
@@ -162,7 +162,7 @@ fn test_leaky_relu_gpu_shader_produces_correct_results() {
             "  incoming={:.4}, outgoing={:.4}, improvement={:.4}%",
             c.incoming_weight,
             c.outgoing_weight,
-            c.expected_improvement_percentage * 100.0
+            c.expected_creature_score_gain * 100.0
         );
     }
 
@@ -287,7 +287,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
             "  incoming={:.4}, outgoing={:.4}, improvement={:.4}%",
             c.incoming_weight,
             c.outgoing_weight,
-            c.expected_improvement_percentage * 100.0
+            c.expected_creature_score_gain * 100.0
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -876,9 +876,9 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
     // Verify the candidate makes sense
     let best = &result.helpful_neurons[0];
     assert!(
-        best.expected_improvement_percentage > 0.0,
+        best.expected_creature_score_gain > 0.0,
         "Best candidate should show positive improvement, got {}",
-        best.expected_improvement_percentage
+        best.expected_creature_score_gain
     );
 
     // The source should be input-0 (the correlated input)
@@ -982,19 +982,19 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
     // Verify the candidate has reasonable expected improvement
     let best = &result.helpful_neurons[0];
     assert!(
-        best.expected_improvement_percentage > 0.0,
+        best.expected_creature_score_gain > 0.0,
         "Expected improvement should be positive, got {}",
-        best.expected_improvement_percentage
+        best.expected_creature_score_gain
     );
 
     // Key assertion: the improvement prediction should be realistic (not inflated)
     // With the bug, predictions were often 10x higher than reality
     // After the fix, predictions should be < 50% (a reasonable upper bound)
     assert!(
-        best.expected_improvement_percentage < 50.0,
+        best.expected_creature_score_gain < 50.0,
         "Expected improvement should be realistic (< 50%), got {}%. \
          This may indicate the bias-aware weight calculation is not working.",
-        best.expected_improvement_percentage
+        best.expected_creature_score_gain
     );
 
     // Note: bias=0 is a valid value (the optimal bias search includes 0.0)
@@ -1075,17 +1075,17 @@ fn test_bias_improves_neuron_performance() {
     if !result.helpful_neurons.is_empty() {
         for neuron in &result.helpful_neurons {
             assert!(
-                neuron.expected_improvement_percentage > 0.0,
+                neuron.expected_creature_score_gain > 0.0,
                 "Neuron candidate should show positive improvement, got {}",
-                neuron.expected_improvement_percentage
+                neuron.expected_creature_score_gain
             );
 
             // The fact that the neuron passed the threshold with the calculated bias
             // means the bias is helping (otherwise it wouldn't have passed)
             assert!(
-                neuron.expected_improvement_percentage >= 0.01,
+                neuron.expected_creature_score_gain >= 0.01,
                 "Neuron should meet improvement threshold of 0.01, got {}",
-                neuron.expected_improvement_percentage
+                neuron.expected_creature_score_gain
             );
         }
     }
@@ -1227,7 +1227,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
 
 /// REGRESSION TEST: Hidden neuron candidates must have discounted predictions.
 ///
-/// When a candidate targets a hidden neuron, the expected_improvement_percentage
+/// When a candidate targets a hidden neuron, the expected_creature_score_gain
 /// should be discounted by the hidden neuron's impact score (path to outputs).
 ///
 /// Impact is calculated as: (weight to child / total inbound to child) × child_impact
@@ -1388,18 +1388,18 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
             // With impact = 0.5, predictions should be discounted by 50%
             // So maximum possible is 50% even if raw prediction was 100%
             assert!(
-                candidate.expected_improvement_percentage <= 0.5,
+                candidate.expected_creature_score_gain <= 0.5,
                 "Hidden neuron candidate improvement {:.4}% exceeds impact-adjusted maximum of 50%. \
                 Hidden-0 has impact ~0.5, so predictions should be discounted. \
                 This suggests impact discounting is not being applied.",
-                candidate.expected_improvement_percentage * 100.0
+                candidate.expected_creature_score_gain * 100.0
             );
 
             eprintln!(
                 "Hidden neuron candidate (impact ~0.5): {} -> {} improvement={:.4}%",
                 candidate.source_neuron_uuid,
                 candidate.target_neuron_uuid,
-                candidate.expected_improvement_percentage * 100.0
+                candidate.expected_creature_score_gain * 100.0
             );
         }
     } else {

--- a/tests/regression_v0_1_123.rs
+++ b/tests/regression_v0_1_123.rs
@@ -194,7 +194,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
 ///
 /// BUG (fixed in v0.1.123): Fallback candidates with very low predicted improvement
 /// v0.1.134: Removed the arbitrary 2% MIN_FALLBACK_IMPROVEMENT threshold.
-/// v0.1.135: Added split-error evaluation - expected_improvement_percentage is now
+/// v0.1.135: Added split-error evaluation - expected_creature_score_gain is now
 /// the NET improvement across ALL samples, not just a subset.
 ///
 /// The only requirement is positive improvement. TypeScript evaluates actual score.
@@ -272,20 +272,20 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
 
     // v0.1.134/v0.1.135: All returned candidates must have positive improvement.
-    // The expected_improvement_percentage is now the NET improvement across ALL samples
+    // The expected_creature_score_gain is now the NET improvement across ALL samples
     // (thanks to split-error evaluation), so TypeScript can trust this value directly.
     for candidate in &result.helpful_neurons {
         assert!(
-            candidate.expected_improvement_percentage > 0.0,
+            candidate.expected_creature_score_gain > 0.0,
             "Candidate should have positive expected improvement, got {:.4}%",
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
         eprintln!(
             "Candidate: {} -> {} ({}), improvement: {:.4}%",
             candidate.source_neuron_uuid,
             candidate.target_neuron_uuid,
             candidate.squash,
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
     }
 
@@ -546,16 +546,16 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
     // TypeScript will evaluate the actual score change.
     for candidate in &result.helpful_neurons {
         assert!(
-            candidate.expected_improvement_percentage > 0.0,
+            candidate.expected_creature_score_gain > 0.0,
             "Candidate should have positive expected improvement, got {:.6}%",
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
         eprintln!(
             "Candidate: {} -> {} ({}), improvement: {:.4}%",
             candidate.source_neuron_uuid,
             candidate.target_neuron_uuid,
             candidate.squash,
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
     }
 

--- a/tests/split_error_all_activations.rs
+++ b/tests/split_error_all_activations.rs
@@ -172,7 +172,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
             "  {} via {}: {:.4}% expected",
             c.target_neuron_uuid,
             c.squash,
-            c.expected_improvement_percentage * 100.0
+            c.expected_creature_score_gain * 100.0
         );
     }
 
@@ -187,17 +187,17 @@ fn test_non_relu_activations_use_split_error_evaluation() {
     for candidate in &input1_candidates {
         // This assertion will help us verify the fix works
         assert!(
-            candidate.expected_improvement_percentage > 0.0,
+            candidate.expected_creature_score_gain > 0.0,
             "Returned candidates must have positive expected improvement"
         );
 
         // ADDITIONAL CHECK: With 50/50 split and weak correlation,
         // improvements should be small and close to zero
         // Large improvements (>10%) with 50/50 split suggests a bug
-        if candidate.expected_improvement_percentage > 0.10 {
+        if candidate.expected_creature_score_gain > 0.10 {
             eprintln!(
                 "WARNING: Large improvement ({:.2}%) with 50/50 split errors - verify accuracy",
-                candidate.expected_improvement_percentage * 100.0
+                candidate.expected_creature_score_gain * 100.0
             );
         }
     }
@@ -295,14 +295,14 @@ fn test_skewed_errors_return_candidates() {
             c.source_neuron_uuid,
             c.target_neuron_uuid,
             c.squash,
-            c.expected_improvement_percentage * 100.0
+            c.expected_creature_score_gain * 100.0
         );
     }
 
     // Verify all returned candidates have positive improvement
     for candidate in &result.helpful_neurons {
         assert!(
-            candidate.expected_improvement_percentage > 0.0,
+            candidate.expected_creature_score_gain > 0.0,
             "All candidates should have positive expected improvement"
         );
     }

--- a/tests/split_error_fallback_candidates.rs
+++ b/tests/split_error_fallback_candidates.rs
@@ -181,8 +181,8 @@ fn regression_split_error_must_return_fallback_candidates() {
             "  {} via {}: {:.4}% expected (threshold check: {})",
             c.target_neuron_uuid,
             c.squash,
-            c.expected_improvement_percentage * 100.0,
-            if c.expected_improvement_percentage >= 0.50 {
+            c.expected_creature_score_gain * 100.0,
+            if c.expected_creature_score_gain >= 0.50 {
                 "PASS"
             } else {
                 "FALLBACK"
@@ -199,16 +199,14 @@ fn regression_split_error_must_return_fallback_candidates() {
     let positive_candidates: Vec<_> = result
         .helpful_neurons
         .iter()
-        .filter(|c| c.expected_improvement_percentage > 0.0)
+        .filter(|c| c.expected_creature_score_gain > 0.0)
         .collect();
 
     // Also check if any candidates have improvement below threshold (the fallback case)
     let below_threshold_candidates: Vec<_> = result
         .helpful_neurons
         .iter()
-        .filter(|c| {
-            c.expected_improvement_percentage > 0.0 && c.expected_improvement_percentage < 0.50
-        })
+        .filter(|c| c.expected_creature_score_gain > 0.0 && c.expected_creature_score_gain < 0.50)
         .collect();
 
     eprintln!(
@@ -349,7 +347,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
             c.source_neuron_uuid,
             c.target_neuron_uuid,
             c.squash,
-            c.expected_improvement_percentage * 100.0
+            c.expected_creature_score_gain * 100.0
         );
     }
 
@@ -358,7 +356,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
     let positive_candidates: Vec<_> = result
         .helpful_neurons
         .iter()
-        .filter(|c| c.expected_improvement_percentage > 0.0)
+        .filter(|c| c.expected_creature_score_gain > 0.0)
         .collect();
 
     eprintln!(
@@ -371,7 +369,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
     // specifically targets the split-error path where the bug manifests.
     for candidate in &positive_candidates {
         assert!(
-            candidate.expected_improvement_percentage > 0.0,
+            candidate.expected_creature_score_gain > 0.0,
             "All returned candidates should have positive improvement"
         );
     }

--- a/tests/step_hidden_neuron_prediction.rs
+++ b/tests/step_hidden_neuron_prediction.rs
@@ -184,7 +184,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
     // If we found any candidates for this STEP hidden neuron, check the prediction accuracy
     for candidate in &result.helpful_neurons {
         if candidate.target_neuron_uuid == "hidden-step" {
-            let expected_pct = candidate.expected_improvement_percentage;
+            let expected_pct = candidate.expected_creature_score_gain;
             println!(
                 "Candidate {} -> {}: expected improvement = {:.4}%",
                 candidate.source_neuron_uuid,
@@ -192,7 +192,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
                 expected_pct * 100.0
             );
 
-            // The bug: For STEP hidden neurons, `expected_improvement_percentage` is "flip rate"
+            // The bug: For STEP hidden neurons, `expected_creature_score_gain` is "flip rate"
             // not actual error reduction. If this is > 5%, the prediction is likely wrong.
             //
             // With our test data, ~50% of samples would flip, so expected_pct might be ~0.5 (50%)
@@ -276,7 +276,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
                 This is equivalent to a synapse: IDENTITY(x×{} + 0) × {} = x × {}",
                 candidate.source_neuron_uuid,
                 candidate.target_neuron_uuid,
-                candidate.expected_improvement_percentage * 100.0,
+                candidate.expected_creature_score_gain * 100.0,
                 candidate.incoming_weight,
                 candidate.outgoing_weight,
                 candidate.incoming_weight * candidate.outgoing_weight

--- a/tests/synapse_impact_discounting.rs
+++ b/tests/synapse_impact_discounting.rs
@@ -213,7 +213,7 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         println!(
             "Found candidate: {} → hidden-b, expected_improvement: {:.4}%",
             candidate.from_neuron_uuid,
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
 
         // hidden-b has impact ≈ 0.1 (10%), so the expected improvement should be
@@ -222,23 +222,23 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         // The key assertion: this value is CREATURE-LEVEL, not neuron-level.
         // TypeScript should use this directly without re-calculation.
         assert!(
-            candidate.expected_improvement_percentage >= 0.0,
+            candidate.expected_creature_score_gain >= 0.0,
             "Expected improvement should be non-negative"
         );
 
         // With impact ≈ 0.1, even a 100% neuron-level improvement becomes ~10% creature-level
         // So we expect the value to be relatively small
         assert!(
-            candidate.expected_improvement_percentage <= 0.5,
+            candidate.expected_creature_score_gain <= 0.5,
             "Expected improvement should be discounted (≤50% for low-impact hidden neuron), got {:.2}%",
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
     }
 }
 
 /// Test that synapse candidates targeting output neurons have full impact (no discount).
 ///
-/// Output neurons have impact = 1.0, so their expected_improvement_percentage
+/// Output neurons have impact = 1.0, so their expected_creature_score_gain
 /// should not be discounted at all.
 #[test]
 fn test_synapse_candidate_output_neuron_no_discount() {
@@ -313,11 +313,11 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         println!(
             "Output candidate: {} → output-0, expected_improvement: {:.4}%",
             candidate.from_neuron_uuid,
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
 
         // Output neurons have impact = 1.0, so no discount should be applied
-        // The expected_improvement_percentage IS the creature-level improvement
+        // The expected_creature_score_gain IS the creature-level improvement
     }
 }
 
@@ -403,7 +403,7 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
             "  {} → {}, expected_improvement: {:.4}%",
             candidate.from_neuron_uuid,
             candidate.to_neuron_uuid,
-            candidate.expected_improvement_percentage * 100.0
+            candidate.expected_creature_score_gain * 100.0
         );
     }
 


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.1.168 to 0.2.0.
- Refactor candidate metrics to use creature-level metrics instead of neuron-level percentages, enhancing clarity and accuracy in expected improvement calculations.
- Remove the `expected_improvement_percentage` field and replace it with `target_neuron_impact`, `expected_creature_error_reduction`, and `expected_creature_score_gain` in relevant structs.
- Update README to reflect changes in metrics and their implications for candidate evaluation.

These changes improve the reliability of predictions and streamline the analysis framework for better performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `expectedImprovementPercentage` with creature-level metrics (impact, error reduction, score gain) across analysis, APIs, logs, and tests, and sorts/ranks by creature score gain; bumps version to 0.2.0.
> 
> - **Metrics Refactor (breaking)**:
>   - Remove `expected_improvement_percentage`; add `targetNeuronImpact`, `expectedCreatureErrorReduction`, `expectedCreatureScoreGain` to `Candidate*Json` and diagnostics.
>   - Compute/update creature-level metrics in analysis; apply impact discounting (`targetNeuronImpact`) and derive `expectedCreature*` values; comparisons/sorting now use `expectedCreatureScoreGain`.
>   - Update verbose logs and upsert logic to reference creature-level metrics.
> - **README**:
>   - Document creature-level metrics, their meaning/usage, and field naming guidance; replace prior neuron-level percentage guidance.
> - **Tests**:
>   - Add `tests/creature_level_metrics.rs` and update existing tests to assert new fields and sorting by `expectedCreatureScoreGain`.
> - **Version**:
>   - Bump crate version to `0.2.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ea3bf8a9418a52efa0043540cd8793d9309689. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->