### PR TITLE
Update version to 0.2.22 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -280,6 +280,11 @@ measured by NEAT-AI.
   candidate. These entries summarise the reason (no samples, below threshold,
   etc.) plus supporting counts so controllers can relay the explanation even
   when verbose logging is disabled.
+- Optional production experiment (29-Dec-2025): If you are seeing a large volume of failed
+  add-neuron candidates targeting hidden neurons, you can force **output-only** focus targets
+  for add-neuron analysis by setting `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY=1`.
+  This is intentionally opt-in for backwards compatibility; when enabled, hidden focus targets
+  will be reported as `HiddenNeuronFiltered` in diagnostics.
 - When an analysis deadline is supplied, discovery honours it **vertically**:
   focus neurons are processed in priority order and each neuron is analysed
   completely (including upstream candidates) where possible before moving to

--- a/README.md
+++ b/README.md
@@ -959,9 +959,8 @@ IDENTITY(input × incoming_weight + 0) × outgoing_weight = input × incoming ×
 This is just a synapse with `weight = incoming_weight × outgoing_weight`. Discovery
 now filters out these candidates:
 
-1. **Minimum improvement threshold**: IDENTITY requires at least 5% improvement
-2. **Bias filtering**: IDENTITY candidates with `|bias| < 0.01` are rejected
-3. **Use synapse analysis**: Direct connections should use `add-synapses`, not `add-neurons`
+1. **Bias filtering**: IDENTITY candidates with `|bias| < 0.01` are rejected
+2. **Use synapse analysis**: Direct connections should use `add-synapses`, not `add-neurons`
 
 #### Add-neuron target neuron filtering
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7311,13 +7311,108 @@ fn evaluate_discrete_candidate(
     best_candidate
 }
 
+/// Result of filtering focus targets for add-neuron analysis.
+///
+/// This is split out to keep the rules testable without needing a GPU (the main analysis path
+/// asserts GPU availability).
+#[derive(Debug, Default)]
+struct FocusTargetFilterResult {
+    focus_order: Vec<String>,
+    skipped_hidden: Vec<String>,
+    skipped_input: Vec<String>,
+    skipped_constant: Vec<String>,
+    threshold_targets: Vec<String>,
+}
+
+/// Filter and classify focus targets for add-neuron analysis.
+///
+/// Notes (Dec 2025):
+/// - By default we allow both output and hidden focus targets (hidden will be impact-discounted later).
+/// - When `output_only_targets` is enabled, hidden (and unknown treated-as-hidden) targets are filtered out.
+/// - STEP/BIPOLAR targets are tracked in `threshold_targets` for visibility (and potential future branching).
+fn filter_focus_targets_for_neuron_analysis(
+    unique_focus: &[&String],
+    neuron_type_map: &HashMap<String, String>,
+    neuron_squash_map: &HashMap<String, String>,
+    output_only_targets: bool,
+) -> FocusTargetFilterResult {
+    let mut result = FocusTargetFilterResult::default();
+
+    // Helper: record STEP/BIPOLAR targets consistently across output/hidden/unknown.
+    let mut record_threshold_target = |uuid: &String| {
+        if let Some(squash) = neuron_squash_map.get(uuid) {
+            if is_threshold_activation(squash) {
+                result.threshold_targets.push(uuid.clone());
+            }
+        }
+    };
+
+    result.focus_order = unique_focus
+        .iter()
+        .filter_map(|uuid| {
+            // By default we analyse both output and hidden focus targets (hidden will be discounted).
+            // If `output_only_targets` is set, hidden targets are filtered.
+            let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
+            match neuron_type {
+                Some("output") => {
+                    record_threshold_target(uuid);
+                    Some((*uuid).clone())
+                }
+                Some("hidden") => {
+                    if output_only_targets {
+                        result.skipped_hidden.push((*uuid).clone());
+                        None
+                    } else {
+                        record_threshold_target(uuid);
+                        Some((*uuid).clone())
+                    }
+                }
+                Some("input") => {
+                    // Input neurons are observation sources, not computation nodes.
+                    result.skipped_input.push((*uuid).clone());
+                    None
+                }
+                Some("constant") => {
+                    // Constant neurons don't receive inputs - filter them out.
+                    result.skipped_constant.push((*uuid).clone());
+                    None
+                }
+                Some(unknown_type) => {
+                    // Unknown type - treat as hidden.
+                    eprintln!(
+                        "[NEAT-AI-Discovery] Warning: Unknown neuron type '{unknown_type}' for UUID '{uuid}'. \
+                        Treating as hidden neuron."
+                    );
+                    if output_only_targets {
+                        result.skipped_hidden.push((*uuid).clone());
+                        None
+                    } else {
+                        record_threshold_target(uuid);
+                        Some((*uuid).clone())
+                    }
+                }
+                None => {
+                    // Unknown UUID - this is likely a bug, skip it.
+                    eprintln!(
+                        "[NEAT-AI-Discovery] Warning: Unknown neuron UUID '{uuid}' in focus list \
+                        (not found in creature). Skipping."
+                    );
+                    None
+                }
+            }
+        })
+        .collect();
+
+    result
+}
+
 pub(crate) fn analyze_neurons_with_cache(
     input: &AnalyzeNeuronsInput,
     cache: Arc<RecordCache>,
 ) -> Result<AnalyzeNeuronsResult> {
-    // v0.1.134: Default threshold is 0 - return ALL positive improvements.
-    // TypeScript will decide which candidates are worth the cost of growth.
-    let threshold = input.improvement_threshold.unwrap_or(0.0);
+    // v0.1.134: Return ALL positive improvements.
+    // NEAT-AI applies the cost-of-growth gate during evaluation.
+    let threshold = 0.0;
     let ordered_neurons = build_ordered_neurons(&input.creature);
 
     // Build a lookup map for neuron squash functions to identify discrete targets
@@ -7431,7 +7526,7 @@ pub(crate) fn analyze_neurons_with_cache(
     let gpu_used = true;
     let analysis_timed_out = Arc::new(Mutex::new(false));
 
-    // Filter focus neurons to ONLY output neurons for add-neuron analysis.
+    // Filter focus neurons to valid add-neuron targets.
     //
     // Rationale: Add-neuron candidates predict error reduction at the target neuron.
     // For OUTPUT neurons, this directly corresponds to creature score improvement.
@@ -7444,18 +7539,6 @@ pub(crate) fn analyze_neurons_with_cache(
     // Non-output neurons are skipped here but still tracked in diagnostics so the
     // caller knows they were received but filtered out (with the correct reason).
     let original_focus_count = unique_focus.len();
-    let mut skipped_hidden: Vec<String> = Vec::new();
-    let mut skipped_input: Vec<String> = Vec::new();
-    let mut skipped_constant: Vec<String> = Vec::new();
-
-    // Randomize the focus neuron order so that repeated runs with timeouts will
-    // eventually cover all neurons. Convert to owned strings, shuffle, then use.
-    //
-    // All neurons are processed - no activation functions are skipped. STEP/BIPOLAR
-    // neurons use a specialised threshold-crossing model; all others use the standard
-    // linear error model (which is an approximation but still finds useful patterns).
-    let mut threshold_targets: Vec<String> = Vec::new();
-
     // Optional production experiment (29-Dec-2025): allow callers to force output-only
     // focus targets for add-neuron analysis.
     //
@@ -7464,64 +7547,18 @@ pub(crate) fn analyze_neurons_with_cache(
     //
     // Enable by setting `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY=1`.
     let output_only_targets = std::env::var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY").is_ok();
-
-    let mut focus_order: Vec<String> = unique_focus
-        .iter()
-        .filter_map(|uuid| {
-            // By default we analyse both output and hidden focus targets (hidden will be discounted).
-            // If `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY` is set, hidden targets are filtered.
-            let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
-            match neuron_type {
-                Some("output") => {
-                    if let Some(squash) = neuron_squash_map.get(*uuid) {
-                        if is_threshold_activation(squash) {
-                            threshold_targets.push((*uuid).clone());
-                        }
-                    }
-                    Some((*uuid).clone())
-                }
-                Some("hidden") => {
-                    if output_only_targets {
-                        skipped_hidden.push((*uuid).clone());
-                        None
-                    } else {
-                        Some((*uuid).clone())
-                    }
-                }
-                Some("input") => {
-                    // Input neurons are observation sources, not computation nodes
-                    skipped_input.push((*uuid).clone());
-                    None
-                }
-                Some("constant") => {
-                    // Constant neurons don't receive inputs - filtering them out
-                    skipped_constant.push((*uuid).clone());
-                    None
-                }
-                Some(unknown_type) => {
-                    // Unknown type - treat as hidden.
-                    eprintln!(
-                        "[NEAT-AI-Discovery] Warning: Unknown neuron type '{unknown_type}' for UUID '{uuid}'. \
-                        Treating as hidden neuron."
-                    );
-                    if output_only_targets {
-                        skipped_hidden.push((*uuid).clone());
-                        None
-                    } else {
-                        Some((*uuid).clone())
-                    }
-                }
-                None => {
-                    // Unknown UUID - this is likely a bug, skip it
-                    eprintln!(
-                        "[NEAT-AI-Discovery] Warning: Unknown neuron UUID '{uuid}' in focus list \
-                        (not found in creature). Skipping."
-                    );
-                    None
-                }
-            }
-        })
-        .collect();
+    let FocusTargetFilterResult {
+        mut focus_order,
+        skipped_hidden,
+        skipped_input,
+        skipped_constant,
+        threshold_targets,
+    } = filter_focus_targets_for_neuron_analysis(
+        &unique_focus,
+        &neuron_type_map,
+        &neuron_squash_map,
+        output_only_targets,
+    );
 
     // Log when non-output neurons are filtered out
     let total_skipped = skipped_hidden.len() + skipped_input.len() + skipped_constant.len();
@@ -8907,9 +8944,9 @@ pub(crate) fn analyze_synapses_with_cache(
     let total_focus_count = focus_order.len();
     let completed_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
-    // v0.1.134: Default threshold is 0 - return ALL positive improvements.
-    // TypeScript will decide which candidates are worth the cost of growth.
-    let threshold = input.improvement_threshold.unwrap_or(0.0);
+    // v0.1.134: Return ALL positive improvements.
+    // NEAT-AI applies the cost-of-growth gate during evaluation.
+    let threshold = 0.0;
 
     // Collect all helpful evaluation work first for batching
     struct HelpfulWork {
@@ -10999,7 +11036,6 @@ mod tests_synapses {
             parquet_file: parquet_file.clone(),
             creature,
             focus_neurons: vec!["output-0".to_string(), "output-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11073,7 +11109,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string(), "output-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11183,7 +11218,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["hidden-0".to_string(), "output-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11323,7 +11357,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["hidden-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11373,7 +11406,6 @@ mod tests_synapses {
             parquet_file: "unused.parquet".to_string(),
             creature,
             focus_neurons: Vec::new(),
-            improvement_threshold: None,
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11426,7 +11458,6 @@ mod tests_synapses {
             parquet_file: parquet_file.clone(),
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11525,7 +11556,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string(), "output-1".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11611,8 +11641,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.05),
-            harmful_threshold: Some(-0.05),
             max_synapse_candidates: Some(5),
             max_neuron_candidates: Some(5),
             analysis_deadline_ms: None,
@@ -11672,7 +11700,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -11772,7 +11799,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string(), "output-1".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             // Any non-None deadline value will exercise the override sequence.
             analysis_deadline_ms: Some(1_000_000),
@@ -11904,7 +11930,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string(), "output-1".to_string()],
-            improvement_threshold: Some(0.05),
             max_candidates: None,
             // Any non-None deadline value will exercise the override sequence.
             analysis_deadline_ms: None,
@@ -12262,12 +12287,10 @@ mod tests_synapses {
             synapses: Vec::new(), // No existing synapse from input-0 to output-0
         };
 
-        // Set threshold to 0.1 - we expect a positive but below-threshold improvement to be accepted
         let input = AnalyzeSynapsesInput {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.1),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -12365,7 +12388,6 @@ mod tests_synapses {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.1),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -12435,12 +12457,10 @@ mod tests_synapses {
             synapses: Vec::new(),
         };
 
-        // Set threshold to 0.1 - we expect improvement above this to be accepted
         let input = AnalyzeSynapsesInput {
             parquet_file,
             creature,
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.1),
             max_candidates: None,
             analysis_deadline_ms: None,
         };
@@ -12729,6 +12749,119 @@ mod tests_synapses {
         assert!(
             !is_threshold_activation("UNKNOWN"),
             "Unknown uses standard model"
+        );
+    }
+
+    #[test]
+    fn test_filter_focus_targets_tracks_threshold_targets_for_hidden_and_unknown_when_allowed() {
+        use std::collections::HashMap;
+
+        // Regression coverage (29-Dec-2025): when output/hidden handling was split, the
+        // STEP/BIPOLAR tracking was accidentally only applied to output targets.
+        let focus = [
+            "hidden-step".to_string(),
+            "output-tanh".to_string(),
+            "unknown-bipolar".to_string(),
+        ];
+        let unique_focus: Vec<&String> = focus.iter().collect();
+
+        let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+        neuron_type_map.insert("hidden-step".to_string(), "hidden".to_string());
+        neuron_type_map.insert("output-tanh".to_string(), "output".to_string());
+        neuron_type_map.insert("unknown-bipolar".to_string(), "mystery".to_string());
+
+        let mut neuron_squash_map: HashMap<String, String> = HashMap::new();
+        neuron_squash_map.insert("hidden-step".to_string(), "STEP".to_string());
+        neuron_squash_map.insert("output-tanh".to_string(), "TANH".to_string());
+        neuron_squash_map.insert("unknown-bipolar".to_string(), "BIPOLAR".to_string());
+
+        let result = filter_focus_targets_for_neuron_analysis(
+            &unique_focus,
+            &neuron_type_map,
+            &neuron_squash_map,
+            false,
+        );
+
+        assert!(
+            result.focus_order.contains(&"hidden-step".to_string()),
+            "hidden-step should be included when output-only mode is disabled"
+        );
+        assert!(
+            result.focus_order.contains(&"unknown-bipolar".to_string()),
+            "unknown-bipolar should be included when output-only mode is disabled (treated as hidden)"
+        );
+        assert!(
+            result
+                .threshold_targets
+                .contains(&"hidden-step".to_string()),
+            "hidden-step (STEP) should be tracked as a threshold target"
+        );
+        assert!(
+            result
+                .threshold_targets
+                .contains(&"unknown-bipolar".to_string()),
+            "unknown-bipolar (BIPOLAR) should be tracked as a threshold target"
+        );
+        assert!(
+            !result
+                .threshold_targets
+                .contains(&"output-tanh".to_string()),
+            "output-tanh (TANH) should not be tracked as a threshold target"
+        );
+        assert!(
+            result.skipped_hidden.is_empty(),
+            "No hidden targets should be skipped when output-only mode is disabled"
+        );
+    }
+
+    #[test]
+    fn test_filter_focus_targets_respects_output_only_mode_for_hidden_and_unknown() {
+        use std::collections::HashMap;
+
+        let focus = [
+            "hidden-step".to_string(),
+            "output-step".to_string(),
+            "unknown-bipolar".to_string(),
+        ];
+        let unique_focus: Vec<&String> = focus.iter().collect();
+
+        let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+        neuron_type_map.insert("hidden-step".to_string(), "hidden".to_string());
+        neuron_type_map.insert("output-step".to_string(), "output".to_string());
+        neuron_type_map.insert("unknown-bipolar".to_string(), "mystery".to_string());
+
+        let mut neuron_squash_map: HashMap<String, String> = HashMap::new();
+        neuron_squash_map.insert("hidden-step".to_string(), "STEP".to_string());
+        neuron_squash_map.insert("output-step".to_string(), "STEP".to_string());
+        neuron_squash_map.insert("unknown-bipolar".to_string(), "BIPOLAR".to_string());
+
+        let result = filter_focus_targets_for_neuron_analysis(
+            &unique_focus,
+            &neuron_type_map,
+            &neuron_squash_map,
+            true,
+        );
+
+        assert_eq!(
+            result.focus_order,
+            vec!["output-step".to_string()],
+            "Only output targets should remain when output-only mode is enabled"
+        );
+        assert_eq!(
+            result.threshold_targets,
+            vec!["output-step".to_string()],
+            "Threshold targets should only include remaining focus targets"
+        );
+
+        assert!(
+            result.skipped_hidden.contains(&"hidden-step".to_string()),
+            "hidden-step should be reported as skipped when output-only mode is enabled"
+        );
+        assert!(
+            result
+                .skipped_hidden
+                .contains(&"unknown-bipolar".to_string()),
+            "unknown-bipolar should be reported as skipped when output-only mode is enabled"
         );
     }
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7444,7 +7444,7 @@ pub(crate) fn analyze_neurons_with_cache(
     // Non-output neurons are skipped here but still tracked in diagnostics so the
     // caller knows they were received but filtered out (with the correct reason).
     let original_focus_count = unique_focus.len();
-    let skipped_hidden: Vec<String> = Vec::new();
+    let mut skipped_hidden: Vec<String> = Vec::new();
     let mut skipped_input: Vec<String> = Vec::new();
     let mut skipped_constant: Vec<String> = Vec::new();
 
@@ -7455,22 +7455,38 @@ pub(crate) fn analyze_neurons_with_cache(
     // neurons use a specialised threshold-crossing model; all others use the standard
     // linear error model (which is an approximation but still finds useful patterns).
     let mut threshold_targets: Vec<String> = Vec::new();
+
+    // Optional production experiment (29-Dec-2025): allow callers to force output-only
+    // focus targets for add-neuron analysis.
+    //
+    // This is disabled by default for backwards compatibility (existing regression tests
+    // and older pipelines expect hidden targets to be analysed with impact discounting).
+    //
+    // Enable by setting `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY=1`.
+    let output_only_targets = std::env::var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY").is_ok();
+
     let mut focus_order: Vec<String> = unique_focus
         .iter()
         .filter_map(|uuid| {
-            // Check neuron type - allow output and hidden neurons for add-neuron analysis
-            // Hidden neurons are analysed with impact-based discounting (v0.1.123)
+            // By default we analyse both output and hidden focus targets (hidden will be discounted).
+            // If `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY` is set, hidden targets are filtered.
             let neuron_type = neuron_type_map.get(*uuid).map(|s| s.as_str());
             match neuron_type {
-                Some("output") | Some("hidden") => {
-                    // Output and hidden neurons are valid targets
-                    // Hidden neuron predictions will be discounted by impact later
+                Some("output") => {
                     if let Some(squash) = neuron_squash_map.get(*uuid) {
                         if is_threshold_activation(squash) {
                             threshold_targets.push((*uuid).clone());
                         }
                     }
                     Some((*uuid).clone())
+                }
+                Some("hidden") => {
+                    if output_only_targets {
+                        skipped_hidden.push((*uuid).clone());
+                        None
+                    } else {
+                        Some((*uuid).clone())
+                    }
                 }
                 Some("input") => {
                     // Input neurons are observation sources, not computation nodes
@@ -7483,12 +7499,17 @@ pub(crate) fn analyze_neurons_with_cache(
                     None
                 }
                 Some(unknown_type) => {
-                    // Unknown type - treat as hidden (analysable with discount)
+                    // Unknown type - treat as hidden.
                     eprintln!(
                         "[NEAT-AI-Discovery] Warning: Unknown neuron type '{unknown_type}' for UUID '{uuid}'. \
-                        Treating as hidden neuron (will apply impact discount)."
+                        Treating as hidden neuron."
                     );
-                    Some((*uuid).clone())
+                    if output_only_targets {
+                        skipped_hidden.push((*uuid).clone());
+                        None
+                    } else {
+                        Some((*uuid).clone())
+                    }
                 }
                 None => {
                     // Unknown UUID - this is likely a bug, skip it

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -103,7 +103,6 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             parquet_file: input.parquet_file.clone(),
             creature: input.creature.clone(),
             focus_neurons: input.focus_neurons.clone(),
-            improvement_threshold: input.improvement_threshold,
             max_candidates: input.max_synapse_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
         })
@@ -116,7 +115,6 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             parquet_file: input.parquet_file.clone(),
             creature: input.creature.clone(),
             focus_neurons: input.focus_neurons.clone(),
-            improvement_threshold: input.improvement_threshold,
             max_candidates: input.max_neuron_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,10 +303,6 @@ pub struct AnalyzeParallelInput {
     pub creature: CreatureJson,
     pub focus_neurons: Vec<String>,
     #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
-    pub harmful_threshold: Option<f32>,
-    #[serde(default)]
     pub max_synapse_candidates: Option<usize>,
     #[serde(default)]
     pub max_neuron_candidates: Option<usize>,
@@ -386,8 +382,6 @@ pub struct AnalyzeSynapsesInput {
     pub creature: CreatureJson,
     pub focus_neurons: Vec<String>,
     #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
     pub max_candidates: Option<usize>,
     #[serde(default)]
     pub analysis_deadline_ms: Option<u64>,
@@ -401,8 +395,6 @@ pub struct AnalyzeNeuronsInput {
     pub creature: CreatureJson,
     pub focus_neurons: Vec<String>,
     #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
     pub max_candidates: Option<usize>,
     #[serde(default)]
     pub analysis_deadline_ms: Option<u64>,
@@ -415,10 +407,6 @@ pub struct AnalyzeAllInput {
     pub parquet_file: String,
     pub creature: CreatureJson,
     pub focus_neurons: Vec<String>,
-    #[serde(default)]
-    pub improvement_threshold: Option<f32>,
-    #[serde(default)]
-    pub harmful_threshold: Option<f32>,
     #[serde(default)]
     pub max_synapse_candidates: Option<usize>,
     #[serde(default)]
@@ -926,8 +914,6 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
         parquet_file: input.parquet_file,
         creature: input.creature,
         focus_neurons: input.focus_neurons,
-        improvement_threshold: input.improvement_threshold,
-        harmful_threshold: input.harmful_threshold,
         max_synapse_candidates: input.max_synapse_candidates,
         max_neuron_candidates: input.max_neuron_candidates,
         analysis_deadline_ms: input.analysis_deadline_ms,
@@ -2521,8 +2507,6 @@ mod tests {
                 "output": 1
             },
             "focusNeurons": ["output-0"],
-            "improvementThreshold": 0.01,
-            "harmfulThreshold": -0.05,
             "maxSynapseCandidates": 5,
             "maxNeuronCandidates": 5,
             "requireGpu": false

--- a/tests/analysis_timeout.rs
+++ b/tests/analysis_timeout.rs
@@ -105,7 +105,6 @@ fn synapse_analysis_respects_deadline() {
             "output-1".to_string(),
             "output-2".to_string(),
         ],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: Some(deadline_ms),
     };
@@ -193,7 +192,6 @@ fn neuron_analysis_respects_deadline() {
             "output-1".to_string(),
             "output-2".to_string(),
         ],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: Some(deadline_ms),
     };
@@ -276,7 +274,6 @@ fn focus_neurons_are_randomised_across_runs() {
             parquet_file: parquet_file.clone(),
             creature: creature.clone(),
             focus_neurons: focus_neurons.clone(),
-            improvement_threshold: Some(0.0),
             max_candidates: None,
             analysis_deadline_ms: Some(60_000), // 1 minute - enough to complete
         };

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -113,8 +113,6 @@ fn synapse_analysis_runs_under_deadline() {
         parquet_file,
         creature: create_simple_creature(),
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(10),
         max_neuron_candidates: Some(10),
         analysis_deadline_ms: Some(30_000), // 30 second deadline - should be plenty
@@ -157,8 +155,6 @@ fn metadata_indicates_target_value_available() {
         parquet_file,
         creature: create_simple_creature(),
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(10),
         max_neuron_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
@@ -196,8 +192,6 @@ fn metadata_indicates_target_value_not_available() {
         parquet_file,
         creature: create_simple_creature(),
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(10),
         max_neuron_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
@@ -241,8 +235,6 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         parquet_file,
         creature: create_simple_creature(), // Uses HARD_TANH for output-0
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(10),
         max_neuron_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
@@ -283,8 +275,6 @@ fn candidate_counts_tracked_correctly() {
         parquet_file,
         creature: create_simple_creature(),
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(100), // High limit
         max_neuron_candidates: Some(100),  // High limit
         analysis_deadline_ms: Some(30_000),
@@ -387,8 +377,6 @@ fn truncation_reflected_in_candidate_counts() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
-        harmful_threshold: None,
         max_synapse_candidates: Some(2), // Low limit to force truncation
         max_neuron_candidates: Some(2),
         analysis_deadline_ms: Some(30_000),

--- a/tests/complement_via_identity.rs
+++ b/tests/complement_via_identity.rs
@@ -94,7 +94,6 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
             .to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.001),
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/fixed_vs_optimised_params.rs
+++ b/tests/fixed_vs_optimised_params.rs
@@ -147,7 +147,6 @@ fn test_optimised_params_vary_by_sample() {
             parquet_file: file_path.to_string(),
             creature: creature.clone(),
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.0), // Accept any improvement
             max_candidates: Some(100),
             analysis_deadline_ms: None,
         };
@@ -224,7 +223,6 @@ fn test_conservative_params_more_stable_across_samples() {
         parquet_file: subset_temp.path().to_str().unwrap().to_string(),
         creature: creature.clone(),
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(100),
         analysis_deadline_ms: None,
     };
@@ -356,7 +354,6 @@ fn test_relu_fixed_params_consistent_across_samples() {
             parquet_file: temp_file.path().to_str().unwrap().to_string(),
             creature: creature.clone(),
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.0),
             max_candidates: Some(100),
             analysis_deadline_ms: None,
         };
@@ -453,7 +450,6 @@ fn test_synapse_candidates_no_bias_optimisation() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["hidden-0".to_string()], // Focus on hidden neuron for synapse additions
-        improvement_threshold: Some(0.0),
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };
@@ -513,7 +509,6 @@ fn test_synapse_weight_distribution() {
             parquet_file: temp_file.path().to_str().unwrap().to_string(),
             creature: creature.clone(),
             focus_neurons: vec!["output-0".to_string()],
-            improvement_threshold: Some(0.0),
             max_candidates: Some(50),
             analysis_deadline_ms: None,
         };

--- a/tests/gpu_activation_shaders.rs
+++ b/tests/gpu_activation_shaders.rs
@@ -128,7 +128,6 @@ fn test_mish_gpu_shader_produces_correct_results() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(100),
         analysis_deadline_ms: None,
     };
@@ -236,7 +235,6 @@ fn test_all_new_activations_produce_candidates() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(500),
         analysis_deadline_ms: None,
     };

--- a/tests/gpu_work_queue.rs
+++ b/tests/gpu_work_queue.rs
@@ -83,7 +83,6 @@ fn synapse_analysis_works_with_gpu_work_queue() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -149,7 +148,6 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -258,7 +256,6 @@ fn multiple_focus_neurons_work_with_shared_queue() {
             "hidden-1".to_string(),
             "output-0".to_string(),
         ],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -341,7 +338,6 @@ fn harmful_synapse_detection_works_with_queue() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -504,7 +504,6 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01), // Lower threshold to increase chances of finding candidates
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -599,7 +598,6 @@ fn test_bias_values_are_activation_specific() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(50), // Request many candidates to get variety
         analysis_deadline_ms: None,
     };
@@ -868,7 +866,6 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01), // 1% threshold - low to ensure candidates are found
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -976,7 +973,6 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -1074,7 +1070,6 @@ fn test_bias_improves_neuron_performance() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -1203,7 +1198,6 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["hidden-0".to_string()], // Request hidden neuron analysis
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -1365,7 +1359,6 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["hidden-0".to_string()],
-        improvement_threshold: Some(0.001), // Very low threshold to get candidates
         max_candidates: Some(20),
         analysis_deadline_ms: None,
     };

--- a/tests/issue_134_direction_flip.rs
+++ b/tests/issue_134_direction_flip.rs
@@ -77,7 +77,6 @@ fn issue_134_bent_identity_target_simulation_rejects_linear_false_positive() {
         parquet_file: parquet_file.clone(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -134,7 +133,6 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };

--- a/tests/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/issue_156_hidden_focus_neurons_filtered.rs
@@ -115,7 +115,6 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         parquet_file: file_path,
         creature,
         focus_neurons: vec!["hidden-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/issue_156_hidden_focus_neurons_filtered.rs
@@ -1,0 +1,136 @@
+//! Regression test for Issue #156 (29-Dec-2025): allow output-only focus targets for add-neuron analysis.
+//!
+//! This test is intentionally scoped to the **opt-in** mode:
+//! - Default behaviour remains backwards compatible (hidden focus targets are analysed with impact discounting).
+//! - When `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY=1` is set, hidden focus targets are filtered
+//!   and reported as `HiddenNeuronFiltered`.
+
+mod common;
+
+use neat_ai_discovery::analysis::{analyze_neurons, GpuAnalyzer, NeuronNoCandidateReason};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Skip test if no GPU available.
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+/// Minimal env var guard so tests remain isolated (quality.sh runs tests with 1 thread, but keep it tidy).
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+#[test]
+fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled() {
+    skip_without_gpu!();
+
+    // Enable output-only focus targets for add-neuron analysis (production experiment).
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY", "1");
+
+    // Minimal creature:
+    // - 1 hidden neuron (focus target)
+    // - 1 output neuron (exists, but not included in focus list)
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![SynapseJson {
+            from_uuid: "hidden-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+        input: 1,
+        output: 1,
+    };
+
+    // Create a tiny parquet so the record cache can initialise.
+    let mut records = Vec::new();
+    for obs_index in 0..20u32 {
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-0".to_string(),
+            Some(0.1),
+            0.1,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.2),
+            0.2,
+            vec![0.01],
+        ));
+    }
+
+    let temp_file = NamedTempFile::new().expect("temp parquet");
+    let file_path = temp_file.path().to_str().expect("temp path").to_string();
+    write_records_to_parquet(&file_path, &records).expect("write parquet");
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: file_path,
+        creature,
+        focus_neurons: vec!["hidden-0".to_string()],
+        improvement_threshold: Some(0.0),
+        max_candidates: Some(50),
+        analysis_deadline_ms: None,
+    };
+
+    let result = analyze_neurons(&input).expect("analysis should succeed");
+
+    assert!(
+        result.helpful_neurons.is_empty(),
+        "Hidden-only focus list should return no helpful_neurons when output-only mode is enabled"
+    );
+
+    assert!(
+        result.no_candidate_reasons.iter().any(|s| {
+            s.target_uuid == "hidden-0" && s.reason == NeuronNoCandidateReason::HiddenNeuronFiltered
+        }),
+        "Expected HiddenNeuronFiltered reason for hidden-0 focus neuron"
+    );
+}

--- a/tests/leaky_relu_filtered.rs
+++ b/tests/leaky_relu_filtered.rs
@@ -68,7 +68,6 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(64),
         analysis_deadline_ms: None,
     };

--- a/tests/regression_v0_1_123.rs
+++ b/tests/regression_v0_1_123.rs
@@ -132,7 +132,6 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         parquet_file,
         creature,
         focus_neurons: vec!["hidden-0".to_string(), "output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -264,7 +263,6 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01), // 1% threshold
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };
@@ -530,7 +528,6 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         parquet_file,
         creature,
         focus_neurons: vec!["hidden-low-impact".to_string()],
-        improvement_threshold: Some(0.01), // 1% threshold (below MIN_FALLBACK_IMPROVEMENT)
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };
@@ -710,7 +707,6 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         parquet_file,
         creature,
         focus_neurons: vec!["hidden-will-be-discounted".to_string()],
-        improvement_threshold: Some(0.01), // Low threshold so raw candidate is found
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/relu_adjacent_filtered.rs
+++ b/tests/relu_adjacent_filtered.rs
@@ -72,7 +72,6 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         parquet_file: parquet_file.to_str().unwrap().to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(512),
         analysis_deadline_ms: None,
     };

--- a/tests/sample_matching.rs
+++ b/tests/sample_matching.rs
@@ -72,7 +72,6 @@ fn analysis_handles_non_finite_values_gracefully() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -134,7 +133,6 @@ fn analysis_pairs_samples_by_obs_index() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -198,7 +196,6 @@ fn analysis_skips_neurons_without_errors() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };

--- a/tests/source_variance_discounting.rs
+++ b/tests/source_variance_discounting.rs
@@ -128,7 +128,6 @@ fn test_constant_source_gives_zero_improvement() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0), // Accept any positive improvement
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -228,7 +227,6 @@ fn test_low_variance_source_discounts_prediction() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -328,7 +326,6 @@ fn test_high_variance_source_not_discounted() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -435,7 +432,6 @@ fn test_constant_vs_varying_source_comparison() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/split_error_all_activations.rs
+++ b/tests/split_error_all_activations.rs
@@ -147,7 +147,6 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0001), // Very low threshold to catch weak predictions
         max_candidates: Some(100),
         analysis_deadline_ms: None,
     };
@@ -278,7 +277,6 @@ fn test_skewed_errors_return_candidates() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/split_error_fallback_candidates.rs
+++ b/tests/split_error_fallback_candidates.rs
@@ -148,13 +148,10 @@ fn regression_split_error_must_return_fallback_candidates() {
 
     write_records_to_parquet(file_path, &records).unwrap();
 
-    // VERY HIGH threshold (50%) - no candidates will meet this threshold
-    // But candidates with small positive improvement should still be returned as fallbacks
     let input = AnalyzeNeuronsInput {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.50), // 50% threshold - intentionally unreachable
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };
@@ -163,7 +160,7 @@ fn regression_split_error_must_return_fallback_candidates() {
 
     // Log all candidates for debugging
     eprintln!("=== REGRESSION TEST: Split-error fallback candidates ===");
-    eprintln!("Threshold: 50%");
+    eprintln!("Threshold: disabled (always return positive improvements)");
     eprintln!(
         "Total candidates returned: {}",
         result.helpful_neurons.len()
@@ -329,7 +326,6 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.50), // 50% threshold - intentionally high
         max_candidates: Some(50),
         analysis_deadline_ms: None,
     };

--- a/tests/step_hidden_neuron_prediction.rs
+++ b/tests/step_hidden_neuron_prediction.rs
@@ -169,7 +169,6 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         parquet_file: parquet_path.to_string(),
         creature: creature.clone(),
         focus_neurons: vec!["hidden-step".to_string()],
-        improvement_threshold: Some(0.0), // Accept all candidates
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -259,7 +258,6 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         parquet_file: parquet_path.to_string(),
         creature,
         focus_neurons: vec!["hidden-step".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };
@@ -363,7 +361,6 @@ fn test_step_output_neuron_no_identity_candidates() {
         parquet_file: parquet_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(10),
         analysis_deadline_ms: None,
     };

--- a/tests/synapse_candidate_indices.rs
+++ b/tests/synapse_candidate_indices.rs
@@ -96,7 +96,6 @@ fn synapse_candidates_populate_from_and_to_indices() {
         parquet_file: file_path,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
     };

--- a/tests/synapse_impact_discounting.rs
+++ b/tests/synapse_impact_discounting.rs
@@ -177,7 +177,6 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["hidden-b".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
     };
@@ -291,7 +290,6 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
     };
@@ -380,7 +378,6 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
         parquet_file: file_path.to_string(),
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.01),
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
     };

--- a/tests/target_map_optimization.rs
+++ b/tests/target_map_optimization.rs
@@ -81,7 +81,6 @@ fn synapse_analysis_with_target_map_optimization_succeeds() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -159,7 +158,6 @@ fn multiple_focus_neurons_share_target_map_optimization() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string(), "output-1".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -258,7 +256,6 @@ fn target_map_filters_non_finite_values() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };
@@ -326,7 +323,6 @@ fn empty_target_records_skips_source_processing() {
         parquet_file,
         creature,
         focus_neurons: vec!["output-0".to_string()],
-        improvement_threshold: Some(0.0),
         max_candidates: None,
         analysis_deadline_ms: None,
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces opt-in output-only focus targeting for add-neuron analysis and removes threshold parameters across the API.
> 
> - Adds `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY=1` to filter hidden/unknown focus targets in neuron analysis; filtered targets are reported as `HiddenNeuronFiltered`. Threshold (STEP/BIPOLAR) target tracking fixed to include hidden/unknown when allowed.
> - Removes `improvement_threshold`/`harmful_threshold` from `Analyze*Input` types and all call sites; analysis now always returns all positive improvements (`threshold = 0.0`).
> - Extracts focus-target filtering into `filter_focus_targets_for_neuron_analysis` with structured results for diagnostics; adds unit/regression tests for new behavior and updates existing tests.
> - Updates README with the opt-in behavior and adjusts IDENTITY filtering docs; bumps version to `0.2.22`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d7aad31206b1b3e4a15cd5ef46ed2ecd551bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->