### PR TITLE
Update version to 0.2.8 and introduce streaming recording API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 [lib]
@@ -19,6 +19,7 @@ bytemuck = { version = "1.14", features = ["derive"] }
 rayon = "1.8"
 rand = "0.8"
 once_cell = "1.19"
+uuid = { version = "1.6", features = ["v4"] }  # Session ID generation for streaming API
 
 crossbeam-channel = "0.5"  # Efficient multi-producer work queues for GPU thread
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }  # Deadlock detection

--- a/README.md
+++ b/README.md
@@ -2014,6 +2014,15 @@ Many data tools support Parquet natively (Tableau, Apache Spark, etc.)
 - **No mixing**: Never mix data from different training records within a single discovery record write
 - **Matching by obs_index**: TypeScript matches records across neurons by `obs_index` (not by array position), so record order from Rust doesn't matter
 
+## CRITICAL REQUIREMENT: Forward-only activation order (no feedback)
+
+Discovery assumes **forward-only** networks (no recurrent feedback). This is critical for both recording and for applying discovery candidates:
+
+- **Evaluation order matters**: A neuron may only read activations from **earlier** neurons in the creature's evaluation order. In NEAT-AI this means the `creature.neurons[]` list must be in a valid *topological* order for feed-forward execution.
+- **Synapse direction constraint**: For feed-forward creatures, synapses must point from an **earlier** neuron to a **later** neuron. If a new neuron is inserted, it must appear **before** any neuron that consumes it.
+- **Discovered neurons must be inserted, not appended**: When applying an add-neuron candidate, the new neuron must be inserted at the correct index so it is activated before its outgoing synapse is used by the target neuron.
+- **No “remembering” across samples**: If feedback/recurrent connections were enabled, a later neuron could effectively read an activation from a *previous* training sample (stateful recurrence). Discovery explicitly does **not** support that mode - every recorded activation/error is for a single training sample with no cross-sample state.
+
 ## JSON Interface
 
 ### Input Format
@@ -2068,6 +2077,140 @@ Error:
   "error": "Error message here"
 }
 ```
+
+### Streaming Recording API (v0.2.8+)
+
+The streaming API solves the JavaScript "Invalid string length" error that occurs when
+trying to serialise large datasets (6+ minutes of recording) into a single JSON string.
+Instead of one monolithic `record_discovery` call, data is streamed incrementally.
+
+**Why this matters**: JavaScript/V8 has a maximum string length (~2^28 chars). When
+TypeScript accumulated 6+ minutes of discovery data and tried to JSON.stringify it all
+at once for the FFI call, it hit this limit. The streaming API keeps each FFI call small.
+
+#### Usage Pattern
+
+```text
+TypeScript                              Rust (this library)
+────────────────────────────────────────────────────────────────────────
+1. start_discovery_session()       →    Creates session + Parquet file
+   ↓ returns sessionId
+
+2. Loop while collecting data:
+   - Collect records (estimate size)
+   - When batch reaches ~50MB or ~10,000 records:
+     append_discovery_records()    →    Writes batch to Parquet
+
+3. finish_discovery_session()      →    Finalises Parquet file
+   ↓ returns { tempDir, file, totalRecords }
+```
+
+#### FFI Functions
+
+**`start_discovery_session`** - Start a new recording session
+
+Input:
+```json
+{
+  "creature": { "neurons": [...], "synapses": [...], "input": 20, "output": 2 },
+  "tempDir": ".discovery/abc123_456789"
+}
+```
+
+Output:
+```json
+{
+  "success": true,
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**`append_discovery_records`** - Append records to an existing session
+
+Input:
+```json
+{
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "observations": [
+    {
+      "obsIndex": 0,
+      "neuronData": [
+        { "neuronUuid": "hidden-1", "activation": 0.5, "value": 0.4, "errors": [0.1] }
+      ],
+      "inputs": [0.1, 0.2, 0.3]
+    }
+  ]
+}
+```
+
+Output:
+```json
+{
+  "success": true,
+  "recordsWritten": 42
+}
+```
+
+**`finish_discovery_session`** - Finalise and close the Parquet file
+
+Input:
+```json
+{
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+Output:
+```json
+{
+  "success": true,
+  "tempDir": ".discovery/abc123_456789",
+  "file": "discovery_data.parquet",
+  "totalRecords": 12345
+}
+```
+
+**`cancel_discovery_session`** - Cancel a session (cleanup without finalising)
+
+Input:
+```json
+{
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+Output:
+```json
+{
+  "success": true
+}
+```
+
+#### Size Estimation for TypeScript
+
+To decide when to flush, estimate the JSON size before serialising:
+
+```typescript
+// Rough estimate: ~200 bytes per neuron record + input array
+const estimatedBytes = observations.length * (
+  200 * creature.neurons.length + 
+  4 * creature.input
+);
+
+// Flush when approaching 50MB (well under JS string limits)
+const FLUSH_THRESHOLD = 50 * 1024 * 1024;
+if (estimatedBytes > FLUSH_THRESHOLD) {
+  await appendDiscoveryRecords(sessionId, observations);
+  observations = []; // Reset batch
+}
+```
+
+#### Benefits
+
+- **No string length limits**: Each batch is small enough to serialise
+- **Unlimited sample sizes**: Can record for hours without memory issues
+- **Fail-safe**: If process crashes, already-written data is preserved in the Parquet file
+- **Reduced memory pressure**: TypeScript can discard batches after flushing
 
 ## Code Quality
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -1,4 +1,4 @@
-use crate::focus::compute_impacts_public;
+use crate::focus::{compute_impacts_public, compute_impacts_with_activations, RecordProvider};
 use crate::types::DiscoverRecord;
 use crate::{
     AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson, CandidateSynapseJson,
@@ -1268,6 +1268,58 @@ pub(crate) struct RecordCache {
     parquet_file: String,
     cache: Mutex<HashMap<String, Arc<CachedNeuronRecords>>>,
     loader: Arc<RecordCacheLoader>,
+}
+
+/// Adapter to allow `RecordCache` to be used where focus impact code expects a `RecordProvider`.
+///
+/// This lets us compute squash-aware impacts using *recorded activations* for selection squashes
+/// (MINIMUM/MAXIMUM/IF) during candidate discounting, rather than falling back to the conservative
+/// 1/N probability model.
+struct RecordCacheProvider<'a> {
+    cache: &'a RecordCache,
+}
+
+impl RecordProvider for RecordCacheProvider<'_> {
+    fn get(&self, neuron_uuid: &str) -> Result<Option<Arc<Vec<DiscoverRecord>>>> {
+        let records = self.cache.get(neuron_uuid)?;
+        if records.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(records))
+        }
+    }
+
+    fn len(&self) -> usize {
+        let cache = self
+            .cache
+            .cache
+            .lock()
+            .expect("record cache mutex poisoned");
+        cache.len()
+    }
+}
+
+/// Compute neuron impact scores for candidate discounting.
+///
+/// We prefer activation-based selection statistics when available so MINIMUM/MAXIMUM/IF neurons
+/// don't get incorrectly diluted via the 1/N fallback.
+fn compute_impact_scores_for_discounting(
+    creature: &crate::CreatureJson,
+    cache: &RecordCache,
+) -> HashMap<String, f32> {
+    let provider = RecordCacheProvider { cache };
+    match compute_impacts_with_activations(creature, &provider) {
+        Ok(scores) => scores,
+        Err(err) => {
+            if verbose_enabled() {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Falling back to conservative impact calculation \
+                    (no activation-based selection stats). Reason: {err}"
+                );
+            }
+            compute_impacts_public(creature)
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -2745,6 +2797,8 @@ impl ReluStats {
         Some(CandidateNeuronJson {
             source_neuron_uuid: source_uuid.to_string(),
             target_neuron_uuid: target_uuid.to_string(),
+            source_neuron_index: None, // Set during impact discounting
+            target_neuron_index: None, // Set during impact discounting
             incoming_weight,
             outgoing_weight,
             squash: "ReLU".to_string(),
@@ -6436,6 +6490,8 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
                 best_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_index: None, // Set during impact discounting
+                    target_neuron_index: None, // Set during impact discounting
                     incoming_weight,
                     outgoing_weight,
                     squash: spec.name.to_string(),
@@ -6841,6 +6897,8 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                 fallback_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_index: None, // Set during impact discounting
+                    target_neuron_index: None, // Set during impact discounting
                     incoming_weight,
                     outgoing_weight,
                     squash: spec.name.to_string(),
@@ -6878,6 +6936,8 @@ fn evaluate_activation_candidate<G: GpuEvaluator>(
                 best_candidate = Some(CandidateNeuronJson {
                     source_neuron_uuid: source_uuid.to_string(),
                     target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_index: None, // Set during impact discounting
+                    target_neuron_index: None, // Set during impact discounting
                     incoming_weight,
                     outgoing_weight,
                     squash: spec.name.to_string(),
@@ -7122,6 +7182,8 @@ fn evaluate_discrete_candidate(
                         best_candidate = Some(CandidateNeuronJson {
                             source_neuron_uuid: source_uuid.to_string(),
                             target_neuron_uuid: target_uuid.to_string(),
+                            source_neuron_index: None, // Set during impact discounting
+                            target_neuron_index: None, // Set during impact discounting
                             incoming_weight,
                             outgoing_weight,
                             squash: new_neuron_squash.to_string(),
@@ -7863,8 +7925,11 @@ pub(crate) fn analyze_neurons_with_cache(
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     // Output neurons have impact = 1.0 (no discount).
     // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
-    let impact_scores = compute_impacts_public(&input.creature);
+    let impact_scores = compute_impact_scores_for_discounting(&input.creature, cache.as_ref());
     for candidate in &mut helpful_results {
+        candidate.source_neuron_index = order_map_arc.get(&candidate.source_neuron_uuid).copied();
+        candidate.target_neuron_index = order_map_arc.get(&candidate.target_neuron_uuid).copied();
+
         let is_hidden = neuron_type_map
             .get(&candidate.target_neuron_uuid)
             .map(|t| t != "output")
@@ -7940,6 +8005,104 @@ mod tests {
     use crate::analysis::ACTIVATION_SPECS;
 
     // ==================== GPU Tier Detection Tests ====================
+
+    #[test]
+    fn impact_discounting_uses_activation_based_selection_stats_for_minimum() -> Result<()> {
+        // This is a targeted regression test for impact discounting consistency:
+        // - MINIMUM/MAXIMUM/IF impacts should use activation-based win probabilities when
+        //   recorded activations are available (via RecordCache).
+        //
+        // Without activation stats, MINIMUM uses a conservative 1/N model, which can
+        // under-estimate impact and cause downstream discounting to be too aggressive.
+
+        let creature = crate::CreatureJson {
+            neurons: vec![
+                crate::NeuronJson {
+                    uuid: "hidden-a".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+                crate::NeuronJson {
+                    uuid: "hidden-b".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+                crate::NeuronJson {
+                    uuid: "min-0".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "MINIMUM".to_string(),
+                    bias: 0.0,
+                },
+                crate::NeuronJson {
+                    uuid: "output-0".to_string(),
+                    neuron_type: "output".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: vec![
+                crate::SynapseJson {
+                    from_uuid: "hidden-a".to_string(),
+                    to_uuid: "min-0".to_string(),
+                    weight: 1.0,
+                    synapse_type: None,
+                },
+                crate::SynapseJson {
+                    from_uuid: "hidden-b".to_string(),
+                    to_uuid: "min-0".to_string(),
+                    weight: 1.0,
+                    synapse_type: None,
+                },
+                crate::SynapseJson {
+                    from_uuid: "min-0".to_string(),
+                    to_uuid: "output-0".to_string(),
+                    weight: 1.0,
+                    synapse_type: None,
+                },
+            ],
+            input: 0,
+            output: 1,
+        };
+
+        // Build a cache that returns activations where hidden-a ALWAYS wins MINIMUM.
+        let cache = Arc::new(RecordCache::with_loader(
+            "unused.parquet",
+            Arc::new(|_file, uuid| {
+                let mut records = Vec::new();
+                for obs_index in 0..10u32 {
+                    let activation = match uuid {
+                        "hidden-a" => 0.0,
+                        "hidden-b" => 1.0,
+                        _ => 0.0,
+                    };
+                    records.push(DiscoverRecord {
+                        obs_index,
+                        neuron_uuid: uuid.to_string(),
+                        value: None,
+                        activation,
+                        errors: vec![0.0],
+                    });
+                }
+                Ok(records)
+            }),
+        ));
+
+        let impacts = compute_impact_scores_for_discounting(&creature, cache.as_ref());
+        let a = impacts.get("hidden-a").copied().unwrap_or(0.0);
+        let b = impacts.get("hidden-b").copied().unwrap_or(0.0);
+
+        assert!(
+            a > 0.9,
+            "hidden-a should have near-full impact via MINIMUM win probability, got {a}"
+        );
+        assert!(
+            b < 0.1,
+            "hidden-b should have near-zero impact via MINIMUM win probability, got {b}"
+        );
+        Ok(())
+    }
 
     /// Test that M4 is detected as high-performance tier.
     #[test]
@@ -8987,6 +9150,8 @@ pub(crate) fn analyze_synapses_with_cache(
                     candidates_to_add.push(CandidateSynapseJson {
                         from_neuron_uuid: work.source_uuid.clone(),
                         to_neuron_uuid: work.target_uuid.clone(),
+                        from_neuron_index: None,
+                        to_neuron_index: None,
                         weight,
                         target_neuron_impact: 1.0,
                         expected_creature_error_reduction: neuron_error_improvement,
@@ -9090,6 +9255,8 @@ pub(crate) fn analyze_synapses_with_cache(
                             harmful_candidates.push(CandidateSynapseJson {
                                 from_neuron_uuid: work.synapse.from_uuid.clone(),
                                 to_neuron_uuid: work.synapse.to_uuid.clone(),
+                                from_neuron_index: None,
+                                to_neuron_index: None,
                                 weight: work.synapse.weight,
                                 target_neuron_impact: 1.0,
                                 expected_creature_error_reduction: neuron_error_improvement,
@@ -9138,7 +9305,7 @@ pub(crate) fn analyze_synapses_with_cache(
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     // Output neurons have impact = 1.0 (no discount).
     // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
-    let impact_scores = compute_impacts_public(&input.creature);
+    let impact_scores = compute_impact_scores_for_discounting(&input.creature, cache.as_ref());
     let neuron_type_map: HashMap<String, String> = input
         .creature
         .neurons
@@ -12695,6 +12862,8 @@ mod tests_synapses {
         let positive_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
             incoming_weight: 1.0, // Positive orientation
             outgoing_weight: 0.5,
             squash: "ReLU".to_string(),
@@ -12712,6 +12881,8 @@ mod tests_synapses {
         let negative_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
             incoming_weight: -1.0, // Negative orientation
             outgoing_weight: 0.4,  // Same outgoing sign
             squash: "ReLU".to_string(),
@@ -12778,6 +12949,8 @@ mod tests_synapses {
         let positive_error_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
             incoming_weight: 1.0, // Same orientation
             outgoing_weight: 0.5, // POSITIVE: pushes output UP
             squash: "ReLU".to_string(),
@@ -12796,6 +12969,8 @@ mod tests_synapses {
         let negative_error_candidate = CandidateNeuronJson {
             source_neuron_uuid: "source-1".to_string(),
             target_neuron_uuid: "target-1".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
             incoming_weight: 1.0,  // Same orientation
             outgoing_weight: -0.4, // NEGATIVE: pushes output DOWN
             squash: "ReLU".to_string(),

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -1082,10 +1082,15 @@ pub fn rank_focus_neurons(
     // 2. Have high impact (changes will affect output)
     // This ensures output neurons and neurons close to outputs are prioritised
     // over high-error hidden neurons with minimal impact on the creature's score.
+    //
+    // Dec 2025: We deliberately soften (but do not remove) the output bias by applying a
+    // sub-linear exponent to impact. This increases exploration of hidden neurons without
+    // letting low-impact neurons dominate purely due to noisy per-neuron errors.
     const IMPACT_EPSILON: f32 = 0.0001;
+    const IMPACT_GAMMA: f32 = 0.8;
     neurons.sort_by(|a, b| {
-        let a_weighted = a.total_error * (a.impact + IMPACT_EPSILON);
-        let b_weighted = b.total_error * (b.impact + IMPACT_EPSILON);
+        let a_weighted = a.total_error * (a.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
+        let b_weighted = b.total_error * (b.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
         b_weighted
             .partial_cmp(&a_weighted)
             .unwrap_or(Ordering::Equal)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod debug;
 pub mod focus;
 pub mod parquet_format;
 pub mod record;
+pub mod streaming;
 pub mod types;
 
 use anyhow::Result;
@@ -109,11 +110,113 @@ pub struct RecordDiscoveryOutput {
     pub error: Option<String>,
 }
 
+// ============================================================================
+// Streaming Recording API Types
+// ============================================================================
+// These support incremental recording to avoid JavaScript "Invalid string length"
+// errors when serialising large datasets.
+
+/// JSON input for start_discovery_session function
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartSessionInput {
+    pub creature: CreatureJson,
+    pub temp_dir: String,
+}
+
+/// JSON output from start_discovery_session function
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartSessionOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// A single observation to append to a streaming session
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StreamingObservation {
+    pub obs_index: u32,
+    pub neuron_data: Vec<NeuronData>,
+    pub inputs: Vec<f32>,
+}
+
+/// JSON input for append_discovery_records function
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppendRecordsInput {
+    pub session_id: String,
+    pub observations: Vec<StreamingObservation>,
+}
+
+/// JSON output from append_discovery_records function
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppendRecordsOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub records_written: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// JSON input for finish_discovery_session function
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinishSessionInput {
+    pub session_id: String,
+}
+
+/// JSON output from finish_discovery_session function
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinishSessionOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temp_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_records: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// JSON input for cancel_discovery_session function
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelSessionInput {
+    pub session_id: String,
+}
+
+/// JSON output from cancel_discovery_session function
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelSessionOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CandidateSynapseJson {
     pub from_neuron_uuid: String,
     pub to_neuron_uuid: String,
+    /// Index of `from_neuron_uuid` in the creature's forward-only evaluation order.
+    ///
+    /// This includes input neurons (`input-0..`) followed by `creature.neurons[]` in order.
+    /// Provided for debugging and ranking analysis (eg why candidates cluster near the end).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_neuron_index: Option<usize>,
+    /// Index of `to_neuron_uuid` in the creature's forward-only evaluation order.
+    ///
+    /// This includes input neurons (`input-0..`) followed by `creature.neurons[]` in order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_neuron_index: Option<usize>,
     pub weight: f32,
     /// Impact of the target neuron on the creature's output (0.0 to 1.0).
     /// Output neurons have impact = 1.0, hidden neurons have discounted impact.
@@ -148,6 +251,16 @@ pub struct NeuronStatsJson {
 pub struct CandidateNeuronJson {
     pub source_neuron_uuid: String,
     pub target_neuron_uuid: String,
+    /// Index of `source_neuron_uuid` in the creature's forward-only evaluation order.
+    ///
+    /// This includes input neurons (`input-0..`) followed by `creature.neurons[]` in order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_neuron_index: Option<usize>,
+    /// Index of `target_neuron_uuid` in the creature's forward-only evaluation order.
+    ///
+    /// This includes input neurons (`input-0..`) followed by `creature.neurons[]` in order.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_neuron_index: Option<usize>,
     pub incoming_weight: f32,
     pub outgoing_weight: f32,
     pub squash: String,
@@ -938,6 +1051,403 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
             msg.replace('\\', "\\\\").replace('"', "\\\"")
         );
         // This should never fail, but if it does, we return null pointer
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
+// ============================================================================
+// Streaming Recording API - FFI Entry Points
+// ============================================================================
+// These functions support incremental recording to avoid JavaScript
+// "Invalid string length" errors when serialising large datasets.
+//
+// Usage pattern from TypeScript:
+//   1. start_discovery_session() → returns session_id
+//   2. Loop: append_discovery_records() as data accumulates
+//   3. finish_discovery_session() → finalises Parquet file
+//
+// Benefits:
+//   - Each append call is small enough to serialise (e.g., ~50MB)
+//   - Unlimited total sample size
+//   - Partial data preserved if process crashes
+
+/// Start a new streaming discovery session.
+///
+/// Creates a Parquet file and returns a session ID for subsequent append/finish calls.
+///
+/// Input JSON:
+/// ```json
+/// {
+///   "creature": { ... },
+///   "tempDir": "/path/to/temp/dir"
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true,
+///   "sessionId": "uuid-string"
+/// }
+/// ```
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn start_discovery_session(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let input: StartSessionInput = match serde_json::from_str(input_str) {
+            Ok(input) => input,
+            Err(e) => {
+                let output = StartSessionOutput {
+                    success: false,
+                    session_id: None,
+                    error: Some(format!("Failed to parse input JSON: {e}")),
+                };
+                let json = serde_json::to_string(&output).unwrap();
+                return CString::new(json).unwrap().into_raw();
+            }
+        };
+
+        let output = match streaming::start_session(input.creature, input.temp_dir) {
+            Ok(session_id) => StartSessionOutput {
+                success: true,
+                session_id: Some(session_id),
+                error: None,
+            },
+            Err(e) => StartSessionOutput {
+                success: false,
+                session_id: None,
+                error: Some(e.to_string()),
+            },
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        CString::new(json).unwrap().into_raw()
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
+/// Append records to an existing streaming session.
+///
+/// Input JSON:
+/// ```json
+/// {
+///   "sessionId": "uuid-string",
+///   "observations": [
+///     {
+///       "obsIndex": 0,
+///       "neuronData": [{ "neuronUuid": "...", "activation": 0.5, "value": 0.4, "errors": [0.1] }],
+///       "inputs": [0.1, 0.2, 0.3]
+///     }
+///   ]
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true,
+///   "recordsWritten": 42
+/// }
+/// ```
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn append_discovery_records(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let input: AppendRecordsInput = match serde_json::from_str(input_str) {
+            Ok(input) => input,
+            Err(e) => {
+                let output = AppendRecordsOutput {
+                    success: false,
+                    records_written: None,
+                    error: Some(format!("Failed to parse input JSON: {e}")),
+                };
+                let json = serde_json::to_string(&output).unwrap();
+                return CString::new(json).unwrap().into_raw();
+            }
+        };
+
+        // Convert observations to the internal format
+        let batches: Vec<(u32, Vec<NeuronData>, Vec<f32>)> = input
+            .observations
+            .into_iter()
+            .map(|obs| (obs.obs_index, obs.neuron_data, obs.inputs))
+            .collect();
+
+        let output = match streaming::append_records(&input.session_id, batches) {
+            Ok(records_written) => AppendRecordsOutput {
+                success: true,
+                records_written: Some(records_written),
+                error: None,
+            },
+            Err(e) => AppendRecordsOutput {
+                success: false,
+                records_written: None,
+                error: Some(e.to_string()),
+            },
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        CString::new(json).unwrap().into_raw()
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
+/// Finish a streaming session and finalise the Parquet file.
+///
+/// Input JSON:
+/// ```json
+/// {
+///   "sessionId": "uuid-string"
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true,
+///   "tempDir": "/path/to/temp/dir",
+///   "file": "discovery_data.parquet",
+///   "totalRecords": 12345
+/// }
+/// ```
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn finish_discovery_session(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let input: FinishSessionInput = match serde_json::from_str(input_str) {
+            Ok(input) => input,
+            Err(e) => {
+                let output = FinishSessionOutput {
+                    success: false,
+                    temp_dir: None,
+                    file: None,
+                    total_records: None,
+                    error: Some(format!("Failed to parse input JSON: {e}")),
+                };
+                let json = serde_json::to_string(&output).unwrap();
+                return CString::new(json).unwrap().into_raw();
+            }
+        };
+
+        let output = match streaming::finish_session(&input.session_id) {
+            Ok((temp_dir, file, total_records)) => FinishSessionOutput {
+                success: true,
+                temp_dir: Some(temp_dir),
+                file: Some(file),
+                total_records: Some(total_records),
+                error: None,
+            },
+            Err(e) => FinishSessionOutput {
+                success: false,
+                temp_dir: None,
+                file: None,
+                total_records: None,
+                error: Some(e.to_string()),
+            },
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        CString::new(json).unwrap().into_raw()
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
+/// Cancel a streaming session without finalising.
+///
+/// Use this to clean up if recording fails or is cancelled.
+///
+/// Input JSON:
+/// ```json
+/// {
+///   "sessionId": "uuid-string"
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true
+/// }
+/// ```
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn cancel_discovery_session(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let input: CancelSessionInput = match serde_json::from_str(input_str) {
+            Ok(input) => input,
+            Err(e) => {
+                let output = CancelSessionOutput {
+                    success: false,
+                    error: Some(format!("Failed to parse input JSON: {e}")),
+                };
+                let json = serde_json::to_string(&output).unwrap();
+                return CString::new(json).unwrap().into_raw();
+            }
+        };
+
+        let output = match streaming::cancel_session(&input.session_id) {
+            Ok(()) => CancelSessionOutput {
+                success: true,
+                error: None,
+            },
+            Err(e) => CancelSessionOutput {
+                success: false,
+                error: Some(e.to_string()),
+            },
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        CString::new(json).unwrap().into_raw()
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
         CString::new(error_json)
             .unwrap_or_else(|_| {
                 CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,0 +1,433 @@
+//! Streaming recording session management
+//!
+//! This module provides a streaming API for recording discovery data incrementally,
+//! solving the JavaScript "Invalid string length" error that occurs when trying to
+//! serialise large datasets in a single JSON string.
+//!
+//! ## Usage Pattern
+//!
+//! ```text
+//! TypeScript                          Rust (this library)
+//! ─────────────────────────────────────────────────────────────
+//! 1. start_discovery_session()   →    Creates session + Parquet file
+//!    ↓ returns session_id
+//!
+//! 2. Loop while collecting data:
+//!    - Collect records (estimate size)
+//!    - When batch reaches ~50MB:
+//!      append_discovery_records()  →   Writes batch to Parquet
+//!
+//! 3. finish_discovery_session()  →    Finalises Parquet file
+//!    ↓ returns { temp_dir, file }
+//! ```
+//!
+//! ## Benefits
+//!
+//! - **No string length limits**: Each batch is small enough to serialise
+//! - **Unlimited sample sizes**: Can record for hours without memory issues
+//! - **Fail-safe**: Partial data is preserved if process crashes mid-recording
+
+use anyhow::{Context, Result};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::parquet_format::ParquetRecordWriter;
+use crate::types::DiscoverRecord;
+use crate::{CreatureJson, NeuronData};
+
+/// Maximum estimated capacity for streaming sessions.
+/// This is a large value since we don't know the final size upfront.
+const STREAMING_MAX_CAPACITY: usize = i32::MAX as usize;
+
+/// Global session storage
+static SESSIONS: once_cell::sync::Lazy<Arc<Mutex<HashMap<String, RecordingSession>>>> =
+    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+/// A recording session that holds an open Parquet writer
+pub struct RecordingSession {
+    writer: ParquetRecordWriter,
+    creature: CreatureJson,
+    temp_dir: String,
+    records_written: u64,
+}
+
+impl RecordingSession {
+    fn new(creature: CreatureJson, temp_dir: String, parquet_path: &str) -> Result<Self> {
+        let max_arrow_offset = i32::MAX as usize;
+        let writer = ParquetRecordWriter::new(
+            parquet_path,
+            max_arrow_offset,
+            max_arrow_offset,
+            STREAMING_MAX_CAPACITY,
+        )
+        .context("Failed to initialise Parquet writer for streaming session")?;
+
+        Ok(Self {
+            writer,
+            creature,
+            temp_dir,
+            records_written: 0,
+        })
+    }
+}
+
+/// Start a new recording session
+///
+/// Creates a Parquet file and returns a session ID for subsequent append/finish calls.
+pub fn start_session(creature: CreatureJson, temp_dir: String) -> Result<String> {
+    // Create temp directory
+    let temp_path = Path::new(&temp_dir);
+    fs::create_dir_all(temp_path)
+        .with_context(|| format!("Failed to create temp directory: {temp_dir}"))?;
+
+    // Validate creature has non-input neurons
+    let non_input_neuron_count = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type != "input")
+        .count();
+
+    if non_input_neuron_count == 0 {
+        anyhow::bail!(
+            "Cannot start recording session: creature has no non-input neurons. \
+             Discovery recording requires at least one hidden or output neuron."
+        );
+    }
+
+    // Generate session ID
+    let session_id = Uuid::new_v4().to_string();
+
+    // Create Parquet file path
+    let parquet_file = temp_path.join("discovery_data.parquet");
+    let parquet_path = parquet_file
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid file path"))?;
+
+    // Create session
+    let session = RecordingSession::new(creature, temp_dir, parquet_path)?;
+
+    // Store session
+    let mut sessions = SESSIONS.lock();
+    sessions.insert(session_id.clone(), session);
+
+    Ok(session_id)
+}
+
+/// Append records to an existing session
+///
+/// Returns the number of records written in this batch.
+pub fn append_records(
+    session_id: &str,
+    neuron_data_batches: Vec<(u32, Vec<NeuronData>, Vec<f32>)>, // (obs_index, neuron_data, inputs)
+) -> Result<u64> {
+    let mut sessions = SESSIONS.lock();
+    let session = sessions
+        .get_mut(session_id)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+
+    let mut records_in_batch = 0u64;
+
+    for (obs_index, neuron_data, inputs) in neuron_data_batches {
+        let mut batch_records = Vec::new();
+
+        // Process neuron data
+        for neuron_info in neuron_data {
+            // Skip non-existent neurons (match existing behaviour)
+            let neuron = match session
+                .creature
+                .neurons
+                .iter()
+                .find(|n| n.uuid == neuron_info.neuron_uuid)
+            {
+                Some(n) => n,
+                None => continue,
+            };
+
+            // Skip input neurons
+            if neuron.neuron_type == "input" {
+                continue;
+            }
+
+            let record = DiscoverRecord::new(
+                obs_index,
+                neuron_info.neuron_uuid.clone(),
+                neuron_info.value,
+                neuron_info.activation,
+                neuron_info.errors.clone(),
+            );
+
+            batch_records.push(record);
+        }
+
+        // Record input neuron activations
+        for (input_index, value) in inputs.iter().enumerate() {
+            let input_uuid = format!("input-{input_index}");
+            let record =
+                DiscoverRecord::new(obs_index, input_uuid, Some(*value), *value, Vec::new());
+            batch_records.push(record);
+        }
+
+        if !batch_records.is_empty() {
+            session
+                .writer
+                .write_records(&batch_records)
+                .context("Failed to write records to Parquet")?;
+            records_in_batch += batch_records.len() as u64;
+        }
+    }
+
+    session.records_written += records_in_batch;
+    Ok(records_in_batch)
+}
+
+/// Finish a recording session
+///
+/// Finalises the Parquet file and returns the file location.
+/// The session is removed from storage after this call.
+pub fn finish_session(session_id: &str) -> Result<(String, String, u64)> {
+    let mut sessions = SESSIONS.lock();
+    let session = sessions
+        .remove(session_id)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+
+    if session.records_written == 0 {
+        anyhow::bail!("No records were written to the session");
+    }
+
+    session
+        .writer
+        .finish()
+        .context("Failed to finalise Parquet writer")?;
+
+    Ok((
+        session.temp_dir,
+        "discovery_data.parquet".to_string(),
+        session.records_written,
+    ))
+}
+
+/// Cancel a recording session without finalising
+///
+/// Use this to clean up if recording fails or is cancelled.
+pub fn cancel_session(session_id: &str) -> Result<()> {
+    let mut sessions = SESSIONS.lock();
+    sessions
+        .remove(session_id)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+    // Session and writer are dropped, file may be incomplete but that's OK
+    Ok(())
+}
+
+/// Get the number of active sessions (for diagnostics)
+pub fn active_session_count() -> usize {
+    SESSIONS.lock().len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NeuronData, NeuronJson};
+    use tempfile::TempDir;
+
+    fn create_test_creature() -> CreatureJson {
+        CreatureJson {
+            neurons: vec![
+                NeuronJson {
+                    uuid: "hidden-1".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "TANH".to_string(),
+                    bias: 0.0,
+                },
+                NeuronJson {
+                    uuid: "output-0".to_string(),
+                    neuron_type: "output".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: vec![],
+            input: 2,
+            output: 1,
+        }
+    }
+
+    #[test]
+    fn test_streaming_session_lifecycle() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+
+        // Capture initial count (tests run in parallel, so other tests may have sessions)
+        let initial_count = active_session_count();
+
+        // Start session
+        let session_id =
+            start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
+        assert!(!session_id.is_empty());
+        assert!(active_session_count() > initial_count);
+
+        // Append records - batch 1
+        let batch1 = vec![(
+            0u32,
+            vec![
+                NeuronData {
+                    neuron_uuid: "hidden-1".to_string(),
+                    activation: 0.5,
+                    value: Some(0.4),
+                    errors: vec![0.1],
+                },
+                NeuronData {
+                    neuron_uuid: "output-0".to_string(),
+                    activation: 0.5,
+                    value: Some(0.5),
+                    errors: vec![0.0],
+                },
+            ],
+            vec![0.1, 0.2], // inputs
+        )];
+        let written1 = append_records(&session_id, batch1).unwrap();
+        assert!(written1 > 0);
+
+        // Append records - batch 2
+        let batch2 = vec![(
+            1u32,
+            vec![
+                NeuronData {
+                    neuron_uuid: "hidden-1".to_string(),
+                    activation: 0.6,
+                    value: Some(0.5),
+                    errors: vec![0.15],
+                },
+                NeuronData {
+                    neuron_uuid: "output-0".to_string(),
+                    activation: 0.6,
+                    value: Some(0.6),
+                    errors: vec![0.0],
+                },
+            ],
+            vec![0.3, 0.4], // inputs
+        )];
+        let written2 = append_records(&session_id, batch2).unwrap();
+        assert!(written2 > 0);
+
+        // Finish session
+        let count_before_finish = active_session_count();
+        let (result_dir, file, total_records) = finish_session(&session_id).unwrap();
+        assert_eq!(file, "discovery_data.parquet");
+        assert_eq!(total_records, written1 + written2);
+        assert!(active_session_count() < count_before_finish);
+
+        // Verify file exists
+        let parquet_path = Path::new(&result_dir).join(&file);
+        assert!(parquet_path.exists());
+    }
+
+    #[test]
+    fn test_streaming_session_cancel() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+
+        let count_before = active_session_count();
+        let session_id =
+            start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
+        assert!(active_session_count() > count_before);
+
+        // Cancel without writing
+        let count_before_cancel = active_session_count();
+        cancel_session(&session_id).unwrap();
+        assert!(active_session_count() < count_before_cancel);
+    }
+
+    #[test]
+    fn test_streaming_session_not_found() {
+        let result = append_records("nonexistent-session", vec![]);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Session not found"));
+    }
+
+    #[test]
+    fn test_streaming_rejects_input_only_creature() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = CreatureJson {
+            neurons: vec![NeuronJson {
+                uuid: "input-0".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            }],
+            synapses: vec![],
+            input: 1,
+            output: 0,
+        };
+
+        let result = start_session(creature, temp_dir.path().to_str().unwrap().to_string());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("no non-input neurons"));
+    }
+
+    #[test]
+    fn test_streaming_empty_session_fails_to_finish() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+
+        let session_id =
+            start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
+
+        // Try to finish without writing any records
+        let result = finish_session(&session_id);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No records were written"));
+    }
+
+    #[test]
+    fn test_streaming_multiple_batches_large_indices() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+
+        let session_id =
+            start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
+
+        // Write with large, non-sequential indices (simulating sampled data)
+        let batches: Vec<_> = [0, 1000, 50000, 123456]
+            .iter()
+            .map(|&idx| {
+                (
+                    idx as u32,
+                    vec![
+                        NeuronData {
+                            neuron_uuid: "hidden-1".to_string(),
+                            activation: 0.5,
+                            value: Some(0.4),
+                            errors: vec![0.1],
+                        },
+                        NeuronData {
+                            neuron_uuid: "output-0".to_string(),
+                            activation: 0.5,
+                            value: Some(0.5),
+                            errors: vec![0.0],
+                        },
+                    ],
+                    vec![0.1, 0.2],
+                )
+            })
+            .collect();
+
+        let written = append_records(&session_id, batches).unwrap();
+        assert!(written > 0);
+
+        let (_, _, total) = finish_session(&session_id).unwrap();
+        assert_eq!(total, written);
+    }
+}

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -15,6 +15,8 @@ fn extreme_candidate_comment_does_not_claim_pairing_when_limit_prevents_variant(
     let candidate = CandidateNeuronJson {
         source_neuron_uuid: "source-1".to_string(),
         target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
         incoming_weight: 3.0, // extreme (above clamp max)
         outgoing_weight: 0.1,
         squash: "TANH".to_string(),
@@ -51,6 +53,8 @@ fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
     let candidate = CandidateNeuronJson {
         source_neuron_uuid: "source-1".to_string(),
         target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
         incoming_weight: 2.0 + 5e-7,
         outgoing_weight: 0.1,
         squash: "TANH".to_string(),


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.7 to 0.2.8.
- Add support for a streaming recording API to handle large datasets incrementally, preventing JavaScript "Invalid string length" errors during serialization.
- Enhance README with detailed usage patterns and API function specifications for the new streaming capabilities.
- Modify focus neuron ranking to apply a sub-linear exponent to impact, improving exploration of hidden neurons while maintaining output bias.

These changes enhance the system's ability to manage large data efficiently and improve the overall functionality of neuron impact calculations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a streaming recording API with FFI session endpoints, activation-aware impact discounting, and softened focus ranking; add optional index fields to candidate payloads, update docs, and bump to v0.2.8.
> 
> - **Streaming recording (v0.2.8)**:
>   - New module `src/streaming.rs` with session management and Parquet writer.
>   - FFI endpoints: `start_discovery_session`, `append_discovery_records`, `finish_discovery_session`, `cancel_discovery_session`.
>   - Added streaming types and `pub mod streaming` in `lib.rs`.
> - **Impact discounting improvements**:
>   - Use recorded activations for selection squashes via `compute_impacts_with_activations` and a `RecordProvider` adapter; fallback to conservative calc on error.
>   - Applied in candidate discounting for neurons/synapses and in focus ranking.
> - **Focus ranking tweak**:
>   - Soften output bias by weighting with `(impact + ε)^0.8` when sorting.
> - **Candidate payloads**:
>   - Add optional `source_neuron_index`/`target_neuron_index` to `CandidateNeuronJson` and `from_neuron_index`/`to_neuron_index` to `CandidateSynapseJson`; populated during impact discounting.
> - **Docs**:
>   - README: add forward-only execution requirement and detailed Streaming API usage, size hints, and benefits.
> - **Tests**:
>   - New streaming session lifecycle and edge-case tests; regression test for activation-based MINIMUM impacts; updates for new candidate fields.
> - **Dependencies/Version**:
>   - Add `uuid` dep for session IDs; bump version to `0.2.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59444137fdbad939f1ad36328f0ae43f56d4270c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->