### PR TITLE
Update version to 0.2.14 and enhance README and debugging capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1661,6 +1661,29 @@ Call graph:
 --- End of call graph (37 threads) ---
 ```
 
+**Important (unattended workers)**: `sample` is best-effort and has an internal timeout
+so it cannot hang your process forever while trying to print diagnostics.
+
+### Hang watchdog (unattended machines)
+
+Deadlocks are only one kind of hang. If the process becomes stuck (eg GPU driver wedge,
+wgpu call that never returns, or other kernel-level stall), you want the worker to crash
+so your orchestration can capture logs and restart.
+
+The library includes an optional stall watchdog that:
+- triggers a SIGUSR1 thread dump, then
+- aborts the process (so logs/crash reports are captured).
+
+Enable it with:
+
+```bash
+# Abort if discovery makes no progress for 30 minutes
+export NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS=1800
+
+# Optional: delay between SIGUSR1 dump and abort (default: 2 seconds)
+export NEAT_AI_DISCOVERY_WATCHDOG_ABORT_DELAY_SECS=2
+```
+
 **Note**: We use `SIGUSR1` (user-defined signal) which has no default action,
 making it safe for diagnostics. Java uses `SIGQUIT` (kill -3).
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -293,79 +293,124 @@ fn calculate_gpu_batch_timeout(deadline: &Option<std::time::SystemTime>) -> Dura
     }
 }
 
+/// Poll the GPU device until it has no work in flight, or a timeout is reached.
+///
+/// This intentionally avoids `Maintain::Wait` because that can block forever on
+/// some machines if the GPU driver wedges. Instead, we poll in a loop and bail
+/// out with an error so unattended workers can recover (or watchdog can abort).
+fn poll_device_until_idle(device: &wgpu::Device, timeout: Duration, label: &str) -> Result<()> {
+    use std::time::Instant;
+    let start = Instant::now();
+    loop {
+        let result = device.poll(wgpu::Maintain::Poll);
+        if result.is_queue_empty() {
+            return Ok(());
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow!(
+                "GPU device poll timed out after {:.1}s ({label}). The GPU driver may be unresponsive.",
+                timeout.as_secs_f64()
+            ));
+        }
+        // Short sleep to avoid busy-waiting.
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
 /// Wait for a GPU buffer mapping to complete.
 ///
-/// Uses `Maintain::Wait` which blocks until all submitted GPU work completes.
-/// This is the reliable way to wait for buffer mapping on all backends,
-/// especially Metal where non-blocking polls can fail to progress GPU work.
-///
-/// The timeout_secs parameter is for documentation and future use - currently
-/// timeouts are enforced at the work queue level (channel recv_timeout).
+/// We avoid `Maintain::Wait` because that can block forever on some machines if
+/// the GPU driver is wedged. Instead, we poll in a loop until the callback fires
+/// or the timeout is reached.
 fn wait_for_buffer_map(
     device: &wgpu::Device,
     receiver: &std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>,
-    _timeout_secs: u64,
+    timeout_secs: u64,
 ) -> Result<()> {
-    // Block until all GPU work completes - this is the reliable way to wait
-    // for buffer mapping on all backends, especially Metal/M4.
-    // Note: If GPU hangs, this blocks forever, but the work queue timeout
-    // at the channel level will fire and the main thread will continue.
-    device.poll(wgpu::Maintain::Wait);
+    use std::time::Instant;
 
-    // After Wait completes, the callback should have fired
-    match receiver.try_recv() {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(err)) => Err(anyhow!("Buffer mapping failed: {err}")),
-        Err(std::sync::mpsc::TryRecvError::Empty) => {
-            // This shouldn't happen after Maintain::Wait, but handle it
-            Err(anyhow!(
-                "Buffer mapping callback did not fire after device.poll(Wait). \
-                 This may indicate a GPU driver issue."
-            ))
+    let timeout = Duration::from_secs(timeout_secs);
+    let start = Instant::now();
+    loop {
+        match receiver.try_recv() {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(err)) => return Err(anyhow!("Buffer mapping failed: {err}")),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(anyhow!("GPU callback channel disconnected"));
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                // Not ready yet; keep polling.
+            }
         }
-        Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-            Err(anyhow!("GPU callback channel disconnected"))
+
+        let result = device.poll(wgpu::Maintain::Poll);
+        if result.is_queue_empty() && start.elapsed() > Duration::from_millis(250) {
+            // If the queue is empty but the callback hasn't fired, something is off.
+            // Keep trying until timeout, but this is a strong signal of driver trouble.
         }
+
+        if start.elapsed() > timeout {
+            return Err(anyhow!(
+                "GPU buffer mapping timed out after {:.1}s. The GPU driver may be unresponsive.",
+                timeout.as_secs_f64()
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
     }
 }
 
 /// Wait for multiple GPU buffer mappings to complete.
-///
-/// Uses `Maintain::Wait` which blocks until all submitted GPU work completes.
-/// This is the reliable way to wait for buffer mapping on all backends,
-/// especially Metal where non-blocking polls can fail to progress GPU work.
 fn wait_for_buffer_maps_batch(
     device: &wgpu::Device,
     receivers: &[std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>],
-    _timeout_secs: u64,
+    timeout_secs: u64,
 ) -> Result<()> {
     if receivers.is_empty() {
         return Ok(());
     }
 
-    // Block until all GPU work completes
-    device.poll(wgpu::Maintain::Wait);
+    use std::time::Instant;
 
-    // After Wait completes, all callbacks should have fired
-    for (i, receiver) in receivers.iter().enumerate() {
-        match receiver.try_recv() {
-            Ok(Ok(())) => {} // Buffer mapped successfully
-            Ok(Err(err)) => {
-                return Err(anyhow!("Buffer {i} mapping failed: {err}"));
+    let timeout = Duration::from_secs(timeout_secs);
+    let start = Instant::now();
+    let mut done: Vec<Option<Result<(), wgpu::BufferAsyncError>>> = vec![None; receivers.len()];
+
+    loop {
+        // Drain as many completion callbacks as possible.
+        for (i, receiver) in receivers.iter().enumerate() {
+            if done[i].is_some() {
+                continue;
             }
-            Err(std::sync::mpsc::TryRecvError::Empty) => {
-                return Err(anyhow!(
-                    "Buffer {i} mapping callback did not fire after device.poll(Wait). \
-                     This may indicate a GPU driver issue."
-                ));
-            }
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                return Err(anyhow!("Buffer {i} callback channel disconnected"));
+            match receiver.try_recv() {
+                Ok(result) => done[i] = Some(result),
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    return Err(anyhow!("Buffer {i} callback channel disconnected"));
+                }
             }
         }
-    }
 
-    Ok(())
+        if done.iter().all(|x| x.is_some()) {
+            // Validate all results.
+            for (i, result) in done.into_iter().enumerate() {
+                match result.expect("checked is_some") {
+                    Ok(()) => {}
+                    Err(err) => return Err(anyhow!("Buffer {i} mapping failed: {err}")),
+                }
+            }
+            return Ok(());
+        }
+
+        device.poll(wgpu::Maintain::Poll);
+
+        if start.elapsed() > timeout {
+            return Err(anyhow!(
+                "GPU batch buffer mapping timed out after {:.1}s. The GPU driver may be unresponsive.",
+                timeout.as_secs_f64()
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 /// Detected GPU performance tier for auto-tuning.
@@ -4266,9 +4311,15 @@ impl GpuAnalyzer {
         let (bias_layout, bias_pipeline) = Self::build_bias_pipeline(&device, "bias-pipeline");
 
         // CRITICAL: Warm up the GPU by polling to ensure all pipeline creation work is complete.
-        // On Metal/M4, the GPU can get into a bad state if we start submitting compute work
-        // before shader compilation has finished. This blocking poll ensures the GPU is ready.
-        device.poll(wgpu::Maintain::Wait);
+        //
+        // We intentionally avoid `Maintain::Wait` here because it can block forever if the
+        // GPU driver wedges on a specific machine. If this doesn't settle quickly, treat it
+        // as a GPU initialisation failure and return an error so callers can restart/skip.
+        poll_device_until_idle(
+            &device,
+            Duration::from_secs(GPU_INIT_TIMEOUT_SECS),
+            "GPU warm-up after pipeline creation",
+        )?;
 
         Ok(Self {
             device: Some(device),
@@ -4806,7 +4857,13 @@ impl GpuAnalyzer {
             // CRITICAL: Ensure Metal releases command buffers before creating new ones.
             // Without this, we can exhaust Metal's command buffer pool when processing
             // many batches, causing the GPU thread to hang in semaphore_wait_trap.
-            device.poll(wgpu::Maintain::Wait);
+            //
+            // Avoid an unbounded wait - bail out with an error if the driver is wedged.
+            poll_device_until_idle(
+                device,
+                Duration::from_secs(5),
+                "post-harmful-batch command buffer release",
+            )?;
         }
 
         Ok(all_results)
@@ -5522,7 +5579,13 @@ impl GpuAnalyzer {
             // CRITICAL: Ensure Metal releases command buffers before creating new ones.
             // Without this, we can exhaust Metal's command buffer pool when processing
             // many batches, causing the GPU thread to hang in semaphore_wait_trap.
-            device.poll(wgpu::Maintain::Wait);
+            //
+            // Avoid an unbounded wait - bail out with an error if the driver is wedged.
+            poll_device_until_idle(
+                device,
+                Duration::from_secs(5),
+                "post-helpful-batch command buffer release",
+            )?;
         }
 
         Ok(all_results)
@@ -7542,6 +7605,10 @@ pub(crate) fn analyze_neurons_with_cache(
                 return Ok(());
             }
 
+            crate::watchdog::beat(format!(
+                "neuron analysis → processing target {target_uuid}"
+            ));
+
             // Use the shared GPU work queue instead of creating a new GpuAnalyzer per thread.
             // This eliminates device creation overhead and improves GPU utilisation.
             let gpu = &*gpu_queue;
@@ -7900,8 +7967,12 @@ pub(crate) fn analyze_neurons_with_cache(
                 }
             }
 
-            // Track completion of this focus neuron for timeout reporting
-            completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            // Track completion of this focus neuron for timeout reporting.
+            let completed =
+                completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            crate::watchdog::beat(format!(
+                "neuron analysis → completed {completed}/{total_focus_count} (last target {target_uuid})"
+            ));
             Ok(())
         })?;
 
@@ -8752,6 +8823,10 @@ pub(crate) fn analyze_synapses_with_cache(
                 return Ok(());
             }
 
+            crate::watchdog::beat(format!(
+                "synapse analysis → processing target {target_uuid}"
+            ));
+
             // Use the shared GPU work queue instead of creating a new GpuAnalyzer per thread.
             // This eliminates device creation overhead and improves GPU utilisation.
             let gpu = &*gpu_queue;
@@ -9278,8 +9353,12 @@ pub(crate) fn analyze_synapses_with_cache(
                 }
             }
 
-            // Track completion of this focus neuron for timeout reporting
-            completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            // Track completion of this focus neuron for timeout reporting.
+            let completed =
+                completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            crate::watchdog::beat(format!(
+                "synapse analysis → completed {completed}/{total_focus_count} (last target {target_uuid})"
+            ));
             Ok(())
         })?;
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -43,6 +43,24 @@ use crate::{AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput};
 use anyhow::Result;
 use std::sync::Arc;
 
+fn run_optional_analysis<T>(
+    enabled: bool,
+    starting: &'static str,
+    finished: &'static str,
+    skipped: &'static str,
+    f: impl FnOnce() -> Result<T>,
+) -> Result<Option<T>> {
+    if enabled {
+        crate::watchdog::beat(starting);
+        let result = f()?;
+        crate::watchdog::beat(finished);
+        Ok(Some(result))
+    } else {
+        crate::watchdog::beat(skipped);
+        Ok(None)
+    }
+}
+
 /// Combined analysis function that runs both synapse and neuron analysis.
 pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Optional hang watchdog for unattended workers.
@@ -97,27 +115,27 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Run neuron analysis FIRST (priority), then synapse analysis.
     // Neuron discovery is more valuable as it can create new network structure.
     // With pre-loaded cache, both run fast, but neurons get priority if timeout approaches.
-    let neuron_result = if let Some(inner) = neuron_input.clone() {
-        crate::watchdog::beat("analysis::analyze_all → neuron analysis starting");
-        Some(implementation::analyze_neurons_with_cache(
-            &inner,
-            Arc::clone(&shared_cache),
-        )?)
-    } else {
-        None
-    };
-    crate::watchdog::beat("analysis::analyze_all → neuron analysis finished");
+    let neuron_result = run_optional_analysis(
+        neuron_input.is_some(),
+        "analysis::analyze_all → neuron analysis starting",
+        "analysis::analyze_all → neuron analysis finished",
+        "analysis::analyze_all → neuron analysis skipped",
+        || {
+            let inner = neuron_input.expect("checked is_some");
+            implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
+        },
+    )?;
 
-    let synapse_result = if let Some(inner) = synapse_input.clone() {
-        crate::watchdog::beat("analysis::analyze_all → synapse analysis starting");
-        Some(implementation::analyze_synapses_with_cache(
-            &inner,
-            Arc::clone(&shared_cache),
-        )?)
-    } else {
-        None
-    };
-    crate::watchdog::beat("analysis::analyze_all → synapse analysis finished");
+    let synapse_result = run_optional_analysis(
+        synapse_input.is_some(),
+        "analysis::analyze_all → synapse analysis starting",
+        "analysis::analyze_all → synapse analysis finished",
+        "analysis::analyze_all → synapse analysis skipped",
+        || {
+            let inner = synapse_input.expect("checked is_some");
+            implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
+        },
+    )?;
 
     Ok(AnalyzeAllResult {
         synapse: synapse_result,
@@ -130,3 +148,45 @@ pub use gpu::GpuAnalyzer;
 pub use gpu::GpuAvailabilityResult;
 pub use neuron::analyze_neurons;
 pub use synapse::analyze_synapses;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watchdog_beats_do_not_claim_finished_when_analysis_is_skipped() {
+        let _lock = crate::watchdog::lock_for_test_serialisation();
+        // Ensure a watchdog is active so `beat()` is observable in tests.
+        let wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+            stall_timeout: std::time::Duration::from_secs(60),
+            abort_delay: std::time::Duration::from_secs(1),
+        });
+
+        let skipped = "analysis::analyze_all → neuron analysis skipped";
+        let finished = "analysis::analyze_all → neuron analysis finished";
+
+        // When disabled, we should record "skipped" and never execute the closure.
+        let result: Option<()> =
+            run_optional_analysis(false, "starting", finished, skipped, || -> Result<()> {
+                unreachable!("disabled analysis closure must not run")
+            })
+            .expect("should not error");
+        assert!(result.is_none());
+        assert_eq!(
+            crate::watchdog::active_stage_for_test().as_deref(),
+            Some(skipped)
+        );
+
+        // When enabled, we should end on "finished".
+        let result: Option<()> =
+            run_optional_analysis(true, "starting", finished, "skipped", || Ok(()))
+                .expect("should not error");
+        assert!(result.is_some());
+        assert_eq!(
+            crate::watchdog::active_stage_for_test().as_deref(),
+            Some(finished)
+        );
+
+        drop(wd);
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -45,6 +45,10 @@ use std::sync::Arc;
 
 /// Combined analysis function that runs both synapse and neuron analysis.
 pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
+    // Optional hang watchdog for unattended workers.
+    // If enabled, this will emit a thread dump then abort the process if analysis stalls.
+    let _watchdog = crate::watchdog::start_from_env("analysis::analyze_all");
+
     let include_synapse = input.include_synapse_analysis.unwrap_or(true);
     let include_neuron = input.include_neuron_analysis.unwrap_or(true);
 
@@ -55,11 +59,14 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         });
     }
 
+    crate::watchdog::beat("analysis::analyze_all → loading parquet cache");
+
     // Pre-load ALL records from parquet in one pass. This is MUCH faster than
     // lazy-loading each neuron separately (1 scan vs ~2000 scans for large creatures).
     let shared_cache = Arc::new(implementation::RecordCache::new_adaptive(
         &input.parquet_file,
     )?);
+    crate::watchdog::beat("analysis::analyze_all → parquet cache loaded");
 
     let synapse_input = if include_synapse {
         Some(AnalyzeSynapsesInput {
@@ -91,6 +98,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Neuron discovery is more valuable as it can create new network structure.
     // With pre-loaded cache, both run fast, but neurons get priority if timeout approaches.
     let neuron_result = if let Some(inner) = neuron_input.clone() {
+        crate::watchdog::beat("analysis::analyze_all → neuron analysis starting");
         Some(implementation::analyze_neurons_with_cache(
             &inner,
             Arc::clone(&shared_cache),
@@ -98,8 +106,10 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     } else {
         None
     };
+    crate::watchdog::beat("analysis::analyze_all → neuron analysis finished");
 
     let synapse_result = if let Some(inner) = synapse_input.clone() {
+        crate::watchdog::beat("analysis::analyze_all → synapse analysis starting");
         Some(implementation::analyze_synapses_with_cache(
             &inner,
             Arc::clone(&shared_cache),
@@ -107,6 +117,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     } else {
         None
     };
+    crate::watchdog::beat("analysis::analyze_all → synapse analysis finished");
 
     Ok(AnalyzeAllResult {
         synapse: synapse_result,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -212,28 +212,75 @@ fn dump_all_threads() {
 /// Run macOS `sample` command to capture all thread backtraces.
 #[cfg(target_os = "macos")]
 fn run_sample_command(pid: u32) {
-    use std::process::Command;
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
 
-    // Run sample for 1 millisecond to get a snapshot (not a profile)
-    let output = Command::new("sample")
+    // IMPORTANT: This must NEVER hang. It's used for debugging stuck processes.
+    //
+    // On some macOS installs, `sample` can itself hang (eg if the kernel is under
+    // extreme pressure or a driver is wedged). If we block here, we make the
+    // original hang harder to diagnose on unattended machines.
+    const SAMPLE_TIMEOUT_SECS: u64 = 5;
+
+    // Run sample for 1 second to get a snapshot (not a profile).
+    // Note: We use `-mayDie` to avoid requiring elevated permissions.
+    let mut child = match Command::new("sample")
         .args([&pid.to_string(), "1", "-mayDie"])
-        .output();
-
-    match output {
-        Ok(result) => {
-            if result.status.success() {
-                let stdout = String::from_utf8_lossy(&result.stdout);
-                // Filter to show the most relevant parts
-                print_filtered_sample_output(&stdout);
-            } else {
-                let stderr = String::from_utf8_lossy(&result.stderr);
-                eprintln!("'sample' command failed: {stderr}");
-                eprintln!("Try manually: sample {pid} 1 -file /tmp/sample.txt");
-            }
-        }
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
         Err(e) => {
             eprintln!("Failed to run 'sample': {e}");
             eprintln!("Try manually: sample {pid} 1 -file /tmp/sample.txt");
+            return;
+        }
+    };
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = Vec::new();
+                let mut stderr = Vec::new();
+
+                if let Some(mut out) = child.stdout.take() {
+                    let _ = out.read_to_end(&mut stdout);
+                }
+                if let Some(mut err) = child.stderr.take() {
+                    let _ = err.read_to_end(&mut stderr);
+                }
+
+                if status.success() {
+                    let stdout = String::from_utf8_lossy(&stdout);
+                    // Filter to show the most relevant parts.
+                    print_filtered_sample_output(&stdout);
+                } else {
+                    let stderr = String::from_utf8_lossy(&stderr);
+                    eprintln!("'sample' command failed: {stderr}");
+                    eprintln!("Try manually: sample {pid} 1 -file /tmp/sample.txt");
+                }
+                return;
+            }
+            Ok(None) => {
+                if start.elapsed() > Duration::from_secs(SAMPLE_TIMEOUT_SECS) {
+                    eprintln!(
+                        "[NEAT-AI-Discovery][debug] WARNING: 'sample' did not exit within {SAMPLE_TIMEOUT_SECS}s. \
+                         Skipping thread dump capture to avoid hanging the process."
+                    );
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return;
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                eprintln!("Failed to run 'sample': {e}");
+                eprintln!("Try manually: sample {pid} 1 -file /tmp/sample.txt");
+                return;
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod parquet_format;
 pub mod record;
 pub mod streaming;
 pub mod types;
+mod watchdog;
 
 use anyhow::Result;
 use once_cell::sync::OnceCell;

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,0 +1,258 @@
+//! Process hang watchdog.
+//!
+//! This is designed for unattended discovery workers where "hang forever" is worse than
+//! a crash. When enabled, the watchdog monitors a heartbeat and will:
+//! - trigger a SIGUSR1 thread dump (if available), then
+//! - abort the process so orchestration can capture logs and restart.
+//!
+//! Configuration is via environment variables so callers can tune per machine:
+//! - `NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS` (u64): If set > 0, enables the watchdog and
+//!   triggers if no heartbeat occurs for this many seconds.
+//! - `NEAT_AI_DISCOVERY_WATCHDOG_ABORT_DELAY_SECS` (u64): Delay between requesting a thread
+//!   dump and aborting (default: 2 seconds).
+//!
+//! Notes:
+//! - We use `abort()` rather than `panic!()` because the library is commonly used through
+//!   Deno FFI entrypoints that wrap calls in `catch_unwind()`. A panic would be caught and
+//!   returned as JSON, but would not terminate the worker process.
+//! - All comments are written in Australian English.
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Global watchdog heartbeat state (if watchdog is enabled for the current operation).
+static ACTIVE: Lazy<Mutex<Option<Arc<BeatState>>>> = Lazy::new(|| Mutex::new(None));
+
+/// Watchdog configuration loaded from environment variables.
+#[derive(Debug, Clone)]
+pub(crate) struct WatchdogConfig {
+    pub(crate) stall_timeout: Duration,
+    pub(crate) abort_delay: Duration,
+}
+
+impl WatchdogConfig {
+    /// Load watchdog configuration from environment variables.
+    ///
+    /// Returns `None` when watchdog is disabled.
+    pub(crate) fn from_env() -> Option<Self> {
+        let stall_secs = std::env::var("NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        if stall_secs == 0 {
+            return None;
+        }
+
+        let abort_delay_secs = std::env::var("NEAT_AI_DISCOVERY_WATCHDOG_ABORT_DELAY_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(2);
+
+        Some(Self {
+            stall_timeout: Duration::from_secs(stall_secs),
+            abort_delay: Duration::from_secs(abort_delay_secs),
+        })
+    }
+}
+
+/// Update the watchdog heartbeat if a watchdog is currently active.
+///
+/// This is intentionally a no-op when watchdog is disabled, so call sites can keep
+/// instrumentation cheap and simple.
+pub(crate) fn beat(stage: impl Into<String>) {
+    let guard = ACTIVE.lock();
+    let Some(state) = guard.as_ref() else {
+        return;
+    };
+    state.beat(stage.into());
+}
+
+/// Start a watchdog if enabled via environment variables.
+///
+/// Returns a handle that must be kept alive for the duration of the operation.
+pub(crate) fn start_from_env(initial_stage: &str) -> Option<Watchdog> {
+    let config = WatchdogConfig::from_env()?;
+    let wd = Watchdog::start(config);
+    beat(initial_stage.to_string());
+    Some(wd)
+}
+
+struct BeatState {
+    last_beat_ms: AtomicU64,
+    stage: Mutex<String>,
+}
+
+impl BeatState {
+    fn new(initial_stage: &str) -> Self {
+        Self {
+            last_beat_ms: AtomicU64::new(monotonic_ms()),
+            stage: Mutex::new(initial_stage.to_string()),
+        }
+    }
+
+    fn beat(&self, stage: String) {
+        *self.stage.lock() = stage;
+        self.last_beat_ms.store(monotonic_ms(), Ordering::Relaxed);
+    }
+}
+
+/// A handle used to refresh the watchdog heartbeat and provide context.
+///
+/// If this handle is dropped, the watchdog thread is requested to stop (best effort).
+pub(crate) struct Watchdog {
+    stop: Arc<AtomicBool>,
+    state: Arc<BeatState>,
+    _thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Watchdog {
+    pub(crate) fn start(config: WatchdogConfig) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(BeatState::new("initialising"));
+
+        // Make this watchdog globally available for lightweight instrumentation.
+        *ACTIVE.lock() = Some(Arc::clone(&state));
+
+        let thread_stop = Arc::clone(&stop);
+        let thread_state = Arc::clone(&state);
+
+        let handle = thread::Builder::new()
+            .name("hang-watchdog".to_string())
+            .spawn(move || watchdog_loop(config, thread_stop, thread_state))
+            .ok();
+
+        Self {
+            stop,
+            state,
+            _thread: handle,
+        }
+    }
+}
+
+impl Drop for Watchdog {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        // Clear the active global watchdog (best effort; only if it's the same instance).
+        let mut active = ACTIVE.lock();
+        if let Some(current) = active.as_ref() {
+            if Arc::ptr_eq(current, &self.state) {
+                *active = None;
+            }
+        }
+        if let Some(handle) = self._thread.take() {
+            // Best effort join; if something is wrong, don't block here.
+            let _ = handle.join();
+        }
+    }
+}
+
+fn watchdog_loop(config: WatchdogConfig, stop: Arc<AtomicBool>, state: Arc<BeatState>) {
+    // Poll periodically; we don't need high resolution.
+    let poll_every = Duration::from_secs(5).min(config.stall_timeout.max(Duration::from_secs(1)));
+
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let now_ms = monotonic_ms();
+        let last_ms = state.last_beat_ms.load(Ordering::Relaxed);
+
+        let elapsed_ms = now_ms.saturating_sub(last_ms);
+        if elapsed_ms >= config.stall_timeout.as_millis() as u64 {
+            let current_stage = state.stage.lock().clone();
+
+            eprintln!("\n{}", "=".repeat(80));
+            eprintln!("[NEAT-AI-Discovery] WATCHDOG STALL DETECTED");
+            eprintln!(
+                "[NEAT-AI-Discovery] No progress heartbeat for {:.1} minutes (stall timeout = {:.1} minutes).",
+                elapsed_ms as f64 / 1000.0 / 60.0,
+                config.stall_timeout.as_secs_f64() / 60.0
+            );
+            eprintln!("[NEAT-AI-Discovery] Last known stage: {current_stage}");
+            eprintln!(
+                "[NEAT-AI-Discovery] Triggering SIGUSR1 thread dump, then aborting in {:.1} seconds.",
+                config.abort_delay.as_secs_f64()
+            );
+            eprintln!("{}", "=".repeat(80));
+
+            // Trigger a thread dump if supported (Unix). This is best-effort.
+            #[cfg(unix)]
+            {
+                use signal_hook::consts::SIGUSR1;
+                let _ = signal_hook::low_level::raise(SIGUSR1);
+            }
+
+            thread::sleep(config.abort_delay);
+
+            // Abort the process so orchestration captures logs and restarts.
+            //
+            // We intentionally do NOT panic here because most FFI entrypoints use
+            // `catch_unwind()`, which would swallow a panic and keep the worker alive.
+            std::process::abort();
+        }
+
+        thread::sleep(poll_every);
+    }
+}
+
+fn monotonic_ms() -> u64 {
+    // `Instant` is monotonic but not directly representable as a duration since epoch.
+    // We emulate a monotonic counter using a static start.
+    static START: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+    let start = START.get_or_init(Instant::now);
+    start.elapsed().as_millis().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Basic smoke test: config parsing should disable when env var missing.
+    #[test]
+    fn watchdog_config_disabled_by_default() {
+        std::env::remove_var("NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS");
+        assert!(WatchdogConfig::from_env().is_none());
+    }
+
+    /// Test the heartbeat machinery without aborting the process by running the loop logic
+    /// with an injected "abort" path.
+    ///
+    /// We keep this as a unit test to avoid exposing watchdog internals as public API.
+    #[test]
+    fn watchdog_heartbeat_updates_stage_and_timestamp() {
+        let cfg = WatchdogConfig {
+            stall_timeout: Duration::from_secs(60),
+            abort_delay: Duration::from_secs(1),
+        };
+
+        let wd = Watchdog::start(cfg);
+        beat("stage A");
+        let a = wd.state.last_beat_ms.load(Ordering::Relaxed);
+        assert!(!wd.state.stage.lock().is_empty());
+
+        thread::sleep(Duration::from_millis(10));
+        beat("stage B");
+        let b = wd.state.last_beat_ms.load(Ordering::Relaxed);
+        assert!(b >= a);
+        assert_eq!(&*wd.state.stage.lock(), "stage B");
+    }
+
+    /// Regression guard: `monotonic_ms` should be non-decreasing.
+    #[test]
+    fn monotonic_ms_is_monotonic() {
+        let mut last = monotonic_ms();
+        for _ in 0..10 {
+            let now = monotonic_ms();
+            assert!(now >= last);
+            last = now;
+        }
+    }
+}

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -84,6 +84,26 @@ pub(crate) fn start_from_env(initial_stage: &str) -> Option<Watchdog> {
     Some(wd)
 }
 
+/// Test-only global lock to prevent parallel tests from racing on the global ACTIVE state.
+#[cfg(test)]
+static TEST_SERIAL: Lazy<parking_lot::Mutex<()>> = Lazy::new(|| parking_lot::Mutex::new(()));
+
+/// Acquire the test-only serialisation lock (used by tests that touch global watchdog state).
+#[cfg(test)]
+pub(crate) fn lock_for_test_serialisation() -> parking_lot::MutexGuard<'static, ()> {
+    TEST_SERIAL.lock()
+}
+
+/// Test-only helper to read the current watchdog stage (if any).
+///
+/// This is intentionally `pub(crate)` and only compiled for tests so we don't expose
+/// watchdog internals as part of the public API.
+#[cfg(test)]
+pub(crate) fn active_stage_for_test() -> Option<String> {
+    let guard = ACTIVE.lock();
+    guard.as_ref().map(|state| state.stage.lock().clone())
+}
+
 struct BeatState {
     last_beat_ms: AtomicU64,
     stage: Mutex<String>,
@@ -140,14 +160,23 @@ impl Drop for Watchdog {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         // Clear the active global watchdog (best effort; only if it's the same instance).
-        let mut active = ACTIVE.lock();
-        if let Some(current) = active.as_ref() {
-            if Arc::ptr_eq(current, &self.state) {
-                *active = None;
+        //
+        // IMPORTANT: Do not hold the global ACTIVE lock while joining the watchdog thread.
+        // The watchdog thread can sleep for up to `poll_every` (currently up to 5 seconds),
+        // and other threads calling `beat()` should not be blocked for that duration.
+        {
+            let mut active = ACTIVE.lock();
+            if let Some(current) = active.as_ref() {
+                if Arc::ptr_eq(current, &self.state) {
+                    *active = None;
+                }
             }
         }
         if let Some(handle) = self._thread.take() {
-            // Best effort join; if something is wrong, don't block here.
+            // Best effort join.
+            //
+            // Note: This may block until the watchdog thread wakes up and observes `stop`.
+            // However, we intentionally avoid holding any global locks while waiting.
             let _ = handle.join();
         }
     }
@@ -218,6 +247,7 @@ mod tests {
     /// Basic smoke test: config parsing should disable when env var missing.
     #[test]
     fn watchdog_config_disabled_by_default() {
+        let _lock = lock_for_test_serialisation();
         std::env::remove_var("NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS");
         assert!(WatchdogConfig::from_env().is_none());
     }
@@ -228,6 +258,7 @@ mod tests {
     /// We keep this as a unit test to avoid exposing watchdog internals as public API.
     #[test]
     fn watchdog_heartbeat_updates_stage_and_timestamp() {
+        let _lock = lock_for_test_serialisation();
         let cfg = WatchdogConfig {
             stall_timeout: Duration::from_secs(60),
             abort_delay: Duration::from_secs(1),
@@ -248,11 +279,57 @@ mod tests {
     /// Regression guard: `monotonic_ms` should be non-decreasing.
     #[test]
     fn monotonic_ms_is_monotonic() {
+        let _lock = lock_for_test_serialisation();
         let mut last = monotonic_ms();
         for _ in 0..10 {
             let now = monotonic_ms();
             assert!(now >= last);
             last = now;
         }
+    }
+
+    /// Regression test: dropping a watchdog must not hold the global ACTIVE lock while it
+    /// waits for the watchdog thread to exit.
+    ///
+    /// Without this, a concurrent `beat()` from another thread can block for up to the
+    /// watchdog thread's sleep interval (currently up to 5 seconds), which contradicts the
+    /// intent of lightweight instrumentation.
+    #[test]
+    fn drop_does_not_block_beat_on_active_lock() {
+        let _lock = lock_for_test_serialisation();
+
+        let cfg = WatchdogConfig {
+            stall_timeout: Duration::from_secs(60),
+            abort_delay: Duration::from_secs(1),
+        };
+
+        let wd = Watchdog::start(cfg);
+
+        // Give the watchdog thread a chance to start and enter its sleep loop so `join()`
+        // is likely to block for a noticeable period.
+        thread::sleep(Duration::from_millis(100));
+
+        // Drop the watchdog on another thread so we can call `beat()` concurrently.
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        thread::spawn(move || {
+            drop(wd);
+            let _ = tx.send(());
+        });
+
+        // Small delay to increase the chance that the drop thread has reached `join()`.
+        thread::sleep(Duration::from_millis(20));
+
+        let start = std::time::Instant::now();
+        beat("concurrent beat during drop");
+        let elapsed = start.elapsed();
+
+        // If the ACTIVE lock is incorrectly held across `join()`, this can take ~5 seconds.
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "beat() was blocked for {elapsed:?}; drop() may be holding ACTIVE lock while joining"
+        );
+
+        // Ensure the drop thread completed (avoid a detached thread lingering in the test).
+        let _ = rx.recv_timeout(Duration::from_secs(10));
     }
 }


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.13 to 0.2.14.
- Add detailed instructions in README for enabling a hang watchdog to prevent process stalls on unattended machines.
- Improve the `run_sample_command` function in `src/debug.rs` to include a timeout mechanism, ensuring it does not hang indefinitely.
- Introduce a new `watchdog` module to manage process monitoring and logging during analysis tasks.

These changes enhance the robustness of the library by providing better diagnostics and preventing hangs during execution, particularly in unattended environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness on unattended machines and prevents indefinite hangs.
> 
> - Introduces `watchdog` module (env-configured) that heartbeats via `watchdog::beat`, dumps threads on stall (SIGUSR1), then aborts; wired into `analysis::analyze_all` and key analysis loops; adds unit tests
> - Replaces `device.poll(Maintain::Wait)` with non-blocking polling + timeouts: new `poll_device_until_idle`, updated `wait_for_buffer_map` and `wait_for_buffer_maps_batch`; applies after pipeline creation and between GPU batches to avoid deadlocks
> - Hardens macOS `run_sample_command` with a short timeout and safe process handling so thread dumps can’t hang
> - Bumps crate to `0.2.14` and documents the watchdog usage in `README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b1eeb46b6812b5b8509abcbaf4f105f35fff9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->