### PR TITLE
Update version to 0.2.15 and introduce activations module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 
 [lib]

--- a/src/activations.rs
+++ b/src/activations.rs
@@ -155,11 +155,20 @@ pub fn apply_scalar_squash(name: &str, x: f32) -> Option<f32> {
             }
         }
         "LOGSIGMOID" => {
-            // -ln(1 + exp(-x)), with overflow protection.
-            if x <= -LN_F32_MAX {
-                Some(f32::MIN)
+            // LOGSIGMOID(x) = -ln(1 + exp(-x))
+            //
+            // Numerically-stable formulation (important for f32):
+            // - For x >= 0:  -ln(1 + exp(-x))        = -ln1p(exp(-x))  (no overflow; exp(-x) <= 1)
+            // - For x < 0:   -ln(1 + exp(-x))
+            //              = -ln(exp(-x) * (1 + exp(x)))
+            //              = -(-x + ln(1 + exp(x)))
+            //              = x - ln1p(exp(x))        (no overflow; exp(x) <= 1)
+            //
+            // This also preserves the correct asymptote: LOGSIGMOID(x) → x as x → -∞.
+            if x >= 0.0 {
+                Some(-(-x).exp().ln_1p())
             } else {
-                Some(-(1.0 + (-x).exp()).ln())
+                Some(x - x.exp().ln_1p())
             }
         }
         "MISH" => {
@@ -268,10 +277,11 @@ pub fn target_simulation_fn(name: &str) -> Option<fn(f32) -> f32> {
             }
         }),
         "LOGSIGMOID" => Some(|x| {
-            if x <= -LN_F32_MAX {
-                f32::MIN
+            // See `apply_scalar_squash` for derivation.
+            if x >= 0.0 {
+                -(-x).exp().ln_1p()
             } else {
-                -(1.0 + (-x).exp()).ln()
+                x - x.exp().ln_1p()
             }
         }),
         "MISH" => Some(|x| {

--- a/src/activations.rs
+++ b/src/activations.rs
@@ -1,0 +1,324 @@
+//! Activation (squash) functions and name handling.
+//!
+//! This module exists to keep squash name handling consistent between:
+//! - the TypeScript `NEAT-AI` activation registry (`src/methods/activations`), and
+//! - this Rust discovery library.
+//!
+//! Why this matters (Dec 2025):
+//! - Discovery records store `value` (pre-activation) and `activation` (post-squash) for each neuron.
+//! - Our analysis uses **value-domain** errors (see README: "VALUE domain error interpretation").
+//! - To make meaningful predictions for *any* target squash (not just ReLU/TANH families),
+//!   we must be able to re-apply the target squash when simulating candidate contributions.
+//!
+//! Notes:
+//! - Some "activations" in NEAT-AI are actually **aggregate** neurons (eg MINIMUM/MAXIMUM/IF/HYPOT)
+//!   which cannot be expressed as a pure `f(value)`; we treat them as non-scalar here.
+//! - Name matching is case-insensitive and includes NEAT-AI aliases (eg CLIPPED, RELU, INVERSE, SINUSOID).
+
+use std::borrow::Cow;
+
+/// Uppercase, canonical-ish name for an activation.
+///
+/// We normalise to an uppercase string so matching is case-insensitive and robust to
+/// historical naming differences between projects (eg `Softplus` vs `SOFTPLUS`).
+pub fn normalise_squash_name(name: &str) -> Cow<'_, str> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Cow::Borrowed("");
+    }
+    // Fast path: already uppercase ASCII.
+    if trimmed.bytes().all(|b| !b.is_ascii_lowercase()) {
+        return Cow::Borrowed(trimmed);
+    }
+    Cow::Owned(trimmed.to_ascii_uppercase())
+}
+
+/// Returns true if this library explicitly recognises the squash name (including aliases).
+///
+/// This does **not** mean we can perfectly simulate it as `f(value)` (aggregate squashes are
+/// recognised but not scalar), only that we won't treat it as "unknown".
+pub fn is_known_squash_name(name: &str) -> bool {
+    let n = normalise_squash_name(name);
+    matches!(
+        n.as_ref(),
+        // --- Core scalar squashes (types/) ---
+        "ABSOLUTE"
+            | "ARCTAN"
+            | "BENT_IDENTITY"
+            | "BIPOLAR"
+            | "BIPOLAR_SIGMOID"
+            | "COMPLEMENT"
+            | "INVERSE" // alias for COMPLEMENT
+            | "COSINE"
+            | "CUBE"
+            | "ELU"
+            | "EXPONENTIAL"
+            | "GAUSSIAN"
+            | "GELU"
+            | "HARD_TANH"
+            | "CLIPPED" // alias for HARD_TANH
+            | "IDENTITY"
+            | "ISRU"
+            | "LEAKYRELU"
+            | "LOGISTIC"
+            | "LOGSIGMOID"
+            | "MISH"
+            | "RELU"
+            | "RELU6"
+            | "SELU"
+            | "SINE"
+            | "SINUSOID" // alias for SINE
+            | "SOFTPLUS"
+            | "SOFTSIGN"
+            | "SQRT"
+            | "SQUARE"
+            | "STDINVERSE"
+            | "STEP"
+            | "SWISH"
+            | "TAN"
+            | "TANH"
+            // --- Aggregate-ish squashes (aggregate/, deprecated/, etc.) ---
+            | "IF"
+            | "MAXIMUM"
+            | "MINIMUM"
+            | "MEAN"
+            | "HYPOT"
+            | "HYPOTV2"
+    )
+}
+
+/// Returns true if the squash is an *aggregate* neuron (not a pure `f(value)`).
+pub fn is_aggregate_squash(name: &str) -> bool {
+    let n = normalise_squash_name(name);
+    matches!(
+        n.as_ref(),
+        "IF" | "MAXIMUM" | "MINIMUM" | "MEAN" | "HYPOT" | "HYPOTV2"
+    )
+}
+
+/// Apply a scalar squash `f(x)` for the given activation name.
+///
+/// Returns `None` for aggregate squashes (eg MINIMUM/MAXIMUM/IF/HYPOT) because they are not
+/// representable as a simple scalar function of a pre-activation value.
+pub fn apply_scalar_squash(name: &str, x: f32) -> Option<f32> {
+    let n = normalise_squash_name(name);
+    match n.as_ref() {
+        "ABSOLUTE" => Some(x.abs()),
+        "ARCTAN" => Some(x.atan()),
+        "BENT_IDENTITY" => Some(((x * x + 1.0).sqrt() - 1.0) / 2.0 + x),
+        "BIPOLAR" => Some(if x > 0.0 { 1.0 } else { -1.0 }),
+        "BIPOLAR_SIGMOID" => Some(2.0 / (1.0 + (-x).exp()) - 1.0),
+        "COMPLEMENT" | "INVERSE" => Some(1.0 - x),
+        "COSINE" => Some(x.cos()),
+        "CUBE" => Some(x * x * x),
+        "ELU" => Some(if x >= 0.0 { x } else { x.exp() - 1.0 }),
+        "EXPONENTIAL" => {
+            // Match NEAT-AI's safety behaviour: avoid overflow when exp(x) would blow up.
+            if x >= 709.0 {
+                Some(f32::MAX)
+            } else {
+                Some(x.exp())
+            }
+        }
+        "GAUSSIAN" => {
+            // Match NEAT-AI: clamp to abs(x) <= 100 to avoid underflow noise.
+            let safe_x = x.abs().min(100.0);
+            Some((-safe_x * safe_x).exp())
+        }
+        "GELU" => {
+            // GELU(x) ≈ 0.5x(1 + tanh(√(2/π)(x + 0.044715x^3)))
+            let x3 = x * x * x;
+            let tanh_arg = 0.797_884_6_f32 * (x + 0.044_715_f32 * x3);
+            Some(0.5 * x * (1.0 + tanh_arg.tanh()))
+        }
+        "HARD_TANH" | "CLIPPED" => Some(x.clamp(-1.0, 1.0)),
+        "IDENTITY" => Some(x),
+        "ISRU" => {
+            // NEAT-AI uses α=1.0: x / sqrt(1 + x^2)
+            Some(x / (1.0 + x * x).sqrt())
+        }
+        "LEAKYRELU" => Some(if x >= 0.0 { x } else { 0.01 * x }),
+        "LOGISTIC" => {
+            // Numerically stable logistic.
+            if x >= 0.0 {
+                Some(1.0 / (1.0 + (-x).exp()))
+            } else {
+                let exp_x = x.exp();
+                Some(exp_x / (1.0 + exp_x))
+            }
+        }
+        "LOGSIGMOID" => {
+            // -ln(1 + exp(-x)), with overflow protection.
+            if x <= -709.0 {
+                Some(f32::MIN)
+            } else {
+                Some(-(1.0 + (-x).exp()).ln())
+            }
+        }
+        "MISH" => {
+            // Mish(x) = x * tanh(softplus(x))
+            let sp = if x > 20.0 { x } else { (1.0 + x.exp()).ln() };
+            Some(x * sp.tanh())
+        }
+        "RELU" => Some(x.max(0.0)),
+        "RELU6" => Some(x.clamp(0.0, 6.0)),
+        "SELU" => {
+            // Standard SELU parameters.
+            const ALPHA: f32 = 1.673_263_2;
+            const LAMBDA: f32 = 1.050_701;
+            Some(if x >= 0.0 {
+                LAMBDA * x
+            } else {
+                LAMBDA * ALPHA * (x.exp() - 1.0)
+            })
+        }
+        "SINE" | "SINUSOID" => Some(x.sin()),
+        "SOFTPLUS" => {
+            // Match NEAT-AI: linearise beyond ~20 to avoid ln(1+exp(x)) overflow.
+            Some(if x > 20.0 { x } else { (1.0 + x.exp()).ln() })
+        }
+        "SOFTSIGN" => Some(x / (1.0 + x.abs())),
+        "SQRT" => Some(if x.is_finite() && x >= 0.0 {
+            x.sqrt()
+        } else {
+            0.0
+        }),
+        "SQUARE" => Some(x * x),
+        "STDINVERSE" => {
+            // Match NEAT-AI `StdInverse.squash()` behaviour: 1/x with epsilon protection.
+            let eps = 1e-15_f32;
+            let safe_x = if x.abs() < eps {
+                if x >= 0.0 {
+                    eps
+                } else {
+                    -eps
+                }
+            } else {
+                x
+            };
+            Some(1.0 / safe_x)
+        }
+        "STEP" => Some(if x > 0.0 { 1.0 } else { 0.0 }),
+        "SWISH" => {
+            // Swish(x) = x * sigmoid(x)
+            let sigmoid = if x >= 0.0 {
+                1.0 / (1.0 + (-x).exp())
+            } else {
+                let exp_x = x.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            Some(x * sigmoid)
+        }
+        "TAN" => Some(x.tan()),
+        "TANH" => Some(x.tanh()),
+
+        // Aggregate or unknown.
+        _ => None,
+    }
+}
+
+/// Returns a function pointer for target simulation.
+///
+/// This is a subset of `apply_scalar_squash` for performance: it returns `fn(f32) -> f32`
+/// so hot loops can avoid repeated string matching.
+///
+/// Notes:
+/// - We intentionally return `None` for aggregate squashes.
+/// - We also return `None` for STEP because Discovery uses a dedicated threshold-crossing model
+///   (see README: "Threshold-crossing model for STEP/BIPOLAR"). Treating STEP as smooth is misleading.
+pub fn target_simulation_fn(name: &str) -> Option<fn(f32) -> f32> {
+    let n = normalise_squash_name(name);
+    match n.as_ref() {
+        "ABSOLUTE" => Some(|x| x.abs()),
+        "ARCTAN" => Some(|x| x.atan()),
+        "BENT_IDENTITY" => Some(|x| ((x * x + 1.0).sqrt() - 1.0) / 2.0 + x),
+        "BIPOLAR" => Some(|x| if x > 0.0 { 1.0 } else { -1.0 }),
+        "BIPOLAR_SIGMOID" => Some(|x| 2.0 / (1.0 + (-x).exp()) - 1.0),
+        "COMPLEMENT" | "INVERSE" => Some(|x| 1.0 - x),
+        "COSINE" => Some(|x| x.cos()),
+        "CUBE" => Some(|x| x * x * x),
+        "ELU" => Some(|x| if x >= 0.0 { x } else { x.exp() - 1.0 }),
+        "EXPONENTIAL" => Some(|x| if x >= 709.0 { f32::MAX } else { x.exp() }),
+        "GAUSSIAN" => Some(|x| {
+            let safe_x = x.abs().min(100.0);
+            (-safe_x * safe_x).exp()
+        }),
+        "GELU" => Some(|x| {
+            let x3 = x * x * x;
+            let tanh_arg = 0.797_884_6_f32 * (x + 0.044_715_f32 * x3);
+            0.5 * x * (1.0 + tanh_arg.tanh())
+        }),
+        "HARD_TANH" | "CLIPPED" => Some(|x| x.clamp(-1.0, 1.0)),
+        "IDENTITY" => Some(|x| x),
+        "ISRU" => Some(|x| x / (1.0 + x * x).sqrt()),
+        "LEAKYRELU" => Some(|x| if x >= 0.0 { x } else { 0.01 * x }),
+        "LOGISTIC" => Some(|x| {
+            if x >= 0.0 {
+                1.0 / (1.0 + (-x).exp())
+            } else {
+                let exp_x = x.exp();
+                exp_x / (1.0 + exp_x)
+            }
+        }),
+        "LOGSIGMOID" => Some(|x| {
+            if x <= -709.0 {
+                f32::MIN
+            } else {
+                -(1.0 + (-x).exp()).ln()
+            }
+        }),
+        "MISH" => Some(|x| {
+            let sp = if x > 20.0 { x } else { (1.0 + x.exp()).ln() };
+            x * sp.tanh()
+        }),
+        "RELU" => Some(|x| x.max(0.0)),
+        "RELU6" => Some(|x| x.clamp(0.0, 6.0)),
+        "SELU" => Some(|x| {
+            const ALPHA: f32 = 1.673_263_2;
+            const LAMBDA: f32 = 1.050_701;
+            if x >= 0.0 {
+                LAMBDA * x
+            } else {
+                LAMBDA * ALPHA * (x.exp() - 1.0)
+            }
+        }),
+        "SINE" | "SINUSOID" => Some(|x| x.sin()),
+        "SOFTPLUS" => Some(|x| if x > 20.0 { x } else { (1.0 + x.exp()).ln() }),
+        "SOFTSIGN" => Some(|x| x / (1.0 + x.abs())),
+        "SQRT" => Some(|x| {
+            if x.is_finite() && x >= 0.0 {
+                x.sqrt()
+            } else {
+                0.0
+            }
+        }),
+        "SQUARE" => Some(|x| x * x),
+        "STDINVERSE" => Some(|x| {
+            let eps = 1e-15_f32;
+            let safe_x = if x.abs() < eps {
+                if x >= 0.0 {
+                    eps
+                } else {
+                    -eps
+                }
+            } else {
+                x
+            };
+            1.0 / safe_x
+        }),
+        // STEP handled via threshold-crossing model.
+        "STEP" => None,
+        "SWISH" => Some(|x| {
+            let sigmoid = if x >= 0.0 {
+                1.0 / (1.0 + (-x).exp())
+            } else {
+                let exp_x = x.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            x * sigmoid
+        }),
+        "TAN" => Some(|x| x.tan()),
+        "TANH" => Some(|x| x.tanh()),
+        _ => None,
+    }
+}

--- a/src/activations.rs
+++ b/src/activations.rs
@@ -17,6 +17,12 @@
 
 use std::borrow::Cow;
 
+/// Natural logarithm of the largest finite `f32`.
+///
+/// `ln(f32::MAX) ≈ 88.72`, so using `88.0` as a conservative cutoff prevents `exp(x)`
+/// overflow from producing `inf` for `f32` inputs.
+const LN_F32_MAX: f32 = 88.0;
+
 /// Uppercase, canonical-ish name for an activation.
 ///
 /// We normalise to an uppercase string so matching is case-insensitive and robust to
@@ -114,7 +120,8 @@ pub fn apply_scalar_squash(name: &str, x: f32) -> Option<f32> {
         "ELU" => Some(if x >= 0.0 { x } else { x.exp() - 1.0 }),
         "EXPONENTIAL" => {
             // Match NEAT-AI's safety behaviour: avoid overflow when exp(x) would blow up.
-            if x >= 709.0 {
+            // Note: this is `f32`, so the safe cutoff is `ln(f32::MAX)` (not `ln(f64::MAX)`).
+            if x >= LN_F32_MAX {
                 Some(f32::MAX)
             } else {
                 Some(x.exp())
@@ -149,7 +156,7 @@ pub fn apply_scalar_squash(name: &str, x: f32) -> Option<f32> {
         }
         "LOGSIGMOID" => {
             // -ln(1 + exp(-x)), with overflow protection.
-            if x <= -709.0 {
+            if x <= -LN_F32_MAX {
                 Some(f32::MIN)
             } else {
                 Some(-(1.0 + (-x).exp()).ln())
@@ -238,7 +245,7 @@ pub fn target_simulation_fn(name: &str) -> Option<fn(f32) -> f32> {
         "COSINE" => Some(|x| x.cos()),
         "CUBE" => Some(|x| x * x * x),
         "ELU" => Some(|x| if x >= 0.0 { x } else { x.exp() - 1.0 }),
-        "EXPONENTIAL" => Some(|x| if x >= 709.0 { f32::MAX } else { x.exp() }),
+        "EXPONENTIAL" => Some(|x| if x >= LN_F32_MAX { f32::MAX } else { x.exp() }),
         "GAUSSIAN" => Some(|x| {
             let safe_x = x.abs().min(100.0);
             (-safe_x * safe_x).exp()
@@ -261,7 +268,7 @@ pub fn target_simulation_fn(name: &str) -> Option<fn(f32) -> f32> {
             }
         }),
         "LOGSIGMOID" => Some(|x| {
-            if x <= -709.0 {
+            if x <= -LN_F32_MAX {
                 f32::MIN
             } else {
                 -(1.0 + (-x).exp()).ln()

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -5805,42 +5805,13 @@ fn hard_tanh(x: f32) -> f32 {
     x.clamp(-1.0, 1.0)
 }
 
-/// ReLU activation for target simulation
-#[inline(always)]
-fn relu(x: f32) -> f32 {
-    x.max(0.0)
-}
-
-/// Get the activation function for a given squash name.
-/// Returns None for activations that are approximately linear and don't need simulation.
+/// Get the target simulation function for a squash name.
 ///
-/// v0.1.121: Added ELU, SELU, GELU, Softplus to improve prediction accuracy
-/// for these commonly-used non-linear activations.
+/// This delegates to `crate::activations::target_simulation_fn`, which is kept in sync
+/// with NEAT-AI's activation registry (and supports aliases + case-insensitive names).
 #[inline]
 fn get_target_activation_fn(squash: &str) -> Option<fn(f32) -> f32> {
-    match squash {
-        // Saturating activations - simulation critical near boundaries
-        "HARD_TANH" => Some(hard_tanh),
-        "TANH" => Some(|x: f32| x.tanh()),
-        "LOGISTIC" => Some(logistic_activation),
-        "CLIPPED" => Some(clipped_activation),
-        "BIPOLAR" => Some(bipolar_activation),
-        // ReLU family - simulation important for threshold behaviour
-        "ReLU" => Some(relu),
-        "LeakyReLU" => Some(leaky_relu_activation),
-        // Smooth non-linear activations - simulation improves accuracy (v0.1.121)
-        "ELU" => Some(elu_activation),
-        "SELU" => Some(selu_activation),
-        "GELU" => Some(gelu_activation),
-        "Softplus" => Some(softplus_activation),
-        // Additional production activations - simulation improves accuracy (Issue #134)
-        "BENT_IDENTITY" => Some(bent_identity_activation),
-        "SOFTSIGN" => Some(softsign_activation),
-        "ArcTan" => Some(arctan_activation),
-        "ReLU6" => Some(relu6_activation),
-        // IDENTITY (and other linear-ish squashes) don't need simulation
-        _ => None,
-    }
+    crate::activations::target_simulation_fn(squash)
 }
 
 /// Check if samples support target activation simulation (all have target data).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! during the discovery training phase, then scanning recorded data to identify
 //! beneficial new synapses/neurons that would reduce error.
 
+pub mod activations;
 pub mod analysis;
 pub mod debug;
 pub mod export;

--- a/tests/activation_coverage_neat_ai_registry.rs
+++ b/tests/activation_coverage_neat_ai_registry.rs
@@ -1,0 +1,142 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+fn extract_import_path(line: &str) -> Option<String> {
+    // Example:
+    // import { Softplus } from "./types/Softplus.ts";
+    // import { HYPOT } from "../../deprecated/HYPOT.ts";
+    let from_idx = line.find(" from ")?;
+    let first_quote = line[from_idx..].find('"')? + from_idx;
+    let rest = &line[(first_quote + 1)..];
+    let second_quote = rest.find('"')?;
+    Some(rest[..second_quote].to_string())
+}
+
+fn extract_activation_name(ts_source: &str) -> Option<String> {
+    // Handles:
+    // public static readonly NAME = "Softplus";
+    // public static NAME = "Cosine";
+    // public static readonly NAME = "BIPOLAR_SIGMOID";
+    // public static NAME = "StdInverse";
+    //
+    // We intentionally keep this simple to avoid adding a regex crate.
+    let needle = "NAME";
+    for line in ts_source.lines() {
+        if !line.contains(needle) || !line.contains('=') || !line.contains('"') {
+            continue;
+        }
+        // Find the first occurrence of NAME = "..."
+        let name_pos = line.find("NAME")?;
+        let after_name = &line[name_pos..];
+        let eq_pos = after_name.find('=')?;
+        let after_eq = after_name[(eq_pos + 1)..].trim();
+        if !after_eq.starts_with('"') {
+            continue;
+        }
+        let after_quote = &after_eq[1..];
+        let end_quote = after_quote.find('"')?;
+        let value = &after_quote[..end_quote];
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn activations_ts_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../NEAT-AI/src/methods/activations/Activations.ts")
+}
+
+#[test]
+fn discovery_knows_all_neat_ai_activation_names() {
+    let activations_ts = activations_ts_path();
+    if !activations_ts.exists() {
+        eprintln!(
+            "Skipping: sibling NEAT-AI repo not found at {}",
+            activations_ts.display()
+        );
+        return;
+    }
+
+    let base_dir = activations_ts
+        .parent()
+        .expect("Activations.ts must have a parent directory");
+    let source = fs::read_to_string(&activations_ts).expect("Failed to read Activations.ts");
+
+    let mut names: BTreeSet<String> = BTreeSet::new();
+
+    // Gather activation files from imports and read each NAME constant.
+    for line in source.lines() {
+        let line = line.trim();
+        if !line.starts_with("import ") || !line.contains(" from ") {
+            continue;
+        }
+        let import_path = match extract_import_path(line) {
+            Some(path) => path,
+            None => continue,
+        };
+
+        // Only consider local TS files.
+        if !import_path.ends_with(".ts") {
+            continue;
+        }
+
+        // Resolve relative to Activations.ts directory.
+        let file_path = base_dir.join(import_path);
+        if !file_path.exists() {
+            // Some imports may be resolved differently in Deno; ignore missing files.
+            continue;
+        }
+
+        let file_source =
+            fs::read_to_string(&file_path).expect("Failed to read imported activation file");
+        if let Some(name) = extract_activation_name(&file_source) {
+            names.insert(name);
+        }
+    }
+
+    // NEAT-AI registry aliases (see `Activations.ts`).
+    names.insert("CLIPPED".to_string());
+    names.insert("RELU".to_string());
+    names.insert("INVERSE".to_string());
+    names.insert("SINUSOID".to_string());
+
+    assert!(
+        !names.is_empty(),
+        "Expected to discover activation names from NEAT-AI imports, but found none"
+    );
+
+    let mut unknown: Vec<String> = Vec::new();
+    let mut not_scalar_but_expected_scalar: Vec<String> = Vec::new();
+
+    for name in &names {
+        if !neat_ai_discovery::activations::is_known_squash_name(name) {
+            unknown.push(name.clone());
+            continue;
+        }
+
+        let is_aggregate = neat_ai_discovery::activations::is_aggregate_squash(name);
+        let applied = neat_ai_discovery::activations::apply_scalar_squash(name, 0.123);
+
+        if is_aggregate {
+            assert!(
+                applied.is_none(),
+                "Aggregate squash {name} must not be treated as a scalar f(x)"
+            );
+        } else if applied.is_none() {
+            not_scalar_but_expected_scalar.push(name.clone());
+        }
+    }
+
+    if !unknown.is_empty() {
+        panic!("Discovery does not recognise these NEAT-AI activation names: {unknown:?}");
+    }
+
+    if !not_scalar_but_expected_scalar.is_empty() {
+        panic!(
+            "Discovery recognises these squashes but cannot compute a scalar f(x) for them: {not_scalar_but_expected_scalar:?}"
+        );
+    }
+}

--- a/tests/activation_overflow_protection_f32.rs
+++ b/tests/activation_overflow_protection_f32.rs
@@ -40,34 +40,38 @@ fn exponential_target_simulation_should_saturate_to_f32_max_before_overflow() {
 }
 
 #[test]
-fn logsigmoid_should_saturate_to_f32_min_before_overflow() {
-    let x = -100.0_f32; // exp(-x)=exp(100) overflows for f32
+fn logsigmoid_should_approach_x_for_large_negative_inputs() {
+    // LOGSIGMOID(x) = -ln(1 + exp(-x)) has asymptotic behaviour LOGSIGMOID(x) → x as x → -∞.
+    //
+    // We also want overflow protection: a naive implementation that computes exp(-x) for
+    // x=-100 would attempt exp(100) which overflows for f32. The stable formulation avoids
+    // this and should return a value very close to x.
+    let x = -100.0_f32;
     let y = neat_ai_discovery::activations::apply_scalar_squash("LOGSIGMOID", x)
         .expect("LOGSIGMOID must be a scalar squash");
     assert!(
         y.is_finite(),
-        "Expected LOGSIGMOID({x}) to be finite (saturated), got {y}"
+        "Expected LOGSIGMOID({x}) to be finite, got {y}"
     );
-    assert_eq!(
-        y,
-        f32::MIN,
-        "Expected LOGSIGMOID({x}) to saturate to f32::MIN"
+    assert!(
+        (y - x).abs() < 1e-3,
+        "Expected LOGSIGMOID({x}) ≈ {x} for large negative x, got {y}"
     );
 }
 
 #[test]
-fn logsigmoid_target_simulation_should_saturate_to_f32_min_before_overflow() {
-    let x = -100.0_f32; // exp(-x)=exp(100) overflows for f32
+fn logsigmoid_target_simulation_should_approach_x_for_large_negative_inputs() {
+    // Target simulation must match the scalar squash behaviour for large negative inputs.
+    let x = -100.0_f32;
     let f = neat_ai_discovery::activations::target_simulation_fn("LOGSIGMOID")
         .expect("LOGSIGMOID must have a target simulation function");
     let y = f(x);
     assert!(
         y.is_finite(),
-        "Expected LOGSIGMOID target simulation({x}) to be finite (saturated), got {y}"
+        "Expected LOGSIGMOID target simulation({x}) to be finite, got {y}"
     );
-    assert_eq!(
-        y,
-        f32::MIN,
-        "Expected LOGSIGMOID target simulation({x}) to saturate to f32::MIN"
+    assert!(
+        (y - x).abs() < 1e-3,
+        "Expected LOGSIGMOID target simulation({x}) ≈ {x} for large negative x, got {y}"
     );
 }

--- a/tests/activation_overflow_protection_f32.rs
+++ b/tests/activation_overflow_protection_f32.rs
@@ -1,0 +1,73 @@
+//! Regression tests for f32 overflow protection in activation functions.
+//!
+//! Why this matters (24-Dec-2025):
+//! - The implementation operates on `f32` values, where `ln(f32::MAX) ≈ 88.72`.
+//! - Using an f64-scale cutoff (eg 709) allows `exp(x)` to overflow to infinity
+//!   for inputs in ~[89, 709), producing `inf`/`-inf` instead of saturating to
+//!   finite `f32::MAX` / `f32::MIN`.
+
+#[test]
+fn exponential_should_saturate_to_f32_max_before_overflow() {
+    let x = 100.0_f32; // exp(100) overflows for f32
+    let y = neat_ai_discovery::activations::apply_scalar_squash("EXPONENTIAL", x)
+        .expect("EXPONENTIAL must be a scalar squash");
+    assert!(
+        y.is_finite(),
+        "Expected EXPONENTIAL({x}) to be finite (saturated), got {y}"
+    );
+    assert_eq!(
+        y,
+        f32::MAX,
+        "Expected EXPONENTIAL({x}) to saturate to f32::MAX"
+    );
+}
+
+#[test]
+fn exponential_target_simulation_should_saturate_to_f32_max_before_overflow() {
+    let x = 100.0_f32; // exp(100) overflows for f32
+    let f = neat_ai_discovery::activations::target_simulation_fn("EXPONENTIAL")
+        .expect("EXPONENTIAL must have a target simulation function");
+    let y = f(x);
+    assert!(
+        y.is_finite(),
+        "Expected EXPONENTIAL target simulation({x}) to be finite (saturated), got {y}"
+    );
+    assert_eq!(
+        y,
+        f32::MAX,
+        "Expected EXPONENTIAL target simulation({x}) to saturate to f32::MAX"
+    );
+}
+
+#[test]
+fn logsigmoid_should_saturate_to_f32_min_before_overflow() {
+    let x = -100.0_f32; // exp(-x)=exp(100) overflows for f32
+    let y = neat_ai_discovery::activations::apply_scalar_squash("LOGSIGMOID", x)
+        .expect("LOGSIGMOID must be a scalar squash");
+    assert!(
+        y.is_finite(),
+        "Expected LOGSIGMOID({x}) to be finite (saturated), got {y}"
+    );
+    assert_eq!(
+        y,
+        f32::MIN,
+        "Expected LOGSIGMOID({x}) to saturate to f32::MIN"
+    );
+}
+
+#[test]
+fn logsigmoid_target_simulation_should_saturate_to_f32_min_before_overflow() {
+    let x = -100.0_f32; // exp(-x)=exp(100) overflows for f32
+    let f = neat_ai_discovery::activations::target_simulation_fn("LOGSIGMOID")
+        .expect("LOGSIGMOID must have a target simulation function");
+    let y = f(x);
+    assert!(
+        y.is_finite(),
+        "Expected LOGSIGMOID target simulation({x}) to be finite (saturated), got {y}"
+    );
+    assert_eq!(
+        y,
+        f32::MIN,
+        "Expected LOGSIGMOID target simulation({x}) to saturate to f32::MIN"
+    );
+}


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.14 to 0.2.15.
- Add a new `activations` module containing functions for activation name normalization, recognition, and application of scalar squashes.
- Refactor target simulation function in `src/analysis/implementation.rs` to delegate to the new `activations` module, improving code organization and maintainability.
- Introduce tests for activation coverage to ensure all NEAT-AI activation names are recognized and handled correctly.

These changes enhance the library's functionality by providing a comprehensive framework for managing activation functions, improving both usability and performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies activation handling and improves numerical safety while simplifying analysis code.
> 
> - **New module:** `src/activations.rs` providing `normalise_squash_name`, `is_known_squash_name`, `is_aggregate_squash`, `apply_scalar_squash`, and `target_simulation_fn` with alias/case-insensitive support and f32-safe implementations (e.g., EXPONENTIAL saturation, stable `LOGSIGMOID`, Softplus linearization, aggregate squashes excluded)
> - **Refactor:** `analysis/implementation.rs` now delegates target activation simulation via `crate::activations::target_simulation_fn`
> - **Library export:** exposes `pub mod activations` in `src/lib.rs`
> - **Tests:**
>   - `tests/activation_coverage_neat_ai_registry.rs` verifies Discovery recognizes all NEAT-AI activation names and flags aggregates
>   - `tests/activation_overflow_protection_f32.rs` guards against f32 overflow/underflow in EXPONENTIAL and LOGSIGMOID paths
> - **Chore:** bump `Cargo.toml` version to `0.2.15`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f15a559342f3368597e56a9f3485306e3dc4bc09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->