### PR TITLE
Update version to 0.2.10 and introduce "Gentle Nudge" safety variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 
 [lib]

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -151,6 +151,17 @@ fn make_gentle_nudge_add_neuron_variant(candidate: &CandidateNeuronJson) -> Cand
 }
 
 fn candidates_meaningfully_differ(a: &CandidateNeuronJson, b: &CandidateNeuronJson) -> bool {
+    // Two candidates connecting different neuron pairs (or using different neuron squash)
+    // are fundamentally different operations, even if clamping produces identical weights.
+    if a.source_neuron_uuid != b.source_neuron_uuid
+        || a.target_neuron_uuid != b.target_neuron_uuid
+        || a.source_neuron_index != b.source_neuron_index
+        || a.target_neuron_index != b.target_neuron_index
+        || a.squash != b.squash
+    {
+        return true;
+    }
+
     (a.incoming_weight - b.incoming_weight).abs() > 1e-6
         || (a.bias - b.bias).abs() > 1e-6
         || (a.outgoing_weight - b.outgoing_weight).abs() > 1e-6

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -35,6 +35,18 @@ const CONSERVATIVE_OUTGOING_ABS_MAX: f32 = 0.05;
 const CONSERVATIVE_OUTGOING_SCALE: f32 = 0.2;
 const CONSERVATIVE_EXPECTED_MULTIPLIER: f32 = 0.5;
 
+/// Guard rails for the "Gentle Nudge" safety variant.
+///
+/// The intent is to preserve a meaningful incoming/bias range (so the neuron can still
+/// represent a useful feature), while keeping the outgoing effect small and stable.
+///
+/// This is a third candidate returned alongside the original and the conservative clamp.
+const GENTLE_NUDGE_INCOMING_ABS_MAX: f32 = 50.0;
+const GENTLE_NUDGE_BIAS_ABS_MAX: f32 = 10.0;
+const GENTLE_NUDGE_OUTGOING_ABS_MAX: f32 = 0.02;
+const GENTLE_NUDGE_OUTGOING_SCALE: f32 = 0.1;
+const GENTLE_NUDGE_EXPECTED_MULTIPLIER: f32 = 0.75;
+
 /// Returns true if this add-neuron candidate is "extreme" enough to warrant a conservative pair.
 ///
 /// We intentionally base this on incoming weight and bias (not outgoing), because outgoing
@@ -92,6 +104,58 @@ fn make_conservative_add_neuron_variant(candidate: &CandidateNeuronJson) -> Cand
     conservative
 }
 
+/// Create a "Gentle Nudge" variant of an add-neuron candidate.
+///
+/// This is intentionally more permissive than the conservative clamp:
+/// - incoming is clamped to a moderate range (not forced all the way down to ~2.0)
+/// - bias is clamped to a range that still allows threshold crossing in many squashes
+/// - outgoing weight is kept very small (a gentle correction rather than a shove)
+fn make_gentle_nudge_add_neuron_variant(candidate: &CandidateNeuronJson) -> CandidateNeuronJson {
+    let incoming_sign = if candidate.incoming_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+    let outgoing_sign = if candidate.outgoing_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+
+    let incoming_weight = incoming_sign
+        * candidate
+            .incoming_weight
+            .abs()
+            .min(GENTLE_NUDGE_INCOMING_ABS_MAX);
+    let bias = candidate
+        .bias
+        .clamp(-GENTLE_NUDGE_BIAS_ABS_MAX, GENTLE_NUDGE_BIAS_ABS_MAX);
+
+    let mut outgoing_weight = (candidate.outgoing_weight * GENTLE_NUDGE_OUTGOING_SCALE).clamp(
+        -GENTLE_NUDGE_OUTGOING_ABS_MAX,
+        GENTLE_NUDGE_OUTGOING_ABS_MAX,
+    );
+    // Keep a small non-zero weight so the candidate actually does something.
+    if outgoing_weight.abs() <= 1e-6 {
+        outgoing_weight = outgoing_sign * 0.005;
+    }
+
+    let mut gentle = candidate.clone();
+    gentle.incoming_weight = incoming_weight;
+    gentle.bias = bias;
+    gentle.outgoing_weight = outgoing_weight;
+    gentle.expected_creature_error_reduction *= GENTLE_NUDGE_EXPECTED_MULTIPLIER;
+    gentle.expected_creature_score_gain = gentle.expected_creature_error_reduction;
+    gentle.comment = Some("Gentle Nudge variant (tight outgoing, bias tamed)".to_string());
+    gentle
+}
+
+fn candidates_meaningfully_differ(a: &CandidateNeuronJson, b: &CandidateNeuronJson) -> bool {
+    (a.incoming_weight - b.incoming_weight).abs() > 1e-6
+        || (a.bias - b.bias).abs() > 1e-6
+        || (a.outgoing_weight - b.outgoing_weight).abs() > 1e-6
+}
+
 /// Pair extreme candidates with a conservative variant, respecting max_candidates.
 ///
 /// Input is expected to be pre-sorted by expected_creature_score_gain (highest first).
@@ -117,26 +181,40 @@ pub fn pair_extreme_candidates_with_conservative_variants(
         output.push(candidate.clone());
 
         let mut added_conservative = false;
+        let mut added_gentle_nudge = false;
         if should_pair && output.len() < limit {
             let conservative = make_conservative_add_neuron_variant(&candidate);
             // Only add if it meaningfully differs (avoid duplicates).
-            if (conservative.incoming_weight - candidate.incoming_weight).abs() > 1e-6
-                || (conservative.bias - candidate.bias).abs() > 1e-6
-                || (conservative.outgoing_weight - candidate.outgoing_weight).abs() > 1e-6
-            {
+            if candidates_meaningfully_differ(&conservative, &candidate) {
                 output.push(conservative);
                 added_conservative = true;
             }
         }
 
-        // Avoid misleading diagnostics: only claim "paired" once we have actually returned
-        // the conservative variant (and we had room under max_candidates).
+        if should_pair && output.len() < limit {
+            let gentle = make_gentle_nudge_add_neuron_variant(&candidate);
+            // Only add if it meaningfully differs (avoid duplicates).
+            if candidates_meaningfully_differ(&gentle, &candidate)
+                && output
+                    .iter()
+                    .all(|existing| candidates_meaningfully_differ(existing, &gentle))
+            {
+                output.push(gentle);
+                added_gentle_nudge = true;
+            }
+        }
+
+        // Avoid misleading diagnostics: only claim pairing once we have actually returned
+        // variants (and we had room under max_candidates).
         if should_pair && output[original_index].comment.is_none() {
             output[original_index].comment = Some(
-                if added_conservative {
-                    "Extreme candidate (paired with conservative variant)"
-                } else {
-                    "Extreme candidate (conservative variant not included)"
+                match (added_conservative, added_gentle_nudge) {
+                    (true, true) => {
+                        "Extreme candidate (paired with Conservative + Gentle Nudge variants)"
+                    }
+                    (true, false) => "Extreme candidate (paired with Conservative variant only)",
+                    (false, true) => "Extreme candidate (paired with Gentle Nudge variant only)",
+                    (false, false) => "Extreme candidate (no safety variants included)",
                 }
                 .to_string(),
             );

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -237,6 +237,10 @@ mod tests {
     use crate::{NeuronData, NeuronJson};
     use tempfile::TempDir;
 
+    fn session_exists(session_id: &str) -> bool {
+        SESSIONS.lock().contains_key(session_id)
+    }
+
     fn create_test_creature() -> CreatureJson {
         CreatureJson {
             neurons: vec![
@@ -264,14 +268,14 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let creature = create_test_creature();
 
-        // Capture initial count (tests run in parallel, so other tests may have sessions)
-        let initial_count = active_session_count();
-
         // Start session
         let session_id =
             start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
         assert!(!session_id.is_empty());
-        assert!(active_session_count() > initial_count);
+        assert!(
+            session_exists(&session_id),
+            "expected started session to exist"
+        );
 
         // Append records - batch 1
         let batch1 = vec![(
@@ -318,11 +322,17 @@ mod tests {
         assert!(written2 > 0);
 
         // Finish session
-        let count_before_finish = active_session_count();
+        assert!(
+            session_exists(&session_id),
+            "expected session to exist before finish"
+        );
         let (result_dir, file, total_records) = finish_session(&session_id).unwrap();
         assert_eq!(file, "discovery_data.parquet");
         assert_eq!(total_records, written1 + written2);
-        assert!(active_session_count() < count_before_finish);
+        assert!(
+            !session_exists(&session_id),
+            "expected finished session to be removed"
+        );
 
         // Verify file exists
         let parquet_path = Path::new(&result_dir).join(&file);
@@ -334,15 +344,19 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let creature = create_test_creature();
 
-        let count_before = active_session_count();
         let session_id =
             start_session(creature, temp_dir.path().to_str().unwrap().to_string()).unwrap();
-        assert!(active_session_count() > count_before);
+        assert!(
+            session_exists(&session_id),
+            "expected started session to exist"
+        );
 
         // Cancel without writing
-        let count_before_cancel = active_session_count();
         cancel_session(&session_id).unwrap();
-        assert!(active_session_count() < count_before_cancel);
+        assert!(
+            !session_exists(&session_id),
+            "expected cancelled session to be removed"
+        );
     }
 
     #[test]

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -145,3 +145,84 @@ fn extreme_candidate_includes_gentle_nudge_variant_when_limit_allows() {
         "expected gentle variant to be tagged clearly"
     );
 }
+
+#[test]
+fn gentle_nudge_variants_are_not_deduped_across_different_neuron_pairs() {
+    // Regression (Dec 2025):
+    // Gentle Nudge variants were incorrectly treated as duplicates across *different*
+    // source/target neuron pairs when the clamping produced identical weights.
+    //
+    // Two candidates connecting different neuron pairs are fundamentally different
+    // operations, even if their clamped weights happen to match.
+    let candidate_a = CandidateNeuronJson {
+        source_neuron_uuid: "source-a".to_string(),
+        target_neuron_uuid: "target-a".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 200.0,
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 50.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    let candidate_b = CandidateNeuronJson {
+        source_neuron_uuid: "source-b".to_string(),
+        target_neuron_uuid: "target-b".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 200.0,
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 50.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.19,
+        expected_creature_score_gain: 0.19,
+        improved_count: 9,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    // Limit allows both originals plus both safety variants per candidate.
+    let paired =
+        pair_extreme_candidates_with_conservative_variants(vec![candidate_a, candidate_b], Some(6));
+
+    assert_eq!(
+        paired.len(),
+        6,
+        "expected two originals + two conservative + two Gentle Nudge variants"
+    );
+
+    // Expect a Gentle Nudge variant for each distinct neuron pair.
+    let gentle_pairs: Vec<(&str, &str)> = paired
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Gentle Nudge")
+        })
+        .map(|c| (c.source_neuron_uuid.as_str(), c.target_neuron_uuid.as_str()))
+        .collect();
+
+    assert_eq!(
+        gentle_pairs.len(),
+        2,
+        "expected two Gentle Nudge variants (one per unique neuron pair)"
+    );
+    assert!(
+        gentle_pairs.contains(&("source-a", "target-a")),
+        "expected Gentle Nudge for candidate_a connection"
+    );
+    assert!(
+        gentle_pairs.contains(&("source-b", "target-b")),
+        "expected Gentle Nudge for candidate_b connection"
+    );
+}

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -207,7 +207,7 @@ fn gentle_nudge_variants_are_not_deduped_across_different_neuron_pairs() {
             c.comment
                 .as_deref()
                 .unwrap_or_default()
-                .contains("Gentle Nudge")
+                .starts_with("Gentle Nudge variant")
         })
         .map(|c| (c.source_neuron_uuid.as_str(), c.target_neuron_uuid.as_str()))
         .collect();

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -30,14 +30,14 @@ fn extreme_candidate_comment_does_not_claim_pairing_when_limit_prevents_variant(
         target_neuron_stats: None,
     };
 
-    // Limit leaves no room for the conservative variant.
+    // Limit leaves no room for any safety variants.
     let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(1));
 
     assert_eq!(paired.len(), 1, "expected only the original candidate");
     assert_eq!(
         paired[0].comment.as_deref(),
-        Some("Extreme candidate (conservative variant not included)"),
-        "comment should not claim pairing when the variant cannot be returned"
+        Some("Extreme candidate (no safety variants included)"),
+        "comment should not claim pairing when variants cannot be returned"
     );
 }
 
@@ -73,7 +73,11 @@ fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
     assert_eq!(paired.len(), 2, "expected original + conservative variant");
 
     // Original is returned first.
-    assert!(paired[0].comment.is_some());
+    assert_eq!(
+        paired[0].comment.as_deref(),
+        Some("Extreme candidate (paired with Conservative variant only)"),
+        "comment should reflect what was actually returned"
+    );
 
     // Conservative variant should have meaningfully smaller outgoing weight.
     // 0.1 * 0.2 = 0.02 (within outgoing clamp).
@@ -82,4 +86,62 @@ fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
         "expected outgoing weight to be scaled to ~0.02"
     );
     assert!(paired[1].comment.is_some());
+}
+
+#[test]
+fn extreme_candidate_includes_gentle_nudge_variant_when_limit_allows() {
+    let candidate = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 200.0,
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 50.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(3));
+
+    assert_eq!(paired.len(), 3, "expected original + two safety variants");
+    assert_eq!(
+        paired[0].comment.as_deref(),
+        Some("Extreme candidate (paired with Conservative + Gentle Nudge variants)"),
+        "comment should reflect both variants were returned"
+    );
+
+    // Conservative variant: outgoing scaled to 0.02 and bias clamped to 1.0.
+    assert!(
+        (paired[1].outgoing_weight - 0.02).abs() < 1e-6,
+        "expected conservative outgoing weight ~0.02"
+    );
+    assert!(
+        (paired[1].bias - 1.0).abs() < 1e-6,
+        "expected conservative bias to be clamped to 1.0"
+    );
+
+    // Gentle Nudge variant: even smaller outgoing (~0.01) but a looser bias clamp (~10.0).
+    assert!(
+        (paired[2].outgoing_weight - 0.01).abs() < 1e-6,
+        "expected gentle outgoing weight ~0.01"
+    );
+    assert!(
+        (paired[2].bias - 10.0).abs() < 1e-6,
+        "expected gentle bias to be clamped to 10.0"
+    );
+    assert!(
+        paired[2]
+            .comment
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Gentle Nudge"),
+        "expected gentle variant to be tagged clearly"
+    );
 }


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.9 to 0.2.10.
- Add a new "Gentle Nudge" variant for add-neuron candidates in utils.rs, providing a more permissive approach to weight and bias adjustments while maintaining stability in outgoing effects.
- Enhance candidate pairing logic to include the "Gentle Nudge" variant alongside conservative variants, improving the diversity of evaluated candidates.
- Update tests to verify the inclusion and behavior of the new variant in candidate pairing scenarios.

These changes enhance the flexibility and safety of neuron candidate evaluations, allowing for more nuanced adjustments in the analysis process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a third "Gentle Nudge" add‑neuron safety variant and updates pairing/dedup/comment logic, with focused test coverage; minor streaming test assertions tightened; version bumped to 0.2.10.
> 
> - **Analysis/Utils (`src/analysis/utils.rs`)**:
>   - Introduce "Gentle Nudge" variant with guard-rail constants and builder (`make_gentle_nudge_add_neuron_variant`).
>   - Add `candidates_meaningfully_differ` to compare neuron identity/squash and weights for dedup.
>   - Extend pairing to include Conservative + Gentle Nudge variants (respecting `max_candidates`), avoid duplicates, and refine original candidate comments based on actual inclusions.
> - **Tests**:
>   - Expand extreme-candidate tests to cover: outgoing-weight differences, inclusion of Gentle Nudge, no-variant messaging under limits, and no cross-pair dedup for different neuron connections.
>   - Streaming tests: replace count-based checks with explicit `session_exists` assertions.
> - **Version**:
>   - Bump `Cargo.toml` to `0.2.10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9852f80c1e28a5f009bd4852ed4cc082ee620e08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->