### PR TITLE
Enhance CandidateNeuronJson with optional comment field and update RE…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,10 @@ Small, focused test files make it **obvious when tests change**:
 - Clear separation of concerns
 - Don't need to make APIs public just for testing
 
+**Rule of thumb**: Put new tests under `tests/` whenever practical. Only place tests under
+`src/` (`#[cfg(test)]`) when the behaviour cannot be exercised cleanly via the public API
+without making implementation details public.
+
 #### 3. Don't make APIs public just for testing
 
 If a function is internal, keep it internal. Use integration tests to verify

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -2749,6 +2749,7 @@ impl ReluStats {
             outgoing_weight,
             squash: "ReLU".to_string(),
             bias: optimal_bias,
+            comment: None,
             target_neuron_impact: 1.0,
             expected_creature_error_reduction: expected_improvement,
             expected_creature_score_gain: expected_improvement,
@@ -5557,6 +5558,10 @@ fn weight_sign(weight: f32) -> i8 {
     }
 }
 
+/// Returns true if this add-neuron candidate is "extreme" enough to warrant a conservative pair.
+///
+/// We intentionally base this on incoming weight and bias (not outgoing), because outgoing
+/// weight is already clamped and ReLU candidates commonly use outgoing=0.1 by design.
 fn upsert_candidate(
     map: &mut HashMap<(String, String, String, i8, i8), CandidateNeuronJson>,
     candidate: CandidateNeuronJson,
@@ -6345,6 +6350,7 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
+                    comment: None,
                     target_neuron_impact: 1.0,
                     expected_creature_error_reduction: net_improvement,
                     expected_creature_score_gain: net_improvement,
@@ -6721,6 +6727,7 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
+                    comment: None,
                     target_neuron_impact: 1.0,
                     expected_creature_error_reduction: neuron_error_improvement,
                     expected_creature_score_gain: neuron_error_improvement,
@@ -6757,6 +6764,7 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                     outgoing_weight,
                     squash: spec.name.to_string(),
                     bias: optimal_bias,
+                    comment: None,
                     target_neuron_impact: 1.0,
                     expected_creature_error_reduction: neuron_error_improvement,
                     expected_creature_score_gain: neuron_error_improvement,
@@ -7000,6 +7008,7 @@ fn evaluate_discrete_candidate(
                             outgoing_weight,
                             squash: new_neuron_squash.to_string(),
                             bias: 0.0, // IDENTITY doesn't need bias for threshold crossing
+                            comment: None,
                             target_neuron_impact: 1.0,
                             expected_creature_error_reduction: improvement,
                             expected_creature_score_gain: improvement,
@@ -7780,9 +7789,13 @@ pub(crate) fn analyze_neurons_with_cache(
             .unwrap_or(Ordering::Equal)
     });
 
-    if let Some(limit) = input.max_candidates {
-        helpful_results.truncate(limit);
-    }
+    // Production experiment: pair "extreme" candidates with a conservative variant.
+    // This keeps the output size bounded by max_candidates while increasing
+    // evaluation diversity in TypeScript.
+    helpful_results = crate::analysis::utils::pair_extreme_candidates_with_conservative_variants(
+        helpful_results,
+        input.max_candidates,
+    );
 
     let no_candidate_reasons = diagnostics.no_candidate_summaries();
     diagnostics.emit_logs();
@@ -12571,6 +12584,7 @@ mod tests_synapses {
             outgoing_weight: 0.5,
             squash: "ReLU".to_string(),
             bias: 0.0,
+            comment: None,
             target_neuron_impact: 1.0,
             expected_creature_error_reduction: 0.15,
             expected_creature_score_gain: 0.15,
@@ -12587,6 +12601,7 @@ mod tests_synapses {
             outgoing_weight: 0.4,  // Same outgoing sign
             squash: "ReLU".to_string(),
             bias: 0.0,
+            comment: None,
             target_neuron_impact: 1.0,
             expected_creature_error_reduction: 0.12,
             expected_creature_score_gain: 0.12,
@@ -12652,6 +12667,7 @@ mod tests_synapses {
             outgoing_weight: 0.5, // POSITIVE: pushes output UP
             squash: "ReLU".to_string(),
             bias: 0.0,
+            comment: None,
             target_neuron_impact: 1.0,
             expected_creature_error_reduction: 0.10,
             expected_creature_score_gain: 0.10,
@@ -12669,6 +12685,7 @@ mod tests_synapses {
             outgoing_weight: -0.4, // NEGATIVE: pushes output DOWN
             squash: "ReLU".to_string(),
             bias: 0.0,
+            comment: None,
             target_neuron_impact: 1.0,
             expected_creature_error_reduction: 0.08,
             expected_creature_score_gain: 0.08,

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -107,18 +107,16 @@ pub fn pair_extreme_candidates_with_conservative_variants(
 
     let mut output = Vec::with_capacity(sorted_candidates.len().min(limit));
 
-    for mut candidate in sorted_candidates.into_iter() {
+    for candidate in sorted_candidates.into_iter() {
         if output.len() >= limit {
             break;
         }
 
         let should_pair = is_extreme_add_neuron_candidate(&candidate);
-        if should_pair && candidate.comment.is_none() {
-            candidate.comment =
-                Some("Extreme candidate (paired with conservative variant)".to_string());
-        }
+        let original_index = output.len();
         output.push(candidate.clone());
 
+        let mut added_conservative = false;
         if should_pair && output.len() < limit {
             let conservative = make_conservative_add_neuron_variant(&candidate);
             // Only add if it meaningfully differs (avoid duplicates).
@@ -127,7 +125,21 @@ pub fn pair_extreme_candidates_with_conservative_variants(
                 || (conservative.outgoing_weight - candidate.outgoing_weight).abs() > 1e-6
             {
                 output.push(conservative);
+                added_conservative = true;
             }
+        }
+
+        // Avoid misleading diagnostics: only claim "paired" once we have actually returned
+        // the conservative variant (and we had room under max_candidates).
+        if should_pair && output[original_index].comment.is_none() {
+            output[original_index].comment = Some(
+                if added_conservative {
+                    "Extreme candidate (paired with conservative variant)"
+                } else {
+                    "Extreme candidate (conservative variant not included)"
+                }
+                .to_string(),
+            );
         }
     }
 

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -124,6 +124,7 @@ pub fn pair_extreme_candidates_with_conservative_variants(
             // Only add if it meaningfully differs (avoid duplicates).
             if (conservative.incoming_weight - candidate.incoming_weight).abs() > 1e-6
                 || (conservative.bias - candidate.bias).abs() > 1e-6
+                || (conservative.outgoing_weight - candidate.outgoing_weight).abs() > 1e-6
             {
                 output.push(conservative);
             }

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -12,6 +12,127 @@ pub fn verbose_enabled() -> bool {
     *VERBOSE.get_or_init(|| std::env::var("NEAT_AI_DISCOVERY_VERBOSE").is_ok())
 }
 
+// ============================================================================
+// Production experiment helpers
+// ============================================================================
+
+use crate::CandidateNeuronJson;
+
+/// Conservative parameter clamps for add-neuron candidates.
+///
+/// Production evidence (Dec 2025): many failed add-neuron candidates are generated with very
+/// large incoming weights and biases (eg incoming=200, bias=50). These can create a near-constant
+/// or overly-aggressive correction, which tends to fail when evaluated on the full training set.
+///
+/// A simple production experiment is to return a *paired* candidate:
+/// - the original ("extreme") candidate discovered by the current search
+/// - a "conservative" variant with clamped incoming/bias and smaller outgoing weight
+///
+/// TypeScript still does the real validation by scoring both candidates.
+const CONSERVATIVE_INCOMING_ABS_MAX: f32 = 2.0;
+const CONSERVATIVE_BIAS_ABS_MAX: f32 = 1.0;
+const CONSERVATIVE_OUTGOING_ABS_MAX: f32 = 0.05;
+const CONSERVATIVE_OUTGOING_SCALE: f32 = 0.2;
+const CONSERVATIVE_EXPECTED_MULTIPLIER: f32 = 0.5;
+
+/// Returns true if this add-neuron candidate is "extreme" enough to warrant a conservative pair.
+///
+/// We intentionally base this on incoming weight and bias (not outgoing), because outgoing
+/// weight is already clamped for add-neuron candidates and ReLU candidates commonly use
+/// outgoing=0.1 by design.
+fn is_extreme_add_neuron_candidate(candidate: &CandidateNeuronJson) -> bool {
+    candidate.incoming_weight.abs() > CONSERVATIVE_INCOMING_ABS_MAX
+        || candidate.bias.abs() > CONSERVATIVE_BIAS_ABS_MAX
+}
+
+/// Create a conservative variant of an add-neuron candidate.
+///
+/// Notes:
+/// - We *do not* attempt to re-run the full optimisation here. This is intentionally cheap.
+/// - We scale expected improvement down so the conservative variant doesn't displace the
+///   original in ranking, while still being returned for evaluation by TypeScript.
+fn make_conservative_add_neuron_variant(candidate: &CandidateNeuronJson) -> CandidateNeuronJson {
+    let incoming_sign = if candidate.incoming_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+    let outgoing_sign = if candidate.outgoing_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+
+    let incoming_weight = incoming_sign
+        * candidate
+            .incoming_weight
+            .abs()
+            .min(CONSERVATIVE_INCOMING_ABS_MAX);
+    let bias = candidate
+        .bias
+        .clamp(-CONSERVATIVE_BIAS_ABS_MAX, CONSERVATIVE_BIAS_ABS_MAX);
+
+    let mut outgoing_weight = (candidate.outgoing_weight * CONSERVATIVE_OUTGOING_SCALE).clamp(
+        -CONSERVATIVE_OUTGOING_ABS_MAX,
+        CONSERVATIVE_OUTGOING_ABS_MAX,
+    );
+    // Keep a small non-zero weight so the candidate actually does something.
+    if outgoing_weight.abs() <= 1e-6 {
+        outgoing_weight = outgoing_sign * 0.01;
+    }
+
+    let mut conservative = candidate.clone();
+    conservative.incoming_weight = incoming_weight;
+    conservative.bias = bias;
+    conservative.outgoing_weight = outgoing_weight;
+    conservative.expected_creature_error_reduction *= CONSERVATIVE_EXPECTED_MULTIPLIER;
+    conservative.expected_creature_score_gain = conservative.expected_creature_error_reduction;
+    conservative.comment =
+        Some("Conservative variant (clamped incoming/bias, outgoing scaled)".to_string());
+    conservative
+}
+
+/// Pair extreme candidates with a conservative variant, respecting max_candidates.
+///
+/// Input is expected to be pre-sorted by expected_creature_score_gain (highest first).
+#[doc(hidden)]
+pub fn pair_extreme_candidates_with_conservative_variants(
+    sorted_candidates: Vec<CandidateNeuronJson>,
+    max_candidates: Option<usize>,
+) -> Vec<CandidateNeuronJson> {
+    let limit = max_candidates.unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut output = Vec::with_capacity(sorted_candidates.len().min(limit));
+
+    for mut candidate in sorted_candidates.into_iter() {
+        if output.len() >= limit {
+            break;
+        }
+
+        let should_pair = is_extreme_add_neuron_candidate(&candidate);
+        if should_pair && candidate.comment.is_none() {
+            candidate.comment =
+                Some("Extreme candidate (paired with conservative variant)".to_string());
+        }
+        output.push(candidate.clone());
+
+        if should_pair && output.len() < limit {
+            let conservative = make_conservative_add_neuron_variant(&candidate);
+            // Only add if it meaningfully differs (avoid duplicates).
+            if (conservative.incoming_weight - candidate.incoming_weight).abs() > 1e-6
+                || (conservative.bias - candidate.bias).abs() > 1e-6
+            {
+                output.push(conservative);
+            }
+        }
+    }
+
+    output
+}
+
 // TODO: Move other utility functions from impl.rs here:
 // - check_memory_for_parquet
 // - get_memory_info (platform-specific)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,12 @@ pub struct CandidateNeuronJson {
     pub outgoing_weight: f32,
     pub squash: String,
     pub bias: f32,
+    /// Optional human-readable comment for diagnostics and production experiments.
+    ///
+    /// This is intentionally optional to maintain backwards compatibility with older
+    /// consumers that don't expect the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
     /// Impact of the target neuron on the creature's output (0.0 to 1.0).
     /// Output neurons have impact = 1.0, hidden neurons have discounted impact.
     pub target_neuron_impact: f32,

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -11,6 +11,35 @@ use neat_ai_discovery::{
 };
 
 #[test]
+fn extreme_candidate_comment_does_not_claim_pairing_when_limit_prevents_variant() {
+    let candidate = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        incoming_weight: 3.0, // extreme (above clamp max)
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    // Limit leaves no room for the conservative variant.
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(1));
+
+    assert_eq!(paired.len(), 1, "expected only the original candidate");
+    assert_eq!(
+        paired[0].comment.as_deref(),
+        Some("Extreme candidate (conservative variant not included)"),
+        "comment should not claim pairing when the variant cannot be returned"
+    );
+}
+
+#[test]
 fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
     // This is the edge case highlighted in PR review:
     // - incoming is barely above the clamp threshold, but within 1e-6 after clamping

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -1,0 +1,52 @@
+//! Regression tests for extreme-candidate pairing logic.
+//!
+//! Production experiment (Dec 2025): when an add-neuron candidate is deemed "extreme",
+//! we want to return both the original candidate and a conservative variant.
+//!
+//! This file ensures we do not accidentally drop the conservative variant due to an
+//! overly-narrow duplicate check.
+
+use neat_ai_discovery::{
+    analysis::utils::pair_extreme_candidates_with_conservative_variants, CandidateNeuronJson,
+};
+
+#[test]
+fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
+    // This is the edge case highlighted in PR review:
+    // - incoming is barely above the clamp threshold, but within 1e-6 after clamping
+    // - bias is already within the clamp threshold
+    // - outgoing weight is meaningfully reduced by the conservative variant
+    //
+    // If we don't consider outgoing weight in the duplicate check, we incorrectly drop the
+    // conservative variant and return only a single candidate.
+    let candidate = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        incoming_weight: 2.0 + 5e-7,
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(2));
+
+    assert_eq!(paired.len(), 2, "expected original + conservative variant");
+
+    // Original is returned first.
+    assert!(paired[0].comment.is_some());
+
+    // Conservative variant should have meaningfully smaller outgoing weight.
+    // 0.1 * 0.2 = 0.02 (within outgoing clamp).
+    assert!(
+        (paired[1].outgoing_weight - 0.02).abs() < 1e-6,
+        "expected outgoing weight to be scaled to ~0.02"
+    );
+    assert!(paired[1].comment.is_some());
+}


### PR DESCRIPTION
…ADME guidelines for test placement. Introduce conservative candidate pairing logic in analysis utilities to improve evaluation diversity while maintaining output limits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conservative pairing for extreme add-neuron candidates (respecting `maxCandidates`) and introduces optional `comment` on `CandidateNeuronJson`, with tests and docs updates.
> 
> - **Analysis (neurons)**:
>   - Pair “extreme” add-neuron candidates with a conservative variant via `analysis::utils::pair_extreme_candidates_with_conservative_variants`, keeping list size within `input.max_candidates`.
>   - New helper logic clamps `incoming_weight`/`bias`, scales `outgoing_weight`, and annotates candidates via `comment`.
>   - Integrates pairing into `analyze_neurons` result truncation flow in `src/analysis/implementation.rs`.
> - **API**:
>   - `CandidateNeuronJson` gains optional `comment: Option<String>` (serde-skipped when `None`).
>   - All candidate construction sites updated to set `comment: None`.
> - **Utils**:
>   - Add `is_extreme_add_neuron_candidate`, `make_conservative_add_neuron_variant`, and public `pair_extreme_candidates_with_conservative_variants` in `src/analysis/utils.rs`.
> - **Tests**:
>   - New `tests/extreme_candidate_pairing.rs` covering max-candidate limit behavior and non-duplicate pairing.
> - **Docs**:
>   - README testing guidance refined (prefer `tests/` with clarified rule of thumb).
> - **Version**:
>   - Bump `Cargo.toml` to `0.2.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f60cc9526bf7af44e4eca21b02d944c36000d3c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->