### PR TITLE
V0.2.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 
 [lib]

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -2894,16 +2894,6 @@ fn elu_activation(x: f32) -> f32 {
     }
 }
 
-fn selu_activation(x: f32) -> f32 {
-    const SELU_ALPHA: f32 = 1.673_263_2;
-    const SELU_LAMBDA: f32 = 1.050_701;
-    if x >= 0.0 {
-        SELU_LAMBDA * x
-    } else {
-        SELU_LAMBDA * SELU_ALPHA * (x.exp() - 1.0)
-    }
-}
-
 fn softplus_activation(x: f32) -> f32 {
     if x > 20.0 {
         x
@@ -2970,16 +2960,6 @@ fn mish_activation(x: f32) -> f32 {
 
 /// Swish - 1 successful discovery evolved ReLU → Swish
 /// Self-gated activation: x * sigmoid(x)
-fn swish_activation(x: f32) -> f32 {
-    let sigmoid = if x >= 0.0 {
-        1.0 / (1.0 + (-x).exp())
-    } else {
-        let exp_x = x.exp();
-        exp_x / (1.0 + exp_x)
-    };
-    x * sigmoid
-}
-
 /// HARD_TANH - 1 successful discovery evolved CLIPPED → HARD_TANH
 /// Linear in [-1, 1], saturates outside. Same as CLIPPED but named for NEAT-AI.
 fn hard_tanh_activation(x: f32) -> f32 {
@@ -3034,7 +3014,7 @@ fn activation_name_to_gpu_id(name: &str) -> u32 {
     }
 }
 
-pub const ACTIVATION_SPECS: [ActivationCandidateSpec; 17] = [
+pub const ACTIVATION_SPECS: [ActivationCandidateSpec; 15] = [
     // ========================================================================
     // ORIGINAL ACTIVATIONS (v0.1.x)
     // ========================================================================
@@ -3050,13 +3030,6 @@ pub const ACTIVATION_SPECS: [ActivationCandidateSpec; 17] = [
         orientations: &ORIENTATIONS_BIDIRECTIONAL,
         scales: &SCALES_WIDE,
         activation: elu_activation,
-        min_improvement: 0.0,
-    },
-    ActivationCandidateSpec {
-        name: "SELU",
-        orientations: &ORIENTATIONS_BIDIRECTIONAL,
-        scales: &SCALES_SMOOTH,
-        activation: selu_activation,
         min_improvement: 0.0,
     },
     ActivationCandidateSpec {
@@ -3116,19 +3089,18 @@ pub const ACTIVATION_SPECS: [ActivationCandidateSpec; 17] = [
     // new neuron type. In practice it behaves very similarly to ReLU (α=0.01),
     // and production runs show many low-quality LeakyReLU candidates. We still
     // fully support LeakyReLU in existing creatures (targets and sources).
+    //
+    // NOTE (Issue #148, 26-Dec-2025): We also do not propose Swish or SELU as new
+    // neuron squashes. In our value-domain discovery workflow they are close enough
+    // to ReLU in practice that scanning them is usually a poor trade in time-bounded
+    // runs. This preserves the budget to scan more (source,target) possibilities
+    // while still allowing existing creatures to use any squash.
     ActivationCandidateSpec {
         name: "Mish",
         orientations: &ORIENTATIONS_BIDIRECTIONAL,
         scales: &SCALES_SMOOTH,
         activation: mish_activation,
         min_improvement: 0.0, // 2 successful discoveries evolved TO Mish
-    },
-    ActivationCandidateSpec {
-        name: "Swish",
-        orientations: &ORIENTATIONS_BIDIRECTIONAL,
-        scales: &SCALES_SMOOTH,
-        activation: swish_activation,
-        min_improvement: 0.0, // 1 successful discovery evolved ReLU → Swish
     },
     ActivationCandidateSpec {
         name: "HARD_TANH",
@@ -8477,6 +8449,10 @@ Pages speculative:                        12345.
         assert!(names.contains(&"CLIPPED"));
         assert!(names.contains(&"ABSOLUTE"));
         assert!(
+            !names.contains(&"SELU"),
+            "SELU should not be suggested as a new neuron activation (Issue #148: time-bounded runs)"
+        );
+        assert!(
             !names.contains(&"INVERSE"),
             "INVERSE (complement) should not be suggested as a new neuron activation. \
              It can be represented via IDENTITY with bias and negative incoming weights."
@@ -8491,8 +8467,8 @@ Pages speculative:                        12345.
             "Mish should be included - 2 successful discoveries!"
         );
         assert!(
-            names.contains(&"Swish"),
-            "Swish should be included - successful discovery!"
+            !names.contains(&"Swish"),
+            "Swish should not be suggested as a new neuron activation (Issue #148: time-bounded runs)"
         );
         assert!(names.contains(&"HARD_TANH"), "HARD_TANH should be included");
         assert!(
@@ -8506,7 +8482,7 @@ Pages speculative:                        12345.
         assert!(names.contains(&"ArcTan"), "ArcTan should be included");
         assert!(names.contains(&"ReLU6"), "ReLU6 should be included");
         // Total count
-        assert_eq!(names.len(), 17, "Should have 17 activation specs");
+        assert_eq!(names.len(), 15, "Should have 15 activation specs");
     }
 
     // ==================== Saturation Detection Tests (Issue #123) ====================

--- a/tests/activation_coverage_neat_ai_registry.rs
+++ b/tests/activation_coverage_neat_ai_registry.rs
@@ -26,17 +26,33 @@ fn extract_activation_name(ts_source: &str) -> Option<String> {
         if !line.contains(needle) || !line.contains('=') || !line.contains('"') {
             continue;
         }
-        // Find the first occurrence of NAME = "..."
-        let name_pos = line.find("NAME")?;
-        let after_name = &line[name_pos..];
-        let eq_pos = after_name.find('=')?;
-        let after_eq = after_name[(eq_pos + 1)..].trim();
+        // Find the first occurrence of `NAME = "..."`.
+        //
+        // Important: do NOT use `?` in this loop, because a malformed line should not
+        // cause the entire function to return `None`. We want to keep scanning until
+        // we find a valid `NAME = "..."` declaration. (See regression test below.)
+        let Some(name_pos) = line.find("NAME") else {
+            continue;
+        };
+
+        // Only parse '=' that occurs *after* NAME. (Some comment lines may contain both,
+        // but in a different order, eg `// x = "5" NAME`.)
+        let after_name = &line[(name_pos + "NAME".len())..];
+        let Some(eq_pos) = after_name.find('=') else {
+            continue;
+        };
+
+        let after_eq = after_name[(eq_pos + 1)..].trim_start();
         if !after_eq.starts_with('"') {
             continue;
         }
+
         let after_quote = &after_eq[1..];
-        let end_quote = after_quote.find('"')?;
-        let value = &after_quote[..end_quote];
+        let Some(end_quote) = after_quote.find('"') else {
+            continue;
+        };
+
+        let value = after_quote[..end_quote].trim();
         if !value.is_empty() {
             return Some(value.to_string());
         }
@@ -139,4 +155,21 @@ fn discovery_knows_all_neat_ai_activation_names() {
             "Discovery recognises these squashes but cannot compute a scalar f(x) for them: {not_scalar_but_expected_scalar:?}"
         );
     }
+}
+
+#[test]
+fn extract_activation_name_skips_malformed_lines_and_keeps_scanning() {
+    // Regression test (24-Dec-2025):
+    // A line may contain `NAME`, `=` and quotes but still be malformed for our parser,
+    // for example when '=' appears before 'NAME'. The extractor must not stop early;
+    // it should keep scanning until it finds a valid `NAME = "..."` declaration.
+    let ts_source = r#"
+// x = "5" NAME
+public static readonly NAME = "Softplus";
+"#;
+
+    assert_eq!(
+        extract_activation_name(ts_source),
+        Some("Softplus".to_string())
+    );
 }

--- a/tests/relu_adjacent_filtered.rs
+++ b/tests/relu_adjacent_filtered.rs
@@ -1,0 +1,100 @@
+//! Regression test ensuring ReLU-adjacent squashes are not suggested as add-neuron candidates.
+//!
+//! Rationale (26-Dec-2025, Issue #148):
+//! - NEAT-AI-Discovery uses value-domain errors and correlation-style evaluation rather than
+//!   derivative backpropagation.
+//! - In a time-bounded discovery run, proposing ReLU-adjacent squashes (eg Swish/SELU/LeakyReLU)
+//!   reduces the budget available to scan more (source,target) structural possibilities.
+//! - Existing creatures can still *use* any squash; this is only about what we propose as NEW
+//!   add-neuron candidates.
+
+mod common;
+
+use neat_ai_discovery::record_discovery_internal;
+use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson};
+use tempfile::TempDir;
+
+#[test]
+fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
+    skip_without_gpu!();
+
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Simple creature: single output neuron.
+    let creature = CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![],
+        input: 2,
+        output: 1,
+    };
+
+    // Training data with a strong positive correlation between input-0 and output error.
+    //
+    // We keep input-0 strictly positive so ReLU is always active. This makes many smooth
+    // squashes (including the ReLU-adjacent ones) look beneficial unless filtered.
+    let mut training_data = Vec::new();
+    for i in 0..128 {
+        let input_0_val = (i as f32 + 1.0) / 128.0; // (0, 1]
+        let input_1_val = 0.5;
+        let error = input_0_val * 0.5;
+        training_data.push(serde_json::json!({
+            "input": [input_0_val, input_1_val],
+            "output": [0.0],
+            "neuron_data": [{
+                "neuron_uuid": "output-0",
+                "activation": 0.0,
+                "value": 0.0,
+                "errors": [error]
+            }]
+        }));
+    }
+
+    let input_json = serde_json::json!({
+        "creature": creature.clone(),
+        "training_data": training_data,
+        "temp_dir": temp_path.to_str().unwrap()
+    });
+
+    let record_input = serde_json::to_string(&input_json).unwrap();
+    let record_output_json = record_discovery_internal(&record_input).unwrap();
+    let record_output: serde_json::Value = serde_json::from_str(&record_output_json).unwrap();
+    assert_eq!(record_output["success"], true);
+
+    let parquet_file = temp_path.join(record_output["file"].as_str().unwrap());
+
+    let analyze_input = AnalyzeNeuronsInput {
+        parquet_file: parquet_file.to_str().unwrap().to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        max_candidates: Some(512),
+        analysis_deadline_ms: None,
+    };
+
+    let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
+        .expect("Analysis should succeed");
+
+    assert!(
+        !result.helpful_neurons.is_empty(),
+        "Expected at least one add-neuron candidate for the correlated-error scenario"
+    );
+
+    let forbidden = ["LeakyReLU", "Swish", "SELU"];
+    let found: Vec<&str> = result
+        .helpful_neurons
+        .iter()
+        .map(|c| c.squash.as_str())
+        .filter(|s| forbidden.contains(s))
+        .collect();
+
+    assert!(
+        found.is_empty(),
+        "ReLU-adjacent squashes should not be suggested as add-neuron candidates. Found: {found:?}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes activation candidate scanning more selective and adds tests to enforce it.
> 
> - Remove `SELU` and `Swish` functions from suggested activation candidates; reduce `ACTIVATION_SPECS` from 17 → 15 and add notes explaining exclusion in time-bounded runs
> - Update tests to assert `SELU`/`Swish` are not suggested and adjust expected count to 15
> - Add regression test `relu_adjacent_filtered.rs` ensuring ReLU-adjacent squashes (`LeakyReLU`, `Swish`, `SELU`) are never proposed as add-neuron candidates
> - Harden `extract_activation_name` parser to skip malformed lines and keep scanning; add a targeted regression test
> - Bump crate version to `0.2.16`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 381695b8e65e86f427747fe7b7e068a31b8d2ce6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->