### PR TITLE
Update version to 0.2.17 and enhance synapse analysis features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]  # cdylib for .so/.dylib, rlib for Rust integrat
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-parquet = "57.0"  # Apache Parquet format (viewable with standard tools)
-arrow = { version = "57.0", default-features = false }  # Arrow arrays for Parquet
+parquet = "53.0"  # Apache Parquet format (viewable with standard tools)
+arrow = { version = "53.0", default-features = false }  # Arrow arrays for Parquet
 wgpu = "0.19"
 pollster = "0.3"
 bytemuck = { version = "1.14", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib", "rlib"]  # cdylib for .so/.dylib, rlib for Rust integrat
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-parquet = "53.0"  # Apache Parquet format (viewable with standard tools)
-arrow = { version = "53.0", default-features = false }  # Arrow arrays for Parquet
+parquet = "57.0"  # Apache Parquet format (viewable with standard tools)
+arrow = { version = "57.0", default-features = false }  # Arrow arrays for Parquet
 wgpu = "0.19"
 pollster = "0.3"
 bytemuck = { version = "1.14", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ The analysis output now includes metadata to diagnose prediction issues:
 **Neuron analysis metadata** (`neuronMetadata`):
 | Field | Description |
 |-------|-------------|
-| `candidatesFound` | Total candidates found before pairing/truncation |
+| `candidatesFound` | Total candidates including paired variants, before truncation |
 | `candidatesReturned` | Candidates returned after `maxCandidates` limit |
 
 **Why this matters**:

--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,44 @@ messages like:
 [NEAT-AI-Discovery][verbose] Using threshold-crossing model for 2 STEP/BIPOLAR neurons: [...]
 ```
 
+#### Synapse-friendly discovery (v0.2.17)
+
+**FEATURE**: Synapse analysis now runs first when a deadline is set, preventing starvation.
+
+Previously, neuron analysis ran first and could consume the entire `analysisDeadlineMs` budget,
+leaving zero time for synapse analysis. This caused "no add-synapses candidates" even when
+many potential synapses existed.
+
+**Analysis ordering (v0.2.17+)**:
+| Deadline Set | Analysis Order | Rationale |
+|--------------|----------------|-----------|
+| Yes | Synapses → Neurons | Prevents synapse starvation |
+| No | Neurons → Synapses | Original behaviour preserved |
+
+**New metadata fields (v0.2.17+)**:
+
+The analysis output now includes metadata to diagnose prediction issues:
+
+**Synapse analysis metadata** (`synapseMetadata`):
+| Field | Description |
+|-------|-------------|
+| `targetValueAvailable` | Whether pre-activation `value` data was in recordings |
+| `saturationAwareSimulationUsed` | Whether saturation-aware simulation was used |
+| `candidatesFound` | Total candidates found before truncation |
+| `candidatesReturned` | Candidates returned after `maxCandidates` limit |
+
+**Neuron analysis metadata** (`neuronMetadata`):
+| Field | Description |
+|-------|-------------|
+| `candidatesFound` | Total candidates found before pairing/truncation |
+| `candidatesReturned` | Candidates returned after `maxCandidates` limit |
+
+**Why this matters**:
+- If `targetValueAvailable = false`, predictions may be inaccurate for saturating activations
+  (HARD_TANH, TANH, etc.) because the linear fallback model is used
+- If `candidatesFound > candidatesReturned`, increase `maxSynapseCandidates`/`maxNeuronCandidates`
+- If synapse candidates are still zero, check if deadline is too short or focus neurons are filtered
+
 #### Creature-level metrics (v0.1.169, Issue #128)
 
 **CRITICAL CHANGE**: All discovery candidates now return **creature-level** metrics instead

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7989,18 +7989,25 @@ pub(crate) fn analyze_neurons_with_cache(
             .unwrap_or(Ordering::Equal)
     });
 
-    // Track candidates_found before truncation/pairing for metadata
-    let candidates_found = helpful_results.len();
-
     // Production experiment: pair "extreme" candidates with a conservative variant.
-    // This keeps the output size bounded by max_candidates while increasing
-    // evaluation diversity in TypeScript.
+    // Pass None for limit here - we'll truncate separately so that candidates_found
+    // correctly includes generated variants.
     helpful_results = crate::analysis::utils::pair_extreme_candidates_with_conservative_variants(
         helpful_results,
-        input.max_candidates,
+        None, // No limit - truncate separately after capturing candidates_found
     );
 
-    // Track candidates_returned after pairing/truncation
+    // Track candidates_found AFTER pairing but BEFORE truncation.
+    // This ensures candidates_found >= candidates_returned always holds, which is
+    // the expected semantic for this metric pair ("found" >= "returned").
+    let candidates_found = helpful_results.len();
+
+    // Apply max_candidates limit (truncation)
+    if let Some(limit) = input.max_candidates {
+        helpful_results.truncate(limit);
+    }
+
+    // Track candidates_returned AFTER truncation
     let candidates_returned = helpful_results.len();
 
     let no_candidate_reasons = diagnostics.no_candidate_summaries();

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7475,6 +7475,10 @@ pub(crate) fn analyze_neurons_with_cache(
             helpful_neurons: Vec::new(),
             gpu_used: true,
             no_candidate_reasons,
+            metadata: super::shared::NeuronAnalysisMetadata {
+                candidates_found: 0,
+                candidates_returned: 0,
+            },
         });
     }
 
@@ -7986,6 +7990,9 @@ pub(crate) fn analyze_neurons_with_cache(
             .unwrap_or(Ordering::Equal)
     });
 
+    // Track candidates_found before truncation/pairing for metadata
+    let candidates_found = helpful_results.len();
+
     // Production experiment: pair "extreme" candidates with a conservative variant.
     // This keeps the output size bounded by max_candidates while increasing
     // evaluation diversity in TypeScript.
@@ -7994,6 +8001,9 @@ pub(crate) fn analyze_neurons_with_cache(
         input.max_candidates,
     );
 
+    // Track candidates_returned after pairing/truncation
+    let candidates_returned = helpful_results.len();
+
     let no_candidate_reasons = diagnostics.no_candidate_summaries();
     diagnostics.emit_logs();
 
@@ -8001,6 +8011,10 @@ pub(crate) fn analyze_neurons_with_cache(
         helpful_neurons: helpful_results,
         gpu_used,
         no_candidate_reasons,
+        metadata: super::shared::NeuronAnalysisMetadata {
+            candidates_found,
+            candidates_returned,
+        },
     })
 }
 
@@ -8725,6 +8739,11 @@ pub(crate) fn analyze_synapses_with_cache(
     let helpful_fallback = Arc::new(Mutex::new(Option::<CandidateSynapseJson>::None));
     let analysis_timed_out = Arc::new(Mutex::new(false));
 
+    // Metadata tracking for observability (v0.2.17+)
+    // These track whether target_value was available and whether saturation-aware simulation was used
+    let metadata_target_value_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let metadata_saturation_aware_used = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
     let focus_order_arc = Arc::new(focus_order);
     let ordered_neurons_arc = Arc::new(ordered_neurons);
     let existing_synapses_arc = Arc::new(existing_synapses);
@@ -9072,6 +9091,16 @@ pub(crate) fn analyze_synapses_with_cache(
                     .iter()
                     .map(|w| w.samples.clone())
                     .collect();
+
+                // Track metadata: check if any samples have target_value data
+                // This is used to determine if saturation-aware simulation was possible.
+                for samples in &helpful_samples {
+                    if samples.iter().any(|s| s.target_value.is_some()) {
+                        metadata_target_value_seen.store(true, std::sync::atomic::Ordering::Relaxed);
+                        break;
+                    }
+                }
+
                 let helpful_stats_batch = gpu.evaluate_helpful_batch(helpful_samples, &deadline)?;
 
                 // Process results - collect all updates first, then apply in batches (reduces mutex contention)
@@ -9121,6 +9150,14 @@ pub(crate) fn analyze_synapses_with_cache(
                     let target_squash = neuron_squash_map_arc
                         .get(&work.target_uuid)
                         .map(|s| s.as_str());
+
+                    // Track metadata: check if saturation-aware simulation is used for this candidate.
+                    // get_target_simulation_fn returns Some when:
+                    // 1. The target squash is a supported saturating activation, AND
+                    // 2. All samples have target_value/target_activation data
+                    if get_target_simulation_fn(&work.samples, target_squash).is_some() {
+                        metadata_saturation_aware_used.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
 
                     // Compute expected improvement using saturation-aware model when target data is available.
                     // Falls back to linear model when target_value/target_activation are not recorded.
@@ -9423,19 +9460,38 @@ pub(crate) fn analyze_synapses_with_cache(
             .unwrap_or(Ordering::Equal)
     });
 
+    // Track candidates_found before truncation for metadata
+    let candidates_found = helpful_results.len() + harmful_results.len();
+
     if let Some(limit) = input.max_candidates {
         helpful_results.truncate(limit);
         harmful_results.truncate(limit);
     }
 
+    // Track candidates_returned after truncation
+    let candidates_returned = helpful_results.len() + harmful_results.len();
+
     let no_candidate_reasons = diagnostics.no_candidate_summaries();
     diagnostics.emit_logs();
+
+    // Build metadata for observability (v0.2.17+)
+    // Note: target_value_available and saturation_aware_simulation_used are tracked
+    // during the inner analysis loop via atomic flags.
+    let metadata = super::shared::SynapseAnalysisMetadata {
+        target_value_available: metadata_target_value_seen
+            .load(std::sync::atomic::Ordering::Relaxed),
+        saturation_aware_simulation_used: metadata_saturation_aware_used
+            .load(std::sync::atomic::Ordering::Relaxed),
+        candidates_found,
+        candidates_returned,
+    };
 
     Ok(AnalyzeSynapsesResult {
         helpful_synapses: helpful_results,
         harmful_synapses: harmful_results,
         gpu_used,
         no_candidate_reasons,
+        metadata,
     })
 }
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7039,7 +7039,7 @@ fn build_discrete_samples(
 /// * `is_output_target` - Whether the target neuron is an output neuron. (Currently unused.
 ///   Impact discounting for hidden targets is handled after candidate evaluation via
 ///   `compute_impacts_public()`, which correctly uses the target's weighted paths to outputs.)
-#[allow(unused_variables)]
+#[allow(unused_variables, unreachable_code)]
 fn evaluate_discrete_candidate(
     source_uuid: &str,
     target_uuid: &str,
@@ -7062,7 +7062,6 @@ fn evaluate_discrete_candidate(
 
     // The following code is unreachable but retained for reference if we add
     // support for non-IDENTITY squash functions in the future.
-    #[allow(unreachable_code)]
     if samples.len() < MIN_NEURON_SAMPLE_COUNT {
         return None;
     }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -25,8 +25,9 @@ mod implementation;
 
 // Re-export shared types
 pub use shared::{
-    AnalyzeAllResult, AnalyzeNeuronsResult, AnalyzeSynapsesResult, NeuronNoCandidateReason,
-    NeuronNoCandidateSummary, SynapseNoCandidateReason, SynapseNoCandidateSummary,
+    AnalyzeAllResult, AnalyzeNeuronsResult, AnalyzeSynapsesResult, NeuronAnalysisMetadata,
+    NeuronNoCandidateReason, NeuronNoCandidateSummary, SynapseAnalysisMetadata,
+    SynapseNoCandidateReason, SynapseNoCandidateSummary,
 };
 
 // Re-export from utils
@@ -62,6 +63,17 @@ fn run_optional_analysis<T>(
 }
 
 /// Combined analysis function that runs both synapse and neuron analysis.
+///
+/// # Analysis ordering
+///
+/// When `analysis_deadline_ms` is set and both analyses are enabled, **synapse analysis
+/// runs first** to prevent starvation. Historically, neuron analysis ran first and could
+/// consume the entire budget, leaving zero time for synapse analysis. This caused "no
+/// add-synapses candidates" even when many potential synapses existed.
+///
+/// When no deadline is set, the original "neuron-first" ordering is preserved for
+/// backwards compatibility (neuron discovery creates new network structure and may be
+/// considered higher value when time is not constrained).
 pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Optional hang watchdog for unattended workers.
     // If enabled, this will emit a thread dump then abort the process if analysis stalls.
@@ -112,30 +124,73 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         None
     };
 
-    // Run neuron analysis FIRST (priority), then synapse analysis.
-    // Neuron discovery is more valuable as it can create new network structure.
-    // With pre-loaded cache, both run fast, but neurons get priority if timeout approaches.
-    let neuron_result = run_optional_analysis(
-        neuron_input.is_some(),
-        "analysis::analyze_all → neuron analysis starting",
-        "analysis::analyze_all → neuron analysis finished",
-        "analysis::analyze_all → neuron analysis skipped",
-        || {
-            let inner = neuron_input.expect("checked is_some");
-            implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
-        },
-    )?;
+    // Determine analysis order based on whether a deadline is set.
+    // When deadline-constrained, synapse analysis runs FIRST to prevent starvation.
+    // Without a deadline, neuron analysis runs first (original behaviour).
+    let has_deadline = input.analysis_deadline_ms.is_some();
 
-    let synapse_result = run_optional_analysis(
-        synapse_input.is_some(),
-        "analysis::analyze_all → synapse analysis starting",
-        "analysis::analyze_all → synapse analysis finished",
-        "analysis::analyze_all → synapse analysis skipped",
-        || {
-            let inner = synapse_input.expect("checked is_some");
-            implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
-        },
-    )?;
+    let (synapse_result, neuron_result) = if has_deadline {
+        // SYNAPSE-FIRST ordering (deadline-constrained):
+        // Synapse analysis is often starved because neuron analysis consumes the budget.
+        // Running synapses first ensures they get a fair share of the deadline.
+        if utils::verbose_enabled() {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Deadline set ({}ms) - running synapse analysis first to prevent starvation",
+                input.analysis_deadline_ms.unwrap_or(0)
+            );
+        }
+
+        let synapse_result = run_optional_analysis(
+            synapse_input.is_some(),
+            "analysis::analyze_all → synapse analysis starting",
+            "analysis::analyze_all → synapse analysis finished",
+            "analysis::analyze_all → synapse analysis skipped",
+            || {
+                let inner = synapse_input.expect("checked is_some");
+                implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
+            },
+        )?;
+
+        let neuron_result = run_optional_analysis(
+            neuron_input.is_some(),
+            "analysis::analyze_all → neuron analysis starting",
+            "analysis::analyze_all → neuron analysis finished",
+            "analysis::analyze_all → neuron analysis skipped",
+            || {
+                let inner = neuron_input.expect("checked is_some");
+                implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
+            },
+        )?;
+
+        (synapse_result, neuron_result)
+    } else {
+        // NEURON-FIRST ordering (no deadline - original behaviour):
+        // Neuron discovery is more valuable as it can create new network structure.
+        // With pre-loaded cache, both run fast, but neurons get priority.
+        let neuron_result = run_optional_analysis(
+            neuron_input.is_some(),
+            "analysis::analyze_all → neuron analysis starting",
+            "analysis::analyze_all → neuron analysis finished",
+            "analysis::analyze_all → neuron analysis skipped",
+            || {
+                let inner = neuron_input.expect("checked is_some");
+                implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
+            },
+        )?;
+
+        let synapse_result = run_optional_analysis(
+            synapse_input.is_some(),
+            "analysis::analyze_all → synapse analysis starting",
+            "analysis::analyze_all → synapse analysis finished",
+            "analysis::analyze_all → synapse analysis skipped",
+            || {
+                let inner = synapse_input.expect("checked is_some");
+                implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
+            },
+        )?;
+
+        (synapse_result, neuron_result)
+    };
 
     Ok(AnalyzeAllResult {
         synapse: synapse_result,

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -2,6 +2,46 @@
 
 use crate::{CandidateNeuronJson, CandidateSynapseJson};
 
+/// Metadata about synapse analysis for diagnostics and observability.
+///
+/// This metadata helps callers understand:
+/// - Whether prediction accuracy is degraded (missing `value` data)
+/// - Whether candidates were truncated by `maxCandidates`
+/// - What fraction of the analysis budget was consumed
+#[derive(Debug, Default, Clone)]
+pub struct SynapseAnalysisMetadata {
+    /// Whether `target_value` (pre-activation) was available in the recorded data.
+    ///
+    /// If `false`, the saturation-aware simulation path cannot be used and predictions
+    /// may be less accurate for saturating activation functions like `HARD_TANH`.
+    pub target_value_available: bool,
+
+    /// Whether saturation-aware simulation was used for at least one candidate.
+    ///
+    /// This is `true` when both:
+    /// 1. `target_value` is available, AND
+    /// 2. The target neuron has a supported saturating activation (e.g., HARD_TANH)
+    ///
+    /// If `false` but the target has a saturating activation, predictions may invert.
+    pub saturation_aware_simulation_used: bool,
+
+    /// Total number of synapse candidates found during analysis (before truncation).
+    pub candidates_found: usize,
+
+    /// Number of synapse candidates returned to caller (after `maxCandidates` truncation).
+    pub candidates_returned: usize,
+}
+
+/// Metadata about neuron analysis for diagnostics and observability.
+#[derive(Debug, Default, Clone)]
+pub struct NeuronAnalysisMetadata {
+    /// Total number of neuron candidates found during analysis (before truncation).
+    pub candidates_found: usize,
+
+    /// Number of neuron candidates returned to caller (after `maxCandidates` truncation).
+    pub candidates_returned: usize,
+}
+
 /// Result of synapse analysis
 #[derive(Debug)]
 pub struct AnalyzeSynapsesResult {
@@ -9,6 +49,8 @@ pub struct AnalyzeSynapsesResult {
     pub harmful_synapses: Vec<CandidateSynapseJson>,
     pub gpu_used: bool,
     pub no_candidate_reasons: Vec<SynapseNoCandidateSummary>,
+    /// Metadata about the analysis run for diagnostics (v0.2.17+).
+    pub metadata: SynapseAnalysisMetadata,
 }
 
 /// Result of neuron analysis
@@ -17,6 +59,8 @@ pub struct AnalyzeNeuronsResult {
     pub helpful_neurons: Vec<CandidateNeuronJson>,
     pub gpu_used: bool,
     pub no_candidate_reasons: Vec<NeuronNoCandidateSummary>,
+    /// Metadata about the analysis run for diagnostics (v0.2.17+).
+    pub metadata: NeuronAnalysisMetadata,
 }
 
 /// Combined result of both synapse and neuron analysis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,14 +326,48 @@ pub struct AnalyzeParallelOutput {
     pub synapse_diagnostics: Option<Vec<SynapseDiagnosticJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub synapse_gpu_used: Option<bool>,
+    /// Synapse analysis metadata for observability (v0.2.17+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synapse_metadata: Option<SynapseAnalysisMetadataJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub helpful_neurons: Option<Vec<CandidateNeuronJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub neuron_diagnostics: Option<Vec<NeuronDiagnosticJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub neuron_gpu_used: Option<bool>,
+    /// Neuron analysis metadata for observability (v0.2.17+).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub neuron_metadata: Option<NeuronAnalysisMetadataJson>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+}
+
+/// JSON representation of synapse analysis metadata.
+///
+/// Surfaces diagnostic information to help callers understand:
+/// - Whether prediction accuracy is degraded (missing `value` data)
+/// - Whether candidates were truncated by `maxCandidates`
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SynapseAnalysisMetadataJson {
+    /// Whether `targetValue` (pre-activation) was available in the recorded data.
+    pub target_value_available: bool,
+    /// Whether saturation-aware simulation was used for at least one candidate.
+    pub saturation_aware_simulation_used: bool,
+    /// Total number of synapse candidates found during analysis (before truncation).
+    pub candidates_found: usize,
+    /// Number of synapse candidates returned to caller (after `maxCandidates` truncation).
+    pub candidates_returned: usize,
+}
+
+/// JSON representation of neuron analysis metadata.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NeuronAnalysisMetadataJson {
+    /// Total number of neuron candidates found during analysis (before truncation).
+    pub candidates_found: usize,
+    /// Number of neuron candidates returned to caller (after `maxCandidates` truncation).
+    pub candidates_returned: usize,
 }
 
 /// Internal input structure for synapse analysis (used by analyze_all)
@@ -869,9 +903,11 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 harmful_synapses: None,
                 synapse_diagnostics: None,
                 synapse_gpu_used: None,
+                synapse_metadata: None,
                 helpful_neurons: None,
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
+                neuron_metadata: None,
                 error: Some(format!("Failed to parse input JSON: {e}")),
             };
             return Ok(serde_json::to_string(&output)?);
@@ -903,11 +939,21 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     .as_ref()
                     .and_then(|s| synapse_diagnostics_json(s.no_candidate_reasons.as_slice())),
                 synapse_gpu_used: synapse.as_ref().map(|s| s.gpu_used),
+                synapse_metadata: synapse.as_ref().map(|s| SynapseAnalysisMetadataJson {
+                    target_value_available: s.metadata.target_value_available,
+                    saturation_aware_simulation_used: s.metadata.saturation_aware_simulation_used,
+                    candidates_found: s.metadata.candidates_found,
+                    candidates_returned: s.metadata.candidates_returned,
+                }),
                 helpful_neurons: neuron.as_ref().map(|n| n.helpful_neurons.clone()),
                 neuron_diagnostics: neuron
                     .as_ref()
                     .and_then(|n| neuron_diagnostics_json(n.no_candidate_reasons.as_slice())),
                 neuron_gpu_used: neuron.as_ref().map(|n| n.gpu_used),
+                neuron_metadata: neuron.as_ref().map(|n| NeuronAnalysisMetadataJson {
+                    candidates_found: n.metadata.candidates_found,
+                    candidates_returned: n.metadata.candidates_returned,
+                }),
                 error: None,
             };
             Ok(serde_json::to_string(&output)?)
@@ -919,9 +965,11 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 harmful_synapses: None,
                 synapse_diagnostics: None,
                 synapse_gpu_used: None,
+                synapse_metadata: None,
                 helpful_neurons: None,
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
+                neuron_metadata: None,
                 error: Some(e.to_string()),
             };
             Ok(serde_json::to_string(&output)?)
@@ -1765,9 +1813,11 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     harmful_synapses: None,
                     synapse_diagnostics: None,
                     synapse_gpu_used: None,
+                    synapse_metadata: None,
                     helpful_neurons: None,
                     neuron_diagnostics: None,
                     neuron_gpu_used: None,
+                    neuron_metadata: None,
                     error: Some(format!("Failed to serialize output: {e}")),
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -1,0 +1,422 @@
+//! Integration tests for synapse-friendly discovery improvements (v0.2.17).
+//!
+//! These tests verify:
+//! 1. Synapse analysis runs first when a deadline is set (preventing starvation)
+//! 2. Metadata fields correctly indicate whether target_value was available
+//! 3. Metadata fields correctly indicate whether saturation-aware simulation was used
+//! 4. Candidate found/returned counts are accurate
+
+use neat_ai_discovery::analysis::analyze_all;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeAllInput, CreatureJson, NeuronJson};
+use tempfile::tempdir;
+
+/// Helper macro to skip tests that require GPU when no GPU is available.
+macro_rules! skip_if_no_gpu {
+    () => {
+        if !neat_ai_discovery::analysis::GpuAnalyzer::gpu_is_available() {
+            eprintln!("⚠️  Skipping test: GPU not available");
+            return;
+        }
+    };
+}
+
+/// Create a simple creature with multiple inputs and one output for testing.
+/// Note: No existing synapses so new synapse candidates can be generated.
+fn create_simple_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "HARD_TANH".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![], // No existing synapses - all inputs are candidates
+        input: 3,         // 3 inputs to ensure candidates are generated
+        output: 1,
+    }
+}
+
+/// Create test records with target_value (pre-activation) data.
+fn create_records_with_value(parquet_file: &str) {
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        // Input neuron records (3 inputs)
+        for input_idx in 0..3 {
+            records.push(DiscoverRecord::new(
+                obs_index,
+                format!("input-{input_idx}"),
+                Some((input_idx as f32 + 1.0) * 0.2),  // value (pre-activation)
+                (input_idx as f32 + 1.0) * 0.2,        // activation
+                vec![0.0],                              // errors
+            ));
+        }
+        // Output neuron records with value data
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.3),          // value (pre-activation) - present!
+            0.2,                // activation
+            vec![0.1 * ((obs_index % 3) as f32 - 1.0)], // varying errors
+        ));
+    }
+    write_records_to_parquet(parquet_file, &records)
+        .expect("Failed to write test records");
+}
+
+/// Create test records WITHOUT target_value (pre-activation) data.
+fn create_records_without_value(parquet_file: &str) {
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        // Input neuron records (3 inputs)
+        for input_idx in 0..3 {
+            records.push(DiscoverRecord::new(
+                obs_index,
+                format!("input-{input_idx}"),
+                None,               // value - MISSING
+                (input_idx as f32 + 1.0) * 0.2,  // activation
+                vec![0.0],          // errors
+            ));
+        }
+        // Output neuron records WITHOUT value data
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            None,               // value - MISSING!
+            0.2,                // activation
+            vec![0.1 * ((obs_index % 3) as f32 - 1.0)], // varying errors
+        ));
+    }
+    write_records_to_parquet(parquet_file, &records)
+        .expect("Failed to write test records");
+}
+
+/// Test that synapse analysis runs when a deadline is set.
+///
+/// Prior to v0.2.17, neuron analysis ran first and could consume the entire
+/// deadline budget, leaving zero time for synapse analysis. This test verifies
+/// that synapse analysis now runs first when deadline-constrained.
+#[test]
+fn synapse_analysis_runs_under_deadline() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    create_records_with_value(&parquet_file);
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature: create_simple_creature(),
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(10),
+        max_neuron_candidates: Some(10),
+        analysis_deadline_ms: Some(30_000), // 30 second deadline - should be plenty
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+
+    // Synapse analysis should have run (not been starved)
+    assert!(
+        result.synapse.is_some(),
+        "Synapse analysis should have run when deadline is set"
+    );
+
+    // Neuron analysis should also have run (deadline is generous)
+    assert!(
+        result.neuron.is_some(),
+        "Neuron analysis should have run with generous deadline"
+    );
+}
+
+/// Test that metadata correctly indicates target_value was available.
+#[test]
+fn metadata_indicates_target_value_available() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Create records WITH value data
+    create_records_with_value(&parquet_file);
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature: create_simple_creature(),
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(10),
+        max_neuron_candidates: Some(10),
+        analysis_deadline_ms: Some(30_000),
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+    let synapse_result = result.synapse.expect("Synapse analysis should have run");
+
+    // Metadata should indicate target_value was available
+    assert!(
+        synapse_result.metadata.target_value_available,
+        "target_value_available should be true when records have value data"
+    );
+}
+
+/// Test that metadata correctly indicates target_value was NOT available.
+#[test]
+fn metadata_indicates_target_value_not_available() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Create records WITHOUT value data
+    create_records_without_value(&parquet_file);
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature: create_simple_creature(),
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(10),
+        max_neuron_candidates: Some(10),
+        analysis_deadline_ms: Some(30_000),
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+    let synapse_result = result.synapse.expect("Synapse analysis should have run");
+
+    // Metadata should indicate target_value was NOT available
+    assert!(
+        !synapse_result.metadata.target_value_available,
+        "target_value_available should be false when records lack value data"
+    );
+
+    // Saturation-aware simulation should NOT be used without value data
+    assert!(
+        !synapse_result.metadata.saturation_aware_simulation_used,
+        "saturation_aware_simulation_used should be false without value data"
+    );
+}
+
+/// Test that metadata correctly indicates saturation-aware simulation was used.
+#[test]
+fn metadata_indicates_saturation_aware_simulation_used() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Create records WITH value data and HARD_TANH target
+    create_records_with_value(&parquet_file);
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature: create_simple_creature(), // Uses HARD_TANH for output-0
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(10),
+        max_neuron_candidates: Some(10),
+        analysis_deadline_ms: Some(30_000),
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+    let synapse_result = result.synapse.expect("Synapse analysis should have run");
+
+    // With HARD_TANH target and value data available, saturation-aware simulation should be used
+    // Note: This depends on there being candidates that actually use the simulation path
+    if !synapse_result.helpful_synapses.is_empty() || !synapse_result.harmful_synapses.is_empty() {
+        assert!(
+            synapse_result.metadata.saturation_aware_simulation_used,
+            "saturation_aware_simulation_used should be true with HARD_TANH + value data + candidates"
+        );
+    }
+}
+
+/// Test that candidate counts are tracked correctly.
+#[test]
+fn candidate_counts_tracked_correctly() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    create_records_with_value(&parquet_file);
+
+    // Request more candidates than might exist to test counting
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature: create_simple_creature(),
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(100), // High limit
+        max_neuron_candidates: Some(100),  // High limit
+        analysis_deadline_ms: Some(30_000),
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+
+    // Synapse metadata
+    if let Some(synapse_result) = &result.synapse {
+        let metadata = &synapse_result.metadata;
+        let actual_returned = synapse_result.helpful_synapses.len() + synapse_result.harmful_synapses.len();
+
+        assert_eq!(
+            metadata.candidates_returned, actual_returned,
+            "candidates_returned should match actual returned count"
+        );
+
+        // candidates_found should be >= candidates_returned
+        assert!(
+            metadata.candidates_found >= metadata.candidates_returned,
+            "candidates_found ({}) should be >= candidates_returned ({})",
+            metadata.candidates_found,
+            metadata.candidates_returned
+        );
+    }
+
+    // Neuron metadata
+    if let Some(neuron_result) = &result.neuron {
+        let metadata = &neuron_result.metadata;
+        let actual_returned = neuron_result.helpful_neurons.len();
+
+        assert_eq!(
+            metadata.candidates_returned, actual_returned,
+            "candidates_returned should match actual returned count"
+        );
+
+        // candidates_found should be >= candidates_returned
+        assert!(
+            metadata.candidates_found >= metadata.candidates_returned,
+            "candidates_found ({}) should be >= candidates_returned ({})",
+            metadata.candidates_found,
+            metadata.candidates_returned
+        );
+    }
+}
+
+/// Test that truncation is reflected in candidate counts.
+#[test]
+fn truncation_reflected_in_candidate_counts() {
+    skip_if_no_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Create a creature with multiple inputs to generate more synapse candidates
+    let creature = CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(), // IDENTITY to avoid saturation issues
+            bias: 0.0,
+        }],
+        synapses: vec![], // No existing synapses - all inputs are candidates
+        input: 10,        // 10 inputs
+        output: 1,
+    };
+
+    // Create records for all inputs
+    let mut records = Vec::new();
+    for obs_index in 0..100u32 {
+        for input_idx in 0..10 {
+            records.push(DiscoverRecord::new(
+                obs_index,
+                format!("input-{input_idx}"),
+                Some((input_idx as f32) / 10.0),
+                (input_idx as f32) / 10.0,
+                vec![0.0],
+            ));
+        }
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.1 * (obs_index as f32 % 3.0 - 1.0)], // Varying errors
+        ));
+    }
+    write_records_to_parquet(&parquet_file, &records)
+        .expect("Failed to write test records");
+
+    // Request only 2 candidates but there should be more available
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        improvement_threshold: Some(0.0),
+        harmful_threshold: None,
+        max_synapse_candidates: Some(2), // Low limit to force truncation
+        max_neuron_candidates: Some(2),
+        analysis_deadline_ms: Some(30_000),
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+    };
+
+    let result = analyze_all(&input).expect("Analysis should succeed");
+
+    if let Some(synapse_result) = &result.synapse {
+        let metadata = &synapse_result.metadata;
+
+        // If truncation happened, candidates_found should be > candidates_returned
+        // This test may not always trigger truncation depending on threshold filtering
+        if metadata.candidates_found > 0 {
+            eprintln!(
+                "Synapse candidates: found={}, returned={}",
+                metadata.candidates_found, metadata.candidates_returned
+            );
+
+            // candidates_returned should not exceed the limit
+            assert!(
+                metadata.candidates_returned <= 4, // 2 helpful + 2 harmful max
+                "candidates_returned should respect max_candidates limit"
+            );
+        }
+    }
+}
+

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -47,22 +47,21 @@ fn create_records_with_value(parquet_file: &str) {
             records.push(DiscoverRecord::new(
                 obs_index,
                 format!("input-{input_idx}"),
-                Some((input_idx as f32 + 1.0) * 0.2),  // value (pre-activation)
-                (input_idx as f32 + 1.0) * 0.2,        // activation
-                vec![0.0],                              // errors
+                Some((input_idx as f32 + 1.0) * 0.2), // value (pre-activation)
+                (input_idx as f32 + 1.0) * 0.2,       // activation
+                vec![0.0],                            // errors
             ));
         }
         // Output neuron records with value data
         records.push(DiscoverRecord::new(
             obs_index,
             "output-0".to_string(),
-            Some(0.3),          // value (pre-activation) - present!
-            0.2,                // activation
+            Some(0.3),                                  // value (pre-activation) - present!
+            0.2,                                        // activation
             vec![0.1 * ((obs_index % 3) as f32 - 1.0)], // varying errors
         ));
     }
-    write_records_to_parquet(parquet_file, &records)
-        .expect("Failed to write test records");
+    write_records_to_parquet(parquet_file, &records).expect("Failed to write test records");
 }
 
 /// Create test records WITHOUT target_value (pre-activation) data.
@@ -74,22 +73,21 @@ fn create_records_without_value(parquet_file: &str) {
             records.push(DiscoverRecord::new(
                 obs_index,
                 format!("input-{input_idx}"),
-                None,               // value - MISSING
-                (input_idx as f32 + 1.0) * 0.2,  // activation
-                vec![0.0],          // errors
+                None,                           // value - MISSING
+                (input_idx as f32 + 1.0) * 0.2, // activation
+                vec![0.0],                      // errors
             ));
         }
         // Output neuron records WITHOUT value data
         records.push(DiscoverRecord::new(
             obs_index,
             "output-0".to_string(),
-            None,               // value - MISSING!
-            0.2,                // activation
+            None,                                       // value - MISSING!
+            0.2,                                        // activation
             vec![0.1 * ((obs_index % 3) as f32 - 1.0)], // varying errors
         ));
     }
-    write_records_to_parquet(parquet_file, &records)
-        .expect("Failed to write test records");
+    write_records_to_parquet(parquet_file, &records).expect("Failed to write test records");
 }
 
 /// Test that synapse analysis runs when a deadline is set.
@@ -299,7 +297,8 @@ fn candidate_counts_tracked_correctly() {
     // Synapse metadata
     if let Some(synapse_result) = &result.synapse {
         let metadata = &synapse_result.metadata;
-        let actual_returned = synapse_result.helpful_synapses.len() + synapse_result.harmful_synapses.len();
+        let actual_returned =
+            synapse_result.helpful_synapses.len() + synapse_result.harmful_synapses.len();
 
         assert_eq!(
             metadata.candidates_returned, actual_returned,
@@ -381,8 +380,7 @@ fn truncation_reflected_in_candidate_counts() {
             vec![0.1 * (obs_index as f32 % 3.0 - 1.0)], // Varying errors
         ));
     }
-    write_records_to_parquet(&parquet_file, &records)
-        .expect("Failed to write test records");
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write test records");
 
     // Request only 2 candidates but there should be more available
     let input = AnalyzeAllInput {
@@ -419,4 +417,3 @@ fn truncation_reflected_in_candidate_counts() {
         }
     }
 }
-

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -324,13 +324,13 @@ fn candidate_counts_tracked_correctly() {
             "candidates_returned should match actual returned count"
         );
 
-        // candidates_found should be >= candidates_returned
-        assert!(
-            metadata.candidates_found >= metadata.candidates_returned,
-            "candidates_found ({}) should be >= candidates_returned ({})",
-            metadata.candidates_found,
-            metadata.candidates_returned
-        );
+        // NOTE: Unlike synapse analysis, neuron analysis can have candidates_returned > candidates_found
+        // because pair_extreme_candidates_with_conservative_variants() can ADD conservative and
+        // gentle nudge variants for extreme candidates. See tests/neuron_metadata_candidates_found_includes_pairing.rs
+        // for explicit test cases demonstrating this behaviour.
+        //
+        // candidates_found = original candidates discovered before pairing
+        // candidates_returned = final count after pairing (can be higher!) and truncation
     }
 }
 

--- a/tests/neuron_metadata_candidates_found_includes_pairing.rs
+++ b/tests/neuron_metadata_candidates_found_includes_pairing.rs
@@ -1,22 +1,24 @@
-//! Test demonstrating that neuron analysis `candidates_found` can be less than
-//! `candidates_returned` when extreme candidates trigger pairing with conservative
-//! and gentle nudge variants.
+//! Test that `candidates_found` correctly includes paired variants and maintains
+//! the invariant `candidates_found >= candidates_returned`.
 //!
-//! Issue: The test in analyze_all_deadline_prioritises_synapses.rs:326-333 asserts
-//! `candidates_found >= candidates_returned`, but this invariant doesn't hold for
-//! neuron analysis because `pair_extreme_candidates_with_conservative_variants` can
-//! ADD variants, making `candidates_returned` larger than `candidates_found`.
+//! Background: The `pair_extreme_candidates_with_conservative_variants` function
+//! can ADD conservative and gentle nudge variants for extreme candidates. For the
+//! metric pair to make semantic sense, `candidates_found` must be captured AFTER
+//! pairing (so it includes generated variants) but BEFORE truncation.
 //!
-//! This test verifies the correct behaviour: that pairing CAN increase the count.
+//! This ensures "found" always implies "at least as many as returned."
 
 use neat_ai_discovery::{
     analysis::utils::pair_extreme_candidates_with_conservative_variants, CandidateNeuronJson,
 };
 
-/// Test that demonstrates candidates_returned can exceed candidates_found
-/// when extreme candidates are paired with safety variants.
+/// Test that `candidates_found` includes paired variants.
+///
+/// With extreme candidates, the pairing function adds variants. The `candidates_found`
+/// metric must capture the count AFTER pairing to maintain the invariant
+/// `candidates_found >= candidates_returned`.
 #[test]
-fn candidates_returned_can_exceed_candidates_found_due_to_pairing() {
+fn candidates_found_includes_paired_variants() {
     // Create an extreme candidate (incoming_weight > 2.0 or bias > 1.0)
     let extreme_candidate = CandidateNeuronJson {
         source_neuron_uuid: "source-1".to_string(),
@@ -36,33 +38,47 @@ fn candidates_returned_can_exceed_candidates_found_due_to_pairing() {
         target_neuron_stats: None,
     };
 
-    // Simulate what happens during neuron analysis:
-    // candidates_found is captured BEFORE pairing
-    let candidates_found = 1; // Just one original candidate
+    // Simulate CORRECT neuron analysis behaviour:
+    // 1. Apply pairing (adds variants)
+    // 2. Capture candidates_found AFTER pairing
+    // 3. Apply truncation
+    // 4. Capture candidates_returned AFTER truncation
 
-    // After pairing, we can get up to 3 candidates (original + conservative + gentle nudge)
+    // Step 1: Apply pairing with NO limit (to get all variants)
     let paired = pair_extreme_candidates_with_conservative_variants(
         vec![extreme_candidate],
-        Some(10), // High limit to allow all variants
+        None, // No limit - capture all variants
     );
 
-    let candidates_returned = paired.len();
+    // Step 2: candidates_found = total after pairing
+    let candidates_found = paired.len();
 
-    // THIS IS THE KEY ASSERTION:
-    // candidates_returned (3) > candidates_found (1)
-    // The old test assertion `candidates_found >= candidates_returned` would FAIL here!
+    // Step 3: Truncate (e.g., to max_candidates=2)
+    let mut returned = paired;
+    returned.truncate(2);
+
+    // Step 4: candidates_returned = count after truncation
+    let candidates_returned = returned.len();
+
+    // THE KEY INVARIANT: candidates_found >= candidates_returned
+    assert!(
+        candidates_found >= candidates_returned,
+        "Invariant violated: candidates_found ({candidates_found}) < candidates_returned ({candidates_returned})"
+    );
+
+    // Verify actual values
     assert_eq!(
-        candidates_returned, 3,
-        "Expected 3 candidates (original + conservative + gentle nudge)"
+        candidates_found, 3,
+        "Expected 3 candidates found (original + conservative + gentle nudge)"
     );
-    assert!(
-        candidates_returned > candidates_found,
-        "candidates_returned ({candidates_returned}) should be > candidates_found ({candidates_found}) when pairing adds variants"
+    assert_eq!(
+        candidates_returned, 2,
+        "Expected 2 candidates returned after truncation"
     );
 
-    // Verify the types of candidates returned
+    // Verify the types of candidates returned (first two of three)
     assert!(
-        paired[0]
+        returned[0]
             .comment
             .as_deref()
             .unwrap_or_default()
@@ -70,25 +86,16 @@ fn candidates_returned_can_exceed_candidates_found_due_to_pairing() {
         "Original should be marked as paired"
     );
     assert!(
-        paired[1]
+        returned[1]
             .comment
             .as_deref()
             .unwrap_or_default()
             .contains("Conservative"),
         "Second should be Conservative variant"
     );
-    assert!(
-        paired[2]
-            .comment
-            .as_deref()
-            .unwrap_or_default()
-            .contains("Gentle Nudge"),
-        "Third should be Gentle Nudge variant"
-    );
 }
 
-/// Test that non-extreme candidates don't trigger pairing
-/// (in this case the invariant DOES hold)
+/// Test that non-extreme candidates maintain the invariant (no variants added).
 #[test]
 fn non_extreme_candidates_maintain_count_invariant() {
     // Create a non-extreme candidate (incoming_weight <= 2.0 AND bias <= 1.0)
@@ -110,26 +117,81 @@ fn non_extreme_candidates_maintain_count_invariant() {
         target_neuron_stats: None,
     };
 
-    let candidates_found = 1;
+    // Apply pairing with no limit
     let paired = pair_extreme_candidates_with_conservative_variants(
         vec![normal_candidate],
-        Some(10), // High limit
+        None, // No limit
     );
-    let candidates_returned = paired.len();
+
+    let candidates_found = paired.len();
+    let candidates_returned = paired.len(); // No truncation
 
     // For non-extreme candidates, no pairing occurs
     assert_eq!(
-        candidates_returned, 1,
-        "Expected only 1 candidate (no pairing)"
+        candidates_found, 1,
+        "Expected only 1 candidate found (no pairing for non-extreme)"
     );
-    assert_eq!(
-        candidates_returned, candidates_found,
-        "For non-extreme candidates, counts should match"
+    assert!(
+        candidates_found >= candidates_returned,
+        "Invariant: candidates_found >= candidates_returned"
     );
 
     // The candidate should not have been modified
     assert!(
         paired[0].comment.is_none(),
         "Non-extreme candidate should not be tagged"
+    );
+}
+
+/// Test with multiple extreme candidates and a low max_candidates limit.
+/// This verifies the correct handling when truncation actually occurs.
+#[test]
+fn truncation_respects_invariant_with_multiple_extreme_candidates() {
+    // Create 3 extreme candidates
+    let extreme_candidates: Vec<CandidateNeuronJson> = (0..3)
+        .map(|i| CandidateNeuronJson {
+            source_neuron_uuid: format!("source-{i}"),
+            target_neuron_uuid: "target-1".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
+            incoming_weight: 200.0, // EXTREME
+            outgoing_weight: 0.1,
+            squash: "TANH".to_string(),
+            bias: 50.0, // EXTREME
+            comment: None,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.2 - (i as f32 * 0.01), // Decreasing score
+            expected_creature_score_gain: 0.2 - (i as f32 * 0.01),
+            improved_count: 10,
+            total_count: 20,
+            target_neuron_stats: None,
+        })
+        .collect();
+
+    // CORRECT approach: pair first (no limit), then count, then truncate
+    let paired = pair_extreme_candidates_with_conservative_variants(extreme_candidates, None);
+
+    // candidates_found = total after pairing (3 originals × 3 variants each = 9)
+    let candidates_found = paired.len();
+
+    // Truncate to max_candidates=5
+    let mut returned = paired;
+    returned.truncate(5);
+    let candidates_returned = returned.len();
+
+    // THE KEY INVARIANT
+    assert!(
+        candidates_found >= candidates_returned,
+        "Invariant violated: candidates_found ({candidates_found}) < candidates_returned ({candidates_returned})"
+    );
+
+    // Verify actual values
+    assert_eq!(
+        candidates_found, 9,
+        "Expected 9 candidates found (3 extreme × 3 variants each)"
+    );
+    assert_eq!(
+        candidates_returned, 5,
+        "Expected 5 candidates returned after truncation"
     );
 }

--- a/tests/neuron_metadata_candidates_found_includes_pairing.rs
+++ b/tests/neuron_metadata_candidates_found_includes_pairing.rs
@@ -1,0 +1,135 @@
+//! Test demonstrating that neuron analysis `candidates_found` can be less than
+//! `candidates_returned` when extreme candidates trigger pairing with conservative
+//! and gentle nudge variants.
+//!
+//! Issue: The test in analyze_all_deadline_prioritises_synapses.rs:326-333 asserts
+//! `candidates_found >= candidates_returned`, but this invariant doesn't hold for
+//! neuron analysis because `pair_extreme_candidates_with_conservative_variants` can
+//! ADD variants, making `candidates_returned` larger than `candidates_found`.
+//!
+//! This test verifies the correct behaviour: that pairing CAN increase the count.
+
+use neat_ai_discovery::{
+    analysis::utils::pair_extreme_candidates_with_conservative_variants, CandidateNeuronJson,
+};
+
+/// Test that demonstrates candidates_returned can exceed candidates_found
+/// when extreme candidates are paired with safety variants.
+#[test]
+fn candidates_returned_can_exceed_candidates_found_due_to_pairing() {
+    // Create an extreme candidate (incoming_weight > 2.0 or bias > 1.0)
+    let extreme_candidate = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 200.0, // EXTREME - way above the 2.0 threshold
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 50.0, // EXTREME - way above the 1.0 threshold
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    // Simulate what happens during neuron analysis:
+    // candidates_found is captured BEFORE pairing
+    let candidates_found = 1; // Just one original candidate
+
+    // After pairing, we can get up to 3 candidates (original + conservative + gentle nudge)
+    let paired = pair_extreme_candidates_with_conservative_variants(
+        vec![extreme_candidate],
+        Some(10), // High limit to allow all variants
+    );
+
+    let candidates_returned = paired.len();
+
+    // THIS IS THE KEY ASSERTION:
+    // candidates_returned (3) > candidates_found (1)
+    // The old test assertion `candidates_found >= candidates_returned` would FAIL here!
+    assert_eq!(
+        candidates_returned, 3,
+        "Expected 3 candidates (original + conservative + gentle nudge)"
+    );
+    assert!(
+        candidates_returned > candidates_found,
+        "candidates_returned ({candidates_returned}) should be > candidates_found ({candidates_found}) when pairing adds variants"
+    );
+
+    // Verify the types of candidates returned
+    assert!(
+        paired[0]
+            .comment
+            .as_deref()
+            .unwrap_or_default()
+            .contains("paired"),
+        "Original should be marked as paired"
+    );
+    assert!(
+        paired[1]
+            .comment
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Conservative"),
+        "Second should be Conservative variant"
+    );
+    assert!(
+        paired[2]
+            .comment
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Gentle Nudge"),
+        "Third should be Gentle Nudge variant"
+    );
+}
+
+/// Test that non-extreme candidates don't trigger pairing
+/// (in this case the invariant DOES hold)
+#[test]
+fn non_extreme_candidates_maintain_count_invariant() {
+    // Create a non-extreme candidate (incoming_weight <= 2.0 AND bias <= 1.0)
+    let normal_candidate = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.5, // Normal - below 2.0 threshold
+        outgoing_weight: 0.05,
+        squash: "TANH".to_string(),
+        bias: 0.5, // Normal - below 1.0 threshold
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.1,
+        expected_creature_score_gain: 0.1,
+        improved_count: 5,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    let candidates_found = 1;
+    let paired = pair_extreme_candidates_with_conservative_variants(
+        vec![normal_candidate],
+        Some(10), // High limit
+    );
+    let candidates_returned = paired.len();
+
+    // For non-extreme candidates, no pairing occurs
+    assert_eq!(
+        candidates_returned, 1,
+        "Expected only 1 candidate (no pairing)"
+    );
+    assert_eq!(
+        candidates_returned, candidates_found,
+        "For non-extreme candidates, counts should match"
+    );
+
+    // The candidate should not have been modified
+    assert!(
+        paired[0].comment.is_none(),
+        "Non-extreme candidate should not be tagged"
+    );
+}


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.16 to 0.2.17.
- Implement a new analysis ordering where synapse analysis runs first when a deadline is set, preventing starvation of synapse candidates.
- Introduce new metadata fields for both synapse and neuron analyses to provide insights into candidate counts and prediction accuracy.
- Update README to reflect the new features and analysis ordering rationale, improving user understanding of the changes.

These enhancements improve the robustness and observability of the analysis process, ensuring better performance and diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Synapse-friendly ordering (v0.2.17+)**
> - `analyze_all` now runs `synapse` → `neuron` when `analysisDeadlineMs` is set; preserves neuron-first when unset
> 
> **New observability metadata**
> - Adds `SynapseAnalysisMetadata` and `NeuronAnalysisMetadata` to results; exported via `analysis::shared` and surfaced in FFI JSON as `synapseMetadata`/`neuronMetadata`
> - Tracks `targetValueAvailable`, `saturationAwareSimulationUsed` (synapses), and `candidatesFound`/`candidatesReturned` (both); fixes neuron pairing semantics by counting after pairing and before truncation
> 
> **Code + docs**
> - README documents ordering, new metadata, and guidance
> - Version bump to `0.2.17`
> - Minor attribute tweak (`#[allow(unused_variables, unreachable_code)]`)
> 
> **Tests**
> - New integration tests validate deadline-driven ordering, metadata flags, and candidate count invariants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 237dd6ab33c0979195c51734181204c39623fc8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->