### PR TITLE
Update version to 0.2.21 and implement sensible parameter ranges for …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.19"
+version = "0.2.21"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -926,6 +926,22 @@ The improvement calculation now includes the proposed bias when evaluating neuro
 candidates. This ensures the predicted improvement matches the actual improvement
 when the neuron is applied with its computed bias value.
 
+#### Sensible parameter ranges (add-neurons)
+
+In practice, we cache failures and do not re-try them. That makes it important to
+avoid proposing candidates with absurd parameters that are very unlikely to survive
+full rescoring.
+
+As a production guard rail (Dec 2025), add-neuron candidates are only returned when
+their parameters are within sensible bounds:
+
+- **incomingWeight**: \(|w| \le 20\)
+- **bias**: \(|b| \le 10\)
+- **outgoingWeight**: \(|w| \le 0.1\) (already clamped by the optimiser)
+
+This filtering is applied after the "Extreme → Conservative/Gentle Nudge" pairing so
+unsafe originals can be dropped while still allowing safe variants to be evaluated.
+
 #### IDENTITY neuron filtering
 
 **IDENTITY neurons with bias ≈ 0 are redundant** because they're mathematically

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -2928,13 +2928,11 @@ const ORIENTATIONS_BIDIRECTIONAL: [f32; 2] = [1.0, -1.0];
 /// efficiently. Evolution will fine-tune the exact values after discovery.
 /// Extended to very large scales (50, 100) for aggressive signal amplification.
 /// Note: Very large scales may cause numerical instability with some activations.
-const SCALES_WIDE: [f32; 12] = [
-    0.1, 0.2, 0.35, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0,
-];
+const SCALES_WIDE: [f32; 9] = [0.1, 0.2, 0.35, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0];
 /// Log-spaced scales for smooth activation functions (TANH, LOGISTIC, SELU) that
 /// saturate at large inputs. Larger scales included but will saturate the output,
 /// which may still be useful for binary-like thresholding behaviour.
-const SCALES_SMOOTH: [f32; 10] = [0.1, 0.2, 0.35, 0.5, 1.0, 2.0, 4.0, 10.0, 25.0, 50.0];
+const SCALES_SMOOTH: [f32; 8] = [0.1, 0.2, 0.35, 0.5, 1.0, 2.0, 4.0, 10.0];
 
 fn gelu_activation(x: f32) -> f32 {
     let x_cubed = x * x * x;
@@ -3205,18 +3203,11 @@ pub const ACTIVATION_SPECS: [ActivationCandidateSpec; 15] = [
 /// - IDENTITY: Widest range as pure offset (scales with large weights)
 fn get_bias_range(squash: &str) -> (f32, f32, f32) {
     match squash {
-        // ReLU/ELU: extended negative for high-threshold neurons with large weights
-        "ReLU" | "ELU" | "SELU" => (-25.0, 10.0, 0.5),
-        // Symmetric activation functions: extended for large weight configurations
-        "TANH" | "LOGISTIC" => (-10.0, 10.0, 0.5),
-        // IDENTITY: widest range - acts as offset, scales with incoming weights
-        "IDENTITY" => (-50.0, 50.0, 1.0),
-        // Softplus and GELU: extended negative thresholds
-        "Softplus" | "GELU" => (-10.0, 10.0, 0.5),
-        // Other activation functions get expanded range
-        "ABSOLUTE" | "CLIPPED" => (-10.0, 10.0, 0.5),
+        // Sensible default ranges (Dec 2025):
+        // We intentionally avoid very large bias grids (e.g. ±25, ±50) because they
+        // frequently yield brittle candidates that fail full rescoring.
         "BIPOLAR" => (-10.0, 10.0, 1.0),
-        _ => (-10.0, 10.0, 0.5), // Generous default
+        _ => (-10.0, 10.0, 0.5), // Generous default (but still bounded)
     }
 }
 
@@ -3227,29 +3218,14 @@ fn get_bias_range(squash: &str) -> (f32, f32, f32) {
 fn get_bias_values(squash: &str) -> Vec<f32> {
     // Base log-spaced positive values (denser near 0, extended to larger values)
     let base_positive: &[f32] = match squash {
-        // ReLU/ELU: extended for large weight thresholding
-        "ReLU" | "ELU" | "SELU" => &[0.0, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
-        // Symmetric activations: extended range for shifting operating point
-        "TANH" | "LOGISTIC" => &[0.0, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
-        // IDENTITY: widest range (pure offset, scales with large weights)
-        "IDENTITY" => &[0.0, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0],
-        // Softplus/GELU: extended for large weight configurations
-        "Softplus" | "GELU" => &[0.0, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
-        // Others: moderate extended range
-        _ => &[0.0, 0.1, 0.5, 1.0, 2.0, 5.0],
+        // Keep within sensible ranges (Dec 2025): avoid large offsets.
+        "IDENTITY" => &[0.0, 0.5, 1.0, 2.0, 5.0, 10.0],
+        _ => &[0.0, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
     };
 
     let base_negative: &[f32] = match squash {
-        // ReLU/ELU: extended negative for high-threshold neurons
-        "ReLU" | "ELU" | "SELU" => &[-0.1, -0.5, -1.0, -2.0, -5.0, -10.0, -25.0],
-        // Symmetric: mirror of positive for operating point shift
-        "TANH" | "LOGISTIC" => &[-0.1, -0.5, -1.0, -2.0, -5.0, -10.0],
-        // IDENTITY: widest range to match large weights
-        "IDENTITY" => &[-0.5, -1.0, -2.0, -5.0, -10.0, -25.0, -50.0],
-        // Softplus/GELU: extended negative thresholds
-        "Softplus" | "GELU" => &[-0.1, -0.5, -1.0, -2.0, -5.0, -10.0],
-        // Others: moderate extended
-        _ => &[-0.1, -0.5, -1.0, -2.0, -5.0],
+        "IDENTITY" => &[-0.5, -1.0, -2.0, -5.0, -10.0],
+        _ => &[-0.1, -0.5, -1.0, -2.0, -5.0, -10.0],
     };
 
     let mut values: Vec<f32> = base_negative.to_vec();
@@ -3416,6 +3392,12 @@ fn calculate_optimal_identity_outgoing_and_bias(
         return None;
     }
 
+    // Guard rail: absurd IDENTITY biases are almost always brittle in production.
+    let bias_abs_max = crate::analysis::utils::sensible_bias_abs_max_for_squash("IDENTITY");
+    if bias.abs() > bias_abs_max {
+        return None;
+    }
+
     Some((outgoing_weight, bias))
 }
 
@@ -3465,7 +3447,11 @@ fn calculate_optimal_bias(
                 activation_type,
                 bias_range,
             ) {
-                return optimal_bias;
+                // Guard rail: only accept biases within sensible ranges.
+                let bias_abs_max = crate::analysis::utils::sensible_bias_abs_max_for_squash(squash);
+                if optimal_bias.is_finite() && optimal_bias.abs() <= bias_abs_max {
+                    return optimal_bias;
+                }
             }
             // If GPU fails, fall through to CPU
         }
@@ -6597,6 +6583,13 @@ fn evaluate_activation_for_subset<G: GpuEvaluator>(
 
             // Track best candidate
             if net_improvement > best_net_improvement {
+                // Guard rail: do not return candidates with absurd bias values.
+                let bias_abs_max =
+                    crate::analysis::utils::sensible_bias_abs_max_for_squash(spec.name);
+                if !optimal_bias.is_finite() || optimal_bias.abs() > bias_abs_max {
+                    continue;
+                }
+
                 best_net_improvement = net_improvement;
 
                 let target_stats = NeuronStats::from_samples(all_samples).map(|s| s.to_json());
@@ -8125,6 +8118,10 @@ pub(crate) fn analyze_neurons_with_cache(
         helpful_results,
         None, // No limit - truncate separately after capturing candidates_found
     );
+
+    // Production guard rail (Dec 2025): only return candidates within sensible parameter ranges.
+    // This avoids wasting the evaluation budget on absurd bias/weight configurations.
+    helpful_results = crate::analysis::utils::filter_candidates_to_sensible_ranges(helpful_results);
 
     // Track candidates_found AFTER pairing but BEFORE truncation.
     // This ensures candidates_found >= candidates_returned always holds, which is
@@ -12605,9 +12602,9 @@ mod tests_synapses {
     /// Note: get_bias_range is used by GPU, get_bias_values is used by CPU
     #[test]
     fn test_get_bias_range() {
-        // Test ReLU range (extended negative for high-threshold neurons)
+        // Sensible-range policy (Dec 2025): keep GPU bias search ranges bounded.
         let (min, max, step) = get_bias_range("ReLU");
-        assert_eq!(min, -25.0);
+        assert_eq!(min, -10.0);
         assert_eq!(max, 10.0);
         assert_eq!(step, 0.5);
 
@@ -12623,11 +12620,11 @@ mod tests_synapses {
         assert_eq!(max, 10.0);
         assert_eq!(step, 0.5);
 
-        // Test IDENTITY range (widest - acts as pure offset, scales with large weights)
+        // Test IDENTITY range (bounded - avoid absurd offsets that fail ablation tests)
         let (min, max, step) = get_bias_range("IDENTITY");
-        assert_eq!(min, -50.0);
-        assert_eq!(max, 50.0);
-        assert_eq!(step, 1.0);
+        assert_eq!(min, -10.0);
+        assert_eq!(max, 10.0);
+        assert_eq!(step, 0.5);
 
         // Test default range for unknown activation (generous)
         let (min, max, step) = get_bias_range("UNKNOWN");
@@ -12983,7 +12980,7 @@ mod tests_synapses {
     /// Test get_bias_values returns log-spaced values for efficient search
     #[test]
     fn test_get_bias_values() {
-        // ReLU should have extended negative range for high-threshold neurons
+        // ReLU should include meaningful negative bias values for threshold shifting.
         let relu_values = get_bias_values("ReLU");
         assert!(relu_values.contains(&0.0), "Should include 0");
         assert!(
@@ -12995,15 +12992,15 @@ mod tests_synapses {
             "Should be efficient (log-spaced, not linear)"
         );
 
-        // IDENTITY should have widest range (scales with large weights)
+        // IDENTITY should still include moderate offsets, but stay within sensible bounds.
         let identity_values = get_bias_values("IDENTITY");
         assert!(
-            identity_values.iter().any(|&v| v >= 25.0),
-            "IDENTITY should reach 25.0 for large weight configurations"
+            identity_values.iter().any(|&v| v >= 10.0),
+            "IDENTITY should reach 10.0 for moderate offset configurations"
         );
         assert!(
-            identity_values.iter().any(|&v| v <= -25.0),
-            "IDENTITY should reach -25.0"
+            identity_values.iter().any(|&v| v <= -10.0),
+            "IDENTITY should reach -10.0"
         );
 
         // All values should be sorted
@@ -14666,22 +14663,25 @@ mod tests_optimal_outgoing_weight {
             min_improvement: 0.0,
         };
 
-        // 11 positive-error samples with varying activation: affine fit slope should be ~0 here,
-        // so IDENTITY subset evaluation returns None and we fall through to all-samples fallback.
-        let mut samples: Vec<HelpfulSample> = (0..=10)
+        // 11 positive-error samples with varying activation.
+        //
+        // This test is crafted to trigger the all-samples affine fit path while still
+        // producing a *sensible* bias (we reject absurd bias magnitudes as a guard rail).
+        let mut samples: Vec<HelpfulSample> = (1..=11)
             .map(|i| HelpfulSample {
-                activation: 100.0 + (i as f32) * 10.0, // 100..200
+                activation: i as f32, // 1..11
                 avg_error: 1.0,
                 target_value: None,
                 target_activation: None,
             })
             .collect();
 
-        // 9 negative-error samples whose activation sum matches the positive group (1650),
-        // making Σ(activation×error) == 0 for the all-samples no-intercept fit.
-        let negative_activations: [f32; 9] = [
-            200.0, 200.0, 200.0, 200.0, 200.0, 200.0, 150.0, 150.0, 150.0,
-        ];
+        // 9 negative-error samples whose activation sum matches the positive group:
+        // sum(1..11) = 66, so pick 9 values summing to 66.
+        //
+        // This makes Σ(activation×error) == 0 for the all-samples no-intercept fit,
+        // forcing the fallback to rely on the affine (with-intercept) fit.
+        let negative_activations: [f32; 9] = [6.0, 6.0, 6.0, 6.0, 6.0, 6.0, 6.0, 6.0, 18.0];
         for activation in negative_activations {
             samples.push(HelpfulSample {
                 activation,

--- a/src/analysis/utils.rs
+++ b/src/analysis/utils.rs
@@ -18,6 +18,60 @@ pub fn verbose_enabled() -> bool {
 
 use crate::CandidateNeuronJson;
 
+// ============================================================================
+// Sensible-range filtering (production guard rails)
+// ============================================================================
+
+/// Maximum absolute incoming weight we consider "sensible" for add-neuron candidates.
+///
+/// Rationale (Dec 2025): very large incoming weights (50, 100, 200) frequently produce
+/// brittle candidates that look positive under the linear prediction but fail when
+/// applied to the full training set.
+const SENSIBLE_INCOMING_ABS_MAX: f32 = 20.0;
+
+/// Maximum absolute bias we consider "sensible" for add-neuron candidates.
+///
+/// Rationale (Dec 2025): large |bias| often turns the new neuron into a near-constant
+/// offset (or forces saturation), which tends to crater performance in ablation tests.
+const SENSIBLE_BIAS_ABS_MAX: f32 = 10.0;
+
+/// Maximum absolute outgoing weight we consider "sensible" for add-neuron candidates.
+///
+/// This matches `MAX_OUTGOING_WEIGHT` in the analysis implementation. Keeping this
+/// aligned avoids surprising "why is this candidate rejected?" behaviour.
+const SENSIBLE_OUTGOING_ABS_MAX: f32 = 0.1;
+
+pub(crate) fn sensible_bias_abs_max_for_squash(_squash: &str) -> f32 {
+    // For now we keep this uniform across squashes. If we find a function that
+    // legitimately needs a wider bias range, we can special-case it here.
+    SENSIBLE_BIAS_ABS_MAX
+}
+
+/// Drop add-neuron candidates that are outside our "sensible" parameter ranges.
+///
+/// We do not mutate candidates here (no clamping). If a candidate is out of range,
+/// it's simply not worth returning because TypeScript will cache the failure and
+/// never re-try it.
+///
+/// Note: This is applied AFTER the "Extreme → Conservative/Gentle Nudge" pairing, so
+/// unsafe originals can be dropped while still keeping safe variants.
+#[doc(hidden)]
+pub fn filter_candidates_to_sensible_ranges(
+    candidates: Vec<CandidateNeuronJson>,
+) -> Vec<CandidateNeuronJson> {
+    candidates
+        .into_iter()
+        .filter(|c| {
+            c.incoming_weight.is_finite()
+                && c.outgoing_weight.is_finite()
+                && c.bias.is_finite()
+                && c.incoming_weight.abs() <= SENSIBLE_INCOMING_ABS_MAX
+                && c.outgoing_weight.abs() <= SENSIBLE_OUTGOING_ABS_MAX
+                && c.bias.abs() <= sensible_bias_abs_max_for_squash(&c.squash)
+        })
+        .collect()
+}
+
 /// Conservative parameter clamps for add-neuron candidates.
 ///
 /// Production evidence (Dec 2025): many failed add-neuron candidates are generated with very
@@ -41,7 +95,7 @@ const CONSERVATIVE_EXPECTED_MULTIPLIER: f32 = 0.5;
 /// represent a useful feature), while keeping the outgoing effect small and stable.
 ///
 /// This is a third candidate returned alongside the original and the conservative clamp.
-const GENTLE_NUDGE_INCOMING_ABS_MAX: f32 = 50.0;
+const GENTLE_NUDGE_INCOMING_ABS_MAX: f32 = 20.0;
 const GENTLE_NUDGE_BIAS_ABS_MAX: f32 = 10.0;
 const GENTLE_NUDGE_OUTGOING_ABS_MAX: f32 = 0.02;
 const GENTLE_NUDGE_OUTGOING_SCALE: f32 = 0.1;

--- a/tests/sensible_range_filtering.rs
+++ b/tests/sensible_range_filtering.rs
@@ -1,0 +1,91 @@
+//! Regression tests for "sensible range" filtering.
+//!
+//! We cache failures and do not retry them, so it is better to avoid proposing
+//! candidates with absurd weights/biases up front. These tests ensure we never
+//! return out-of-range add-neuron candidates.
+
+use neat_ai_discovery::analysis::utils::{
+    filter_candidates_to_sensible_ranges, pair_extreme_candidates_with_conservative_variants,
+};
+use neat_ai_discovery::CandidateNeuronJson;
+
+#[test]
+fn extreme_candidate_is_not_returned_after_sensible_range_filtering() {
+    // An intentionally extreme candidate: large incoming and bias.
+    let extreme = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 200.0,
+        outgoing_weight: 0.1,
+        squash: "TANH".to_string(),
+        bias: 50.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    // Existing production experiment: pair with safety variants.
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![extreme], Some(3));
+    assert_eq!(paired.len(), 3, "expected original + two safety variants");
+
+    // New policy: do not return out-of-range candidates.
+    let filtered = filter_candidates_to_sensible_ranges(paired);
+
+    // Should drop the original extreme candidate, but keep at least one safe variant.
+    assert!(
+        !filtered.is_empty(),
+        "expected at least one sensible candidate to remain"
+    );
+
+    // No returned candidate should have absurd bias/weights.
+    for c in &filtered {
+        assert!(
+            c.incoming_weight.abs() <= 20.0,
+            "incoming_weight should be kept in a sensible range, got {}",
+            c.incoming_weight
+        );
+        assert!(
+            c.bias.abs() <= 10.0,
+            "bias should be kept in a sensible range, got {}",
+            c.bias
+        );
+        assert!(
+            c.outgoing_weight.abs() <= 0.1,
+            "outgoing_weight is clamped in analysis and should remain ≤0.1, got {}",
+            c.outgoing_weight
+        );
+    }
+}
+
+#[test]
+fn absurd_identity_bias_is_filtered_out() {
+    let absurd = CandidateNeuronJson {
+        source_neuron_uuid: "source-1".to_string(),
+        target_neuron_uuid: "target-1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.0,
+        outgoing_weight: 0.1,
+        squash: "IDENTITY".to_string(),
+        bias: 95_247_370.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+    };
+
+    let filtered = filter_candidates_to_sensible_ranges(vec![absurd]);
+    assert!(
+        filtered.is_empty(),
+        "expected absurd IDENTITY bias candidate to be filtered out"
+    );
+}


### PR DESCRIPTION
…add-neuron candidates

- Bump version in Cargo.toml from 0.2.19 to 0.2.21.
- Introduce sensible parameter ranges for add-neuron candidates to prevent proposing configurations that are likely to fail during evaluation.
- Update README to document the new parameter constraints, including limits on incoming weights, biases, and outgoing weights.
- Enhance analysis functions to filter out candidates with parameters outside the defined sensible ranges, improving robustness in production scenarios.

These changes aim to enhance the stability and performance of the neuron addition process by ensuring only viable candidates are considered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces production guard rails so add-neuron candidates outside sensible bounds are not returned, reducing brittle proposals.
> 
> - Adds `analysis/utils.rs` helpers: `filter_candidates_to_sensible_ranges` and `sensible_bias_abs_max_for_squash`; applied after `pair_extreme_candidates_with_conservative_variants` in the neuron pipeline
> - Tightens search spaces: shrinks `SCALES_WIDE`/`SCALES_SMOOTH`, bounds `get_bias_range`/`get_bias_values`, and validates GPU/IDENTITY bias within `sensible_bias_abs_max_for_squash`
> - Rejects absurd biases during candidate selection; reduces "Gentle Nudge" incoming clamp to `20.0`
> - Updates tests to new ranges and adds `tests/sensible_range_filtering.rs` regression coverage
> - Documents limits in `README.md` (incoming ≤ `20`, bias ≤ `10`, outgoing ≤ `0.1`) and bumps version to `0.2.21`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44a7f366fecfb73a7b097f082174ba5729b2cd22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->