### PR TITLE
V0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -167,7 +167,55 @@ This discovery type exists to escape neutral plateaus and handle interference ca
 }
 ```
 
-**Current status**: 🟠 **Implemented in Rust, not tested in production** – TypeScript must apply and score grouped candidates as a single unit.
+**Operation vocabulary** (7-Jan-2026):
+- `removeSynapse(fromNeuronUuid,toNeuronUuid)`
+- `addSynapse(fromNeuronUuid,toNeuronUuid,weight)`
+- `addNeuron(neuronUuid,neuronType,squash,bias,insertBeforeNeuronUuid?)`
+- `removeNeuron(neuronUuid)`
+- `changeSquash(neuronUuid,squash)`
+- `setBias(neuronUuid,bias)`
+
+**Forward-only note**: for forward-only creatures, `addNeuron.insertBeforeNeuronUuid` is used to place the neuron in the `neurons[]` array before the target neuron so subsequent `addSynapse(newNeuron -> target)` respects the forward-only ordering constraint.
+
+**Example scenario (replace synapse with hidden neuron)**:
+
+```json
+{
+  "coordinatedStructuralCandidates": [
+    {
+      "expectedCreatureScoreGain": 0.00042,
+      "comment": "Coordinated replacement: remove synapse and insert ReLU hidden neuron",
+      "operations": [
+        { "type": "removeSynapse", "fromNeuronUuid": "input-0", "toNeuronUuid": "output-0" },
+        { "type": "addNeuron", "neuronUuid": "coordinated-hidden-deadbeef", "neuronType": "hidden", "squash": "ReLU", "bias": 0, "insertBeforeNeuronUuid": "output-0" },
+        { "type": "addSynapse", "fromNeuronUuid": "input-0", "toNeuronUuid": "coordinated-hidden-deadbeef", "weight": 1.0 },
+        { "type": "addSynapse", "fromNeuronUuid": "coordinated-hidden-deadbeef", "toNeuronUuid": "output-0", "weight": 0.9 }
+      ]
+    }
+  ]
+}
+```
+
+**Example scenario (collapse a 1-in/1-out hidden neuron)**:
+
+```json
+{
+  "coordinatedStructuralCandidates": [
+    {
+      "expectedCreatureScoreGain": 0.00031,
+      "comment": "Coordinated collapse: remove 1-in/1-out hidden neuron and add bypass synapse",
+      "operations": [
+        { "type": "removeSynapse", "fromNeuronUuid": "input-0", "toNeuronUuid": "hidden-0" },
+        { "type": "removeSynapse", "fromNeuronUuid": "hidden-0", "toNeuronUuid": "output-0" },
+        { "type": "removeNeuron", "neuronUuid": "hidden-0" },
+        { "type": "addSynapse", "fromNeuronUuid": "input-0", "toNeuronUuid": "output-0", "weight": 1.0 }
+      ]
+    }
+  ]
+}
+```
+
+**Current status**: 🟢 **Active and tested** – Rust emits ordered groups; NEAT-AI applies the full ordered operation list atomically and re-scores on the full training set.
 
 ---
 

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -5930,6 +5930,130 @@ impl TargetMap {
     }
 }
 
+/// Compute expected gain for a coordinated "replace synapse with neuron" group.
+///
+/// This models the coordinated operation sequence:
+/// 1) remove direct synapse (source -> target)
+/// 2) add hidden neuron with (source -> newNeuron) and (newNeuron -> target)
+///
+/// We approximate the effect of synapse removal in the VALUE domain by adjusting
+/// the target error per-sample:
+///   error' = error + old_weight * source_activation
+///
+/// This is fast and deterministic, and is sufficient for IDENTITY targets (the
+/// common case for our coordinated-structural regression tests).
+///
+/// Notes (7-Jan-2026):
+/// - This intentionally uses the linear model (no saturation-aware simulation),
+///   because we do not have a reliable way to reconstruct `target_value` and
+///   `target_activation` after removing the existing synapse.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
+    cache: &RecordCache,
+    source_uuid: &str,
+    target_uuid: &str,
+    old_weight: f32,
+    incoming_weight: f32,
+    outgoing_weight: f32,
+    bias: f32,
+    squash: &str,
+) -> Option<f32> {
+    let from_records_arc = cache.get(source_uuid).ok()?;
+    let target_records_arc = cache.get(target_uuid).ok()?;
+    if from_records_arc.is_empty() || target_records_arc.is_empty() {
+        return None;
+    }
+
+    let target_map = TargetMap::from_records(target_records_arc.as_ref());
+    if target_map.map.is_empty() {
+        return None;
+    }
+
+    let mut samples = target_map.build_samples_from(from_records_arc.as_ref());
+    if samples.is_empty() {
+        return None;
+    }
+
+    // Adjust baseline errors for the removal of the existing direct synapse.
+    for s in &mut samples {
+        s.avg_error += old_weight * s.activation;
+    }
+
+    let total_baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error * s.avg_error).sum();
+    if total_baseline_error_sq <= EPSILON {
+        return None;
+    }
+
+    if squash.eq_ignore_ascii_case("ReLU") {
+        let (improvement, _improved, _total) = compute_relu_improvement_and_count(
+            samples.as_slice(),
+            incoming_weight,
+            outgoing_weight,
+            bias,
+            total_baseline_error_sq,
+            None, // linear domain (see docstring)
+        );
+        return Some(improvement);
+    }
+
+    // Map squash names to activation functions used by add-neurons discovery.
+    let activation_fn: fn(f32) -> f32 = match squash {
+        "GELU" => gelu_activation,
+        "ELU" => elu_activation,
+        "Softplus" => softplus_activation,
+        "LOGISTIC" => logistic_activation,
+        "TANH" => tanh_activation,
+        "IDENTITY" => identity_activation,
+        "BIPOLAR" => bipolar_activation,
+        "CLIPPED" => clipped_activation,
+        "ABSOLUTE" => absolute_activation,
+        "Mish" => mish_activation,
+        "HARD_TANH" => hard_tanh_activation,
+        "Softsign" => softsign_activation,
+        "BentIdentity" => bent_identity_activation,
+        "Arctan" => arctan_activation,
+        "ReLU6" => relu6_activation,
+        _ => return None,
+    };
+
+    let (improvement, _improved, _total) = compute_activation_improvement_and_count(
+        samples.as_slice(),
+        incoming_weight,
+        outgoing_weight,
+        bias,
+        activation_fn,
+        total_baseline_error_sq,
+        None, // linear domain (see docstring)
+    );
+    Some(improvement)
+}
+
+/// Deterministic UUID generator for coordinated structural `addNeuron` operations.
+///
+/// This deliberately avoids Rust's `Hash` because the default hasher is not stable
+/// across processes. We use a simple FNV-1a 64-bit hash and return a short hex
+/// suffix so candidates are replayable and readable.
+pub(crate) fn deterministic_coordinated_neuron_uuid(
+    source_uuid: &str,
+    target_uuid: &str,
+    squash: &str,
+    incoming_weight: f32,
+    outgoing_weight: f32,
+    bias: f32,
+) -> String {
+    // 7-Jan-2026: keep stable across runs, but include weights/bias so distinct ops don't collide.
+    let key = format!(
+        "replace-synapse-with-neuron|{source_uuid}|{target_uuid}|{squash}|{incoming_weight:.6}|{outgoing_weight:.6}|{bias:.6}"
+    );
+    // FNV-1a 64-bit
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("coordinated-hidden-{hash:016x}")
+}
+
 /// Build samples for testing. In production, use TargetMap::from_records() and
 /// TargetMap::build_samples_from() for better performance when processing
 /// multiple sources against the same target.
@@ -9384,6 +9508,186 @@ pub(crate) fn analyze_synapses_with_cache(
         }
     }
 
+    // Coordinated structural discovery (7-Jan-2026): collapse a simple hidden neuron into a single synapse.
+    //
+    // This is the "reverse" of synapse→neuron insertion: when a hidden neuron forms a simple 1-in/1-out
+    // chain (a → h → b), we can propose removing that neuron and replacing the chain with a direct
+    // synapse (a → b). This must be applied atomically, so it is emitted as a coordinated-structural
+    // candidate group.
+    //
+    // Initial scope: only hidden neurons with exactly one incoming and one outgoing synapse.
+    // This keeps the candidate safe and deterministic; broader graph rewrites can be added later.
+    {
+        // Build incoming/outgoing synapse lists per neuron.
+        let mut incoming: HashMap<String, Vec<SynapseJson>> = HashMap::new();
+        let mut outgoing: HashMap<String, Vec<SynapseJson>> = HashMap::new();
+        for s in &input.creature.synapses {
+            incoming
+                .entry(s.to_uuid.clone())
+                .or_default()
+                .push(s.clone());
+            outgoing
+                .entry(s.from_uuid.clone())
+                .or_default()
+                .push(s.clone());
+        }
+
+        // Quick neuron-type lookup (only creature.neurons; inputs are not here).
+        let neuron_type_map_local: HashMap<String, String> = input
+            .creature
+            .neurons
+            .iter()
+            .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
+            .collect();
+
+        // Precompute existing direct synapses so we don't propose duplicates.
+        let mut existing_edges: HashSet<(String, String)> = HashSet::new();
+        for s in &input.creature.synapses {
+            existing_edges.insert((s.from_uuid.clone(), s.to_uuid.clone()));
+        }
+
+        for neuron in &input.creature.neurons {
+            if neuron.neuron_type != "hidden" {
+                continue;
+            }
+            let h = neuron.uuid.as_str();
+            let Some(ins) = incoming.get(h) else { continue };
+            let Some(outs) = outgoing.get(h) else {
+                continue;
+            };
+            if ins.len() != 1 || outs.len() != 1 {
+                continue;
+            }
+
+            let a_syn = &ins[0];
+            let b_syn = &outs[0];
+            let a = a_syn.from_uuid.as_str();
+            let b = b_syn.to_uuid.as_str();
+
+            // Skip degenerate / non-actionable cases.
+            if a == b || a == h || b == h {
+                continue;
+            }
+            if existing_edges.contains(&(a.to_string(), b.to_string())) {
+                // A direct synapse already exists; collapsing would need additional ops (future work).
+                continue;
+            }
+
+            // Ensure the target exists (either input-* or a neuron) so the op is not stale.
+            let target_is_known = b.starts_with("input-") || neuron_type_map_local.contains_key(b);
+            if !target_is_known {
+                continue;
+            }
+
+            // Build samples: correlate a's activation to b's adjusted error after removing h→b.
+            let Ok(a_records) = cache.get(a) else {
+                continue;
+            };
+            let Ok(h_records) = cache.get(h) else {
+                continue;
+            };
+            let Ok(b_records) = cache.get(b) else {
+                continue;
+            };
+            if a_records.is_empty() || h_records.is_empty() || b_records.is_empty() {
+                continue;
+            }
+
+            let target_map_b = TargetMap::from_records(b_records.as_ref());
+            if target_map_b.map.is_empty() {
+                continue;
+            }
+            let build_act_map = |records: &[DiscoverRecord]| -> HashMap<u32, f32> {
+                let mut map: HashMap<u32, f32> = HashMap::with_capacity(records.len());
+                for r in records {
+                    if r.activation.is_finite() {
+                        map.insert(r.obs_index, r.activation);
+                    }
+                }
+                map
+            };
+            let a_map = build_act_map(a_records.as_ref());
+            let h_map = build_act_map(h_records.as_ref());
+
+            let mut samples: Vec<HelpfulSample> = Vec::with_capacity(target_map_b.map.len());
+            for (obs_index, target) in target_map_b.map.iter() {
+                let Some(a_act) = a_map.get(obs_index) else {
+                    continue;
+                };
+                let Some(h_act) = h_map.get(obs_index) else {
+                    continue;
+                };
+                if !a_act.is_finite() || !h_act.is_finite() || !target.avg_error.is_finite() {
+                    continue;
+                }
+                let adjusted_error = target.avg_error + b_syn.weight * (*h_act);
+                if !adjusted_error.is_finite() {
+                    continue;
+                }
+                samples.push(HelpfulSample {
+                    activation: *a_act,
+                    avg_error: adjusted_error,
+                    target_value: None,
+                    target_activation: None,
+                });
+            }
+
+            if samples.len() < MIN_NEURON_SAMPLE_COUNT {
+                continue;
+            }
+
+            let mut sum_act_sq = 0.0f32;
+            let mut sum_err_act = 0.0f32;
+            let mut baseline_sq = 0.0f32;
+            for s in &samples {
+                sum_act_sq += s.activation * s.activation;
+                sum_err_act += s.activation * s.avg_error;
+                baseline_sq += s.avg_error * s.avg_error;
+            }
+            if baseline_sq <= EPSILON {
+                continue;
+            }
+
+            let Some(weight) = calculate_optimal_outgoing_weight(sum_err_act, sum_act_sq, 1.0)
+            else {
+                continue;
+            };
+
+            let (improvement, improved, worsened, total) =
+                compute_synapse_improvement_and_count(&samples, weight, baseline_sq, None);
+            let _ = (improved, worsened, total);
+            if improvement <= 0.0 {
+                continue;
+            }
+
+            coordinated_structural_results.push(crate::CoordinatedStructuralCandidateJson {
+                operations: vec![
+                    crate::CoordinatedStructuralOpJson::RemoveSynapse {
+                        from_neuron_uuid: a.to_string(),
+                        to_neuron_uuid: h.to_string(),
+                    },
+                    crate::CoordinatedStructuralOpJson::RemoveSynapse {
+                        from_neuron_uuid: h.to_string(),
+                        to_neuron_uuid: b.to_string(),
+                    },
+                    crate::CoordinatedStructuralOpJson::RemoveNeuron {
+                        neuron_uuid: h.to_string(),
+                    },
+                    crate::CoordinatedStructuralOpJson::AddSynapse {
+                        from_neuron_uuid: a.to_string(),
+                        to_neuron_uuid: b.to_string(),
+                        weight,
+                    },
+                ],
+                expected_creature_score_gain: improvement,
+                comment: Some(
+                    "Coordinated collapse: remove 1-in/1-out hidden neuron and add bypass synapse"
+                        .to_string(),
+                ),
+            });
+        }
+    }
+
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     // Output neurons have impact = 1.0 (no discount).
     // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
@@ -9464,17 +9768,34 @@ pub(crate) fn analyze_synapses_with_cache(
 
     // Apply impact discounting to coordinated candidates (based on target neuron UUID).
     for candidate in &mut coordinated_structural_results {
+        // Heuristic: use the last op that targets a concrete neuron, so multi-op groups
+        // (remove+add synapses, add/remove neuron, etc.) get discounted by the final target.
+        // This aligns with coordinated groups that ultimately adjust the inputs of a target neuron.
         let target_uuid = candidate
             .operations
-            .first()
+            .iter()
+            .rev()
             .map(|op| match op {
-                crate::CoordinatedStructuralOpJson::RemoveSynapse { to_neuron_uuid, .. } => {
-                    to_neuron_uuid.as_str()
-                }
                 crate::CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. } => {
                     to_neuron_uuid.as_str()
                 }
+                crate::CoordinatedStructuralOpJson::RemoveSynapse { to_neuron_uuid, .. } => {
+                    to_neuron_uuid.as_str()
+                }
+                crate::CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. } => {
+                    neuron_uuid.as_str()
+                }
+                crate::CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. } => {
+                    neuron_uuid.as_str()
+                }
+                crate::CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. } => {
+                    neuron_uuid.as_str()
+                }
+                crate::CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } => {
+                    neuron_uuid.as_str()
+                }
             })
+            .next()
             .unwrap_or("");
 
         let is_hidden = neuron_type_map

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -40,8 +40,12 @@ pub use shared::{NeuronNoCandidateDetail, SynapseNoCandidateDetail};
 pub use implementation::{check_memory_for_parquet, ACTIVATION_SPECS};
 
 // Implement analyze_all using the module functions
-use crate::{AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput};
+use crate::{
+    AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson,
+    CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson,
+};
 use anyhow::Result;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -243,6 +247,119 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
 
         (synapse_result, neuron_result)
     };
+
+    // Post-process: convert certain add-neuron candidates into coordinated-structural replacements.
+    //
+    // Issue #173 (7-Jan-2026): When a direct synapse already exists between (source -> target),
+    // applying an add-neuron candidate without removing the synapse is often not the intended edit.
+    // We instead emit a coordinated group that removes the synapse and inserts the hidden neuron
+    // path atomically.
+    //
+    // Important: This keeps normal add-neurons discovery working as-is for cases where no direct
+    // synapse exists.
+    let mut synapse_result = synapse_result;
+    let mut neuron_result = neuron_result;
+
+    if let (Some(syn), Some(neuron)) = (synapse_result.as_mut(), neuron_result.as_mut()) {
+        // Build a quick lookup from (from_uuid,to_uuid) to existing weight.
+        let mut direct_synapse_weight: HashMap<(String, String), f32> = HashMap::new();
+        for s in &input.creature.synapses {
+            direct_synapse_weight.insert((s.from_uuid.clone(), s.to_uuid.clone()), s.weight);
+        }
+
+        let mut kept_neurons: Vec<CandidateNeuronJson> =
+            Vec::with_capacity(neuron.helpful_neurons.len());
+        let mut replacements: Vec<CoordinatedStructuralCandidateJson> = Vec::new();
+
+        for candidate in &neuron.helpful_neurons {
+            let key = (
+                candidate.source_neuron_uuid.clone(),
+                candidate.target_neuron_uuid.clone(),
+            );
+            let Some(&old_weight) = direct_synapse_weight.get(&key) else {
+                kept_neurons.push(candidate.clone());
+                continue;
+            };
+
+            let new_neuron_uuid = implementation::deterministic_coordinated_neuron_uuid(
+                &candidate.source_neuron_uuid,
+                &candidate.target_neuron_uuid,
+                &candidate.squash,
+                candidate.incoming_weight,
+                candidate.outgoing_weight,
+                candidate.bias,
+            );
+
+            let mut expected_gain =
+                implementation::expected_gain_replace_synapse_with_hidden_neuron(
+                    shared_cache.as_ref(),
+                    &candidate.source_neuron_uuid,
+                    &candidate.target_neuron_uuid,
+                    old_weight,
+                    candidate.incoming_weight,
+                    candidate.outgoing_weight,
+                    candidate.bias,
+                    &candidate.squash,
+                )
+                .unwrap_or(candidate.expected_creature_score_gain);
+
+            // Apply a conservative impact discount when the target is hidden.
+            // This mirrors the synapse/neurons discounting semantics without requiring deep graph analysis.
+            let is_target_output = input
+                .creature
+                .neurons
+                .iter()
+                .find(|n| n.uuid == candidate.target_neuron_uuid)
+                .map(|n| n.neuron_type == "output")
+                .unwrap_or(false);
+            if !is_target_output {
+                expected_gain *= 0.1;
+            }
+
+            replacements.push(CoordinatedStructuralCandidateJson {
+                operations: vec![
+                    CoordinatedStructuralOpJson::RemoveSynapse {
+                        from_neuron_uuid: candidate.source_neuron_uuid.clone(),
+                        to_neuron_uuid: candidate.target_neuron_uuid.clone(),
+                    },
+                    CoordinatedStructuralOpJson::AddNeuron {
+                        neuron_uuid: new_neuron_uuid.clone(),
+                        neuron_type: "hidden".to_string(),
+                        squash: candidate.squash.clone(),
+                        bias: candidate.bias,
+                        insert_before_neuron_uuid: Some(candidate.target_neuron_uuid.clone()),
+                    },
+                    CoordinatedStructuralOpJson::AddSynapse {
+                        from_neuron_uuid: candidate.source_neuron_uuid.clone(),
+                        to_neuron_uuid: new_neuron_uuid.clone(),
+                        weight: candidate.incoming_weight,
+                    },
+                    CoordinatedStructuralOpJson::AddSynapse {
+                        from_neuron_uuid: new_neuron_uuid,
+                        to_neuron_uuid: candidate.target_neuron_uuid.clone(),
+                        weight: candidate.outgoing_weight,
+                    },
+                ],
+                expected_creature_score_gain: expected_gain,
+                comment: Some(format!(
+                    "Coordinated replacement: remove synapse and insert {} hidden neuron",
+                    candidate.squash
+                )),
+            });
+        }
+
+        // Keep non-replacement add-neurons unchanged.
+        neuron.helpful_neurons = kept_neurons;
+
+        if !replacements.is_empty() {
+            syn.coordinated_structural_candidates.extend(replacements);
+            syn.coordinated_structural_candidates.sort_by(|a, b| {
+                b.expected_creature_score_gain
+                    .partial_cmp(&a.expected_creature_score_gain)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+        }
+    }
 
     Ok(AnalyzeAllResult {
         synapse: synapse_result,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,42 @@ pub enum CoordinatedStructuralOpJson {
         to_neuron_uuid: String,
         weight: f32,
     },
+    /// Add a neuron as part of a coordinated structural candidate.
+    ///
+    /// Notes (7-Jan-2026):
+    /// - `neuronUuid` is emitted by Rust and must be deterministic so coordinated candidates are replayable.
+    /// - For forward-only creatures, `insertBeforeNeuronUuid` provides a placement hint so subsequent
+    ///   `addSynapse(newNeuron -> target)` can satisfy the forward-only ordering constraints.
+    AddNeuron {
+        #[serde(rename = "neuronUuid")]
+        neuron_uuid: String,
+        #[serde(rename = "neuronType")]
+        neuron_type: String,
+        squash: String,
+        bias: f32,
+        #[serde(
+            rename = "insertBeforeNeuronUuid",
+            skip_serializing_if = "Option::is_none"
+        )]
+        insert_before_neuron_uuid: Option<String>,
+    },
+    /// Remove a neuron and any attached synapses.
+    RemoveNeuron {
+        #[serde(rename = "neuronUuid")]
+        neuron_uuid: String,
+    },
+    /// Change a neuron's squash/activation function.
+    ChangeSquash {
+        #[serde(rename = "neuronUuid")]
+        neuron_uuid: String,
+        squash: String,
+    },
+    /// Set a neuron's bias.
+    SetBias {
+        #[serde(rename = "neuronUuid")]
+        neuron_uuid: String,
+        bias: f32,
+    },
 }
 
 /// A grouped candidate that must be applied as a single unit.

--- a/tests/coordinated_structural_collapse_neuron_to_synapse.rs
+++ b/tests/coordinated_structural_collapse_neuron_to_synapse.rs
@@ -1,0 +1,145 @@
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{analyze_parallel_internal, CreatureJson, NeuronJson, SynapseJson};
+
+/// Regression/integration test for coordinated structural collapse (7-Jan-2026).
+///
+/// Verifies we can discover that a simple 1-in/1-out hidden neuron chain should be
+/// replaced by a single synapse, emitted as an atomic coordinated-structural group:
+/// - removeSynapse(a -> h)
+/// - removeSynapse(h -> b)
+/// - removeNeuron(h)
+/// - addSynapse(a -> b)
+#[test]
+fn coordinated_structural_can_collapse_hidden_neuron_to_single_synapse() {
+    // Discovery is GPU-only. On machines without GPU, we skip.
+    if !GpuAnalyzer::gpu_is_available() {
+        return;
+    }
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Creature with a simple chain: input-0 -> hidden-0 -> output-0.
+    //
+    // The chain under-weights the input by 0.5, so a direct synapse with weight=1.0 is better.
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+    };
+
+    // Deterministic dataset:
+    // - hidden activation = x
+    // - current output    = 0.5 * x
+    // - desired output    = x
+    // - error             = desired - current = 0.5 * x
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for obs_index in 0..64u32 {
+        let x = (obs_index % 7) as f32 - 3.0; // [-3..3] repeating
+        let desired = x;
+        let current = 0.5 * x;
+        let error = desired - current;
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(x),
+            x,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "hidden-0".to_string(),
+            Some(x),
+            x,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(current),
+            current,
+            vec![error],
+        ));
+    }
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write discovery records");
+
+    let input_json = serde_json::json!({
+        "parquetFile": parquet_file,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+        "maxSynapseCandidates": 32,
+        "maxNeuronCandidates": 0,
+        "randomSeed": 1
+    })
+    .to_string();
+
+    let output_json =
+        analyze_parallel_internal(&input_json).expect("parallel analysis should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    assert_eq!(output["success"], true);
+
+    let groups = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .expect("should include coordinatedStructuralCandidates array");
+    assert!(
+        !groups.is_empty(),
+        "expected at least one coordinated structural candidate"
+    );
+
+    // Find a group that removes hidden-0 and adds a direct input-0 -> output-0 synapse.
+    let found = groups.iter().any(|g| {
+        let Some(ops) = g["operations"].as_array() else {
+            return false;
+        };
+        let has_remove_neuron = ops
+            .iter()
+            .any(|op| op["type"] == "removeNeuron" && op["neuronUuid"] == "hidden-0");
+        let has_add_bypass = ops.iter().any(|op| {
+            op["type"] == "addSynapse"
+                && op["fromNeuronUuid"] == "input-0"
+                && op["toNeuronUuid"] == "output-0"
+        });
+        has_remove_neuron && has_add_bypass
+    });
+    assert!(
+        found,
+        "expected a coordinated candidate that removes hidden-0 and adds a bypass synapse input-0 -> output-0"
+    );
+}

--- a/tests/coordinated_structural_replace_synapse_with_relu.rs
+++ b/tests/coordinated_structural_replace_synapse_with_relu.rs
@@ -1,0 +1,118 @@
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{analyze_parallel_internal, CreatureJson, NeuronJson, SynapseJson};
+
+/// Regression/integration test for Issue #173 (7-Jan-2026).
+///
+/// This verifies we can discover that an existing direct synapse should be replaced
+/// by inserting a hidden ReLU neuron (as a single coordinated-structural group):
+/// - removeSynapse(source -> target)
+/// - addNeuron(hidden)
+/// - addSynapse(source -> hidden)
+/// - addSynapse(hidden -> target)
+#[test]
+fn coordinated_structural_can_replace_synapse_with_hidden_relu_neuron() {
+    // Discovery is GPU-only. On machines without GPU, we skip.
+    if !GpuAnalyzer::gpu_is_available() {
+        return;
+    }
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Crippled creature: direct synapse only.
+    //
+    // The direct weight is intentionally small so add-neurons discovery prefers to
+    // add a ReLU path even before we convert it into a coordinated replacement.
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![SynapseJson {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 0.01,
+            synapse_type: None,
+        }],
+    };
+
+    // Deterministic dataset and expected behaviour:
+    // - expected = ReLU(x) (the uncrippled creature behaviour)
+    // - current  = 0.01 * x (crippled direct synapse)
+    //
+    // The best coordinated fix is to remove the weak synapse and insert a hidden ReLU.
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for obs_index in 0..64u32 {
+        let x = (obs_index % 5) as f32 - 1.0; // [-1, 0, 1, 2, 3] repeating
+        let expected = x.max(0.0);
+        let current = 0.01 * x;
+        let error = expected - current;
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(x),
+            x,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(current),
+            current,
+            vec![error],
+        ));
+    }
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write discovery records");
+
+    let input_json = serde_json::json!({
+        "parquetFile": parquet_file,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+        "maxSynapseCandidates": 0,
+        "maxNeuronCandidates": 32,
+        "randomSeed": 1
+    })
+    .to_string();
+
+    let output_json =
+        analyze_parallel_internal(&input_json).expect("parallel analysis should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    assert_eq!(output["success"], true);
+
+    let groups = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .expect("should include coordinatedStructuralCandidates array");
+    assert!(
+        !groups.is_empty(),
+        "expected at least one coordinated structural candidate"
+    );
+
+    // Find a group that contains an addNeuron op with ReLU squash.
+    let found = groups.iter().any(|g| {
+        let Some(ops) = g["operations"].as_array() else {
+            return false;
+        };
+        ops.iter()
+            .any(|op| op["type"] == "addNeuron" && op["squash"] == "ReLU")
+            && ops.iter().any(|op| op["type"] == "removeSynapse")
+            && ops.iter().filter(|op| op["type"] == "addSynapse").count() >= 2
+    });
+    assert!(
+        found,
+        "expected a coordinated candidate that removes the synapse and inserts a hidden ReLU"
+    );
+}

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -1014,13 +1014,16 @@ Pages speculative:                        12345.
         assert!(helpful_out.iter().any(|c| c.from_neuron_uuid == "a"));
         assert!(harmful_out.iter().any(|c| c.from_neuron_uuid == "c"));
         assert!(coordinated_out.iter().any(|c| {
-            c.operations.iter().any(|op| match op {
-                crate::CoordinatedStructuralOpJson::RemoveSynapse { from_neuron_uuid, .. } => {
-                    from_neuron_uuid == "d"
-                }
-                crate::CoordinatedStructuralOpJson::AddSynapse { from_neuron_uuid, .. } => {
-                    from_neuron_uuid == "d"
-                }
+            c.operations.iter().any(|op| {
+                matches!(
+                    op,
+                    crate::CoordinatedStructuralOpJson::RemoveSynapse { from_neuron_uuid, .. }
+                        if from_neuron_uuid == "d"
+                ) || matches!(
+                    op,
+                    crate::CoordinatedStructuralOpJson::AddSynapse { from_neuron_uuid, .. }
+                        if from_neuron_uuid == "d"
+                )
             })
         }));
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables coordinated structural discovery and treats certain structural edits as atomic groups.
> 
> - Activates grouped candidates for two cases: (1) replace an existing `source->target` synapse by inserting a hidden neuron; (2) collapse a 1‑in/1‑out hidden neuron into a direct synapse
> - Post-processes `add-neurons` results to emit coordinated replacements when a direct synapse already exists; adjusts impact discounting for coordinated groups (use final op target)
> - Adds scoring utilities: `expected_gain_replace_synapse_with_hidden_neuron(...)` and deterministic IDs via `deterministic_coordinated_neuron_uuid(...)`
> - Extends `CoordinatedStructuralOpJson` with `addNeuron`, `removeNeuron`, `changeSquash`, and `setBias`; updates serialization hints for forward-only placement
> - Updates `docs/DISCOVERY_TYPES.md` with operation vocabulary, examples, and marks status as active/tested; bumps crate to `0.5.0`
> - Adds integration tests covering neuron collapse and synapse→ReLU replacement; minor unit test match refinement
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ddc215a5500e87e02908148c705ae2e09be1dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->