### PR TITLE
V0.2.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 
 [lib]

--- a/examples/generate_snapshot.rs
+++ b/examples/generate_snapshot.rs
@@ -1,0 +1,83 @@
+//! Generate a visualisation snapshot JSON from a parquet file and creature JSON.
+//!
+//! Usage:
+//!   cargo run --example generate_snapshot -- <parquet_file> <creature_json> <output_json> [max_obs]
+//!
+//! Example:
+//!   cargo run --release --example generate_snapshot -- \
+//!     ~/src/GRQ/.discovery/ddc0ce7a-654b-5e40-9d9d-bf34e5b6b0eb/discovery_data.parquet \
+//!     ~/src/GRQ-sampler/samples/GRQ-19-1.json \
+//!     ~/Develop/NEAT-AI-Explore/snapshot.json \
+//!     1000
+
+use neat_ai_discovery::export::{export_visualisation_snapshot, ExportOptions};
+use neat_ai_discovery::CreatureJson;
+use std::env;
+use std::fs;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 4 {
+        eprintln!(
+            "Usage: {} <parquet_file> <creature_json> <output_json> [max_obs]",
+            args[0]
+        );
+        eprintln!();
+        eprintln!("Example:");
+        eprintln!("  cargo run --release --example generate_snapshot -- \\");
+        eprintln!("    ~/src/GRQ/.discovery/.../discovery_data.parquet \\");
+        eprintln!("    ~/src/GRQ-sampler/samples/GRQ-19-1.json \\");
+        eprintln!("    ~/Develop/NEAT-AI-Explore/snapshot.json \\");
+        eprintln!("    1000");
+        std::process::exit(1);
+    }
+
+    let parquet_file = &args[1];
+    let creature_json_path = &args[2];
+    let output_json = &args[3];
+    let max_obs: Option<u32> = args.get(4).and_then(|s| s.parse().ok());
+
+    println!("Reading creature from: {creature_json_path}");
+    let creature_json_str =
+        fs::read_to_string(creature_json_path).expect("Failed to read creature JSON file");
+
+    let creature: CreatureJson =
+        serde_json::from_str(&creature_json_str).expect("Failed to parse creature JSON");
+
+    println!("  Neurons: {}", creature.neurons.len());
+    println!("  Synapses: {}", creature.synapses.len());
+    println!("  Inputs: {}, Outputs: {}", creature.input, creature.output);
+
+    println!("Parquet file: {parquet_file}");
+    println!("Output file: {output_json}");
+    if let Some(max) = max_obs {
+        println!("Max observations: {max}");
+    } else {
+        println!("Max observations: unlimited (may be slow/large)");
+    }
+
+    let options = ExportOptions {
+        include_per_synapse_series: true,
+        include_reconstruction_checks: true,
+        max_obs,
+        top_k_worst_samples: 5,
+    };
+
+    println!();
+    println!("Generating snapshot...");
+
+    match export_visualisation_snapshot(parquet_file, &creature, output_json, &options) {
+        Ok(stats) => {
+            println!();
+            println!("✓ Snapshot written to: {output_json}");
+            println!("  Observations: {}", stats.obs_count);
+            println!("  Neurons: {}", stats.neuron_count);
+            println!("  Synapses: {}", stats.synapse_count);
+        }
+        Err(e) => {
+            eprintln!("✗ Error: {e:?}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,726 @@
+//! Visualisation snapshot export module
+//!
+//! Exports a debug-friendly JSON snapshot of a creature and its recorded
+//! activations/errors for use with the NEAT-AI-Explore visualiser.
+//!
+//! This is an optional debug tool that does not affect existing analysis behaviour.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufWriter;
+
+use crate::focus::compute_impacts_public;
+use crate::parquet_format::read_records_from_parquet_with_limit;
+use crate::types::DiscoverRecord;
+use crate::CreatureJson;
+
+/// Snapshot metadata
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotMeta {
+    pub exported_at: String,
+    pub discovery_version: String,
+    pub parquet_file: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub notes: Option<String>,
+}
+
+/// Per-neuron stats (aggregates)
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NeuronRecordingStats {
+    pub mean_activation: f32,
+    pub activation_variance: f32,
+    pub activation_min: f32,
+    pub activation_max: f32,
+    /// Arithmetic mean of errors (can be misleading as +/- cancel out)
+    pub mean_error: f32,
+    /// Mean Absolute Error - used in focus neuron ranking
+    pub mean_absolute_error: f32,
+    /// Mean Squared Error - matches production creature scoring
+    pub mean_squared_error: f32,
+    pub error_variance: f32,
+    pub error_min: f32,
+    pub error_max: f32,
+    pub record_count: usize,
+}
+
+/// Per-neuron recorded data (columnar format)
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeuronRecording {
+    /// Activation values per obsIndex (aligned with obsIndices array)
+    pub activation: Vec<f32>,
+    /// Value (pre-activation) per obsIndex; null encoded as JSON null
+    pub value: Vec<Option<f32>>,
+    /// Errors per obsIndex (each element is a vector of error values)
+    pub errors: Vec<Vec<f32>>,
+    /// Aggregated stats
+    pub stats: NeuronRecordingStats,
+}
+
+/// Per-synapse stats (aggregates)
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SynapseStats {
+    pub mean_contribution: f32,
+    pub contribution_variance: f32,
+    pub contribution_min: f32,
+    pub contribution_max: f32,
+}
+
+/// Per-synapse derived data (columnar format)
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SynapseDerived {
+    pub from_uuid: String,
+    pub to_uuid: String,
+    pub weight: f32,
+    /// Contribution = fromActivation * weight per obsIndex
+    pub contribution: Vec<f32>,
+    /// Aggregated stats
+    pub stats: SynapseStats,
+}
+
+/// Reconstruction check results for a single neuron
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconstructionCheck {
+    pub neuron_uuid: String,
+    pub squash: String,
+    pub bias: f32,
+    /// max|recordedValue - reconstructedValue|
+    pub max_value_delta: f32,
+    /// max|recordedActivation - reconstructedActivation|
+    pub max_activation_delta: f32,
+    /// mean|valueDelta|
+    pub mean_value_delta: f32,
+    /// mean|activationDelta|
+    pub mean_activation_delta: f32,
+    /// Top-K worst obsIndex + deltas
+    pub worst_samples: Vec<ReconstructionSample>,
+}
+
+/// A single sample's reconstruction delta
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconstructionSample {
+    pub obs_index: u32,
+    pub recorded_value: Option<f32>,
+    pub reconstructed_value: f32,
+    pub value_delta: f32,
+    pub recorded_activation: f32,
+    pub reconstructed_activation: f32,
+    pub activation_delta: f32,
+}
+
+/// Derived data section
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DerivedData {
+    /// Impact scores keyed by neuron UUID
+    pub impacts_by_neuron_uuid: HashMap<String, f32>,
+    /// Synapse-level derived data keyed by "fromUuid->toUuid"
+    pub synapses: HashMap<String, SynapseDerived>,
+    /// Reconstruction checks per neuron (non-input neurons only)
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reconstruction_checks: Option<Vec<ReconstructionCheck>>,
+}
+
+/// Recording data section
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingData {
+    /// Ordered obsIndex values
+    pub obs_indices: Vec<u32>,
+    /// Per-neuron recorded data keyed by neuron UUID
+    pub neurons: HashMap<String, NeuronRecording>,
+}
+
+/// The full snapshot structure written to JSON
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualisationSnapshot {
+    pub meta: SnapshotMeta,
+    pub creature: CreatureJson,
+    pub recording: RecordingData,
+    pub derived: DerivedData,
+}
+
+/// Export options
+pub struct ExportOptions {
+    pub include_per_synapse_series: bool,
+    pub include_reconstruction_checks: bool,
+    pub max_obs: Option<u32>,
+    pub top_k_worst_samples: usize,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            include_per_synapse_series: true,
+            include_reconstruction_checks: true,
+            max_obs: None,
+            top_k_worst_samples: 20,
+        }
+    }
+}
+
+/// Export result statistics
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportStats {
+    pub obs_count: usize,
+    pub neuron_count: usize,
+    pub synapse_count: usize,
+    pub output_count: usize,
+}
+
+/// Apply a squash function by name
+fn apply_squash(squash: &str, value: f32) -> f32 {
+    match squash.to_uppercase().as_str() {
+        "IDENTITY" => value,
+        "TANH" => value.tanh(),
+        "LOGISTIC" | "SIGMOID" => 1.0 / (1.0 + (-value).exp()),
+        "RELU" => value.max(0.0),
+        "LEAKYRELU" => {
+            if value >= 0.0 {
+                value
+            } else {
+                0.01 * value
+            }
+        }
+        "STEP" => {
+            if value > 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        "BIPOLAR" => {
+            if value > 0.0 {
+                1.0
+            } else {
+                -1.0
+            }
+        }
+        "HARD_TANH" | "CLIPPED" => value.clamp(-1.0, 1.0),
+        "SOFTSIGN" => value / (1.0 + value.abs()),
+        "SOFTPLUS" => (1.0 + value.exp()).ln(),
+        "ELU" => {
+            if value >= 0.0 {
+                value
+            } else {
+                value.exp() - 1.0
+            }
+        }
+        "SELU" => {
+            let alpha = 1.673_263_2_f32;
+            let scale = 1.050_701_f32;
+            if value >= 0.0 {
+                scale * value
+            } else {
+                scale * alpha * (value.exp() - 1.0)
+            }
+        }
+        "GELU" => {
+            // Approximate GELU
+            let cdf = 0.5 * (1.0 + (0.797_884_6_f32 * (value + 0.044715 * value.powi(3))).tanh());
+            value * cdf
+        }
+        "MISH" => value * ((1.0 + value.exp()).ln()).tanh(),
+        "SWISH" => value / (1.0 + (-value).exp()),
+        "ARCTAN" => value.atan(),
+        "BENT_IDENTITY" => ((value * value + 1.0).sqrt() - 1.0) / 2.0 + value,
+        "RELU6" => value.clamp(0.0, 6.0),
+        "GAUSSIAN" => (-value * value).exp(),
+        "SINE" | "SIN" => value.sin(),
+        "COSINE" | "COS" => value.cos(),
+        "ABSOLUTE" | "ABS" => value.abs(),
+        "INVERSE" => -value,
+        "COMPLEMENT" => 1.0 - value,
+        // Default to identity for unknown
+        _ => value,
+    }
+}
+
+/// Compute stats from a slice of f32 values
+fn compute_stats(values: &[f32]) -> (f32, f32, f32, f32) {
+    if values.is_empty() {
+        return (0.0, 0.0, 0.0, 0.0);
+    }
+    let n = values.len() as f32;
+    let sum: f32 = values.iter().filter(|v| v.is_finite()).sum();
+    let mean = sum / n;
+    let variance: f32 = values
+        .iter()
+        .filter(|v| v.is_finite())
+        .map(|v| (v - mean).powi(2))
+        .sum::<f32>()
+        / n;
+    let min = values
+        .iter()
+        .filter(|v| v.is_finite())
+        .cloned()
+        .fold(f32::INFINITY, f32::min);
+    let max = values
+        .iter()
+        .filter(|v| v.is_finite())
+        .cloned()
+        .fold(f32::NEG_INFINITY, f32::max);
+    (mean, variance, min, max)
+}
+
+/// Export a visualisation snapshot to JSON
+pub fn export_visualisation_snapshot(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    out_file: &str,
+    options: &ExportOptions,
+) -> Result<ExportStats> {
+    // Read records from Parquet (with optional limit for large files)
+    let all_records = read_records_from_parquet_with_limit(parquet_file, options.max_obs)
+        .with_context(|| format!("Failed to read Parquet file: {parquet_file}"))?;
+
+    // Group records by neuron UUID and collect unique obsIndices
+    let mut obs_indices_set = std::collections::HashSet::new();
+    let mut records_by_neuron: HashMap<String, Vec<&DiscoverRecord>> = HashMap::new();
+
+    for record in &all_records {
+        obs_indices_set.insert(record.obs_index);
+        records_by_neuron
+            .entry(record.neuron_uuid.clone())
+            .or_default()
+            .push(record);
+    }
+
+    // Sort and optionally limit obsIndices
+    let mut obs_indices: Vec<u32> = obs_indices_set.into_iter().collect();
+    obs_indices.sort_unstable();
+
+    if let Some(max_obs) = options.max_obs {
+        obs_indices.truncate(max_obs as usize);
+    }
+
+    // Build obs_index -> position map for alignment
+    let obs_index_pos: HashMap<u32, usize> = obs_indices
+        .iter()
+        .enumerate()
+        .map(|(i, &o)| (o, i))
+        .collect();
+
+    // Build neuron recordings (columnar)
+    let mut neurons_recording: HashMap<String, NeuronRecording> = HashMap::new();
+
+    for (neuron_uuid, records) in &records_by_neuron {
+        let n = obs_indices.len();
+        let mut activation = vec![0.0f32; n];
+        let mut value: Vec<Option<f32>> = vec![None; n];
+        let mut errors: Vec<Vec<f32>> = vec![Vec::new(); n];
+
+        for record in records {
+            if let Some(&pos) = obs_index_pos.get(&record.obs_index) {
+                activation[pos] = record.activation;
+                value[pos] = record.value;
+                errors[pos] = record.errors.clone();
+            }
+        }
+
+        // Compute stats
+        let (mean_act, var_act, min_act, max_act) = compute_stats(&activation);
+
+        // Flatten errors for stats
+        let flat_errors: Vec<f32> = errors.iter().flat_map(|e| e.iter().cloned()).collect();
+        let (mean_err, var_err, min_err, max_err) = compute_stats(&flat_errors);
+
+        // Compute Mean Absolute Error (MAE) - used in focus neuron ranking
+        let mean_absolute_error = if flat_errors.is_empty() {
+            0.0
+        } else {
+            flat_errors.iter().map(|e| e.abs()).sum::<f32>() / flat_errors.len() as f32
+        };
+
+        // Compute Mean Squared Error (MSE) - matches production creature scoring
+        let mean_squared_error = if flat_errors.is_empty() {
+            0.0
+        } else {
+            flat_errors.iter().map(|e| e * e).sum::<f32>() / flat_errors.len() as f32
+        };
+
+        let stats = NeuronRecordingStats {
+            mean_activation: mean_act,
+            activation_variance: var_act,
+            activation_min: min_act,
+            activation_max: max_act,
+            mean_error: mean_err,
+            mean_absolute_error,
+            mean_squared_error,
+            error_variance: var_err,
+            error_min: min_err,
+            error_max: max_err,
+            record_count: records.len(),
+        };
+
+        neurons_recording.insert(
+            neuron_uuid.clone(),
+            NeuronRecording {
+                activation,
+                value,
+                errors,
+                stats,
+            },
+        );
+    }
+
+    // Add input neurons (input-0, input-1, ...) to recording if they exist in parquet
+    // (They may not have explicit recordings - inputs come from observations)
+
+    // Build synapse map for lookup
+    let mut synapse_map: HashMap<String, &crate::SynapseJson> = HashMap::new();
+    for syn in &creature.synapses {
+        let key = format!("{}→{}", syn.from_uuid, syn.to_uuid);
+        synapse_map.insert(key, syn);
+    }
+
+    // Create a creature with synthetic input neurons added for impact calculation.
+    // Input neurons are implied by creature.input count but not in neurons array.
+    // The impact calculation iterates over neurons, so we need to add them explicitly.
+    let creature_with_inputs = {
+        let mut c = creature.clone();
+        for i in 0..creature.input {
+            let uuid = format!("input-{i}");
+            // Only add if not already present
+            if !c.neurons.iter().any(|n| n.uuid == uuid) {
+                c.neurons.push(crate::NeuronJson {
+                    uuid,
+                    neuron_type: "input".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                });
+            }
+        }
+        c
+    };
+
+    // Compute impacts using existing focus module (with input neurons included)
+    let impacts = compute_impacts_public(&creature_with_inputs);
+    let impacts_by_neuron_uuid: HashMap<String, f32> = impacts;
+
+    // Build synapse derived data
+    let mut synapses_derived: HashMap<String, SynapseDerived> = HashMap::new();
+
+    if options.include_per_synapse_series {
+        for syn in &creature.synapses {
+            let key = format!("{}→{}", syn.from_uuid, syn.to_uuid);
+
+            // Get from_neuron activations
+            let contribution: Vec<f32> =
+                if let Some(from_recording) = neurons_recording.get(&syn.from_uuid) {
+                    from_recording
+                        .activation
+                        .iter()
+                        .map(|&a| a * syn.weight)
+                        .collect()
+                } else {
+                    // From neuron might be an input neuron not in recordings
+                    vec![0.0; obs_indices.len()]
+                };
+
+            let (mean_contrib, var_contrib, min_contrib, max_contrib) =
+                compute_stats(&contribution);
+
+            synapses_derived.insert(
+                key,
+                SynapseDerived {
+                    from_uuid: syn.from_uuid.clone(),
+                    to_uuid: syn.to_uuid.clone(),
+                    weight: syn.weight,
+                    contribution,
+                    stats: SynapseStats {
+                        mean_contribution: mean_contrib,
+                        contribution_variance: var_contrib,
+                        contribution_min: min_contrib,
+                        contribution_max: max_contrib,
+                    },
+                },
+            );
+        }
+    }
+
+    // Build reconstruction checks
+    let reconstruction_checks = if options.include_reconstruction_checks {
+        let mut checks = Vec::new();
+
+        // Build neuron lookup
+        let _neuron_map: HashMap<&str, &crate::NeuronJson> = creature
+            .neurons
+            .iter()
+            .map(|n| (n.uuid.as_str(), n))
+            .collect();
+
+        // Build inbound synapses map
+        let mut inbound_synapses: HashMap<&str, Vec<&crate::SynapseJson>> = HashMap::new();
+        for syn in &creature.synapses {
+            inbound_synapses
+                .entry(syn.to_uuid.as_str())
+                .or_default()
+                .push(syn);
+        }
+
+        for neuron in &creature.neurons {
+            // Skip input/constant neurons - they don't have reconstruction
+            if neuron.neuron_type == "input" || neuron.neuron_type == "constant" {
+                continue;
+            }
+
+            let Some(recording) = neurons_recording.get(&neuron.uuid) else {
+                continue;
+            };
+
+            let inbound = inbound_synapses
+                .get(neuron.uuid.as_str())
+                .cloned()
+                .unwrap_or_default();
+
+            let mut worst_samples: Vec<ReconstructionSample> = Vec::new();
+            let mut sum_value_delta = 0.0f32;
+            let mut sum_act_delta = 0.0f32;
+            let mut max_value_delta = 0.0f32;
+            let mut max_act_delta = 0.0f32;
+            let mut count = 0usize;
+
+            for (pos, &obs_index) in obs_indices.iter().enumerate() {
+                // Reconstruct value = bias + sum(from_activation * weight)
+                let mut reconstructed_value = neuron.bias;
+                for syn in &inbound {
+                    if let Some(from_recording) = neurons_recording.get(&syn.from_uuid) {
+                        reconstructed_value += from_recording.activation[pos] * syn.weight;
+                    }
+                }
+
+                let reconstructed_activation = apply_squash(&neuron.squash, reconstructed_value);
+
+                let recorded_value = recording.value[pos];
+                let recorded_activation = recording.activation[pos];
+
+                let value_delta = recorded_value
+                    .map(|rv| (rv - reconstructed_value).abs())
+                    .unwrap_or(0.0);
+                let activation_delta = (recorded_activation - reconstructed_activation).abs();
+
+                if value_delta.is_finite() {
+                    sum_value_delta += value_delta;
+                    max_value_delta = max_value_delta.max(value_delta);
+                }
+                if activation_delta.is_finite() {
+                    sum_act_delta += activation_delta;
+                    max_act_delta = max_act_delta.max(activation_delta);
+                }
+                count += 1;
+
+                // Collect sample for potential worst-K
+                worst_samples.push(ReconstructionSample {
+                    obs_index,
+                    recorded_value,
+                    reconstructed_value,
+                    value_delta,
+                    recorded_activation,
+                    reconstructed_activation,
+                    activation_delta,
+                });
+            }
+
+            // Sort by activation_delta descending and keep top-K
+            worst_samples.sort_by(|a, b| {
+                b.activation_delta
+                    .partial_cmp(&a.activation_delta)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            worst_samples.truncate(options.top_k_worst_samples);
+
+            let mean_value_delta = if count > 0 {
+                sum_value_delta / count as f32
+            } else {
+                0.0
+            };
+            let mean_act_delta = if count > 0 {
+                sum_act_delta / count as f32
+            } else {
+                0.0
+            };
+
+            checks.push(ReconstructionCheck {
+                neuron_uuid: neuron.uuid.clone(),
+                squash: neuron.squash.clone(),
+                bias: neuron.bias,
+                max_value_delta,
+                max_activation_delta: max_act_delta,
+                mean_value_delta,
+                mean_activation_delta: mean_act_delta,
+                worst_samples,
+            });
+        }
+
+        Some(checks)
+    } else {
+        None
+    };
+
+    // Build the snapshot
+    let snapshot = VisualisationSnapshot {
+        meta: SnapshotMeta {
+            exported_at: chrono_lite_now(),
+            discovery_version: env!("CARGO_PKG_VERSION").to_string(),
+            parquet_file: parquet_file.to_string(),
+            notes: None,
+        },
+        creature: creature.clone(),
+        recording: RecordingData {
+            obs_indices,
+            neurons: neurons_recording,
+        },
+        derived: DerivedData {
+            impacts_by_neuron_uuid,
+            synapses: synapses_derived,
+            reconstruction_checks,
+        },
+    };
+
+    // Compute stats
+    let stats = ExportStats {
+        obs_count: snapshot.recording.obs_indices.len(),
+        neuron_count: snapshot.recording.neurons.len(),
+        synapse_count: creature.synapses.len(),
+        output_count: creature.output,
+    };
+
+    // Write to file
+    let file = File::create(out_file)
+        .with_context(|| format!("Failed to create output file: {out_file}"))?;
+    let writer = BufWriter::new(file);
+    serde_json::to_writer(writer, &snapshot)
+        .with_context(|| format!("Failed to write JSON to: {out_file}"))?;
+
+    Ok(stats)
+}
+
+/// Simple ISO 8601 timestamp without external chrono dependency
+fn chrono_lite_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+
+    // Convert to date/time components (UTC)
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Simple year/month/day calculation (good enough for logging)
+    let mut year = 1970;
+    let mut remaining_days = days as i64;
+
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if remaining_days < days_in_year {
+            break;
+        }
+        remaining_days -= days_in_year;
+        year += 1;
+    }
+
+    let days_in_months: [i64; 12] = if is_leap_year(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut month = 1;
+    for &days_in_month in &days_in_months {
+        if remaining_days < days_in_month {
+            break;
+        }
+        remaining_days -= days_in_month;
+        month += 1;
+    }
+    let day = remaining_days + 1;
+
+    format!("{year:04}{month:02}{day:02}T{hours:02}{minutes:02}{seconds:02}Z")
+}
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_squash_identity() {
+        assert!((apply_squash("IDENTITY", 0.5) - 0.5).abs() < 1e-6);
+        assert!((apply_squash("IDENTITY", -1.0) - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_apply_squash_tanh() {
+        assert!((apply_squash("TANH", 0.0) - 0.0).abs() < 1e-6);
+        assert!((apply_squash("TANH", 1.0) - 1.0_f32.tanh()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_apply_squash_relu() {
+        assert!((apply_squash("RELU", 1.0) - 1.0).abs() < 1e-6);
+        assert!((apply_squash("RELU", -1.0) - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_apply_squash_hard_tanh() {
+        assert!((apply_squash("HARD_TANH", 0.5) - 0.5).abs() < 1e-6);
+        assert!((apply_squash("HARD_TANH", 2.0) - 1.0).abs() < 1e-6);
+        assert!((apply_squash("HARD_TANH", -2.0) - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_stats_empty() {
+        let (mean, var, min, max) = compute_stats(&[]);
+        assert_eq!(mean, 0.0);
+        assert_eq!(var, 0.0);
+        assert_eq!(min, 0.0);
+        assert_eq!(max, 0.0);
+    }
+
+    #[test]
+    fn test_compute_stats_single() {
+        let (mean, var, min, max) = compute_stats(&[5.0]);
+        assert!((mean - 5.0).abs() < 1e-6);
+        assert!((var - 0.0).abs() < 1e-6);
+        assert!((min - 5.0).abs() < 1e-6);
+        assert!((max - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_stats_multiple() {
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let (mean, var, min, max) = compute_stats(&values);
+        assert!((mean - 3.0).abs() < 1e-6);
+        assert!((var - 2.0).abs() < 1e-6); // variance of [1,2,3,4,5] = 2
+        assert!((min - 1.0).abs() < 1e-6);
+        assert!((max - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_chrono_lite_now_format() {
+        let timestamp = chrono_lite_now();
+        // Should be in format YYYYMMDDTHHMMSSZ
+        assert_eq!(timestamp.len(), 16);
+        assert!(timestamp.ends_with('Z'));
+        assert!(timestamp.contains('T'));
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -251,25 +251,51 @@ fn compute_stats(values: &[f32]) -> (f32, f32, f32, f32) {
     if values.is_empty() {
         return (0.0, 0.0, 0.0, 0.0);
     }
-    let n = values.len() as f32;
-    let sum: f32 = values.iter().filter(|v| v.is_finite()).sum();
-    let mean = sum / n;
-    let variance: f32 = values
-        .iter()
-        .filter(|v| v.is_finite())
-        .map(|v| (v - mean).powi(2))
-        .sum::<f32>()
-        / n;
-    let min = values
-        .iter()
-        .filter(|v| v.is_finite())
-        .cloned()
-        .fold(f32::INFINITY, f32::min);
-    let max = values
-        .iter()
-        .filter(|v| v.is_finite())
-        .cloned()
-        .fold(f32::NEG_INFINITY, f32::max);
+
+    // We intentionally ignore non-finite values (NaN/±Infinity) so they cannot
+    // corrupt summary statistics or JSON serialisation.
+    //
+    // When there are no finite values, return zeros rather than ±Infinity.
+    // This matches the empty-slice behaviour and keeps the output JSON valid.
+    let mut count: u32 = 0;
+    let mut mean: f32 = 0.0;
+    let mut m2: f32 = 0.0;
+    let mut min: f32 = 0.0;
+    let mut max: f32 = 0.0;
+
+    for &x in values {
+        if !x.is_finite() {
+            continue;
+        }
+
+        if count == 0 {
+            count = 1;
+            mean = x;
+            m2 = 0.0;
+            min = x;
+            max = x;
+            continue;
+        }
+
+        if x < min {
+            min = x;
+        }
+        if x > max {
+            max = x;
+        }
+
+        count += 1;
+        let delta = x - mean;
+        mean += delta / count as f32;
+        let delta2 = x - mean;
+        m2 += delta * delta2;
+    }
+
+    if count == 0 {
+        return (0.0, 0.0, 0.0, 0.0);
+    }
+
+    let variance = m2 / count as f32;
     (mean, variance, min, max)
 }
 
@@ -713,6 +739,31 @@ mod tests {
         assert!((var - 2.0).abs() < 1e-6); // variance of [1,2,3,4,5] = 2
         assert!((min - 1.0).abs() < 1e-6);
         assert!((max - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_stats_ignores_non_finite_values() {
+        // Mean/variance should be computed over finite values only.
+        // This avoids skewing the result when recordings contain NaN/±Infinity.
+        let values = [1.0_f32, 2.0, f32::NAN, 3.0];
+        let (mean, var, min, max) = compute_stats(&values);
+
+        assert!((mean - 2.0).abs() < 1e-6);
+        assert!((var - (2.0 / 3.0)).abs() < 1e-6);
+        assert!((min - 1.0).abs() < 1e-6);
+        assert!((max - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_stats_all_non_finite_returns_zeros() {
+        // Returning ±Infinity here is semantically wrong and can break JSON output.
+        let values = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+        let (mean, var, min, max) = compute_stats(&values);
+
+        assert_eq!(mean, 0.0);
+        assert_eq!(var, 0.0);
+        assert_eq!(min, 0.0);
+        assert_eq!(max, 0.0);
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -299,6 +299,27 @@ fn compute_stats(values: &[f32]) -> (f32, f32, f32, f32) {
     (mean, variance, min, max)
 }
 
+/// Convert a float to a JSON-safe finite value.
+///
+/// `serde_json` will serialise non-finite floats (NaN/±Infinity) as `null`, which
+/// breaks consumers that expect numeric arrays (and breaks round-tripping into
+/// `Vec<f32>`).
+///
+/// We clamp ±Infinity to ±`f32::MAX` and map NaN to 0.0. This keeps exported
+/// snapshots valid JSON while preserving sign/magnitude semantics as much as
+/// possible for debugging.
+fn json_safe_f32(value: f32) -> f32 {
+    if value.is_finite() {
+        value
+    } else if value.is_nan() {
+        0.0
+    } else if value.is_sign_positive() {
+        f32::MAX
+    } else {
+        -f32::MAX
+    }
+}
+
 /// Export a visualisation snapshot to JSON
 pub fn export_visualisation_snapshot(
     parquet_file: &str,
@@ -348,9 +369,25 @@ pub fn export_visualisation_snapshot(
 
         for record in records {
             if let Some(&pos) = obs_index_pos.get(&record.obs_index) {
-                activation[pos] = record.activation;
-                value[pos] = record.value;
-                errors[pos] = record.errors.clone();
+                // Sanitise non-finite values so the exported JSON remains valid and
+                // downstream consumers don't see unexpected nulls in float arrays.
+                activation[pos] = if record.activation.is_finite() {
+                    record.activation
+                } else {
+                    0.0
+                };
+
+                value[pos] = record.value.filter(|v| v.is_finite());
+
+                // We intentionally drop NaN/±Infinity error values. These represent
+                // corrupt data and will otherwise poison aggregates (MAE/MSE) and/or
+                // serialise as nulls inside float arrays.
+                errors[pos] = record
+                    .errors
+                    .iter()
+                    .copied()
+                    .filter(|e| e.is_finite())
+                    .collect();
             }
         }
 
@@ -441,13 +478,15 @@ pub fn export_visualisation_snapshot(
         for syn in &creature.synapses {
             let key = format!("{}→{}", syn.from_uuid, syn.to_uuid);
 
+            let safe_weight = json_safe_f32(syn.weight);
+
             // Get from_neuron activations
             let contribution: Vec<f32> =
                 if let Some(from_recording) = neurons_recording.get(&syn.from_uuid) {
                     from_recording
                         .activation
                         .iter()
-                        .map(|&a| a * syn.weight)
+                        .map(|&a| json_safe_f32(a * safe_weight))
                         .collect()
                 } else {
                     // From neuron might be an input neuron not in recordings
@@ -462,7 +501,7 @@ pub fn export_visualisation_snapshot(
                 SynapseDerived {
                     from_uuid: syn.from_uuid.clone(),
                     to_uuid: syn.to_uuid.clone(),
-                    weight: syn.weight,
+                    weight: safe_weight,
                     contribution,
                     stats: SynapseStats {
                         mean_contribution: mean_contrib,
@@ -519,22 +558,29 @@ pub fn export_visualisation_snapshot(
 
             for (pos, &obs_index) in obs_indices.iter().enumerate() {
                 // Reconstruct value = bias + sum(from_activation * weight)
-                let mut reconstructed_value = neuron.bias;
+                let mut reconstructed_value = json_safe_f32(neuron.bias);
                 for syn in &inbound {
                     if let Some(from_recording) = neurons_recording.get(&syn.from_uuid) {
-                        reconstructed_value += from_recording.activation[pos] * syn.weight;
+                        reconstructed_value += json_safe_f32(
+                            from_recording.activation[pos] * json_safe_f32(syn.weight),
+                        );
                     }
                 }
 
-                let reconstructed_activation = apply_squash(&neuron.squash, reconstructed_value);
+                reconstructed_value = json_safe_f32(reconstructed_value);
+                let reconstructed_activation =
+                    json_safe_f32(apply_squash(&neuron.squash, reconstructed_value));
 
                 let recorded_value = recording.value[pos];
                 let recorded_activation = recording.activation[pos];
 
-                let value_delta = recorded_value
-                    .map(|rv| (rv - reconstructed_value).abs())
-                    .unwrap_or(0.0);
-                let activation_delta = (recorded_activation - reconstructed_activation).abs();
+                let value_delta = json_safe_f32(
+                    recorded_value
+                        .map(|rv| (rv - reconstructed_value).abs())
+                        .unwrap_or(0.0),
+                );
+                let activation_delta =
+                    json_safe_f32((recorded_activation - reconstructed_activation).abs());
 
                 if value_delta.is_finite() {
                     sum_value_delta += value_delta;

--- a/src/export.rs
+++ b/src/export.rs
@@ -255,39 +255,45 @@ fn compute_stats(values: &[f32]) -> (f32, f32, f32, f32) {
     // We intentionally ignore non-finite values (NaN/±Infinity) so they cannot
     // corrupt summary statistics or JSON serialisation.
     //
+    // Important: Even with finite inputs, naive f32 accumulation can overflow
+    // internally (eg variance for `[0.0, f32::MAX]`). We compute in f64 and then
+    // clamp to JSON-safe f32 outputs.
+    //
     // When there are no finite values, return zeros rather than ±Infinity.
     // This matches the empty-slice behaviour and keeps the output JSON valid.
-    let mut count: u32 = 0;
-    let mut mean: f32 = 0.0;
-    let mut m2: f32 = 0.0;
-    let mut min: f32 = 0.0;
-    let mut max: f32 = 0.0;
+    let mut count: u64 = 0;
+    let mut mean: f64 = 0.0;
+    let mut m2: f64 = 0.0;
+    let mut min: f64 = 0.0;
+    let mut max: f64 = 0.0;
 
     for &x in values {
         if !x.is_finite() {
             continue;
         }
 
+        let xf = x as f64;
+
         if count == 0 {
             count = 1;
-            mean = x;
+            mean = xf;
             m2 = 0.0;
-            min = x;
-            max = x;
+            min = xf;
+            max = xf;
             continue;
         }
 
-        if x < min {
-            min = x;
+        if xf < min {
+            min = xf;
         }
-        if x > max {
-            max = x;
+        if xf > max {
+            max = xf;
         }
 
         count += 1;
-        let delta = x - mean;
-        mean += delta / count as f32;
-        let delta2 = x - mean;
+        let delta = xf - mean;
+        mean += delta / count as f64;
+        let delta2 = xf - mean;
         m2 += delta * delta2;
     }
 
@@ -295,8 +301,14 @@ fn compute_stats(values: &[f32]) -> (f32, f32, f32, f32) {
         return (0.0, 0.0, 0.0, 0.0);
     }
 
-    let variance = m2 / count as f32;
-    (mean, variance, min, max)
+    let variance = m2 / count as f64;
+
+    (
+        json_safe_f32(mean as f32),
+        json_safe_f32(variance as f32),
+        json_safe_f32(min as f32),
+        json_safe_f32(max as f32),
+    )
 }
 
 /// Convert a float to a JSON-safe finite value.

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -807,16 +807,16 @@ fn compute_impacts_internal_with_stats(
     // Parallel impact computation using thread-local caches
     // Each thread computes impacts for a subset of neurons, then we merge results.
     // This trades some redundant computation for better CPU utilization.
-    let selectable_neurons: Vec<&NeuronJson> = creature
-        .neurons
-        .iter()
-        .filter(|n| is_selectable_type(&n.neuron_type))
-        .collect();
+    //
+    // Note: We include ALL neurons (including inputs) to compute their impacts.
+    // Input neurons have outgoing synapses and their impact measures their
+    // contribution to the final output. This is useful for visualisation/debugging.
+    let all_neurons: Vec<&NeuronJson> = creature.neurons.iter().collect();
 
     // Use a shared cache protected by a mutex for thread-safe updates
     let shared_cache: Mutex<HashMap<String, f32>> = Mutex::new(HashMap::new());
 
-    selectable_neurons.par_iter().for_each(|neuron| {
+    all_neurons.par_iter().for_each(|neuron| {
         // Check if already computed (another thread might have done it)
         {
             let cache = shared_cache.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod analysis;
 pub mod debug;
+pub mod export;
 pub mod focus;
 pub mod parquet_format;
 pub mod record;
@@ -60,15 +61,22 @@ pub struct NeuronJson {
     pub uuid: String,
     #[serde(rename = "type")]
     pub neuron_type: String,
+    /// Activation function. Defaults to "IDENTITY" for constant neurons.
+    #[serde(default = "default_squash")]
     pub squash: String,
+    #[serde(default)]
     pub bias: f32,
+}
+
+fn default_squash() -> String {
+    "IDENTITY".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SynapseJson {
-    #[serde(default)]
+    #[serde(default, alias = "fromUUID")]
     pub from_uuid: String,
-    #[serde(default)]
+    #[serde(default, alias = "toUUID")]
     pub to_uuid: String,
     #[serde(default)]
     pub weight: f32,
@@ -702,6 +710,64 @@ pub struct MergeParquetOutput {
     pub error: Option<String>,
 }
 
+// ============================================================================
+// Visualisation Snapshot Export API Types
+// ============================================================================
+// These support exporting a debug-friendly JSON snapshot for use with the
+// NEAT-AI-Explore visualiser. This is an optional debug tool.
+
+/// JSON input for export_visualisation_snapshot function
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportVisualisationSnapshotInput {
+    pub parquet_file: String,
+    pub creature: CreatureJson,
+    pub out_file: String,
+    /// Include per-synapse contribution series (default: true)
+    #[serde(default = "default_true")]
+    pub include_per_synapse_series: bool,
+    /// Include reconstruction checks for debugging (default: true)
+    #[serde(default = "default_true")]
+    pub include_reconstruction_checks: bool,
+    /// Maximum number of obsIndex to include (default: all)
+    #[serde(default)]
+    pub max_obs: Option<u32>,
+    /// Top-K worst reconstruction samples to include (default: 20)
+    #[serde(default = "default_top_k")]
+    pub top_k_worst_samples: Option<usize>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_top_k() -> Option<usize> {
+    Some(20)
+}
+
+/// JSON output from export_visualisation_snapshot function
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportVisualisationSnapshotOutput {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub out_file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats: Option<ExportVisualisationStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Statistics from the export operation
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportVisualisationStats {
+    pub obs_count: usize,
+    pub neuron_count: usize,
+    pub synapse_count: usize,
+    pub output_count: usize,
+}
+
 /// Main entry point for recording discovery data
 ///
 /// Takes JSON input and returns JSON output for easy integration with TypeScript/DenoJS
@@ -970,6 +1036,64 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 processed_neurons: None,
                 total_neurons: None,
                 duration_ms: None,
+                error: Some(e.to_string()),
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+    }
+}
+
+/// Export a visualisation snapshot to JSON for debugging with NEAT-AI-Explore.
+///
+/// This is an optional debug tool that reads a Parquet recording and creature,
+/// then writes a comprehensive JSON snapshot with recorded data, impacts, and
+/// reconstruction checks.
+pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String> {
+    let input: ExportVisualisationSnapshotInput = match serde_json::from_str(input_json) {
+        Ok(value) => value,
+        Err(e) => {
+            let output = ExportVisualisationSnapshotOutput {
+                success: false,
+                out_file: None,
+                stats: None,
+                error: Some(format!("Failed to parse input JSON: {e}")),
+            };
+            return Ok(serde_json::to_string(&output)?);
+        }
+    };
+
+    let options = export::ExportOptions {
+        include_per_synapse_series: input.include_per_synapse_series,
+        include_reconstruction_checks: input.include_reconstruction_checks,
+        max_obs: input.max_obs,
+        top_k_worst_samples: input.top_k_worst_samples.unwrap_or(20),
+    };
+
+    match export::export_visualisation_snapshot(
+        &input.parquet_file,
+        &input.creature,
+        &input.out_file,
+        &options,
+    ) {
+        Ok(stats) => {
+            let output = ExportVisualisationSnapshotOutput {
+                success: true,
+                out_file: Some(input.out_file),
+                stats: Some(ExportVisualisationStats {
+                    obs_count: stats.obs_count,
+                    neuron_count: stats.neuron_count,
+                    synapse_count: stats.synapse_count,
+                    output_count: stats.output_count,
+                }),
+                error: None,
+            };
+            Ok(serde_json::to_string(&output)?)
+        }
+        Err(e) => {
+            let output = ExportVisualisationSnapshotOutput {
+                success: false,
+                out_file: None,
+                stats: None,
                 error: Some(e.to_string()),
             };
             Ok(serde_json::to_string(&output)?)
@@ -1974,11 +2098,98 @@ pub extern "C" fn read_discovery_records_ffi(
     })
 }
 
-/// FFI export for freeing memory allocated by read_discovery_records_ffi
+/// Export a visualisation snapshot to JSON for debugging with NEAT-AI-Explore.
 ///
-/// # Safety
-/// This function is unsafe because it frees memory allocated by Rust.
-/// The caller must ensure ptr was returned by read_discovery_records_ffi.
+/// Input JSON:
+/// ```json
+/// {
+///   "parquetFile": "/path/to/records.parquet",
+///   "creature": { ... },
+///   "outFile": "/path/to/snapshot.json",
+///   "includePerSynapseSeries": true,
+///   "includeReconstructionChecks": true,
+///   "maxObs": null,
+///   "topKWorstSamples": 20
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true,
+///   "outFile": "/path/to/snapshot.json",
+///   "stats": { "obsCount": 1000, "neuronCount": 50, "synapseCount": 200, "outputCount": 1 }
+/// }
+/// ```
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn export_visualisation_snapshot(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let json_result = match export_visualisation_snapshot_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                let output = ExportVisualisationSnapshotOutput {
+                    success: false,
+                    out_file: None,
+                    stats: None,
+                    error: Some(e.to_string()),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
+                })
+            }
+        };
+
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
+        }
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn free_discovery_result(ptr: *mut std::ffi::c_char) {

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -542,6 +542,111 @@ pub fn read_records_from_parquet(
     Ok(records)
 }
 
+/// Read ALL discovery records from a Parquet file (no filtering).
+///
+/// Used by the visualisation snapshot export to get all recorded data.
+pub fn read_all_records_from_parquet(file_path: &str) -> Result<Vec<DiscoverRecord>> {
+    read_records_from_parquet_with_limit(file_path, None)
+}
+
+/// Read discovery records from a Parquet file with optional observation limit.
+///
+/// If `max_obs` is Some, stops reading after collecting records for that many
+/// unique obsIndex values. This allows early exit for large parquet files.
+pub fn read_records_from_parquet_with_limit(
+    file_path: &str,
+    max_obs: Option<u32>,
+) -> Result<Vec<DiscoverRecord>> {
+    use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::collections::HashSet;
+    use std::fs::File;
+
+    let file = File::open(file_path)
+        .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+        .context("Failed to create Parquet reader builder")?;
+
+    let reader = builder.build().context("Failed to build Parquet reader")?;
+
+    let mut records = Vec::new();
+    let mut seen_obs_indices: HashSet<u32> = HashSet::new();
+
+    'batch_loop: for batch_result in reader {
+        let batch = batch_result.context("Failed to read record batch")?;
+
+        let obs_index_col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .context("Failed to cast obs_index column")?;
+        let neuron_uuid_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .context("Failed to cast neuron_uuid column")?;
+        let value_col = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .context("Failed to cast value column")?;
+        let activation_col = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .context("Failed to cast activation column")?;
+        let errors_col = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .context("Failed to cast errors column")?;
+
+        for i in 0..batch.num_rows() {
+            let obs_index = obs_index_col.value(i);
+
+            // Check if we've hit the observation limit
+            if let Some(max) = max_obs {
+                if !seen_obs_indices.contains(&obs_index) {
+                    if seen_obs_indices.len() >= max as usize {
+                        // We've collected enough observations, stop
+                        break 'batch_loop;
+                    }
+                    seen_obs_indices.insert(obs_index);
+                }
+            }
+
+            let uuid = neuron_uuid_col.value(i);
+            let value = if value_col.is_null(i) {
+                None
+            } else {
+                Some(value_col.value(i))
+            };
+            let activation = activation_col.value(i);
+
+            // Extract errors array
+            let errors_list = errors_col.value(i);
+            let errors_array = errors_list
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .context("Failed to cast errors array")?;
+            let errors: Vec<f32> = (0..errors_array.len())
+                .map(|j| errors_array.value(j))
+                .collect();
+
+            records.push(DiscoverRecord::new(
+                obs_index,
+                uuid.to_string(),
+                value,
+                activation,
+                errors,
+            ));
+        }
+    }
+
+    Ok(records)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parquet_format.rs
+++ b/src/parquet_format.rs
@@ -551,8 +551,18 @@ pub fn read_all_records_from_parquet(file_path: &str) -> Result<Vec<DiscoverReco
 
 /// Read discovery records from a Parquet file with optional observation limit.
 ///
-/// If `max_obs` is Some, stops reading after collecting records for that many
-/// unique obsIndex values. This allows early exit for large parquet files.
+/// If `max_obs` is Some, returns records for the first `max_obs` distinct
+/// `obs_index` values encountered while scanning the file.
+///
+/// Important: Parquet rows are not guaranteed to be stored in observation-first
+/// order. They may be stored in neuron-first order (all obs for neuron A, then
+/// all obs for neuron B). In that case, **we must not stop reading** as soon as
+/// we see a new `obs_index` beyond the limit, because later rows may still
+/// contain records for already-accepted observation indices.
+///
+/// To guarantee complete data for the accepted observations, this reader:
+/// - Keeps a set of accepted `obs_index` values up to `max_obs`
+/// - Scans the file and **filters** to only accepted observations
 pub fn read_records_from_parquet_with_limit(
     file_path: &str,
     max_obs: Option<u32>,
@@ -561,6 +571,11 @@ pub fn read_records_from_parquet_with_limit(
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::collections::HashSet;
     use std::fs::File;
+
+    // Edge case: treat max_obs=0 as "return no rows".
+    if matches!(max_obs, Some(0)) {
+        return Ok(Vec::new());
+    }
 
     let file = File::open(file_path)
         .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
@@ -571,9 +586,9 @@ pub fn read_records_from_parquet_with_limit(
     let reader = builder.build().context("Failed to build Parquet reader")?;
 
     let mut records = Vec::new();
-    let mut seen_obs_indices: HashSet<u32> = HashSet::new();
+    let mut accepted_obs_indices: HashSet<u32> = HashSet::new();
 
-    'batch_loop: for batch_result in reader {
+    for batch_result in reader {
         let batch = batch_result.context("Failed to read record batch")?;
 
         let obs_index_col = batch
@@ -605,15 +620,26 @@ pub fn read_records_from_parquet_with_limit(
         for i in 0..batch.num_rows() {
             let obs_index = obs_index_col.value(i);
 
-            // Check if we've hit the observation limit
-            if let Some(max) = max_obs {
-                if !seen_obs_indices.contains(&obs_index) {
-                    if seen_obs_indices.len() >= max as usize {
-                        // We've collected enough observations, stop
-                        break 'batch_loop;
+            // Determine whether to include this row under the limit.
+            let include_row = match max_obs {
+                None => true,
+                Some(max) => {
+                    if accepted_obs_indices.contains(&obs_index) {
+                        true
+                    } else if accepted_obs_indices.len() < max as usize {
+                        accepted_obs_indices.insert(obs_index);
+                        true
+                    } else {
+                        // We've accepted enough observations. Skip new obs_index values,
+                        // but keep scanning in case we encounter more rows for accepted
+                        // observations (e.g. neuron-first ordering).
+                        false
                     }
-                    seen_obs_indices.insert(obs_index);
                 }
+            };
+
+            if !include_row {
+                continue;
             }
 
             let uuid = neuron_uuid_col.value(i);

--- a/tests/export_visualisation_snapshot.rs
+++ b/tests/export_visualisation_snapshot.rs
@@ -1,0 +1,482 @@
+//! Integration tests for the visualisation snapshot export feature.
+//!
+//! These tests verify that the export function correctly:
+//! - Reads Parquet recordings
+//! - Computes neuron stats and impacts
+//! - Computes synapse contributions
+//! - Computes reconstruction checks (recorded vs computed values)
+//! - Writes a valid JSON snapshot
+
+use neat_ai_discovery::export::{
+    export_visualisation_snapshot, ExportOptions, VisualisationSnapshot,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::fs::File;
+use std::io::BufReader;
+use tempfile::tempdir;
+
+/// Create a minimal test creature with:
+/// - 2 inputs (input-0, input-1)
+/// - 1 hidden neuron (hidden-0) with IDENTITY squash
+/// - 1 output neuron (output-0) with IDENTITY squash
+fn create_test_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            // input-0 -> hidden-0 (weight 1.0)
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            // input-1 -> hidden-0 (weight 0.5)
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            // hidden-0 -> output-0 (weight 2.0)
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 2.0,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+/// Create test Parquet records for the test creature.
+///
+/// For IDENTITY squash with bias=0:
+/// - input-0 activation = 1.0
+/// - input-1 activation = 2.0
+/// - hidden-0: value = 1.0*1.0 + 2.0*0.5 = 2.0, activation = 2.0 (IDENTITY)
+/// - output-0: value = 2.0*2.0 = 4.0, activation = 4.0 (IDENTITY)
+fn create_test_records() -> Vec<DiscoverRecord> {
+    vec![
+        // obsIndex 0: input neurons
+        DiscoverRecord::new(0, "input-0".to_string(), Some(1.0), 1.0, vec![0.0]),
+        DiscoverRecord::new(0, "input-1".to_string(), Some(2.0), 2.0, vec![0.0]),
+        // obsIndex 0: hidden neuron
+        // value = 1.0*1.0 + 2.0*0.5 = 2.0
+        DiscoverRecord::new(0, "hidden-0".to_string(), Some(2.0), 2.0, vec![0.1]),
+        // obsIndex 0: output neuron
+        // value = 2.0 * 2.0 = 4.0
+        DiscoverRecord::new(0, "output-0".to_string(), Some(4.0), 4.0, vec![0.05]),
+        // obsIndex 1: different activations
+        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![0.0]),
+        DiscoverRecord::new(1, "input-1".to_string(), Some(1.0), 1.0, vec![0.0]),
+        // hidden-0: value = 0.5*1.0 + 1.0*0.5 = 1.0
+        DiscoverRecord::new(1, "hidden-0".to_string(), Some(1.0), 1.0, vec![0.2]),
+        // output-0: value = 1.0 * 2.0 = 2.0
+        DiscoverRecord::new(1, "output-0".to_string(), Some(2.0), 2.0, vec![0.1]),
+    ]
+}
+
+#[test]
+fn test_export_creates_valid_json() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    // Write test records to Parquet
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    // Create test creature
+    let creature = create_test_creature();
+
+    // Export snapshot
+    let options = ExportOptions::default();
+    let stats = export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    // Verify stats
+    assert_eq!(stats.obs_count, 2, "Should have 2 observations");
+    assert_eq!(stats.synapse_count, 3, "Should have 3 synapses");
+    assert_eq!(stats.output_count, 1, "Should have 1 output");
+
+    // Load and parse the JSON
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    // Verify structure
+    assert!(
+        !snapshot.meta.exported_at.is_empty(),
+        "Should have export timestamp"
+    );
+    assert!(
+        !snapshot.meta.discovery_version.is_empty(),
+        "Should have version"
+    );
+    assert_eq!(
+        snapshot.recording.obs_indices.len(),
+        2,
+        "Should have 2 obsIndices"
+    );
+    assert!(
+        snapshot.recording.neurons.contains_key("output-0"),
+        "Should have output-0 in recording"
+    );
+}
+
+#[test]
+fn test_neuron_stats_are_computed_correctly() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+    let options = ExportOptions::default();
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    // Check hidden-0 neuron stats
+    let hidden_recording = snapshot
+        .recording
+        .neurons
+        .get("hidden-0")
+        .expect("Should have hidden-0");
+
+    // hidden-0 activations: [2.0, 1.0]
+    // mean = 1.5, min = 1.0, max = 2.0
+    assert!(
+        (hidden_recording.stats.mean_activation - 1.5).abs() < 1e-5,
+        "hidden-0 mean activation should be 1.5, got {}",
+        hidden_recording.stats.mean_activation
+    );
+    assert!(
+        (hidden_recording.stats.activation_min - 1.0).abs() < 1e-5,
+        "hidden-0 min activation should be 1.0"
+    );
+    assert!(
+        (hidden_recording.stats.activation_max - 2.0).abs() < 1e-5,
+        "hidden-0 max activation should be 2.0"
+    );
+}
+
+#[test]
+fn test_synapse_contributions_are_computed_correctly() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+    let options = ExportOptions::default();
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    // Check hidden-0 -> output-0 synapse (weight 2.0)
+    // hidden-0 activations: [2.0, 1.0]
+    // contribution = activation * weight = [4.0, 2.0]
+    let synapse = snapshot
+        .derived
+        .synapses
+        .get("hidden-0→output-0")
+        .expect("Should have hidden-0→output-0 synapse");
+
+    assert!(
+        (synapse.weight - 2.0).abs() < 1e-5,
+        "Synapse weight should be 2.0"
+    );
+    assert_eq!(
+        synapse.contribution.len(),
+        2,
+        "Should have 2 contribution values"
+    );
+    assert!(
+        (synapse.contribution[0] - 4.0).abs() < 1e-5,
+        "First contribution should be 4.0, got {}",
+        synapse.contribution[0]
+    );
+    assert!(
+        (synapse.contribution[1] - 2.0).abs() < 1e-5,
+        "Second contribution should be 2.0, got {}",
+        synapse.contribution[1]
+    );
+}
+
+#[test]
+fn test_reconstruction_checks_for_identity_network() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+    let options = ExportOptions {
+        include_per_synapse_series: true,
+        include_reconstruction_checks: true,
+        max_obs: None,
+        top_k_worst_samples: 10,
+    };
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    // For an IDENTITY network with correct recordings, reconstruction deltas should be ~0
+    let checks = snapshot
+        .derived
+        .reconstruction_checks
+        .expect("Should have reconstruction checks");
+
+    // Find hidden-0 check
+    let hidden_check = checks.iter().find(|c| c.neuron_uuid == "hidden-0");
+    assert!(hidden_check.is_some(), "Should have check for hidden-0");
+    let hidden_check = hidden_check.unwrap();
+
+    // hidden-0 receives from input-0 (weight 1.0) and input-1 (weight 0.5)
+    // obsIndex 0: reconstructed = 0 + 1.0*1.0 + 2.0*0.5 = 2.0, recorded = 2.0
+    // obsIndex 1: reconstructed = 0 + 0.5*1.0 + 1.0*0.5 = 1.0, recorded = 1.0
+    // So deltas should be 0
+    assert!(
+        hidden_check.max_value_delta < 0.01,
+        "For IDENTITY network, value delta should be ~0, got {}",
+        hidden_check.max_value_delta
+    );
+    assert!(
+        hidden_check.max_activation_delta < 0.01,
+        "For IDENTITY network, activation delta should be ~0, got {}",
+        hidden_check.max_activation_delta
+    );
+}
+
+#[test]
+fn test_impacts_are_computed() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+    let options = ExportOptions::default();
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    // Output neurons should have impact = 1.0
+    let output_impact = snapshot
+        .derived
+        .impacts_by_neuron_uuid
+        .get("output-0")
+        .expect("Should have output-0 impact");
+    assert!(
+        (*output_impact - 1.0).abs() < 1e-5,
+        "Output neuron should have impact 1.0, got {}",
+        output_impact
+    );
+
+    // Hidden neuron should have impact > 0 (since it feeds into output)
+    let hidden_impact = snapshot
+        .derived
+        .impacts_by_neuron_uuid
+        .get("hidden-0")
+        .expect("Should have hidden-0 impact");
+    assert!(
+        *hidden_impact > 0.0,
+        "Hidden neuron should have positive impact, got {}",
+        hidden_impact
+    );
+}
+
+#[test]
+fn test_max_obs_limits_output() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+
+    // Limit to 1 observation
+    let options = ExportOptions {
+        include_per_synapse_series: true,
+        include_reconstruction_checks: true,
+        max_obs: Some(1),
+        top_k_worst_samples: 5,
+    };
+
+    let stats = export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    assert_eq!(stats.obs_count, 1, "Should be limited to 1 observation");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    assert_eq!(
+        snapshot.recording.obs_indices.len(),
+        1,
+        "Should have only 1 obsIndex"
+    );
+}
+
+#[test]
+fn test_export_without_reconstruction_checks() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+
+    let options = ExportOptions {
+        include_per_synapse_series: true,
+        include_reconstruction_checks: false, // Disable
+        max_obs: None,
+        top_k_worst_samples: 5,
+    };
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    assert!(
+        snapshot.derived.reconstruction_checks.is_none(),
+        "Reconstruction checks should be None when disabled"
+    );
+}
+
+#[test]
+fn test_export_without_synapse_series() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_test_records();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_test_creature();
+
+    let options = ExportOptions {
+        include_per_synapse_series: false, // Disable
+        include_reconstruction_checks: true,
+        max_obs: None,
+        top_k_worst_samples: 5,
+    };
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    assert!(
+        snapshot.derived.synapses.is_empty(),
+        "Synapse derived data should be empty when disabled"
+    );
+}

--- a/tests/export_visualisation_snapshot.rs
+++ b/tests/export_visualisation_snapshot.rs
@@ -346,8 +346,7 @@ fn test_impacts_are_computed() {
         .expect("Should have output-0 impact");
     assert!(
         (*output_impact - 1.0).abs() < 1e-5,
-        "Output neuron should have impact 1.0, got {}",
-        output_impact
+        "Output neuron should have impact 1.0, got {output_impact}"
     );
 
     // Hidden neuron should have impact > 0 (since it feeds into output)
@@ -358,8 +357,7 @@ fn test_impacts_are_computed() {
         .expect("Should have hidden-0 impact");
     assert!(
         *hidden_impact > 0.0,
-        "Hidden neuron should have positive impact, got {}",
-        hidden_impact
+        "Hidden neuron should have positive impact, got {hidden_impact}"
     );
 }
 

--- a/tests/export_visualisation_snapshot_non_finite.rs
+++ b/tests/export_visualisation_snapshot_non_finite.rs
@@ -17,7 +17,7 @@ use std::fs::File;
 use std::io::BufReader;
 use tempfile::tempdir;
 
-fn create_creature_with_overflow_weight() -> CreatureJson {
+fn create_creature_with_contribution_overflow() -> CreatureJson {
     CreatureJson {
         neurons: vec![
             NeuronJson {
@@ -40,11 +40,11 @@ fn create_creature_with_overflow_weight() -> CreatureJson {
                 weight: 1.0,
                 synapse_type: None,
             },
-            // Deliberately use +Infinity weight so contribution computation can overflow.
+            // Deliberately keep weight finite, but allow contribution overflow via huge activation.
             SynapseJson {
                 from_uuid: "hidden-0".to_string(),
                 to_uuid: "output-0".to_string(),
-                weight: f32::INFINITY,
+                weight: 2.0,
                 synapse_type: None,
             },
         ],
@@ -89,7 +89,7 @@ fn export_visualisation_snapshot_sanitises_non_finite_series() {
     write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
         .expect("Failed to write Parquet");
 
-    let creature = create_creature_with_overflow_weight();
+    let creature = create_creature_with_contribution_overflow();
     let options = ExportOptions::default();
 
     export_visualisation_snapshot(

--- a/tests/export_visualisation_snapshot_non_finite.rs
+++ b/tests/export_visualisation_snapshot_non_finite.rs
@@ -1,0 +1,121 @@
+//! Regression test: export snapshot must be JSON-safe with non-finite floats.
+//!
+//! The snapshot export includes raw per-observation series (eg synapse contribution).
+//! If any series contains NaN or ±Infinity, `serde_json` will fail because JSON has
+//! no representation for non-finite numbers.
+//!
+//! This test ensures we sanitise non-finite values during export so the snapshot
+//! always serialises successfully.
+
+use neat_ai_discovery::export::{
+    export_visualisation_snapshot, ExportOptions, VisualisationSnapshot,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::fs::File;
+use std::io::BufReader;
+use tempfile::tempdir;
+
+fn create_creature_with_overflow_weight() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            // Deliberately use +Infinity weight so contribution computation can overflow.
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: f32::INFINITY,
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    }
+}
+
+fn create_records_with_non_finite_values() -> Vec<DiscoverRecord> {
+    vec![
+        // obsIndex 0: include a NaN activation (should be sanitised during export).
+        DiscoverRecord::new(0, "input-0".to_string(), Some(1.0), 1.0, vec![0.0]),
+        DiscoverRecord::new(
+            0,
+            "hidden-0".to_string(),
+            Some(0.0),
+            f32::NAN,
+            vec![f32::NAN, 0.1],
+        ),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.0]),
+        // obsIndex 1: use a huge finite activation so (activation * weight) would overflow
+        // without sanitisation.
+        DiscoverRecord::new(1, "input-0".to_string(), Some(1.0), 1.0, vec![0.0]),
+        DiscoverRecord::new(
+            1,
+            "hidden-0".to_string(),
+            Some(0.0),
+            f32::MAX,
+            vec![f32::INFINITY, 0.2],
+        ),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.0]),
+    ]
+}
+
+#[test]
+fn export_visualisation_snapshot_sanitises_non_finite_series() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    let records = create_records_with_non_finite_values();
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_creature_with_overflow_weight();
+    let options = ExportOptions::default();
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed even with NaN/Infinity inputs");
+
+    // If serialisation produced invalid JSON, we would fail to parse it here.
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Snapshot JSON should be valid");
+
+    // Ensure the derived synapse data is finite and JSON-safe.
+    let syn = snapshot
+        .derived
+        .synapses
+        .get("hidden-0→output-0")
+        .expect("Expected hidden-0→output-0 derived synapse entry");
+
+    assert!(syn.weight.is_finite(), "Synapse weight must be finite");
+    assert!(
+        syn.contribution.iter().all(|v| v.is_finite()),
+        "Contribution series must contain only finite numbers"
+    );
+}

--- a/tests/export_visualisation_snapshot_non_finite_contributions.rs
+++ b/tests/export_visualisation_snapshot_non_finite_contributions.rs
@@ -1,0 +1,96 @@
+//! Regression test: non-finite synapse contributions must not break snapshot export.
+//!
+//! The snapshot exporter stores per-synapse `contribution` series as:
+//!   contribution[obs] = from_activation[obs] * weight
+//!
+//! Even when both inputs are finite, this multiplication can overflow to ±Infinity.
+//! JSON cannot represent non-finite floats, so the exporter must sanitise the raw
+//! contribution series before serialisation.
+
+use neat_ai_discovery::export::{
+    export_visualisation_snapshot, ExportOptions, VisualisationSnapshot,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::fs::File;
+use std::io::BufReader;
+use tempfile::tempdir;
+
+fn create_creature_with_single_synapse(weight: f32) -> CreatureJson {
+    CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![SynapseJson {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight,
+            synapse_type: None,
+        }],
+        input: 1,
+        output: 1,
+    }
+}
+
+#[test]
+fn export_visualisation_snapshot_sanitises_non_finite_contribution_series() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    // Finite activation that will overflow when multiplied by weight=2.0.
+    // f32::MAX * 2.0 => +Infinity
+    let records = vec![
+        DiscoverRecord::new(
+            0,
+            "input-0".to_string(),
+            Some(f32::MAX),
+            f32::MAX,
+            vec![0.0],
+        ),
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.0]),
+    ];
+
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_creature_with_single_synapse(2.0);
+
+    // Keep the test focused on synapse series JSON serialisation.
+    let options = ExportOptions {
+        include_per_synapse_series: true,
+        include_reconstruction_checks: false,
+        max_obs: None,
+        top_k_worst_samples: 5,
+    };
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed even if contribution overflows to non-finite");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    let syn = snapshot
+        .derived
+        .synapses
+        .get("input-0→output-0")
+        .expect("Expected derived synapse entry");
+
+    assert_eq!(syn.contribution.len(), 1, "Should have 1 obs entry");
+    assert!(
+        syn.contribution[0].is_finite(),
+        "Contribution series must be JSON-safe (finite), got {}",
+        syn.contribution[0]
+    );
+}

--- a/tests/export_visualisation_snapshot_non_finite_errors.rs
+++ b/tests/export_visualisation_snapshot_non_finite_errors.rs
@@ -1,0 +1,123 @@
+//! Regression test: non-finite error values must not break snapshot export.
+//!
+//! The snapshot exporter computes summary statistics for recorded errors.
+//! `compute_stats()` already filters out NaN/±Infinity so summary stats remain valid,
+//! but MAE/MSE must apply the same filtering to avoid generating NaN in JSON output.
+
+use neat_ai_discovery::export::{
+    export_visualisation_snapshot, ExportOptions, VisualisationSnapshot,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson};
+use std::fs::File;
+use std::io::BufReader;
+use tempfile::tempdir;
+
+fn create_minimal_output_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![],
+        input: 0,
+        output: 1,
+    }
+}
+
+#[test]
+fn export_visualisation_snapshot_filters_non_finite_errors_for_mae_and_mse() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let snapshot_path = temp_dir.path().join("snapshot.json");
+
+    // Two observations, each includes non-finite errors plus finite errors [1.0, -2.0].
+    // Finite-only MAE = (|1| + |2| + |1| + |2|) / 4 = 1.5
+    // Finite-only MSE = (1² + 2² + 1² + 2²) / 4 = 2.5
+    let records = vec![
+        DiscoverRecord::new(
+            0,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![f32::NAN, 1.0, f32::INFINITY, -2.0],
+        ),
+        DiscoverRecord::new(
+            1,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![f32::NEG_INFINITY, 1.0, -2.0, f32::NAN],
+        ),
+    ];
+
+    write_records_to_parquet(parquet_path.to_str().unwrap(), &records)
+        .expect("Failed to write Parquet");
+
+    let creature = create_minimal_output_creature();
+    let options = ExportOptions::default();
+
+    export_visualisation_snapshot(
+        parquet_path.to_str().unwrap(),
+        &creature,
+        snapshot_path.to_str().unwrap(),
+        &options,
+    )
+    .expect("Export should succeed even with non-finite errors");
+
+    let file = File::open(&snapshot_path).expect("Failed to open snapshot");
+    let reader = BufReader::new(file);
+    let snapshot: VisualisationSnapshot =
+        serde_json::from_reader(reader).expect("Failed to parse snapshot JSON");
+
+    let stats = &snapshot
+        .recording
+        .neurons
+        .get("output-0")
+        .expect("Should have output-0 recording")
+        .stats;
+
+    let errors = &snapshot
+        .recording
+        .neurons
+        .get("output-0")
+        .expect("Should have output-0 recording")
+        .errors;
+
+    assert_eq!(errors.len(), 2, "Should have errors for 2 observations");
+    assert_eq!(
+        errors[0].len(),
+        2,
+        "Non-finite errors should be dropped (obs 0 should keep only finite values)"
+    );
+    assert_eq!(
+        errors[1].len(),
+        2,
+        "Non-finite errors should be dropped (obs 1 should keep only finite values)"
+    );
+
+    assert!(
+        stats.mean_absolute_error.is_finite(),
+        "MAE should be finite even with non-finite errors, got {}",
+        stats.mean_absolute_error
+    );
+    assert!(
+        stats.mean_squared_error.is_finite(),
+        "MSE should be finite even with non-finite errors, got {}",
+        stats.mean_squared_error
+    );
+
+    assert!(
+        (stats.mean_absolute_error - 1.5).abs() < 1e-5,
+        "Expected finite-only MAE 1.5, got {}",
+        stats.mean_absolute_error
+    );
+    assert!(
+        (stats.mean_squared_error - 2.5).abs() < 1e-5,
+        "Expected finite-only MSE 2.5, got {}",
+        stats.mean_squared_error
+    );
+}

--- a/tests/parquet_read_limit_ordering.rs
+++ b/tests/parquet_read_limit_ordering.rs
@@ -1,0 +1,57 @@
+//! Regression tests for Parquet read limiting.
+//!
+//! The Parquet reader supports an optional `max_obs` limit to avoid loading huge
+//! recordings into memory.
+//!
+//! Important: The Parquet file may be written in different row orders.
+//! - Observation-first order (all neurons for obs 0, then all neurons for obs 1, ...)
+//! - Neuron-first order (all observations for neuron A, then all observations for neuron B, ...)
+//!
+//! When limiting by `max_obs`, we must ensure we still collect *all* records for
+//! already-accepted observation indices, regardless of row ordering.
+
+use neat_ai_discovery::parquet_format::{
+    read_records_from_parquet_with_limit, write_records_to_parquet,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use std::collections::HashSet;
+use tempfile::NamedTempFile;
+
+#[test]
+fn read_records_from_parquet_with_limit_handles_neuron_first_ordering() {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp Parquet file");
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Write records in neuron-first order:
+    // neuron-a: obs 0, obs 1
+    // neuron-b: obs 0, obs 1
+    // If `max_obs=1`, we want ALL rows for obs 0, including neuron-b's obs 0 row.
+    let records = vec![
+        DiscoverRecord::new(0, "neuron-a".to_string(), Some(1.0), 1.0, vec![0.0]),
+        DiscoverRecord::new(1, "neuron-a".to_string(), Some(2.0), 2.0, vec![0.0]),
+        DiscoverRecord::new(0, "neuron-b".to_string(), Some(3.0), 3.0, vec![0.0]),
+        DiscoverRecord::new(1, "neuron-b".to_string(), Some(4.0), 4.0, vec![0.0]),
+    ];
+
+    write_records_to_parquet(file_path, &records).expect("Failed to write Parquet");
+
+    let limited = read_records_from_parquet_with_limit(file_path, Some(1))
+        .expect("Failed to read Parquet with limit");
+
+    // We should have both neuron rows for obs 0.
+    assert_eq!(
+        limited.len(),
+        2,
+        "Expected all rows for the first accepted obs_index (0), even in neuron-first order"
+    );
+
+    // Ensure we only included obs 0.
+    assert!(
+        limited.iter().all(|r| r.obs_index == 0),
+        "All returned rows should be for obs_index 0"
+    );
+
+    let uuids: HashSet<String> = limited.into_iter().map(|r| r.neuron_uuid).collect();
+    assert!(uuids.contains("neuron-a"), "Missing neuron-a row for obs 0");
+    assert!(uuids.contains("neuron-b"), "Missing neuron-b row for obs 0");
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add JSON visualisation snapshot export from Parquet + creature (with impacts, synapse contributions, reconstruction checks), FFI/internal APIs, example CLI, robust Parquet limiting, and extensive tests with non-finite sanitization.
> 
> - **Export/Visualisation**:
>   - Add `src/export.rs` with `export_visualisation_snapshot` producing JSON snapshot (`meta`, `creature`, `recording`, `derived`).
>   - Includes per-neuron stats, per-synapse `contribution` series, impacts, and optional reconstruction checks; handles non-finite values safely.
> - **API/FFI**:
>   - New internal/FFI entrypoints `export_visualisation_snapshot_internal` and `extern "C" export_visualisation_snapshot`.
>   - Expose module via `pub mod export` and add example `examples/generate_snapshot.rs`.
> - **Parquet I/O**:
>   - Add `read_records_from_parquet_with_limit` and `read_all_records_from_parquet`; correct `max_obs` handling across row orderings.
> - **Focus/Impacts**:
>   - Compute impacts for all neurons (including inputs) in `focus.rs` for better visualisation.
> - **Types**:
>   - `NeuronJson` gains default `squash`; `SynapseJson` accepts `fromUUID`/`toUUID` aliases.
> - **Tests**:
>   - Add comprehensive tests for snapshot export, non-finite sanitization (errors/contributions), and Parquet limit ordering.
> - **Version**:
>   - Bump crate version to `0.2.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 020b582f42a1c89341d45ae4a9eebf54f12f6ddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->