### PR TITLE
Update version to 0.2.24 and enhance analysis input handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 
 [lib]

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7646,17 +7646,16 @@ pub(crate) fn analyze_neurons_with_cache(
                 }
             }
 
-            // Phase 4: Process evaluations - GPU work is done here
+            // Phase 4: Process evaluations - GPU work is done here.
             // Filter to only sources with samples, then evaluate.
             //
             // NOTE: We intentionally skip STEP/BIPOLAR targets here; synapse analysis
             // is the supported discovery mechanism for discrete targets.
-            if is_threshold_target {
-                return Ok(());
-            }
-
-            // Standard continuous activation path
-            for result in work_results {
+            //
+            // Important: We still count the target as "completed" for progress reporting.
+            if !is_threshold_target {
+                // Standard continuous activation path
+                for result in work_results {
                     // Check deadline before each evaluation batch
                     if deadline_passed(&deadline) {
                         *analysis_timed_out.lock().expect("Mutex poisoned") = true;
@@ -7766,6 +7765,7 @@ pub(crate) fn analyze_neurons_with_cache(
                             upsert_candidate(&mut map, candidate);
                         }
                     }
+                }
             }
 
             // Track completion of this focus neuron for timeout reporting.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,13 @@ pub struct AnalyzeParallelInput {
     pub max_neuron_candidates: Option<usize>,
     #[serde(default)]
     pub analysis_deadline_ms: Option<u64>,
+    /// Optional RNG seed to make analysis ordering reproducible.
+    ///
+    /// When `None`, the library uses non-deterministic randomness. This is
+    /// typically desirable for production runs with timeouts, as repeated runs
+    /// will explore different candidates over time.
+    #[serde(default)]
+    pub random_seed: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -929,17 +936,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
         }
     };
 
-    let combined_input = AnalyzeAllInput {
-        parquet_file: input.parquet_file,
-        creature: input.creature,
-        focus_neurons: input.focus_neurons,
-        max_synapse_candidates: input.max_synapse_candidates,
-        max_neuron_candidates: input.max_neuron_candidates,
-        analysis_deadline_ms: input.analysis_deadline_ms,
-        include_synapse_analysis: Some(true),
-        include_neuron_analysis: Some(true),
-        random_seed: None,
-    };
+    let combined_input = build_analyze_all_input_from_parallel(input);
 
     match analysis::analyze_all(&combined_input) {
         Ok(result) => {
@@ -991,6 +988,20 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
             };
             Ok(serde_json::to_string(&output)?)
         }
+    }
+}
+
+fn build_analyze_all_input_from_parallel(input: AnalyzeParallelInput) -> AnalyzeAllInput {
+    AnalyzeAllInput {
+        parquet_file: input.parquet_file,
+        creature: input.creature,
+        focus_neurons: input.focus_neurons,
+        max_synapse_candidates: input.max_synapse_candidates,
+        max_neuron_candidates: input.max_neuron_candidates,
+        analysis_deadline_ms: input.analysis_deadline_ms,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+        random_seed: input.random_seed,
     }
 }
 
@@ -2555,5 +2566,31 @@ mod tests {
             output["neuronGpuUsed"].is_boolean(),
             "parallel analysis should report GPU usage for neurons"
         );
+    }
+
+    #[test]
+    fn analyze_parallel_threads_random_seed_into_combined_input() {
+        let input_json = serde_json::json!({
+            "parquetFile": "example.parquet",
+            "creature": {
+                "neurons": [],
+                "synapses": [],
+                "input": 1,
+                "output": 1
+            },
+            "focusNeurons": ["output-0"],
+            "maxSynapseCandidates": 5,
+            "maxNeuronCandidates": 5,
+            "analysisDeadlineMs": 1234,
+            "randomSeed": 42
+        })
+        .to_string();
+
+        let parsed: AnalyzeParallelInput =
+            serde_json::from_str(&input_json).expect("input JSON should deserialize");
+        let combined = build_analyze_all_input_from_parallel(parsed);
+
+        assert_eq!(combined.random_seed, Some(42));
+        assert_eq!(combined.analysis_deadline_ms, Some(1234));
     }
 }

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -670,3 +670,97 @@ Pages speculative:                        12345.
         // And the shuffle should actually move at least something.
         assert_ne!(a, (0..20).collect::<Vec<i32>>());
     }
+
+    #[test]
+    fn neuron_analysis_counts_threshold_targets_as_completed_for_progress_reporting() -> Result<()> {
+        // 29-Dec-2025: Regression test for progress reporting.
+        //
+        // STEP/BIPOLAR targets are intentionally skipped by add-neuron analysis (synapse analysis
+        // is the supported mechanism for discrete targets), but they still appear in the focus
+        // list and therefore must be counted as "completed" for progress reporting.
+        //
+        // Historically an early `return Ok(())` skipped the completion counter update, leaving the
+        // watchdog stage stuck at "processing target ..." rather than "completed 1/1".
+
+        let _lock = crate::watchdog::lock_for_test_serialisation();
+
+        // Keep this aligned with integration tests: skip rather than fail when no GPU is present.
+        if !crate::analysis::GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return Ok(());
+        }
+
+        let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+            stall_timeout: std::time::Duration::from_secs(60),
+            abort_delay: std::time::Duration::from_secs(1),
+        });
+
+        // Use a unique UUID so other parallel tests (which often use "output-0") won't
+        // accidentally overwrite the watchdog stage while our watchdog is active.
+        let target_uuid = "output-progress-0";
+
+        let creature = crate::CreatureJson {
+            input: 1,
+            output: 1,
+            neurons: vec![crate::NeuronJson {
+                uuid: target_uuid.to_string(),
+                neuron_type: "output".to_string(),
+                squash: "STEP".to_string(),
+                bias: 0.0,
+            }],
+            synapses: Vec::new(),
+        };
+
+        // Use an in-memory loader so the test doesn't need to write a parquet file.
+        let cache = std::sync::Arc::new(RecordCache::with_loader(
+            "unused.parquet",
+            std::sync::Arc::new(move |_file, uuid| {
+                let mut records = Vec::new();
+                for obs_index in 0..20u32 {
+                    match uuid {
+                        "input-0" => {
+                            records.push(DiscoverRecord {
+                                obs_index,
+                                neuron_uuid: uuid.to_string(),
+                                value: None,
+                                activation: (obs_index as f32 - 10.0) / 10.0, // -1.0 .. 0.9
+                                errors: Vec::new(),
+                            });
+                        }
+                        _ if uuid == target_uuid => {
+                            // Provide non-empty errors so the target is considered analysable.
+                            let activation = 0.0;
+                            let error = if obs_index < 10 { 0.25 } else { -0.25 };
+                            records.push(DiscoverRecord {
+                                obs_index,
+                                neuron_uuid: uuid.to_string(),
+                                value: Some(activation),
+                                activation,
+                                errors: vec![error],
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(records)
+            }),
+        ));
+
+        let input = crate::AnalyzeNeuronsInput {
+            parquet_file: "unused.parquet".to_string(),
+            creature,
+            focus_neurons: vec![target_uuid.to_string()],
+            max_candidates: Some(1),
+            analysis_deadline_ms: None,
+            random_seed: Some(123),
+        };
+
+        let _result = analyze_neurons_with_cache(&input, cache)?;
+
+        let stage = crate::watchdog::active_stage_for_test().unwrap_or_default();
+        assert!(
+            stage.contains("neuron analysis → completed 1/1"),
+            "expected progress to reach completed 1/1 for a threshold target, got: {stage}"
+        );
+        Ok(())
+    }


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.23 to 0.2.24.
- Introduce an optional `random_seed` field in `AnalyzeParallelInput` to allow reproducible analysis ordering.
- Refactor the `analyze_parallel_internal` function to utilize a new helper function for building combined input, improving code clarity.
- Add tests to validate the correct handling of the `random_seed` in the analysis process.

These changes improve the flexibility and reliability of the analysis, particularly in scenarios requiring consistent results across runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reproducibility and progress reporting in analysis.
> 
> - Adds optional `random_seed` to `AnalyzeParallelInput` and threads it through via `build_analyze_all_input_from_parallel`
> - Fixes neuron analysis progress: STEP/BIPOLAR targets are skipped for evaluation but still counted as completed for watchdog progress
> - Refactors parallel input construction into a helper for clarity
> - Adds unit tests for `random_seed` propagation and progress reporting regression
> - Bumps crate version to `0.2.24`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f9d90ec8b29dcdd629564b2cbc1f693bfc1c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->