### PR TITLE
Update version to 0.4.1 and enhance target simulation mode for satura…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -6358,7 +6358,9 @@ fn compute_synapse_improvement_with_target_squash(
                 let expected = target_fn(desired_value);
 
                 let baseline_err = expected - target_activation;
-                baseline_error_sq_sum += baseline_err * baseline_err;
+                if baseline_err.is_finite() {
+                    baseline_error_sq_sum += baseline_err * baseline_err;
+                }
 
                 let new_input = target_value + contribution;
                 expected - target_fn(new_input)
@@ -6371,7 +6373,9 @@ fn compute_synapse_improvement_with_target_squash(
                 let expected = target_fn(desired_value);
 
                 let baseline_err = expected - target_activation;
-                baseline_error_sq_sum += baseline_err * baseline_err;
+                if baseline_err.is_finite() {
+                    baseline_error_sq_sum += baseline_err * baseline_err;
+                }
 
                 let new_input = target_value + contribution;
                 expected - target_fn(new_input)

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -6042,6 +6042,62 @@ fn get_target_simulation_fn(
     }
 }
 
+/// Target simulation mode for saturation-aware candidate scoring.
+///
+/// Most accurate mode requires both `target_value` (pre-activation) and `target_activation`
+/// for every sample. In production, `target_value` is not always recorded, but
+/// `target_activation` typically is.
+///
+/// For a small set of squash functions where a reasonable approximation is possible, we can
+/// still simulate in activation domain by approximating `target_value` from the observed
+/// activation. This is particularly important for `HARD_TANH`, where the linear model can
+/// massively overstate improvement near saturation.
+#[derive(Copy, Clone)]
+enum TargetSimulationMode {
+    /// No saturation-aware simulation is available; fall back to the linear (value-domain) model.
+    None,
+    /// Full saturation-aware simulation using recorded `target_value` + `target_activation`.
+    Full(fn(f32) -> f32),
+    /// Saturation-aware simulation using recorded `target_activation` and an approximation for
+    /// `target_value`.
+    ApproximateValueFromActivation(fn(f32) -> f32),
+}
+
+/// Select the best available target simulation mode for the given samples.
+#[inline]
+fn get_target_simulation_mode(
+    samples: &[HelpfulSample],
+    target_squash: Option<&str>,
+) -> TargetSimulationMode {
+    let Some(squash) = target_squash else {
+        return TargetSimulationMode::None;
+    };
+    let Some(activation_fn) = get_target_activation_fn(squash) else {
+        return TargetSimulationMode::None;
+    };
+
+    let all_have_activation = samples.iter().all(|s| s.target_activation.is_some());
+    if !all_have_activation {
+        return TargetSimulationMode::None;
+    }
+
+    let all_have_value = samples.iter().all(|s| s.target_value.is_some());
+    if all_have_value {
+        return TargetSimulationMode::Full(activation_fn);
+    }
+
+    // Approximation path: keep deliberately narrow (Jan 2026).
+    //
+    // `HARD_TANH` is piecewise linear and, when not saturated, `target_activation == target_value`.
+    // When saturated, the exact pre-activation is unknown, but approximating it as ±1 still avoids
+    // the linear-model failure mode where we assume the activation can move beyond the clamp.
+    if squash.eq_ignore_ascii_case("HARD_TANH") {
+        return TargetSimulationMode::ApproximateValueFromActivation(activation_fn);
+    }
+
+    TargetSimulationMode::None
+}
+
 /// Legacy function for backwards compatibility - returns true only for HARD_TANH
 /// Deprecated: Use get_target_simulation_fn instead for more accurate simulation
 #[inline]
@@ -6280,28 +6336,46 @@ fn compute_synapse_improvement_with_target_squash(
         return 0.0;
     }
 
-    // Check if we can use saturation-aware model
-    let target_activation_fn = get_target_simulation_fn(samples, target_squash);
+    let target_sim = get_target_simulation_mode(samples, target_squash);
 
+    let mut baseline_error_sq_sum = 0.0f32; // ACTIVATION domain when simulating
     let mut new_error_sq_sum = 0.0f32;
 
     for sample in samples {
         // Direct synapse contribution: weight × source_activation
         let contribution = weight * sample.activation;
 
-        let new_error = if let Some(target_fn) = target_activation_fn {
-            // Saturation-aware model: apply target's activation function
-            // CRITICAL: avg_error is in VALUE domain (targetValue - currentValue from TypeScript)
-            // So we compute desired_value = target_value + avg_error, then squash to get expected activation
-            // Safety: target_activation_fn is only Some when all samples have target data
-            let target_value = unsafe { sample.target_value.unwrap_unchecked() };
-            let desired_value = target_value + sample.avg_error;
-            let expected = target_fn(desired_value);
-            let new_input = target_value + contribution;
-            expected - target_fn(new_input)
-        } else {
-            // Linear approximation - assumes contribution directly reduces error
-            sample.avg_error - contribution
+        let new_error = match target_sim {
+            TargetSimulationMode::None => {
+                // Linear approximation - assumes contribution directly reduces error (VALUE domain).
+                sample.avg_error - contribution
+            }
+            TargetSimulationMode::Full(target_fn) => {
+                // Saturation-aware model (ACTIVATION domain).
+                let target_value = sample.target_value.unwrap();
+                let target_activation = sample.target_activation.unwrap();
+                let desired_value = target_value + sample.avg_error;
+                let expected = target_fn(desired_value);
+
+                let baseline_err = expected - target_activation;
+                baseline_error_sq_sum += baseline_err * baseline_err;
+
+                let new_input = target_value + contribution;
+                expected - target_fn(new_input)
+            }
+            TargetSimulationMode::ApproximateValueFromActivation(target_fn) => {
+                // Saturation-aware model (ACTIVATION domain), approximating missing target_value.
+                let target_activation = sample.target_activation.unwrap();
+                let target_value = sample.target_value.unwrap_or(target_activation);
+                let desired_value = target_value + sample.avg_error;
+                let expected = target_fn(desired_value);
+
+                let baseline_err = expected - target_activation;
+                baseline_error_sq_sum += baseline_err * baseline_err;
+
+                let new_input = target_value + contribution;
+                expected - target_fn(new_input)
+            }
         };
 
         if new_error.is_finite() {
@@ -6309,7 +6383,15 @@ fn compute_synapse_improvement_with_target_squash(
         }
     }
 
-    let improvement = (total_baseline_error_sq - new_error_sq_sum) / total_baseline_error_sq;
+    let effective_baseline = match target_sim {
+        TargetSimulationMode::None => total_baseline_error_sq,
+        _ => baseline_error_sq_sum,
+    };
+    if effective_baseline <= EPSILON {
+        return 0.0;
+    }
+
+    let improvement = (effective_baseline - new_error_sq_sum) / effective_baseline;
     if improvement.is_finite() {
         improvement
     } else {
@@ -6336,7 +6418,7 @@ fn compute_synapse_improvement_and_count(
         return (0.0, 0, 0, samples.len() as u32);
     }
 
-    let target_activation_fn = get_target_simulation_fn(samples, target_squash);
+    let target_sim = get_target_simulation_mode(samples, target_squash);
 
     let mut baseline_error_sq_sum = 0.0f32; // ACTIVATION domain when simulating
     let mut new_error_sq_sum = 0.0f32;
@@ -6347,25 +6429,38 @@ fn compute_synapse_improvement_and_count(
     for sample in samples {
         let contribution = weight * sample.activation;
 
-        let (baseline_error, new_error) = if let Some(target_fn) = target_activation_fn {
-            // CRITICAL: Use ACTIVATION domain for BOTH baseline and new error.
-            // avg_error is in VALUE domain, but MSE is measured in ACTIVATION domain.
-            let target_value = unsafe { sample.target_value.unwrap_unchecked() };
-            let target_activation = unsafe { sample.target_activation.unwrap_unchecked() };
-            let desired_value = target_value + sample.avg_error;
-            let expected = target_fn(desired_value);
+        let (baseline_error, new_error) = match target_sim {
+            TargetSimulationMode::None => {
+                // Linear approximation: both errors in VALUE domain.
+                (sample.avg_error, sample.avg_error - contribution)
+            }
+            TargetSimulationMode::Full(target_fn) => {
+                // CRITICAL: Use ACTIVATION domain for BOTH baseline and new error.
+                // avg_error is in VALUE domain, but MSE is measured in ACTIVATION domain.
+                let target_value = sample.target_value.unwrap();
+                let target_activation = sample.target_activation.unwrap();
+                let desired_value = target_value + sample.avg_error;
+                let expected = target_fn(desired_value);
 
-            // Baseline error in ACTIVATION domain: expected output - current output
-            let baseline_err = expected - target_activation;
+                let baseline_err = expected - target_activation;
+                let new_input = target_value + contribution;
+                let new_err = expected - target_fn(new_input);
 
-            // New error in ACTIVATION domain: expected output - new output
-            let new_input = target_value + contribution;
-            let new_err = expected - target_fn(new_input);
+                (baseline_err, new_err)
+            }
+            TargetSimulationMode::ApproximateValueFromActivation(target_fn) => {
+                // As above, but approximate missing target_value from the observed activation.
+                let target_activation = sample.target_activation.unwrap();
+                let target_value = sample.target_value.unwrap_or(target_activation);
+                let desired_value = target_value + sample.avg_error;
+                let expected = target_fn(desired_value);
 
-            (baseline_err, new_err)
-        } else {
-            // Linear approximation: both errors in VALUE domain
-            (sample.avg_error, sample.avg_error - contribution)
+                let baseline_err = expected - target_activation;
+                let new_input = target_value + contribution;
+                let new_err = expected - target_fn(new_input);
+
+                (baseline_err, new_err)
+            }
         };
 
         if baseline_error.is_finite() {
@@ -6383,11 +6478,10 @@ fn compute_synapse_improvement_and_count(
         }
     }
 
-    // Use computed ACTIVATION domain baseline when simulating, else use passed VALUE domain
-    let effective_baseline = if target_activation_fn.is_some() {
-        baseline_error_sq_sum
-    } else {
-        total_baseline_error_sq
+    // Use computed ACTIVATION domain baseline when simulating, else use passed VALUE domain.
+    let effective_baseline = match target_sim {
+        TargetSimulationMode::None => total_baseline_error_sq,
+        _ => baseline_error_sq_sum,
     };
 
     let improvement = if effective_baseline > EPSILON {

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -1175,3 +1175,48 @@ Pages speculative:                        12345.
             "expected ~0.0 improvement under saturation, got {improvement}"
         );
     }
+
+    #[test]
+    fn synapse_improvement_with_target_squash_ignores_non_finite_baseline_error_terms() {
+        // Regression test (6-Jan-2026):
+        //
+        // `compute_synapse_improvement_with_target_squash` must not let a single non-finite
+        // baseline error (eg from NaN target_value) poison the baseline accumulation.
+        //
+        // This matches `compute_synapse_improvement_and_count`, which only accumulates finite
+        // baseline errors.
+
+        // Two samples:
+        // - Sample A has NaN target_value, so expected/baseline_err becomes NaN.
+        // - Sample B is valid and should show a strong improvement when weight=0.5.
+        let samples = vec![
+            HelpfulSample {
+                activation: 1.0,
+                avg_error: 0.5,
+                target_value: Some(f32::NAN),
+                target_activation: Some(0.0),
+            },
+            HelpfulSample {
+                activation: 1.0,
+                avg_error: 0.5,
+                target_value: Some(0.0),
+                target_activation: Some(0.0),
+            },
+        ];
+
+        // The value-domain baseline is irrelevant when using squash simulation, but must be > 0.
+        let baseline_sq: f32 = samples.iter().map(|s| s.avg_error * s.avg_error).sum();
+        assert!(baseline_sq > 0.0);
+
+        let improvement = compute_synapse_improvement_with_target_squash(
+            &samples,
+            0.5, // contribution = 0.5 * activation -> fixes Sample B exactly under HARD_TANH
+            baseline_sq,
+            Some("HARD_TANH"),
+        );
+
+        assert!(
+            improvement > 0.9,
+            "expected strong improvement once NaN baseline terms are ignored, got {improvement}"
+        );
+    }

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -1130,3 +1130,48 @@ Pages speculative:                        12345.
             "expected improvement {expected}, got {improvement_applied}"
         );
     }
+
+    #[test]
+    fn synapse_improvement_uses_activation_domain_for_hard_tanh_even_when_target_value_missing() {
+        // Regression test (6-Jan-2026):
+        //
+        // When the target neuron is HARD_TANH and already saturated, the linear model can
+        // over-predict improvement (because additional input doesn't change the activation).
+        //
+        // Production discovery runs do not always record `targetValue` (pre-activation), but they
+        // *do* record `activation`. We should still prefer saturation-aware simulation by
+        // approximating the missing targetValue from the observed activation.
+        //
+        // Scenario:
+        // - target activation is fully saturated at +1.0
+        // - avg_error is +0.5 in VALUE domain (desired value is higher)
+        // - a positive weight would appear to \"fix\" the error in the linear model
+        // - but HARD_TANH output can't exceed 1.0, so true improvement is ~0.0
+
+        let samples = vec![
+            HelpfulSample {
+                activation: 1.0,
+                avg_error: 0.5,
+                target_value: None,
+                target_activation: Some(1.0),
+            },
+            HelpfulSample {
+                activation: 1.0,
+                avg_error: 0.5,
+                target_value: None,
+                target_activation: Some(1.0),
+            },
+        ];
+        let baseline_sq: f32 = samples.iter().map(|s| s.avg_error * s.avg_error).sum();
+
+        let (improvement, improved, worsened, total) =
+            compute_synapse_improvement_and_count(&samples, 0.5, baseline_sq, Some("HARD_TANH"));
+
+        assert_eq!(total, 2);
+        assert_eq!(improved, 0, "no samples should improve under HARD_TANH saturation");
+        assert_eq!(worsened, 0, "no samples should worsen under HARD_TANH saturation");
+        assert!(
+            improvement.abs() < 1e-6,
+            "expected ~0.0 improvement under saturation, got {improvement}"
+        );
+    }


### PR DESCRIPTION
…tion-aware scoring

- Bump version in Cargo.toml from 0.4.0 to 0.4.1.
- Introduce a new `TargetSimulationMode` enum to improve saturation-aware candidate scoring, allowing for better handling of cases where `target_value` is missing.
- Update the `compute_synapse_improvement_with_target_squash` and `compute_synapse_improvement_and_count` functions to utilize the new simulation mode, ensuring accurate error calculations in both activation and value domains.
- Add a regression test to verify correct behavior under saturation conditions for the `HARD_TANH` activation function.

These changes enhance the accuracy of synapse improvement calculations, particularly in scenarios where target values are not recorded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves saturation-aware candidate scoring and correctness in activation domain.
> 
> - Introduces `TargetSimulationMode` (`None` | `Full(fn)` | `ApproximateValueFromActivation(fn)`) and selector to use activation-domain simulation when `target_activation` exists; approximates `target_value` for `HARD_TANH` when missing
> - Updates `compute_synapse_improvement_with_target_squash` and `compute_synapse_improvement_and_count` to accumulate baseline in ACTIVATION domain when simulating, fall back to VALUE domain otherwise, and ignore non-finite baseline terms
> - Adds regression tests covering `HARD_TANH` saturation with missing `target_value` and NaN baseline terms
> - Bumps `Cargo.toml` version to `0.4.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5373d08b8fd714bd4872edee5ec5fe52b322c4a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->