### PR TITLE
Update version to 0.3.0 and enhance analysis coverage features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,16 +171,26 @@ jobs:
       with:
         components: rustfmt, clippy
         
+    - name: Disk usage (before cache)
+      run: |
+        # CI diagnostic (2 Jan 2026): Rust builds can consume significant disk (especially `target/`).
+        # If a job fails with ENOSPC, this makes the cause obvious in logs.
+        df -h
+
     - name: Cache dependencies
       uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+        # Important (2 Jan 2026): do NOT cache `target/` in CI.
+        # It can exceed GitHub runner disk limits after restore + build, causing ENOSPC failures.
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
+
+    - name: Disk usage (after cache restore)
+      run: df -h
       
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.2.24"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1490,6 +1490,25 @@ whether discovery should be enabled:
   but is less than 3 seconds or greater than 1 hour, it will be clamped to the
   10-minute default with a warning message.
   
+  **Design goal (coverage over time)**: Production runs are expected to be
+  **deadline-constrained** and repeated (for example, a worker loop that calls
+  discovery many times per day). The system is designed so that **all discovery
+  work is covered over time**, even when a single run times out:
+  - **All focus neurons** will be covered over time because focus ordering is
+    randomised when a deadline is configured.
+  - **All eligible source neurons** (inputs + hidden + constants, respecting
+    forward-only constraints) will be covered over time because source ordering
+    is also randomised under deadlines.
+  - **All discovery candidate types that Rust emits** (e.g., add-synapse and
+    add-neuron) are intended to get a fair share of work over time under repeated
+    runs. This library now avoids returning the exact same top candidates every
+    run under deadlines (to reduce starvation when controllers cache failures).
+  
+  **Important**: With a hard timeout, a single invocation will often return
+  **partial results** by design. Coverage is achieved via repeated invocations,
+  not by making one run arbitrarily long (which would delay returning improved
+  creatures back into the population).
+  
   **Timeout logging** (v0.1.163): The library now logs when analysis starts and
   when a timeout is reached:
   

--- a/README.md
+++ b/README.md
@@ -1499,6 +1499,10 @@ whether discovery should be enabled:
   - **All eligible source neurons** (inputs + hidden + constants, respecting
     forward-only constraints) will be covered over time because source ordering
     is also randomised under deadlines.
+  - **Synapse vs neuron analysis**: When a deadline is configured and both analyses
+    are enabled, the library **randomises which analysis runs first** each invocation.
+    This means one run may return only synapse candidates and the next may return
+    only neuron candidates. Over repeated runs, both get opportunities to run first.
   - **All discovery candidate types that Rust emits** (e.g., add-synapse and
     add-neuron) are intended to get a fair share of work over time under repeated
     runs. This library now avoids returning the exact same top candidates every

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -7991,7 +7991,12 @@ pub(crate) fn analyze_neurons_with_cache(
             candidates_returned,
             timed_out: analysis_timed_out,
             completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
-            total_focus_neurons: total_focus_count,
+            // Total focus neurons requested for this invocation (pre-filter).
+            //
+            // Note: `total_focus_count` is the post-filter eligible output-neuron count, which can
+            // differ from the requested focus list. We keep the "requested" semantics so callers
+            // can track long-run coverage consistently across early/normal return paths.
+            total_focus_neurons: original_focus_count,
         },
     })
 }

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -1023,6 +1023,65 @@ fn shuffle_slice<T>(items: &mut [T], seed: Option<u64>, context: &str) {
     }
 }
 
+/// Diversify a best-first candidate list by shuffling within the top-K prefix.
+///
+/// Rationale (Jan 2026):
+/// - In production, discovery runs are deadline-constrained and repeated over time.
+/// - The controller (TypeScript) caches failed candidates and will not re-attempt them
+///   until the training data changes.
+/// - If Rust always returns the same top few candidates, categories can starve because
+///   those candidates become permanently skipped for the day.
+///
+/// Shuffling within the top-K keeps us focused on high-quality candidates while still
+/// drifting over time, improving long-run coverage without returning low-quality tails.
+fn shuffle_within_top_k<T>(items: &mut [T], seed: Option<u64>, context: &str, top_k: usize) {
+    if items.len() <= 1 || top_k <= 1 {
+        return;
+    }
+    let k = top_k.min(items.len());
+    shuffle_slice(&mut items[..k], seed, context);
+}
+
+#[cfg(test)]
+mod tests_shuffle_within_top_k {
+    use super::shuffle_within_top_k;
+
+    #[test]
+    fn deterministic_with_seed() {
+        let mut a = [1u32, 2, 3, 4, 5, 6, 7, 8].to_vec();
+        let mut b = a.clone();
+        shuffle_within_top_k(&mut a[..], Some(123), "ctx", 5);
+        shuffle_within_top_k(&mut b[..], Some(123), "ctx", 5);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn only_shuffles_prefix() {
+        let mut items = [1u32, 2, 3, 4, 5, 6, 7, 8].to_vec();
+        shuffle_within_top_k(&mut items[..], Some(123), "ctx", 3);
+        // Suffix must remain untouched.
+        assert_eq!(items[3..], [4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn preserves_multiset() {
+        let mut items = [1u32, 2, 3, 4, 5, 6, 7, 8].to_vec();
+        let mut before = items.clone();
+        before.sort_unstable();
+        shuffle_within_top_k(&mut items[..], Some(999), "ctx", 6);
+        items.sort_unstable();
+        assert_eq!(items, before);
+    }
+
+    #[test]
+    fn no_op_when_top_k_is_zero() {
+        let mut items = [1u32, 2, 3, 4].to_vec();
+        let before = items.clone();
+        shuffle_within_top_k(&mut items[..], Some(1), "ctx", 0);
+        assert_eq!(items, before);
+    }
+}
+
 /// Optional input-index bias for source ordering.
 ///
 /// This is primarily a production knob for timeout-constrained runs. If you are
@@ -1217,58 +1276,91 @@ fn log_analysis_timeout(analysis_type: &str, completed_count: usize, total_count
 
 #[cfg(test)]
 mod deadline_override {
+    use std::cell::RefCell;
     use std::collections::VecDeque;
-    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::{Arc, Mutex};
 
-    static OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
-    static OVERRIDE_SEQUENCE: Mutex<VecDeque<bool>> = Mutex::new(VecDeque::new());
-    static OVERRIDE_ACTIVE: AtomicBool = AtomicBool::new(false);
+    /// Deadline override state shared across a thread pool.
+    ///
+    /// We store this behind an `Arc` so a single override sequence can be consumed
+    /// by multiple worker threads within a *private* Rayon pool.
+    #[derive(Clone)]
+    struct OverrideState {
+        queue: Arc<Mutex<VecDeque<bool>>>,
+    }
+
+    thread_local! {
+        /// Thread-local handle to the active override state.
+        ///
+        /// IMPORTANT (2 Jan 2026):
+        /// Tests run in parallel and analysis uses Rayon. A global override is unsafe because
+        /// *other tests* running concurrently can observe and consume override values.
+        ///
+        /// By using thread-local state, and explicitly broadcasting it into a test's private
+        /// Rayon pool, we:
+        /// - Avoid deadlocks (no cross-thread lock held for the duration of a test)
+        /// - Avoid cross-test interference under default parallel test execution
+        static OVERRIDE_STATE: RefCell<Option<OverrideState>> = const { RefCell::new(None) };
+    }
+
+    fn set_override_state(state: Option<OverrideState>) {
+        OVERRIDE_STATE.with(|cell| {
+            *cell.borrow_mut() = state;
+        });
+    }
 
     pub(super) struct DeadlineOverrideGuard {
-        _lock: MutexGuard<'static, ()>,
+        /// When provided, we clear the override from all worker threads on drop.
+        pool: Option<Arc<rayon::ThreadPool>>,
     }
 
     impl DeadlineOverrideGuard {
+        /// Install an override sequence for the current thread only.
         pub(super) fn with_sequence(sequence: Vec<bool>) -> Self {
-            let lock = OVERRIDE_LOCK
-                .lock()
-                .expect("Deadline override lock should not be poisoned");
-            {
-                let mut queue = OVERRIDE_SEQUENCE
-                    .lock()
-                    .expect("Deadline override queue should not be poisoned");
-                queue.clear();
-                for value in sequence.into_iter() {
-                    queue.push_back(value);
-                }
+            Self::with_sequence_for_pool(sequence, None)
+        }
+
+        /// Install an override sequence for a specific Rayon pool.
+        ///
+        /// This is the safe way to use deadline overrides in multi-threaded tests: create a private
+        /// pool, broadcast the override into that pool, and run analysis inside `pool.install(...)`.
+        pub(super) fn with_sequence_for_pool(
+            sequence: Vec<bool>,
+            pool: Option<Arc<rayon::ThreadPool>>,
+        ) -> Self {
+            let state = OverrideState {
+                queue: Arc::new(Mutex::new(sequence.into_iter().collect::<VecDeque<_>>())),
+            };
+
+            // Always install for the current thread (covers non-parallel code paths).
+            set_override_state(Some(state.clone()));
+
+            // If a pool is provided, broadcast into each worker thread.
+            if let Some(ref p) = pool {
+                p.broadcast(|_| set_override_state(Some(state.clone())));
             }
-            OVERRIDE_ACTIVE.store(true, AtomicOrdering::SeqCst);
-            Self { _lock: lock }
+
+            Self { pool }
         }
     }
 
     impl Drop for DeadlineOverrideGuard {
         fn drop(&mut self) {
-            OVERRIDE_ACTIVE.store(false, AtomicOrdering::SeqCst);
-            let mut queue = OVERRIDE_SEQUENCE
-                .lock()
-                .expect("Deadline override queue should not be poisoned");
-            queue.clear();
+            // Clear on current thread.
+            set_override_state(None);
+            // Clear on pool worker threads (if any).
+            if let Some(ref p) = self.pool {
+                p.broadcast(|_| set_override_state(None));
+            }
         }
     }
 
     pub(super) fn next_override_value() -> Option<bool> {
-        if !OVERRIDE_ACTIVE.load(AtomicOrdering::SeqCst) {
-            return None;
-        }
-        // Allow any thread to consume the override sequence for parallel processing compatibility
-        // With parallel processing via par_iter(), worker threads have different thread IDs,
-        // so we allow all threads to see and consume the override sequence.
-        let mut queue = OVERRIDE_SEQUENCE
-            .lock()
-            .expect("Deadline override queue should not be poisoned");
-        queue.pop_front()
+        OVERRIDE_STATE.with(|cell| {
+            let state = cell.borrow().clone()?;
+            let mut queue = state.queue.lock().expect("Deadline override queue should not be poisoned");
+            queue.pop_front()
+        })
     }
 }
 
@@ -7365,6 +7457,9 @@ pub(crate) fn analyze_neurons_with_cache(
             metadata: super::shared::NeuronAnalysisMetadata {
                 candidates_found: 0,
                 candidates_returned: 0,
+                timed_out: false,
+                completed_focus_neurons: 0,
+                total_focus_neurons: original_focus_count,
             },
         });
     }
@@ -7856,6 +7951,18 @@ pub(crate) fn analyze_neurons_with_cache(
     // This avoids wasting the evaluation budget on absurd bias/weight configurations.
     helpful_results = crate::analysis::utils::filter_candidates_to_sensible_ranges(helpful_results);
 
+    // Deadline coverage (Jan 2026): when deadline-constrained, diversify within the top-K so
+    // repeated runs explore different high-quality candidates over time (helps with failure caches).
+    if input.analysis_deadline_ms.is_some() {
+        const DIVERSIFY_TOP_K: usize = 64;
+        shuffle_within_top_k(
+            helpful_results.as_mut_slice(),
+            input.random_seed,
+            "neuron:candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+    }
+
     // Track candidates_found AFTER pairing but BEFORE truncation.
     // This ensures candidates_found >= candidates_returned always holds, which is
     // the expected semantic for this metric pair ("found" >= "returned").
@@ -7879,6 +7986,9 @@ pub(crate) fn analyze_neurons_with_cache(
         metadata: super::shared::NeuronAnalysisMetadata {
             candidates_found,
             candidates_returned,
+            timed_out: analysis_timed_out,
+            completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
+            total_focus_neurons: total_focus_count,
         },
     })
 }
@@ -8735,6 +8845,24 @@ pub(crate) fn analyze_synapses_with_cache(
             .unwrap_or(Ordering::Equal)
     });
 
+    // Deadline coverage (Jan 2026): diversify within the top-K so repeated runs explore different
+    // high-quality candidates over time (helps with failure caches and avoids category starvation).
+    if input.analysis_deadline_ms.is_some() {
+        const DIVERSIFY_TOP_K: usize = 64;
+        shuffle_within_top_k(
+            helpful_results.as_mut_slice(),
+            input.random_seed,
+            "synapse:helpful_candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+        shuffle_within_top_k(
+            harmful_results.as_mut_slice(),
+            input.random_seed,
+            "synapse:harmful_candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+    }
+
     // Track candidates_found before truncation for metadata
     let candidates_found = helpful_results.len() + harmful_results.len();
 
@@ -8764,6 +8892,8 @@ pub(crate) fn analyze_synapses_with_cache(
         candidates_found,
         candidates_returned,
         timed_out: analysis_timed_out,
+        completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
+        total_focus_neurons: total_focus_count,
         input_index_min_seen_with_records: if saw_any_input { Some(input_min) } else { None },
         input_index_max_seen_with_records: if saw_any_input { Some(input_max) } else { None },
     };
@@ -10511,9 +10641,19 @@ mod tests_synapses {
     #[test]
     fn analyze_synapses_stops_harmful_processing_after_deadline() {
         skip_if_no_gpu!();
-        let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence(vec![
-            false, false, false, false, false, false, true, false, false, false,
-        ]);
+        use rayon::ThreadPoolBuilder;
+        use std::sync::Arc;
+        // Use a private Rayon pool so the deadline override is isolated from other parallel tests.
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("Failed to build Rayon pool"),
+        );
+        let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
+            vec![false, false, false, false, false, false, true, false, false, false],
+            Some(Arc::clone(&pool)),
+        );
 
         let temp_dir = tempdir().expect("Failed to create temporary directory");
         let parquet_path = temp_dir.path().join("records.parquet");
@@ -10591,7 +10731,8 @@ mod tests_synapses {
             random_seed: None,
         };
 
-        let result = analyze_synapses(&input)
+        let result = pool
+            .install(|| analyze_synapses(&input))
             .expect("Synapse analysis should complete even when the deadline triggers");
 
         // With parallel processing, deadline detection order is non-deterministic because
@@ -10757,6 +10898,7 @@ mod tests_synapses {
     fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         skip_if_no_gpu!();
         use rayon::ThreadPoolBuilder;
+        use std::sync::Arc;
 
         // Simulate a deadline that allows at least one focus neuron to start, but
         // triggers before all are processed. The override sequence is consumed
@@ -10768,8 +10910,17 @@ mod tests_synapses {
         // to begin evaluating sources before we trigger the timeout.
         let mut deadline_sequence = vec![false; 64];
         deadline_sequence.push(true);
-        let _deadline_guard =
-            deadline_override::DeadlineOverrideGuard::with_sequence(deadline_sequence);
+        // Use a private pool so the override cannot be consumed by other tests.
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("Failed to build single-threaded Rayon pool"),
+        );
+        let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
+            deadline_sequence,
+            Some(Arc::clone(&pool)),
+        );
 
         let temp_dir = tempdir().expect("Failed to create temporary directory");
         let parquet_path = temp_dir.path().join("records.parquet");
@@ -10838,14 +10989,6 @@ mod tests_synapses {
             random_seed: None,
         };
 
-        // Use a single-threaded Rayon pool so the deadline override sequence remains
-        // deterministic for this test. Note: focus neurons are randomized, so we can't
-        // assume a specific order.
-        let pool = ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("Failed to build single-threaded Rayon pool");
-
         let result = pool
             .install(|| analyze_neurons(&input))
             .expect("Neuron analysis should succeed even when the deadline triggers");
@@ -10881,6 +11024,7 @@ mod tests_synapses {
     fn analyze_synapses_uses_vertical_timeout_with_randomized_order() {
         skip_if_no_gpu!();
         use rayon::ThreadPoolBuilder;
+        use std::sync::Arc;
 
         // Simulate a deadline that allows at least one focus neuron to start, but
         // triggers before all are processed. The override sequence is consumed
@@ -10896,8 +11040,17 @@ mod tests_synapses {
         // the timeout too early, the vertical-timeout behaviour isn't exercised.
         let mut deadline_sequence = vec![false; 64];
         deadline_sequence.push(true);
-        let _deadline_guard =
-            deadline_override::DeadlineOverrideGuard::with_sequence(deadline_sequence);
+        // Use a private pool so the override cannot be consumed by other tests.
+        let pool = Arc::new(
+            ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("Failed to build single-threaded Rayon pool"),
+        );
+        let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
+            deadline_sequence,
+            Some(Arc::clone(&pool)),
+        );
 
         let temp_dir = tempdir().expect("Failed to create temporary directory");
         let parquet_path = temp_dir.path().join("records.parquet");
@@ -10969,14 +11122,6 @@ mod tests_synapses {
             analysis_deadline_ms: None,
             random_seed: None,
         };
-
-        // Use a single-threaded Rayon pool so the deadline override sequence remains
-        // deterministic for this test. Note: focus neurons are randomized, so we can't
-        // assume a specific order.
-        let pool = ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("Failed to build single-threaded Rayon pool");
 
         let result = pool
             .install(|| analyze_synapses(&input))

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -1358,7 +1358,10 @@ mod deadline_override {
     pub(super) fn next_override_value() -> Option<bool> {
         OVERRIDE_STATE.with(|cell| {
             let state = cell.borrow().clone()?;
-            let mut queue = state.queue.lock().expect("Deadline override queue should not be poisoned");
+            let mut queue = state
+                .queue
+                .lock()
+                .expect("Deadline override queue should not be poisoned");
             queue.pop_front()
         })
     }
@@ -10646,12 +10649,14 @@ mod tests_synapses {
         // Use a private Rayon pool so the deadline override is isolated from other parallel tests.
         let pool = Arc::new(
             ThreadPoolBuilder::new()
-            .num_threads(4)
-            .build()
-            .expect("Failed to build Rayon pool"),
+                .num_threads(4)
+                .build()
+                .expect("Failed to build Rayon pool"),
         );
         let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
-            vec![false, false, false, false, false, false, true, false, false, false],
+            vec![
+                false, false, false, false, false, false, true, false, false, false,
+            ],
             Some(Arc::clone(&pool)),
         );
 
@@ -10913,9 +10918,9 @@ mod tests_synapses {
         // Use a private pool so the override cannot be consumed by other tests.
         let pool = Arc::new(
             ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("Failed to build single-threaded Rayon pool"),
+                .num_threads(1)
+                .build()
+                .expect("Failed to build single-threaded Rayon pool"),
         );
         let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
             deadline_sequence,
@@ -11043,9 +11048,9 @@ mod tests_synapses {
         // Use a private pool so the override cannot be consumed by other tests.
         let pool = Arc::new(
             ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("Failed to build single-threaded Rayon pool"),
+                .num_threads(1)
+                .build()
+                .expect("Failed to build single-threaded Rayon pool"),
         );
         let _deadline_guard = deadline_override::DeadlineOverrideGuard::with_sequence_for_pool(
             deadline_sequence,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -43,6 +43,73 @@ pub use implementation::{check_memory_for_parquet, ACTIVATION_SPECS};
 use crate::{AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput};
 use anyhow::Result;
 use std::sync::Arc;
+use std::time::SystemTime;
+
+/// Split a global analysis deadline into two absolute (epoch-ms) deadlines.
+///
+/// This is designed for timeout-constrained production loops that call discovery repeatedly.
+/// We want predictable coverage over time: both synapse and neuron analysis should get a share
+/// of the budget on each invocation.
+///
+/// Notes:
+/// - `raw_deadline_ms` can be either a relative duration (small values) or an absolute timestamp
+///   (epoch milliseconds). This mirrors the parsing rules used by the analysis implementation.
+/// - Returns `None` when the deadline is an absolute timestamp in the past (treated as “no deadline”
+///   by the downstream implementation). In that case, callers should preserve the original value.
+fn split_global_deadline_ms(
+    raw_deadline_ms: u64,
+    now_ms: u64,
+    synapse_share: f64,
+) -> Option<(u64, u64)> {
+    // Mirror implementation bounds.
+    const YEAR_2000_MS: u64 = 946_684_800_000;
+    const MIN_DURATION_MS: u64 = 3_000; // 3 seconds
+    const MAX_DURATION_MS: u64 = 3_600_000; // 1 hour
+
+    let relative_ms_opt: Option<u64> = if raw_deadline_ms < YEAR_2000_MS {
+        Some(raw_deadline_ms)
+    } else if raw_deadline_ms <= now_ms {
+        // Absolute deadline is in the past: downstream treats this as no deadline.
+        None
+    } else {
+        Some(raw_deadline_ms - now_ms)
+    };
+
+    let total_ms = match relative_ms_opt {
+        None => return None,
+        Some(relative_ms) => {
+            if !(MIN_DURATION_MS..=MAX_DURATION_MS).contains(&relative_ms) {
+                // IMPORTANT (2 Jan 2026):
+                // Do NOT clamp/normalise invalid durations here. The downstream implementation
+                // (`calculate_effective_timeout_ms`) is responsible for clamping AND emitting the
+                // documented warning messages. If we intercept here, the warnings never appear,
+                // breaking observability for invalid configs.
+                //
+                // Returning `None` means "do not split" and the caller will pass the original
+                // raw deadline through untouched.
+                return None;
+            } else {
+                relative_ms
+            }
+        }
+    };
+
+    let total_end = now_ms.saturating_add(total_ms);
+
+    // If the budget is too small to safely split (we require >= 3s per analysis window),
+    // do not split. This avoids triggering the downstream “<3s => default 10 minutes” guard.
+    if total_ms < MIN_DURATION_MS.saturating_mul(2) {
+        return Some((total_end, total_end));
+    }
+
+    let share = synapse_share.clamp(0.0, 1.0);
+    let synapse_ms = ((total_ms as f64) * share).round() as u64;
+    let synapse_ms_max = total_ms.saturating_sub(MIN_DURATION_MS);
+    let synapse_ms = synapse_ms.clamp(MIN_DURATION_MS, synapse_ms_max);
+    let synapse_end = now_ms.saturating_add(synapse_ms);
+
+    Some((synapse_end, total_end))
+}
 
 fn run_optional_analysis<T>(
     enabled: bool,
@@ -127,7 +194,45 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Determine analysis order based on whether a deadline is set.
     // When deadline-constrained, synapse analysis runs FIRST to prevent starvation.
     // Without a deadline, neuron analysis runs first (original behaviour).
+    //
+    // Coverage under timeouts:
+    // In production, the controller often supplies `analysis_deadline_ms` and repeats discovery
+    // over time (e.g., GRQ’s `worker/Discovery/run.sh`). If we pass the same deadline to both
+    // analyses, the first can consume the entire budget and starve the second.
+    //
+    // To ensure coverage over time, we split the *global* deadline into two time windows and
+    // pass per-analysis absolute deadlines. This guarantees both synapse and neuron analysis
+    // get a share of the budget each invocation.
     let has_deadline = input.analysis_deadline_ms.is_some();
+
+    // Build per-analysis deadlines (absolute millisecond timestamps) when both analyses are enabled.
+    // This keeps the total wall-clock budget bounded while ensuring both analyses run.
+    //
+    // Note: We intentionally prefer synapse analysis under deadlines, but we also reserve time
+    // for neuron analysis so it is not starved.
+    let (synapse_deadline_ms, neuron_deadline_ms) =
+        if has_deadline && include_synapse && include_neuron {
+            // Share of the *global* budget reserved for synapse analysis.
+            // This is a tuning knob; 0.7 biases toward synapse discovery (historically starved).
+            const SYNAPSE_SHARE: f64 = 0.7;
+
+            // has_deadline is true here, so unwrap is safe.
+            let raw = input
+                .analysis_deadline_ms
+                .expect("has_deadline implies analysis_deadline_ms is set");
+            let now_ms = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .ok()
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+
+            match split_global_deadline_ms(raw, now_ms, SYNAPSE_SHARE) {
+                Some((syn_end, total_end)) => (Some(syn_end), Some(total_end)),
+                None => (input.analysis_deadline_ms, input.analysis_deadline_ms),
+            }
+        } else {
+            (input.analysis_deadline_ms, input.analysis_deadline_ms)
+        };
 
     let (synapse_result, neuron_result) = if has_deadline {
         // SYNAPSE-FIRST ordering (deadline-constrained):
@@ -146,7 +251,8 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             "analysis::analyze_all → synapse analysis finished",
             "analysis::analyze_all → synapse analysis skipped",
             || {
-                let inner = synapse_input.expect("checked is_some");
+                let mut inner = synapse_input.expect("checked is_some");
+                inner.analysis_deadline_ms = synapse_deadline_ms;
                 implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
             },
         )?;
@@ -157,7 +263,8 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             "analysis::analyze_all → neuron analysis finished",
             "analysis::analyze_all → neuron analysis skipped",
             || {
-                let inner = neuron_input.expect("checked is_some");
+                let mut inner = neuron_input.expect("checked is_some");
+                inner.analysis_deadline_ms = neuron_deadline_ms;
                 implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
             },
         )?;
@@ -205,43 +312,4 @@ pub use neuron::analyze_neurons;
 pub use synapse::analyze_synapses;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn watchdog_beats_do_not_claim_finished_when_analysis_is_skipped() {
-        let _lock = crate::watchdog::lock_for_test_serialisation();
-        // Ensure a watchdog is active so `beat()` is observable in tests.
-        let wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
-            stall_timeout: std::time::Duration::from_secs(60),
-            abort_delay: std::time::Duration::from_secs(1),
-        });
-
-        let skipped = "analysis::analyze_all → neuron analysis skipped";
-        let finished = "analysis::analyze_all → neuron analysis finished";
-
-        // When disabled, we should record "skipped" and never execute the closure.
-        let result: Option<()> =
-            run_optional_analysis(false, "starting", finished, skipped, || -> Result<()> {
-                unreachable!("disabled analysis closure must not run")
-            })
-            .expect("should not error");
-        assert!(result.is_none());
-        assert_eq!(
-            crate::watchdog::active_stage_for_test().as_deref(),
-            Some(skipped)
-        );
-
-        // When enabled, we should end on "finished".
-        let result: Option<()> =
-            run_optional_analysis(true, "starting", finished, "skipped", || Ok(()))
-                .expect("should not error");
-        assert!(result.is_some());
-        assert_eq!(
-            crate::watchdog::active_stage_for_test().as_deref(),
-            Some(finished)
-        );
-
-        drop(wd);
-    }
-}
+mod mod_tests;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -45,70 +45,21 @@ use anyhow::Result;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-/// Split a global analysis deadline into two absolute (epoch-ms) deadlines.
+/// Choose analysis ordering when deadline-constrained.
 ///
-/// This is designed for timeout-constrained production loops that call discovery repeatedly.
-/// We want predictable coverage over time: both synapse and neuron analysis should get a share
-/// of the budget on each invocation.
+/// Rationale (2 Jan 2026):
+/// - Production discovery runs are deadline-constrained and repeated over time.
+/// - We randomise (time-vary) the order so that, across repeated runs, both analyses get a turn
+///   running first under the same global deadline.
 ///
 /// Notes:
-/// - `raw_deadline_ms` can be either a relative duration (small values) or an absolute timestamp
-///   (epoch milliseconds). This mirrors the parsing rules used by the analysis implementation.
-/// - Returns `None` when the deadline is an absolute timestamp in the past (treated as “no deadline”
-///   by the downstream implementation). In that case, callers should preserve the original value.
-fn split_global_deadline_ms(
-    raw_deadline_ms: u64,
-    now_ms: u64,
-    synapse_share: f64,
-) -> Option<(u64, u64)> {
-    // Mirror implementation bounds.
-    const YEAR_2000_MS: u64 = 946_684_800_000;
-    const MIN_DURATION_MS: u64 = 3_000; // 3 seconds
-    const MAX_DURATION_MS: u64 = 3_600_000; // 1 hour
-
-    let relative_ms_opt: Option<u64> = if raw_deadline_ms < YEAR_2000_MS {
-        Some(raw_deadline_ms)
-    } else if raw_deadline_ms <= now_ms {
-        // Absolute deadline is in the past: downstream treats this as no deadline.
-        None
-    } else {
-        Some(raw_deadline_ms - now_ms)
-    };
-
-    let total_ms = match relative_ms_opt {
-        None => return None,
-        Some(relative_ms) => {
-            if !(MIN_DURATION_MS..=MAX_DURATION_MS).contains(&relative_ms) {
-                // IMPORTANT (2 Jan 2026):
-                // Do NOT clamp/normalise invalid durations here. The downstream implementation
-                // (`calculate_effective_timeout_ms`) is responsible for clamping AND emitting the
-                // documented warning messages. If we intercept here, the warnings never appear,
-                // breaking observability for invalid configs.
-                //
-                // Returning `None` means "do not split" and the caller will pass the original
-                // raw deadline through untouched.
-                return None;
-            } else {
-                relative_ms
-            }
-        }
-    };
-
-    let total_end = now_ms.saturating_add(total_ms);
-
-    // If the budget is too small to safely split (we require >= 3s per analysis window),
-    // do not split. This avoids triggering the downstream “<3s => default 10 minutes” guard.
-    if total_ms < MIN_DURATION_MS.saturating_mul(2) {
-        return Some((total_end, total_end));
-    }
-
-    let share = synapse_share.clamp(0.0, 1.0);
-    let synapse_ms = ((total_ms as f64) * share).round() as u64;
-    let synapse_ms_max = total_ms.saturating_sub(MIN_DURATION_MS);
-    let synapse_ms = synapse_ms.clamp(MIN_DURATION_MS, synapse_ms_max);
-    let synapse_end = now_ms.saturating_add(synapse_ms);
-
-    Some((synapse_end, total_end))
+/// - `random_seed` is included to allow reproducibility in tests and debugging.
+/// - We deliberately mix in the current time so repeated calls with the same seed can still vary.
+fn choose_deadline_order_synapse_first(random_seed: Option<u64>, now_ms: u64) -> bool {
+    // A tiny, deterministic "coin flip": parity of (seed XOR time).
+    //
+    // This is good enough for long-run fairness (50/50 over time) and is easy to test.
+    ((random_seed.unwrap_or(0) ^ now_ms) & 1) == 0
 }
 
 fn run_optional_analysis<T>(
@@ -133,10 +84,9 @@ fn run_optional_analysis<T>(
 ///
 /// # Analysis ordering
 ///
-/// When `analysis_deadline_ms` is set and both analyses are enabled, **synapse analysis
-/// runs first** to prevent starvation. Historically, neuron analysis ran first and could
-/// consume the entire budget, leaving zero time for synapse analysis. This caused "no
-/// add-synapses candidates" even when many potential synapses existed.
+/// When `analysis_deadline_ms` is set and both analyses are enabled, the library **randomises
+/// the run order** on each invocation. This means one run may return only synapse candidates
+/// (neuron starved) and the next may return only neuron candidates (synapse starved).
 ///
 /// When no deadline is set, the original "neuron-first" ordering is preserved for
 /// backwards compatibility (neuron discovery creates new network structure and may be
@@ -192,84 +142,79 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     };
 
     // Determine analysis order based on whether a deadline is set.
-    // When deadline-constrained, synapse analysis runs FIRST to prevent starvation.
+    // When deadline-constrained, we randomise ordering so that repeated runs provide
+    // long-run coverage even though an individual run can return partial results.
     // Without a deadline, neuron analysis runs first (original behaviour).
-    //
-    // Coverage under timeouts:
-    // In production, the controller often supplies `analysis_deadline_ms` and repeats discovery
-    // over time (e.g., GRQ’s `worker/Discovery/run.sh`). If we pass the same deadline to both
-    // analyses, the first can consume the entire budget and starve the second.
-    //
-    // To ensure coverage over time, we split the *global* deadline into two time windows and
-    // pass per-analysis absolute deadlines. This guarantees both synapse and neuron analysis
-    // get a share of the budget each invocation.
     let has_deadline = input.analysis_deadline_ms.is_some();
 
-    // Build per-analysis deadlines (absolute millisecond timestamps) when both analyses are enabled.
-    // This keeps the total wall-clock budget bounded while ensuring both analyses run.
-    //
-    // Note: We intentionally prefer synapse analysis under deadlines, but we also reserve time
-    // for neuron analysis so it is not starved.
-    let (synapse_deadline_ms, neuron_deadline_ms) =
-        if has_deadline && include_synapse && include_neuron {
-            // Share of the *global* budget reserved for synapse analysis.
-            // This is a tuning knob; 0.7 biases toward synapse discovery (historically starved).
-            const SYNAPSE_SHARE: f64 = 0.7;
-
-            // has_deadline is true here, so unwrap is safe.
-            let raw = input
-                .analysis_deadline_ms
-                .expect("has_deadline implies analysis_deadline_ms is set");
-            let now_ms = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .ok()
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0);
-
-            match split_global_deadline_ms(raw, now_ms, SYNAPSE_SHARE) {
-                Some((syn_end, total_end)) => (Some(syn_end), Some(total_end)),
-                None => (input.analysis_deadline_ms, input.analysis_deadline_ms),
-            }
-        } else {
-            (input.analysis_deadline_ms, input.analysis_deadline_ms)
-        };
-
     let (synapse_result, neuron_result) = if has_deadline {
-        // SYNAPSE-FIRST ordering (deadline-constrained):
-        // Synapse analysis is often starved because neuron analysis consumes the budget.
-        // Running synapses first ensures they get a fair share of the deadline.
+        // Deadline-constrained: randomised ordering.
+        let now_ms = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let synapse_first = include_synapse
+            && include_neuron
+            && choose_deadline_order_synapse_first(input.random_seed, now_ms);
+
         if utils::verbose_enabled() {
             eprintln!(
-                "[NEAT-AI-Discovery][verbose] Deadline set ({}ms) - running synapse analysis first to prevent starvation",
-                input.analysis_deadline_ms.unwrap_or(0)
+                "[NEAT-AI-Discovery][verbose] Deadline set ({}ms) - randomised ordering: {} first",
+                input.analysis_deadline_ms.unwrap_or(0),
+                if synapse_first { "synapse" } else { "neuron" }
             );
         }
 
-        let synapse_result = run_optional_analysis(
-            synapse_input.is_some(),
-            "analysis::analyze_all → synapse analysis starting",
-            "analysis::analyze_all → synapse analysis finished",
-            "analysis::analyze_all → synapse analysis skipped",
-            || {
-                let mut inner = synapse_input.expect("checked is_some");
-                inner.analysis_deadline_ms = synapse_deadline_ms;
-                implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
-            },
-        )?;
+        if synapse_first {
+            let synapse_result = run_optional_analysis(
+                synapse_input.is_some(),
+                "analysis::analyze_all → synapse analysis starting",
+                "analysis::analyze_all → synapse analysis finished",
+                "analysis::analyze_all → synapse analysis skipped",
+                || {
+                    let inner = synapse_input.expect("checked is_some");
+                    implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
+                },
+            )?;
 
-        let neuron_result = run_optional_analysis(
-            neuron_input.is_some(),
-            "analysis::analyze_all → neuron analysis starting",
-            "analysis::analyze_all → neuron analysis finished",
-            "analysis::analyze_all → neuron analysis skipped",
-            || {
-                let mut inner = neuron_input.expect("checked is_some");
-                inner.analysis_deadline_ms = neuron_deadline_ms;
-                implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
-            },
-        )?;
+            let neuron_result = run_optional_analysis(
+                neuron_input.is_some(),
+                "analysis::analyze_all → neuron analysis starting",
+                "analysis::analyze_all → neuron analysis finished",
+                "analysis::analyze_all → neuron analysis skipped",
+                || {
+                    let inner = neuron_input.expect("checked is_some");
+                    implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
+                },
+            )?;
 
-        (synapse_result, neuron_result)
+            (synapse_result, neuron_result)
+        } else {
+            let neuron_result = run_optional_analysis(
+                neuron_input.is_some(),
+                "analysis::analyze_all → neuron analysis starting",
+                "analysis::analyze_all → neuron analysis finished",
+                "analysis::analyze_all → neuron analysis skipped",
+                || {
+                    let inner = neuron_input.expect("checked is_some");
+                    implementation::analyze_neurons_with_cache(&inner, Arc::clone(&shared_cache))
+                },
+            )?;
+
+            let synapse_result = run_optional_analysis(
+                synapse_input.is_some(),
+                "analysis::analyze_all → synapse analysis starting",
+                "analysis::analyze_all → synapse analysis finished",
+                "analysis::analyze_all → synapse analysis skipped",
+                || {
+                    let inner = synapse_input.expect("checked is_some");
+                    implementation::analyze_synapses_with_cache(&inner, Arc::clone(&shared_cache))
+                },
+            )?;
+
+            (synapse_result, neuron_result)
+        }
     } else {
         // NEURON-FIRST ordering (no deadline - original behaviour):
         // Neuron discovery is more valuable as it can create new network structure.

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+#[test]
+fn watchdog_beats_do_not_claim_finished_when_analysis_is_skipped() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    // Ensure a watchdog is active so `beat()` is observable in tests.
+    let wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let skipped = "analysis::analyze_all → neuron analysis skipped";
+    let finished = "analysis::analyze_all → neuron analysis finished";
+
+    // When disabled, we should record "skipped" and never execute the closure.
+    let result: Option<()> =
+        run_optional_analysis(false, "starting", finished, skipped, || -> Result<()> {
+            unreachable!("disabled analysis closure must not run")
+        })
+        .expect("should not error");
+    assert!(result.is_none());
+    assert_eq!(
+        crate::watchdog::active_stage_for_test().as_deref(),
+        Some(skipped)
+    );
+
+    // When enabled, we should end on "finished".
+    let result: Option<()> =
+        run_optional_analysis(true, "starting", finished, "skipped", || Ok(()))
+            .expect("should not error");
+    assert!(result.is_some());
+    assert_eq!(
+        crate::watchdog::active_stage_for_test().as_deref(),
+        Some(finished)
+    );
+
+    drop(wd);
+}
+
+#[test]
+fn split_global_deadline_ms_splits_relative_budget_into_two_absolute_deadlines() {
+    let now_ms = 1_700_000_000_000u64;
+    let raw_relative = 10_000u64;
+    let (syn_end, total_end) = split_global_deadline_ms(raw_relative, now_ms, 0.7).expect("split");
+    assert_eq!(total_end, now_ms + 10_000);
+    assert_eq!(syn_end, now_ms + 7_000);
+    assert!(syn_end < total_end);
+}
+
+#[test]
+fn split_global_deadline_ms_splits_absolute_deadline() {
+    let now_ms = 1_700_000_000_000u64;
+    let absolute_end = now_ms + 10_000;
+    let (syn_end, total_end) = split_global_deadline_ms(absolute_end, now_ms, 0.5).expect("split");
+    assert_eq!(total_end, absolute_end);
+    assert_eq!(syn_end, now_ms + 5_000);
+}
+
+#[test]
+fn split_global_deadline_ms_does_not_split_too_small_budgets() {
+    // Budgets < 6s cannot be safely split into two 3s windows.
+    let now_ms = 1_700_000_000_000u64;
+    let raw_relative = 5_000u64;
+    let (syn_end, total_end) = split_global_deadline_ms(raw_relative, now_ms, 0.7).expect("ok");
+    assert_eq!(syn_end, now_ms + 5_000);
+    assert_eq!(total_end, now_ms + 5_000);
+}
+
+#[test]
+fn split_global_deadline_ms_does_not_intercept_invalid_short_durations() {
+    // Invalid (<3s) should be passed through to downstream validation so warnings are emitted.
+    let now_ms = 1_700_000_000_000u64;
+    let raw_relative = 2_000u64;
+    assert!(split_global_deadline_ms(raw_relative, now_ms, 0.7).is_none());
+}
+
+#[test]
+fn split_global_deadline_ms_does_not_intercept_invalid_long_durations() {
+    // Invalid (>1h) should be passed through to downstream validation so warnings are emitted.
+    let now_ms = 1_700_000_000_000u64;
+    let raw_relative = 3_600_001u64;
+    assert!(split_global_deadline_ms(raw_relative, now_ms, 0.7).is_none());
+}

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -38,46 +38,30 @@ fn watchdog_beats_do_not_claim_finished_when_analysis_is_skipped() {
 }
 
 #[test]
-fn split_global_deadline_ms_splits_relative_budget_into_two_absolute_deadlines() {
+fn choose_deadline_order_is_deterministic_for_fixed_inputs() {
     let now_ms = 1_700_000_000_000u64;
-    let raw_relative = 10_000u64;
-    let (syn_end, total_end) = split_global_deadline_ms(raw_relative, now_ms, 0.7).expect("split");
-    assert_eq!(total_end, now_ms + 10_000);
-    assert_eq!(syn_end, now_ms + 7_000);
-    assert!(syn_end < total_end);
+    assert_eq!(
+        choose_deadline_order_synapse_first(Some(123), now_ms),
+        choose_deadline_order_synapse_first(Some(123), now_ms)
+    );
 }
 
 #[test]
-fn split_global_deadline_ms_splits_absolute_deadline() {
+fn choose_deadline_order_varies_over_time() {
+    // The chooser mixes in epoch-ms, so adjacent milliseconds should flip the result.
     let now_ms = 1_700_000_000_000u64;
-    let absolute_end = now_ms + 10_000;
-    let (syn_end, total_end) = split_global_deadline_ms(absolute_end, now_ms, 0.5).expect("split");
-    assert_eq!(total_end, absolute_end);
-    assert_eq!(syn_end, now_ms + 5_000);
+    assert_ne!(
+        choose_deadline_order_synapse_first(Some(0), now_ms),
+        choose_deadline_order_synapse_first(Some(0), now_ms + 1)
+    );
 }
 
 #[test]
-fn split_global_deadline_ms_does_not_split_too_small_budgets() {
-    // Budgets < 6s cannot be safely split into two 3s windows.
+fn choose_deadline_order_can_be_controlled_by_seed() {
+    // With a fixed time, different seeds should be able to flip ordering.
     let now_ms = 1_700_000_000_000u64;
-    let raw_relative = 5_000u64;
-    let (syn_end, total_end) = split_global_deadline_ms(raw_relative, now_ms, 0.7).expect("ok");
-    assert_eq!(syn_end, now_ms + 5_000);
-    assert_eq!(total_end, now_ms + 5_000);
-}
-
-#[test]
-fn split_global_deadline_ms_does_not_intercept_invalid_short_durations() {
-    // Invalid (<3s) should be passed through to downstream validation so warnings are emitted.
-    let now_ms = 1_700_000_000_000u64;
-    let raw_relative = 2_000u64;
-    assert!(split_global_deadline_ms(raw_relative, now_ms, 0.7).is_none());
-}
-
-#[test]
-fn split_global_deadline_ms_does_not_intercept_invalid_long_durations() {
-    // Invalid (>1h) should be passed through to downstream validation so warnings are emitted.
-    let now_ms = 1_700_000_000_000u64;
-    let raw_relative = 3_600_001u64;
-    assert!(split_global_deadline_ms(raw_relative, now_ms, 0.7).is_none());
+    assert_ne!(
+        choose_deadline_order_synapse_first(Some(0), now_ms),
+        choose_deadline_order_synapse_first(Some(1), now_ms)
+    );
 }

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -34,6 +34,14 @@ pub struct SynapseAnalysisMetadata {
     /// True when analysis hit its deadline and returned partial results.
     pub timed_out: bool,
 
+    /// Number of focus neurons completed before returning.
+    ///
+    /// This allows callers to validate long-run coverage under repeated deadline-constrained runs.
+    pub completed_focus_neurons: usize,
+
+    /// Total focus neurons requested for this analysis invocation.
+    pub total_focus_neurons: usize,
+
     /// Range of input indices that were observed with non-empty record sets during analysis.
     ///
     /// This helps diagnose whether new observation inputs (eg `input-1486+`) are present in the
@@ -50,6 +58,15 @@ pub struct NeuronAnalysisMetadata {
 
     /// Number of neuron candidates returned to caller (after `maxCandidates` truncation).
     pub candidates_returned: usize,
+
+    /// True when analysis hit its deadline and returned partial results.
+    pub timed_out: bool,
+
+    /// Number of focus neurons completed before returning.
+    pub completed_focus_neurons: usize,
+
+    /// Total focus neurons requested for this analysis invocation.
+    pub total_focus_neurons: usize,
 }
 
 /// Result of synapse analysis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,10 @@ pub struct SynapseAnalysisMetadataJson {
     pub candidates_returned: usize,
     /// True when analysis hit its deadline and returned partial results.
     pub timed_out: bool,
+    /// Number of focus neurons completed before returning.
+    pub completed_focus_neurons: usize,
+    /// Total focus neurons requested for this analysis invocation.
+    pub total_focus_neurons: usize,
     /// Minimum input index observed with non-empty records (eg 0).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_index_min_seen_with_records: Option<usize>,
@@ -379,6 +383,12 @@ pub struct NeuronAnalysisMetadataJson {
     pub candidates_found: usize,
     /// Number of neuron candidates returned to caller (after `maxCandidates` truncation).
     pub candidates_returned: usize,
+    /// True when analysis hit its deadline and returned partial results.
+    pub timed_out: bool,
+    /// Number of focus neurons completed before returning.
+    pub completed_focus_neurons: usize,
+    /// Total focus neurons requested for this analysis invocation.
+    pub total_focus_neurons: usize,
 }
 
 /// Internal input structure for synapse analysis (used by analyze_all)
@@ -956,6 +966,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     candidates_found: s.metadata.candidates_found,
                     candidates_returned: s.metadata.candidates_returned,
                     timed_out: s.metadata.timed_out,
+                    completed_focus_neurons: s.metadata.completed_focus_neurons,
+                    total_focus_neurons: s.metadata.total_focus_neurons,
                     input_index_min_seen_with_records: s.metadata.input_index_min_seen_with_records,
                     input_index_max_seen_with_records: s.metadata.input_index_max_seen_with_records,
                 }),
@@ -967,6 +979,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_metadata: neuron.as_ref().map(|n| NeuronAnalysisMetadataJson {
                     candidates_found: n.metadata.candidates_found,
                     candidates_returned: n.metadata.candidates_returned,
+                    timed_out: n.metadata.timed_out,
+                    completed_focus_neurons: n.metadata.completed_focus_neurons,
+                    total_focus_neurons: n.metadata.total_focus_neurons,
                 }),
                 error: None,
             };

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -682,18 +682,11 @@ Pages speculative:                        12345.
         // Historically an early `return Ok(())` skipped the completion counter update, leaving the
         // watchdog stage stuck at "processing target ..." rather than "completed 1/1".
 
-        let _lock = crate::watchdog::lock_for_test_serialisation();
-
         // Keep this aligned with integration tests: skip rather than fail when no GPU is present.
         if !crate::analysis::GpuAnalyzer::gpu_is_available() {
             eprintln!("Skipping test: no GPU available");
             return Ok(());
         }
-
-        let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
-            stall_timeout: std::time::Duration::from_secs(60),
-            abort_delay: std::time::Duration::from_secs(1),
-        });
 
         // Use a unique UUID so other parallel tests (which often use "output-0") won't
         // accidentally overwrite the watchdog stage while our watchdog is active.
@@ -755,12 +748,8 @@ Pages speculative:                        12345.
             random_seed: Some(123),
         };
 
-        let _result = analyze_neurons_with_cache(&input, cache)?;
-
-        let stage = crate::watchdog::active_stage_for_test().unwrap_or_default();
-        assert!(
-            stage.contains("neuron analysis → completed 1/1"),
-            "expected progress to reach completed 1/1 for a threshold target, got: {stage}"
-        );
+        let result = analyze_neurons_with_cache(&input, cache)?;
+        assert_eq!(result.metadata.total_focus_neurons, 1);
+        assert_eq!(result.metadata.completed_focus_neurons, 1);
         Ok(())
     }

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -753,3 +753,96 @@ Pages speculative:                        12345.
         assert_eq!(result.metadata.completed_focus_neurons, 1);
         Ok(())
     }
+
+    #[test]
+    fn neuron_analysis_total_focus_neurons_reports_requested_count_even_when_some_targets_are_filtered()
+    -> Result<()> {
+        // 2-Jan-2026: Regression test for metadata consistency.
+        //
+        // `total_focus_neurons` is documented as "Total focus neurons requested for this analysis
+        // invocation". Some requested focus UUIDs can be filtered out (eg hidden/input/constant),
+        // but the metadata should still report the *requested* count, not the post-filter eligible
+        // output-neuron count.
+
+        // Keep this aligned with integration tests: skip rather than fail when no GPU is present.
+        if !crate::analysis::GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return Ok(());
+        }
+
+        // Use unique UUIDs so other parallel tests won't collide on shared names.
+        let output_uuid = "output-total-focus-0";
+        let hidden_uuid = "hidden-total-focus-0";
+
+        let creature = crate::CreatureJson {
+            input: 1,
+            output: 1,
+            neurons: vec![
+                crate::NeuronJson {
+                    uuid: hidden_uuid.to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+                crate::NeuronJson {
+                    uuid: output_uuid.to_string(),
+                    neuron_type: "output".to_string(),
+                    squash: "STEP".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: Vec::new(),
+        };
+
+        // Use an in-memory loader so the test doesn't need to write a parquet file.
+        let cache = std::sync::Arc::new(RecordCache::with_loader(
+            "unused.parquet",
+            std::sync::Arc::new(move |_file, uuid| {
+                let mut records = Vec::new();
+                for obs_index in 0..20u32 {
+                    match uuid {
+                        "input-0" => {
+                            records.push(DiscoverRecord {
+                                obs_index,
+                                neuron_uuid: uuid.to_string(),
+                                value: None,
+                                activation: (obs_index as f32 - 10.0) / 10.0,
+                                errors: Vec::new(),
+                            });
+                        }
+                        _ if uuid == output_uuid => {
+                            // Provide non-empty errors so the target is considered analysable.
+                            let activation = 0.0;
+                            let error = if obs_index < 10 { 0.25 } else { -0.25 };
+                            records.push(DiscoverRecord {
+                                obs_index,
+                                neuron_uuid: uuid.to_string(),
+                                value: Some(activation),
+                                activation,
+                                errors: vec![error],
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(records)
+            }),
+        ));
+
+        let input = crate::AnalyzeNeuronsInput {
+            parquet_file: "unused.parquet".to_string(),
+            creature,
+            // Request both an output and a hidden target; hidden will be filtered out by add-neuron
+            // analysis, but should still count towards the "requested" total.
+            focus_neurons: vec![output_uuid.to_string(), hidden_uuid.to_string()],
+            max_candidates: Some(1),
+            analysis_deadline_ms: None,
+            random_seed: Some(123),
+        };
+
+        let result = analyze_neurons_with_cache(&input, cache)?;
+        assert_eq!(result.metadata.total_focus_neurons, 2);
+        // Only the eligible output target should be processed/completed.
+        assert_eq!(result.metadata.completed_focus_neurons, 1);
+        Ok(())
+    }


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.2.24 to 0.3.0.
- Introduce new metadata fields in analysis structures to track focus neuron completion and total requests, improving observability of analysis coverage.
- Implement a mechanism to diversify candidate selection within the top-K during deadline-constrained runs, ensuring fair distribution of analysis workload over time.
- Update README to reflect new design goals and coverage strategies for production runs, emphasizing the importance of repeated invocations for comprehensive results.

These changes enhance the robustness and flexibility of the analysis process, particularly in scenarios with strict timing constraints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release: 0.3.0**
> 
> - **Deadline-aware coverage**: Randomizes which analysis runs first (`synapse` vs `neuron`) when `analysis_deadline_ms` is set via `choose_deadline_order_synapse_first`; preserves neuron-first when no deadline
> - **Candidate diversification**: Adds `shuffle_within_top_k` to shuffle within top‑K (64) for returned candidates under deadlines (both neuron and synapse paths)
> - **Observability**: Extends metadata for both analyses with `timed_out`, `completed_focus_neurons`, and `total_focus_neurons`; wires through to JSON (`src/lib.rs`)
> - **Test hardening**: Reworks deadline override to thread‑local state and private Rayon pools; adds focused tests and moves `analyze_all` tests to `src/analysis/mod_tests.rs`
> - **Docs**: README documents deadline-driven coverage over time and randomized ordering
> - **CI**: Adds disk usage diagnostics and stops caching `target/`; cache key now includes `Cargo.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48cab93a53c5d775116efc2265c95e9817031aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->