### PR TITLE
Update version to 0.4.2 and enhance target simulation mode for HARD_T…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [lib]

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -6088,10 +6088,11 @@ fn get_target_simulation_mode(
 
     // Approximation path: keep deliberately narrow (Jan 2026).
     //
-    // `HARD_TANH` is piecewise linear and, when not saturated, `target_activation == target_value`.
+    // `HARD_TANH` (aka `CLIPPED`) is piecewise linear and, when not saturated,
+    // `target_activation == target_value`.
     // When saturated, the exact pre-activation is unknown, but approximating it as ±1 still avoids
     // the linear-model failure mode where we assume the activation can move beyond the clamp.
-    if squash.eq_ignore_ascii_case("HARD_TANH") {
+    if squash.eq_ignore_ascii_case("HARD_TANH") || squash.eq_ignore_ascii_case("CLIPPED") {
         return TargetSimulationMode::ApproximateValueFromActivation(activation_fn);
     }
 

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -462,6 +462,28 @@ Pages speculative:                        12345.
         assert_eq!(clipped_activation(-1.5), -1.0);
     }
 
+    /// Regression test (Jan 2026): CLIPPED is a documented alias for HARD_TANH.
+    ///
+    /// When `target_value` is missing but `target_activation` is present, we should still use
+    /// the saturation-aware approximation path for HARD_TANH (and its alias CLIPPED). Without
+    /// this, improvement predictions near saturation can be materially wrong.
+    #[test]
+    fn target_simulation_mode_treats_clipped_as_hard_tanh_for_approximation() {
+        let samples = vec![HelpfulSample {
+            activation: 0.0,
+            avg_error: 0.1,
+            target_value: None,
+            target_activation: Some(1.0),
+        }];
+
+        // Use mixed case to confirm case-insensitive alias handling.
+        let mode = get_target_simulation_mode(&samples, Some("cLiPpEd"));
+        match mode {
+            TargetSimulationMode::ApproximateValueFromActivation(_) => {}
+            _ => panic!("CLIPPED should enable saturation-aware target simulation approximation"),
+        }
+    }
+
     #[test]
     fn test_absolute_activation() {
         assert_eq!(absolute_activation(1.0), 1.0);


### PR DESCRIPTION
…ANH alias

- Bump version in Cargo.toml from 0.4.1 to 0.4.2.
- Update the handling of the `HARD_TANH` activation function to recognize `CLIPPED` as an alias, ensuring accurate saturation-aware approximations.
- Add a regression test to verify that the alias `CLIPPED` is treated correctly in the target simulation mode, improving prediction accuracy near saturation.

These changes enhance the functionality and robustness of the target simulation mode in the analysis process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves saturation-aware target simulation when `target_value` is missing by recognizing `CLIPPED` as an alias of `HARD_TANH`.
> 
> - Update `get_target_simulation_mode` to handle `"CLIPPED"` (case-insensitive) and use `ApproximateValueFromActivation` for HARD_TANH/CLIPPED
> - Add regression test ensuring CLIPPED follows the HARD_TANH approximation path near saturation
> - Bump crate version in `Cargo.toml` from `0.4.1` to `0.4.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fa50e31a70e581d752cc2771191792dfcd3a929. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->