### PR TITLE
Update version to 0.2.3 and fix costOfGrowth threshold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -552,7 +552,9 @@ This answered "what fraction of blame?" not "what happens when removed?"
 impact = |weight| × child_impact  // CORRECT
 ```
 
-**Also fixed**: `COST_OF_GROWTH` changed from `1e-7` to `0.01` to match TypeScript default.
+**BUG INTRODUCED**: `COST_OF_GROWTH` was incorrectly changed from `1e-7` to `0.01` in this version
+based on a false assumption. **NEAT-AI has always used `1e-7`** (never 0.01). This caused 418
+false removal candidates in production. Reverted in v0.2.3 (Issue #132).
 
 **Tests added**: `tests/impact_calculation_production.rs` captures the production failure
 patterns and verifies the fix prevents regression.
@@ -988,8 +990,48 @@ const complexityPenalty = hiddenNeuronCount * growthCost +
 savings = growthCost × (1 + (N + M) / 10)
 ```
 
-**The fix**: ALL neurons with `activation_weighted_impact < costOfGrowth` (0.01) are
+**The fix**: ALL neurons with `activation_weighted_impact < costOfGrowth` are
 returned as removal candidates, sorted by impact ascending.
+
+#### Configurable costOfGrowth (v0.2.3, Issue #132)
+
+**CRITICAL BUG FIX**: The `costOfGrowth` threshold was incorrectly hardcoded to `0.01`
+(since v0.1.145) based on a false assumption that "TypeScript used 0.01". **NEAT-AI has
+always used `1e-7`** - it was never 0.01. This bug caused **418 false removal candidates**
+in production!
+
+The threshold is now **configurable** with the correct default of `1e-7`:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `costOfGrowth` | `Option<f32>` | `1e-7` | Threshold for removal candidates |
+
+**JSON input example**:
+```json
+{
+  "parquetFile": "/path/to/records.parquet",
+  "creature": { ... },
+  "maxResults": 100,
+  "costOfGrowth": 1e-7
+}
+```
+
+**Behaviour**:
+- Neurons with `activation_weighted_impact < costOfGrowth` are removal candidates
+- Default `1e-7` matches NEAT-AI's Score.ts complexity formula
+- NEAT-AI should pass its configured `costOfGrowth` value for consistency
+
+**Common costOfGrowth values**:
+| Value | Purpose |
+|-------|---------|
+| `1e-7` | Default - standard complexity penalty per neuron |
+| `1e-9` or lower | Encourages creature expansion for evolution on new neurons |
+| Higher values | More aggressive pruning (use with caution) |
+
+**Why the old hardcoded `0.01` was wrong**: With threshold `0.01`, neurons with impact `1e-5`
+were incorrectly flagged for removal even though they contribute meaningfully to output.
+The correct default `1e-7` ensures only truly negligible neurons are removal candidates,
+while still allowing users to override for specific use cases like expansion.
 
 ```
 activation_weighted_impact = structural_impact × mean_absolute_activation

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -966,6 +966,7 @@ pub fn rank_focus_neurons(
     parquet_file: &str,
     creature: &CreatureJson,
     max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
 ) -> Result<RankFocusStats> {
     let start = Instant::now();
     let selectable: Vec<&NeuronJson> = creature
@@ -1108,18 +1109,20 @@ pub fn rank_focus_neurons(
     //   savings = growthCost × (1 + (N + M) / 10)
     // where N = incoming synapses, M = outgoing synapses
     //
-    // Threshold 0.01 means "contributes less than 1% weighted activation to outputs".
-    // This matches the TypeScript default costOfGrowth.
-    const COST_OF_GROWTH: f32 = 0.01;
+    // Issue #132: costOfGrowth should be passed from NEAT-AI, not hardcoded.
+    // The correct default is 1e-7 (per hidden neuron) as per NEAT-AI's Score.ts formula.
+    // v0.1.145 incorrectly changed this to 0.01 which caused 418 false removal candidates.
+    const DEFAULT_COST_OF_GROWTH: f32 = 1e-7;
+    let cost_of_growth_threshold = cost_of_growth.unwrap_or(DEFAULT_COST_OF_GROWTH);
 
     // Return ALL neurons with impact below costOfGrowth as removal candidates
     // Use parallel iteration for faster processing on multi-core systems
     let mut removal_candidates: Vec<RemovalCandidate> = neurons
         .par_iter()
-        .filter(|n| n.activation_weighted_impact < COST_OF_GROWTH)
+        .filter(|n| n.activation_weighted_impact < cost_of_growth_threshold)
         .map(|n| {
             let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
-            let savings = calculate_removal_savings(incoming, outgoing, COST_OF_GROWTH);
+            let savings = calculate_removal_savings(incoming, outgoing, cost_of_growth_threshold);
 
             // Issue #117: expected_error_reduction should be based on activation_weighted_impact,
             // NOT total_error. The activation_weighted_impact represents the actual contribution
@@ -1140,9 +1143,9 @@ pub fn rank_focus_neurons(
                 removal_savings: savings,
                 expected_error_reduction,
                 reason: format!(
-                    "Impact {:.2e} < costOfGrowth ({:.0e}), {} synapses, saves {:.2e}",
+                    "Impact {:.2e} < costOfGrowth ({:.2e}), {} synapses, saves {:.2e}",
                     n.activation_weighted_impact,
-                    COST_OF_GROWTH,
+                    cost_of_growth_threshold,
                     incoming + outgoing,
                     savings
                 ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,13 @@ pub struct RankFocusNeuronsInput {
     pub creature: CreatureJson,
     #[serde(default)]
     pub max_results: Option<usize>,
+    /// The cost of growth from NEAT-AI (default: 1e-7).
+    /// Neurons with activation_weighted_impact below this threshold are
+    /// candidates for removal. The default 1e-7 matches NEAT-AI's Score.ts formula.
+    /// Lower values (e.g., 1e-9) encourage creature expansion for evolution.
+    /// Issue #132: Pass this from NEAT-AI's configured costOfGrowth for consistency.
+    #[serde(default)]
+    pub cost_of_growth: Option<f32>,
 }
 
 #[derive(Debug, Serialize)]
@@ -785,7 +792,12 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
         }
     };
 
-    match focus::rank_focus_neurons(&input.parquet_file, &input.creature, input.max_results) {
+    match focus::rank_focus_neurons(
+        &input.parquet_file,
+        &input.creature,
+        input.max_results,
+        input.cost_of_growth,
+    ) {
         Ok(stats) => {
             let neurons: Vec<RankedNeuronJson> = stats
                 .neurons

--- a/tests/activation_based_impact.rs
+++ b/tests/activation_based_impact.rs
@@ -140,7 +140,7 @@ fn test_minimum_neuron_with_dominant_synapse_gets_proportional_impact() {
 
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Find the hidden neurons' impacts
     let dominant = result
@@ -269,7 +269,7 @@ fn test_maximum_neuron_with_dominant_synapse_gets_proportional_impact() {
 
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let dominant = result
         .neurons
@@ -395,7 +395,7 @@ fn test_if_neuron_synapse_type_based_impact() {
 
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let condition = result
         .neurons
@@ -535,7 +535,7 @@ fn test_if_neuron_without_synapse_types_uses_equal_probability() {
 
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let a = result
         .neurons

--- a/tests/focus.rs
+++ b/tests/focus.rs
@@ -123,7 +123,7 @@ fn test_output_neurons_prioritised_due_to_high_impact() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Output should be ranked first due to impact × error
     // output-0: 0.5 × 1.0 = 0.5
@@ -186,7 +186,7 @@ fn test_weighted_ranking_prefers_high_impact_moderate_error_over_low_impact_high
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
     assert_eq!(result.neurons.len(), 3);
 
     // Output should rank first: 0.6 * 1.0 = 0.6
@@ -258,7 +258,7 @@ fn test_hidden_neuron_can_rank_first_with_very_high_weighted_score() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
     assert_eq!(result.neurons.len(), 2);
 
     // hidden-1 should rank first: 10.0 × ~1.0 = 10.0
@@ -302,7 +302,7 @@ fn test_impact_epsilon_prevents_zero_impact_neurons_from_being_ignored() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Orphan should still appear in results (not filtered out)
     let orphan = result.neurons.iter().find(|n| n.neuron_uuid == "orphan");
@@ -356,9 +356,9 @@ fn test_disconnected_neurons_are_removal_candidates() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
-    // Orphan should be a removal candidate because impact (0) < costOfGrowth (0.01)
+    // Orphan should be a removal candidate because impact (0) < costOfGrowth (1e-7)
     assert!(
         !result.removal_candidates.is_empty(),
         "Should have at least one removal candidate. Neurons: {:?}",
@@ -411,14 +411,14 @@ fn test_high_impact_neurons_not_returned_as_removal_candidates() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    // Both have high error, but both have high impact (well above costOfGrowth 0.01)
+    // Both have high error, but both have high impact (well above costOfGrowth 1e-7)
     let records = create_records(vec![
         ("hidden-1", 100.0), // Very high error, ~100% impact
         ("output-0", 100.0), // Very high error, 100% impact
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // High impact neurons should NOT be removal candidates
     // Both hidden-1 and output-0 have activation_weighted_impact >> 0.01
@@ -435,7 +435,7 @@ fn test_high_impact_neurons_not_returned_as_removal_candidates() {
 
 #[test]
 fn test_only_low_impact_neurons_returned_as_removal_candidates() {
-    // Scenario: Only neurons with activation_weighted_impact < costOfGrowth (0.01)
+    // Scenario: Only neurons with activation_weighted_impact < costOfGrowth (1e-7)
     // are returned as removal candidates. High impact neurons are filtered out.
     let creature = create_creature(
         vec![
@@ -457,8 +457,8 @@ fn test_only_low_impact_neurons_returned_as_removal_candidates() {
 
     // Both neurons have normal activations (0.5), so their activation_weighted_impact
     // will be structural_impact × 0.5:
-    // - low-impact: 0.05 × 0.5 = 0.025 (>> 0.01, NOT a candidate)
-    // - connected: 0.95 × 0.5 = 0.475 (>> 0.01, NOT a candidate)
+    // - low-impact: 0.05 × 0.5 = 0.025 (>> 1e-7, NOT a candidate)
+    // - connected: 0.95 × 0.5 = 0.475 (>> 1e-7, NOT a candidate)
     let records = create_records(vec![
         ("low-impact", 0.1), // Low error, ~5% impact × 0.5 activation = 0.025
         ("connected", 10.0), // High error, 95% impact × 0.5 activation = 0.475
@@ -466,7 +466,7 @@ fn test_only_low_impact_neurons_returned_as_removal_candidates() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // All neurons have impact >> costOfGrowth, so none should be removal candidates
     assert!(
@@ -519,7 +519,7 @@ fn test_negligible_impact_neurons_sorted_first_as_best_removal_candidates() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Verify the negligible neuron has essentially zero impact
     let negligible_neuron = result
@@ -607,7 +607,7 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Verify high-activation neuron has high activation-weighted impact
     let high_act = result
@@ -622,19 +622,19 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
     );
     // Activation-weighted impact should be ~0.1 (10%)
     assert!(
-        high_act.activation_weighted_impact > 0.01,
-        "high-activation should have activation_weighted_impact > 1% (threshold), got {}",
+        high_act.activation_weighted_impact > 1e-7,
+        "high-activation should have activation_weighted_impact > 1e-7 (threshold), got {}",
         high_act.activation_weighted_impact
     );
 
-    // high-activation should NOT be a removal candidate (impact 0.1 >> 0.01)
+    // high-activation should NOT be a removal candidate (impact 0.1 >> 1e-7)
     let high_act_removal = result
         .removal_candidates
         .iter()
         .find(|c| c.neuron_uuid == "high-activation");
     assert!(
         high_act_removal.is_none(),
-        "high-activation should NOT be a removal candidate (impact {:.2e} >> costOfGrowth 0.01)",
+        "high-activation should NOT be a removal candidate (impact {:.2e} >> costOfGrowth 1e-7)",
         high_act.activation_weighted_impact
     );
 
@@ -655,14 +655,14 @@ fn test_activation_weighted_impact_prevents_false_removal_candidates() {
         low_act.activation_weighted_impact
     );
 
-    // low-activation SHOULD be a removal candidate (impact 1e-15 << 0.01)
+    // low-activation SHOULD be a removal candidate (impact 1e-15 << 1e-7)
     let low_act_removal = result
         .removal_candidates
         .iter()
         .find(|c| c.neuron_uuid == "low-activation");
     assert!(
         low_act_removal.is_some(),
-        "low-activation SHOULD be a removal candidate (impact {:.2e} < costOfGrowth 0.01)",
+        "low-activation SHOULD be a removal candidate (impact {:.2e} < costOfGrowth 1e-7)",
         low_act.activation_weighted_impact
     );
 
@@ -706,7 +706,7 @@ fn test_removal_candidates_sorted_by_activation_weighted_impact() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // All three should be removal candidates (disconnected from output)
     assert!(
@@ -782,7 +782,7 @@ fn test_processed_neurons_reports_accurately_when_some_neurons_missing_records()
     write_records_to_parquet(file_path, &records).unwrap();
 
     // Call rank_focus_neurons
-    let result = rank_focus_neurons(file_path, &creature, None);
+    let result = rank_focus_neurons(file_path, &creature, None, None);
 
     // The function should error because hidden-3 and output-0 are missing records
     // (restore old behavior where missing records cause an error)
@@ -852,7 +852,7 @@ fn test_cumulative_impact_for_multiple_outgoing_synapses() {
     let records = create_records(vec![("hub", 0.5), ("output-0", 0.5), ("output-1", 0.5)]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Find the hub neuron's impact
     let hub = result
@@ -934,7 +934,7 @@ fn test_non_finite_activations_handled_gracefully() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Verify the ranking is not corrupted by NaN
     assert!(
@@ -1025,7 +1025,7 @@ fn test_all_non_finite_activations_returns_zero_mean() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Find the all-nan neuron
     let all_nan = result
@@ -1081,7 +1081,7 @@ fn test_cumulative_impact_mixed_direct_and_indirect_paths() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let hub = result
         .neurons
@@ -1112,21 +1112,25 @@ fn test_cumulative_impact_mixed_direct_and_indirect_paths() {
 /// neurons), this should be very small - approximately equal to activation_weighted_impact.
 #[test]
 fn test_removal_candidate_expected_error_reduction_is_impact_based_not_neuron_error() {
-    // Scenario: A neuron with HIGH error (0.27 normalised) but NEGLIGIBLE impact (1e-8).
-    // The bug would predict 27% error reduction, but actual reduction is ~1e-8 (0.000001%).
+    // Scenario: A neuron with HIGH error (0.27 normalised) but NEGLIGIBLE impact (< 1e-7).
+    // The bug would predict 27% error reduction, but actual reduction is tiny.
     //
-    // Network: input-0 -> negligible -> output-0 (tiny weights)
+    // Network: input-0 -> negligible -> output-0 (very tiny weights)
     //          input-0 -> output-0 (direct, large weight)
+    //
+    // Impact calculation (v0.2.3 with 1e-7 threshold):
+    // - negligible → output-0: weight 1e-8 / total_inbound(1.0 + 1e-8) × 1.0 ≈ 1e-8
+    // - activation_weighted_impact = 1e-8 × 0.5 = 5e-9 < 1e-7 ✓
     let creature = create_creature(
         vec![
             ("input-0", "input"),
-            ("negligible", "hidden"), // Negligible impact due to tiny weights
+            ("negligible", "hidden"), // Negligible impact due to very tiny weights
             ("output-0", "output"),
         ],
         vec![
-            // Negligible neuron has tiny weights
-            ("input-0", "negligible", 1e-6),
-            ("negligible", "output-0", 1e-6),
+            // Negligible neuron has very tiny weights (to get impact < 1e-7)
+            ("input-0", "negligible", 1e-8),
+            ("negligible", "output-0", 1e-8),
             // Direct path dominates
             ("input-0", "output-0", 1.0),
         ],
@@ -1136,14 +1140,14 @@ fn test_removal_candidate_expected_error_reduction_is_impact_based_not_neuron_er
     let file_path = temp_file.path().to_str().unwrap();
 
     // Negligible neuron has HIGH error (0.27 or 27% when normalised)
-    // but tiny activation-weighted impact
+    // but very tiny activation-weighted impact (< 1e-7)
     let records = create_records_with_activation(vec![
-        ("negligible", 0.27, 0.5), // High error, moderate activation -> still tiny impact
+        ("negligible", 0.27, 0.5), // High error, moderate activation -> very tiny impact
         ("output-0", 0.5, 0.8),    // Normal error for output
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // The negligible neuron should be a removal candidate
     let negligible_removal = result

--- a/tests/impact_caching.rs
+++ b/tests/impact_caching.rs
@@ -366,8 +366,8 @@ fn rank_focus_neurons_uses_cached_impacts() {
         ],
     };
 
-    let result =
-        rank_focus_neurons(&parquet_file, &creature, None).expect("Focus ranking should succeed");
+    let result = rank_focus_neurons(&parquet_file, &creature, None, None)
+        .expect("Focus ranking should succeed");
 
     // All neurons should be processed
     assert_eq!(

--- a/tests/impact_calculation_production.rs
+++ b/tests/impact_calculation_production.rs
@@ -329,7 +329,8 @@ fn test_activation_weighted_impact_with_recorded_activations() {
         ],
     };
 
-    let result = rank_focus_neurons(parquet_path, &creature, None).expect("Ranking should succeed");
+    let result =
+        rank_focus_neurons(parquet_path, &creature, None, None).expect("Ranking should succeed");
 
     // Find the neurons in results
     let high = result

--- a/tests/impact_squash.rs
+++ b/tests/impact_squash.rs
@@ -103,7 +103,7 @@ fn test_step_neuron_tiny_weight_impact_not_underestimated() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Find hidden-a's impact
     let hidden_a = result
@@ -159,7 +159,7 @@ fn test_bipolar_neuron_threshold_impact() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let hidden_a = result
         .neurons
@@ -230,7 +230,7 @@ fn test_minimum_neuron_selection_impact() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let small = result
         .neurons
@@ -315,7 +315,7 @@ fn test_maximum_neuron_selection_impact() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let small = result
         .neurons
@@ -385,7 +385,7 @@ fn test_removal_candidate_step_output_interaction() {
     ]);
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Check if hidden-critical is flagged as a removal candidate
     let is_removal_candidate = result

--- a/tests/issue_132_cost_of_growth.rs
+++ b/tests/issue_132_cost_of_growth.rs
@@ -1,0 +1,386 @@
+//! Issue #132: costOfGrowth should be passed from NEAT-AI, not hardcoded.
+//!
+//! The correct cost of growth is 1e-7 (per Score.ts formula).
+//! v0.1.145 incorrectly changed this to 0.01, causing 418 false removal candidates.
+//! This test verifies that the costOfGrowth parameter is correctly passed
+//! from the input and used in removal candidate filtering.
+
+mod common;
+
+use neat_ai_discovery::focus::rank_focus_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Helper to create a simple creature with specified neurons and synapses
+fn create_creature(
+    neurons: Vec<(&str, &str)>,       // (uuid, type)
+    synapses: Vec<(&str, &str, f32)>, // (from, to, weight)
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .filter(|(_, neuron_type)| *neuron_type != "input")
+            .map(|(uuid, neuron_type)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: neuron_type.to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, weight)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight,
+                synapse_type: None,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Helper to create parquet records for neurons with specified errors AND activations.
+fn create_records_with_activation(
+    neuron_data: Vec<(&str, f32, f32)>, // (uuid, error, activation)
+) -> Vec<DiscoverRecord> {
+    neuron_data
+        .into_iter()
+        .flat_map(|(uuid, error, activation)| {
+            vec![
+                DiscoverRecord::new(0, uuid.to_string(), Some(0.5), activation, vec![error]),
+                DiscoverRecord::new(1, uuid.to_string(), Some(0.5), activation, vec![error]),
+            ]
+        })
+        .collect()
+}
+
+/// Issue #132: costOfGrowth should be passable from NEAT-AI.
+///
+/// When a neuron has activation_weighted_impact between 1e-7 and 0.01:
+/// - With costOfGrowth = 0.01 (old default): IS a removal candidate
+/// - With costOfGrowth = 1e-7 (typical NEAT-AI value): NOT a removal candidate
+#[test]
+fn test_cost_of_growth_parameter_affects_removal_candidates() {
+    // Create a network where medium-impact neuron has a competing path to output.
+    // This gives normalised structural impact < 1.0.
+    //
+    // Impact calculation (normalised):
+    // - medium-impact → output-0: weight 0.001 / total_inbound(1.001) × 1.0 ≈ 0.001
+    // - direct → output-0: weight 1.0 / total_inbound(1.001) × 1.0 ≈ 0.999
+    //
+    // With mean_activation = 0.01:
+    // - activation_weighted_impact = 0.001 × 0.01 = 1e-5
+    //
+    // This is between 1e-7 and 0.01, perfect for testing threshold behaviour.
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("input-1", "input"), // Direct input to output
+            ("medium-impact", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "medium-impact", 1.0),
+            // Small weight relative to the direct path
+            ("medium-impact", "output-0", 0.001),
+            // Direct path with large weight dominates
+            ("input-1", "output-0", 1.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = create_records_with_activation(vec![
+        ("medium-impact", 0.1, 0.01), // activation_weighted_impact ≈ 1e-5
+        ("output-0", 0.5, 0.5),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // First, verify the activation_weighted_impact is in the expected range
+    let result_check = rank_focus_neurons(file_path, &creature, None, Some(1.0)).unwrap();
+    let medium = result_check
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "medium-impact")
+        .expect("medium-impact should be in results");
+
+    // Log the actual values for debugging
+    eprintln!(
+        "medium-impact: structural_impact={:.6e}, mean_activation={:.6e}, activation_weighted_impact={:.6e}",
+        medium.impact, medium.mean_activation, medium.activation_weighted_impact
+    );
+
+    // The activation_weighted_impact should be between 1e-7 and 0.01
+    assert!(
+        medium.activation_weighted_impact > 1e-7 && medium.activation_weighted_impact < 0.01,
+        "activation_weighted_impact ({:.2e}) should be between 1e-7 and 0.01 for this test to be valid",
+        medium.activation_weighted_impact
+    );
+
+    // Test with high costOfGrowth (0.01 - the old hardcoded default)
+    // Neuron with impact between 1e-7 and 0.01 should be a removal candidate
+    let result_high_cost = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    let has_removal_high = result_high_cost
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "medium-impact");
+    assert!(
+        has_removal_high,
+        "With costOfGrowth=0.01, neuron with impact {:.2e} SHOULD be a removal candidate. \
+         Found candidates: {:?}",
+        medium.activation_weighted_impact,
+        result_high_cost
+            .removal_candidates
+            .iter()
+            .map(|c| (&c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+
+    // Test with low costOfGrowth (1e-7 - typical NEAT-AI value)
+    // Neuron with impact > 1e-7 should NOT be a removal candidate
+    let result_low_cost = rank_focus_neurons(file_path, &creature, None, Some(1e-7)).unwrap();
+
+    let has_removal_low = result_low_cost
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "medium-impact");
+    assert!(
+        !has_removal_low,
+        "With costOfGrowth=1e-7, neuron with impact {:.2e} should NOT be a removal candidate \
+         (impact > threshold 1e-7). Found candidates: {:?}",
+        medium.activation_weighted_impact,
+        result_low_cost
+            .removal_candidates
+            .iter()
+            .map(|c| (&c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Issue #132: The reason message should show the passed costOfGrowth value.
+#[test]
+fn test_removal_candidate_reason_shows_passed_cost_of_growth() {
+    // Create a neuron with very low impact that will definitely be a removal candidate.
+    // Use a competing direct path to ensure normalised impact is low.
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("input-1", "input"),
+            ("low-impact", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "low-impact", 1.0),
+            // Very small weight compared to direct path
+            ("low-impact", "output-0", 1e-10),
+            // Direct path dominates
+            ("input-1", "output-0", 1.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = create_records_with_activation(vec![
+        ("low-impact", 0.1, 0.1), // activation_weighted_impact = structural_impact × 0.1
+        ("output-0", 0.5, 0.5),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Use a high costOfGrowth to ensure the neuron IS a removal candidate
+    let result = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    let removal = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "low-impact");
+    assert!(
+        removal.is_some(),
+        "Should have a removal candidate. Found candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| (&c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+
+    let reason = &removal.unwrap().reason;
+    // The reason should contain the costOfGrowth value (1e-02)
+    assert!(
+        reason.contains("1.00e-2") || reason.contains("1e-02") || reason.contains("0.01"),
+        "Reason should mention the costOfGrowth. Got: {reason}",
+    );
+}
+
+/// Issue #132: When costOfGrowth is not specified, use a sensible default.
+#[test]
+fn test_cost_of_growth_uses_default_when_not_specified() {
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("low-impact", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "low-impact", 1.0),
+            ("low-impact", "output-0", 1e-4),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = create_records_with_activation(vec![
+        ("low-impact", 0.1, 0.01), // activation_weighted_impact ≈ 1e-6
+        ("output-0", 0.5, 0.5),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Call with None for cost_of_growth - should use default
+    // The default should be documented in the README
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    // Just verify it works without error
+    assert!(
+        !result.neurons.is_empty(),
+        "Should have processed neurons with default costOfGrowth"
+    );
+}
+
+/// REGRESSION TEST Issue #132: Default costOfGrowth MUST be 1e-7, NOT 0.01
+///
+/// This test exists because v0.1.145 incorrectly changed the default from 1e-7 to 0.01,
+/// which caused 418 false removal candidates in production. The previous tests didn't
+/// catch this because they only tested the mechanism, not the correctness of the value.
+///
+/// NEAT-AI's Score.ts formula uses costOfGrowth = 1e-7 per hidden neuron.
+/// If the default is wrong (e.g., 0.01), this test WILL FAIL because:
+/// - With threshold 0.01: both neurons would be removal candidates (WRONG)
+/// - With threshold 1e-7: only the truly negligible neuron is a candidate (CORRECT)
+///
+/// DO NOT change this test to match a different default. If this test fails,
+/// the default costOfGrowth has been incorrectly changed.
+#[test]
+fn regression_default_cost_of_growth_must_be_1e7_not_001() {
+    // Create two neurons with different impacts:
+    // - "medium-impact": impact ≈ 1e-5 (between 1e-7 and 0.01)
+    // - "negligible": impact ≈ 1e-9 (below 1e-7)
+    //
+    // If default is WRONG (0.01): BOTH would be removal candidates
+    // If default is CORRECT (1e-7): only "negligible" is a candidate
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("medium-impact", "hidden"), // Impact ~1e-5: should NOT be removal candidate
+            ("negligible", "hidden"),    // Impact ~1e-9: SHOULD be removal candidate
+            ("output-0", "output"),
+        ],
+        vec![
+            // medium-impact: small but not negligible connection
+            ("input-0", "medium-impact", 1.0),
+            ("medium-impact", "output-0", 1e-4), // structural_impact ≈ 1e-4
+            // negligible: truly tiny connection
+            ("input-0", "negligible", 1.0),
+            ("negligible", "output-0", 1e-8), // structural_impact ≈ 1e-8
+            // Direct path to output (to dilute impacts)
+            ("input-0", "output-0", 1.0),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Activations chosen to give desired activation_weighted_impact values
+    let records = create_records_with_activation(vec![
+        ("medium-impact", 0.1, 0.1), // activation_weighted_impact ≈ 1e-5
+        ("negligible", 0.1, 0.1),    // activation_weighted_impact ≈ 1e-9
+        ("output-0", 0.5, 0.5),
+    ]);
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Use default costOfGrowth (None)
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    // Find the neurons
+    let medium = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "medium-impact")
+        .expect("medium-impact should be in results");
+    let negligible = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "negligible")
+        .expect("negligible should be in results");
+
+    println!(
+        "medium-impact: activation_weighted_impact = {:.2e}",
+        medium.activation_weighted_impact
+    );
+    println!(
+        "negligible: activation_weighted_impact = {:.2e}",
+        negligible.activation_weighted_impact
+    );
+
+    // CRITICAL ASSERTION 1: medium-impact should NOT be a removal candidate
+    // If default is 0.01 (WRONG), this would be a candidate and test would fail
+    let medium_is_candidate = result
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "medium-impact");
+    assert!(
+        !medium_is_candidate,
+        "REGRESSION: medium-impact (impact {:.2e}) should NOT be a removal candidate! \
+         If this fails, the default costOfGrowth has been incorrectly changed from 1e-7. \
+         Removal candidates: {:?}",
+        medium.activation_weighted_impact,
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| format!("{}:{:.2e}", c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+
+    // CRITICAL ASSERTION 2: negligible SHOULD be a removal candidate
+    let negligible_is_candidate = result
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "negligible");
+    assert!(
+        negligible_is_candidate,
+        "negligible (impact {:.2e}) should be a removal candidate with default threshold 1e-7. \
+         Removal candidates: {:?}",
+        negligible.activation_weighted_impact,
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| format!("{}:{:.2e}", c.neuron_uuid, c.activation_weighted_impact))
+            .collect::<Vec<_>>()
+    );
+
+    // CRITICAL ASSERTION 3: Verify the impact values are in expected ranges
+    // This ensures the test setup is valid
+    assert!(
+        medium.activation_weighted_impact > 1e-7,
+        "Test setup error: medium-impact should have impact > 1e-7 (got {:.2e})",
+        medium.activation_weighted_impact
+    );
+    assert!(
+        medium.activation_weighted_impact < 0.01,
+        "Test setup error: medium-impact should have impact < 0.01 (got {:.2e})",
+        medium.activation_weighted_impact
+    );
+    assert!(
+        negligible.activation_weighted_impact < 1e-7,
+        "Test setup error: negligible should have impact < 1e-7 (got {:.2e})",
+        negligible.activation_weighted_impact
+    );
+}

--- a/tests/regression_v0_1_127.rs
+++ b/tests/regression_v0_1_127.rs
@@ -41,9 +41,10 @@ use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 use tempfile::NamedTempFile;
 
-/// Default growth cost matching NEAT-AI's typical value (0.01 per TypeScript default)
-/// v0.1.145: Changed from 1e-7 to 0.01 to match TypeScript and work with absolute impacts.
-const COST_OF_GROWTH: f32 = 0.01;
+/// Default growth cost matching NEAT-AI's typical value (1e-7 per Score.ts formula)
+/// v0.1.145: Incorrectly changed to 0.01
+/// v0.2.3 (Issue #132): Reverted to correct value of 1e-7
+const COST_OF_GROWTH: f32 = 1e-7;
 
 /// Test the removal savings calculation matches NEAT-AI's Score.ts formula.
 ///
@@ -240,7 +241,7 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Verify both neurons have similar low activation_weighted_impact
     let few = result
@@ -363,9 +364,9 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     );
 
     // Verify the savings match the NEAT-AI formula: growthCost × (1 + totalSynapses/10)
-    // v0.1.145: COST_OF_GROWTH changed from 1e-7 to 0.01 to match TypeScript
-    let expected_few_savings = COST_OF_GROWTH * (1.0 + 2.0 / 10.0); // 0.012
-    let expected_many_savings = COST_OF_GROWTH * (1.0 + 5.0 / 10.0); // 0.015
+    // v0.2.3 (Issue #132): COST_OF_GROWTH is 1e-7 (correct value per Score.ts)
+    let expected_few_savings = COST_OF_GROWTH * (1.0 + 2.0 / 10.0); // 1.2e-7
+    let expected_many_savings = COST_OF_GROWTH * (1.0 + 5.0 / 10.0); // 1.5e-7
 
     assert!(
         (few_candidate.removal_savings - expected_few_savings).abs() < 1e-6,
@@ -381,23 +382,23 @@ fn regression_removal_uses_dynamic_threshold_based_on_synapse_count() {
     );
 }
 
-/// REGRESSION TEST: Threshold must use costOfGrowth (0.01 per TypeScript).
+/// REGRESSION TEST: Threshold must use costOfGrowth (1e-7 per Score.ts).
 ///
-/// v0.1.145: costOfGrowth changed from 1e-7 to 0.01 to match TypeScript
-/// and work with absolute (non-normalised) impacts.
+/// v0.2.3 (Issue #132): costOfGrowth reverted to correct value of 1e-7
+/// (v0.1.145 incorrectly changed it to 0.01)
 ///
 /// Neurons are removal candidates when:
-///   activation_weighted_impact < costOfGrowth (0.01)
+///   activation_weighted_impact < costOfGrowth (1e-7)
 ///
 /// This test creates a neuron with impact ABOVE costOfGrowth that should NOT
 /// be a removal candidate.
 #[test]
 fn regression_threshold_uses_cost_of_growth() {
     // Create a neuron with significant weight to output
-    // With ABSOLUTE impact (v0.1.145):
-    //   structural_impact = 0.5 × 1.0 = 0.5 (weight × downstream)
+    // With NORMALISED impact (v0.2.1+):
+    //   structural_impact = 1.0 (sole input to output)
     //   mean_activation = 0.5
-    //   activation_weighted_impact = 0.5 × 0.5 = 0.25 >> 0.01
+    //   activation_weighted_impact = 1.0 × 0.5 = 0.5 >> 1e-7
     let creature = CreatureJson {
         input: 1,
         output: 1,
@@ -444,7 +445,7 @@ fn regression_threshold_uses_cost_of_growth() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // Find the neuron in ranked neurons
     let neuron = result
@@ -453,7 +454,7 @@ fn regression_threshold_uses_cost_of_growth() {
         .find(|n| n.neuron_uuid == "high-impact")
         .expect("high-impact should be in ranked neurons");
 
-    // Verify impact is above costOfGrowth (0.01)
+    // Verify impact is above costOfGrowth (1e-7)
     assert!(
         neuron.activation_weighted_impact > COST_OF_GROWTH,
         "activation_weighted_impact ({:.2e}) should be LARGER than costOfGrowth ({:.0e})",
@@ -547,7 +548,7 @@ fn test_removal_reason_includes_synapse_savings() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     // The negligible neuron should be a removal candidate
     let negligible_removal = result

--- a/tests/step_activation_based_impact.rs
+++ b/tests/step_activation_based_impact.rs
@@ -119,7 +119,7 @@ fn test_step_saturated_positive_has_discounted_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -186,7 +186,7 @@ fn test_step_saturated_negative_has_discounted_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -245,7 +245,7 @@ fn test_step_flipping_has_full_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -304,7 +304,7 @@ fn test_bipolar_saturated_positive_has_discounted_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -356,7 +356,7 @@ fn test_bipolar_flipping_has_full_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -413,7 +413,7 @@ fn test_step_insufficient_data_uses_conservative_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons
@@ -476,7 +476,7 @@ fn test_chained_step_neurons_compound_impact() {
     ];
     write_records_to_parquet(file_path, &records).unwrap();
 
-    let result = rank_focus_neurons(file_path, &creature, None).unwrap();
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
 
     let upstream = result
         .neurons


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.2 to 0.2.3.
- Revert costOfGrowth threshold to 1e-7, correcting a critical bug that caused 418 false removal candidates in production (Issue #132).
- Update README to clarify the correct default value and its implications for neuron removal candidates.
- Modify rank_focus_neurons function to accept cost_of_growth as a parameter, ensuring flexibility in threshold configuration.
- Adjust tests to reflect the new costOfGrowth handling, enhancing accuracy in neuron impact assessments.

These changes improve the reliability of neuron removal logic and align the implementation with NEAT-AI's Score.ts formula.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the hardcoded 0.01 removal threshold to a configurable costOfGrowth with correct default 1e-7, updates API/FFI and tests, and documents the change.
> 
> - **Focus ranking / removal logic**:
>   - Use passed `costOfGrowth` (default `1e-7`) instead of hardcoded `0.01` when filtering removal candidates.
>   - Update reason formatting to include the active threshold; compute savings with the chosen value.
> - **API/FFI**:
>   - Extend `rank_focus_neurons(parquet_file, creature, max_results, cost_of_growth)` and `RankFocusNeuronsInput` with optional `costOfGrowth`.
>   - Wire through in `rank_focus_neurons_internal` and JSON I/O types.
> - **Docs**:
>   - README: document `costOfGrowth` parameter, default `1e-7`, behavior, and examples; note prior bug and fix (Issue #132).
> - **Tests**:
>   - Adjust existing tests to new function signature and default threshold.
>   - Add `tests/issue_132_cost_of_growth.rs` and related regressions to verify configurability, default `1e-7`, and messaging.
> - **Version**:
>   - Bump crate version to `0.2.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fb2fc4e2147c4a6a80bad507f11d62f511244cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->