### PR TITLE
Enhance synapse candidate truncation and post-processing logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -323,6 +323,31 @@ measured by NEAT-AI.
   results for earlier focus neurons, and later targets may be skipped or only
   partially analysed.
 
+### Coordinated Structural Discovery (Issue #165)
+
+Some beneficial structural changes are **epistatic**: no single add/remove operation improves score in isolation, but a *group* of edits does. This often shows up on **neutral plateaus** where different parameterisations produce near-identical outputs, and the signal is in second-order effects (error variance, correlation, redundancy) rather than direct score gradients.
+
+To support this, the Rust analysis can return **grouped candidates** via `coordinatedStructuralCandidates` (see [Issue #165](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/165)). Each entry is a single candidate that must be applied atomically (as a unit) during the controller-side ablation test.
+
+- **Operations**: A group contains an `operations` array of atomic edits:
+  - `removeSynapse` / `addSynapse` (with a `weight`)
+  - `addNeuron` (with deterministic `neuronUuid` so candidates are replayable)
+  - `removeNeuron`
+  - `changeSquash`
+  - `setBias`
+- **Weight changes (KISS)**: Existing synapse weight adjustments are represented as **remove+add** operations inside a coordinated group, rather than introducing a separate “set weight” instruction type in TypeScript.
+- **Candidate budgets**: `maxSynapseCandidates` is a **global cap** across `helpfulSynapses + harmfulSynapses + coordinatedStructuralCandidates`. If you set `maxSynapseCandidates: 0`, coordinated structural candidates will also be truncated to zero.
+
+#### Example: “noisy vs trusted” inputs (thermometer pattern)
+
+If two inputs feed the same target with the same starting weight, but one input is much noisier (higher activation variance), a coordinated candidate may:
+
+- remove the noisy synapse
+- remove the trusted synapse
+- add the trusted synapse back with a higher weight
+
+This preserves (or improves) behaviour while reducing variance and redundancy, and avoids the “single edit looks bad” trap during ablation.
+
 ### Discrete activation function handling
 
 The standard discovery algorithm uses a **linear error model** to predict improvement:

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -8302,7 +8302,13 @@ mod tests {
 }
 // analyze_all has been moved to src/analysis/mod.rs
 
-fn truncate_combined_synapse_candidate_sets(
+/// Truncate synapse candidate buckets to a global cap, preserving ordering semantics.
+///
+/// Notes (7-Jan-2026):
+/// - Synapse analysis applies this during candidate assembly.
+/// - `analysis::analyze_all` may add coordinated candidates during post-processing (Issue #173),
+///   so it also reuses this helper to re-apply `maxSynapseCandidates` and keep output sizes stable.
+pub(crate) fn truncate_combined_synapse_candidate_sets(
     helpful: Vec<CandidateSynapseJson>,
     harmful: Vec<CandidateSynapseJson>,
     coordinated: Vec<crate::CoordinatedStructuralCandidateJson>,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 };
 use anyhow::Result;
 use std::collections::HashMap;
+use std::mem;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -82,6 +83,64 @@ fn run_optional_analysis<T>(
         crate::watchdog::beat(skipped);
         Ok(None)
     }
+}
+
+fn merge_coordinated_structural_replacements(
+    synapse: &mut shared::AnalyzeSynapsesResult,
+    mut replacements: Vec<CoordinatedStructuralCandidateJson>,
+    max_synapse_candidates: Option<usize>,
+    diversify: bool,
+) {
+    if replacements.is_empty() {
+        return;
+    }
+
+    synapse
+        .coordinated_structural_candidates
+        .append(&mut replacements);
+
+    // Keep deterministic ordering for non-deadline runs.
+    //
+    // Deadline-diversified runs rely on upstream per-bucket ordering and round-robin selection,
+    // so we avoid resorting here when `diversify` is enabled.
+    if !diversify {
+        synapse.coordinated_structural_candidates.sort_by(|a, b| {
+            b.expected_creature_score_gain
+                .partial_cmp(&a.expected_creature_score_gain)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+
+    if let Some(limit) = max_synapse_candidates {
+        let (helpful, harmful, coordinated) =
+            implementation::truncate_combined_synapse_candidate_sets(
+                mem::take(&mut synapse.helpful_synapses),
+                mem::take(&mut synapse.harmful_synapses),
+                mem::take(&mut synapse.coordinated_structural_candidates),
+                limit,
+                diversify,
+            );
+        synapse.helpful_synapses = helpful;
+        synapse.harmful_synapses = harmful;
+        synapse.coordinated_structural_candidates = coordinated;
+    }
+
+    // Ensure metadata reflects what we actually return to callers.
+    synapse.metadata.candidates_returned = synapse.helpful_synapses.len()
+        + synapse.harmful_synapses.len()
+        + synapse.coordinated_structural_candidates.len();
+}
+
+fn apply_kept_neuron_candidates(
+    neuron: &mut shared::AnalyzeNeuronsResult,
+    kept_neurons: Vec<CandidateNeuronJson>,
+) {
+    // Regression fix (7-Jan-2026):
+    // Post-processing may convert some add-neuron candidates into coordinated structural
+    // replacements. When we filter those out of `helpful_neurons`, we must also update the
+    // metadata so JSON output remains consistent with the returned arrays.
+    neuron.helpful_neurons = kept_neurons;
+    neuron.metadata.candidates_returned = neuron.helpful_neurons.len();
 }
 
 /// Combined analysis function that runs both synapse and neuron analysis.
@@ -349,16 +408,14 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
 
         // Keep non-replacement add-neurons unchanged.
-        neuron.helpful_neurons = kept_neurons;
+        apply_kept_neuron_candidates(neuron, kept_neurons);
 
-        if !replacements.is_empty() {
-            syn.coordinated_structural_candidates.extend(replacements);
-            syn.coordinated_structural_candidates.sort_by(|a, b| {
-                b.expected_creature_score_gain
-                    .partial_cmp(&a.expected_creature_score_gain)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-        }
+        merge_coordinated_structural_replacements(
+            syn,
+            replacements,
+            input.max_synapse_candidates,
+            input.analysis_deadline_ms.is_some(),
+        );
     }
 
     Ok(AnalyzeAllResult {

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::{
+    CandidateNeuronJson, CandidateSynapseJson, CoordinatedStructuralCandidateJson,
+    CoordinatedStructuralOpJson,
+};
 
 #[test]
 fn watchdog_beats_do_not_claim_finished_when_analysis_is_skipped() {
@@ -64,4 +68,206 @@ fn choose_deadline_order_can_be_controlled_by_seed() {
         choose_deadline_order_synapse_first(Some(0), now_ms),
         choose_deadline_order_synapse_first(Some(1), now_ms)
     );
+}
+
+#[test]
+fn postprocess_reapplies_max_synapse_candidates_after_coordinated_merge() {
+    // Regression test (7-Jan-2026):
+    // Neuron→coordinated conversion happens after synapse analysis truncation, so we must
+    // re-apply `maxSynapseCandidates` (Issue #173 follow-up).
+
+    let mut syn = shared::AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: shared::SynapseAnalysisMetadata {
+            candidates_found: 0,
+            candidates_returned: 0,
+            ..Default::default()
+        },
+    };
+
+    let replacements = vec![CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: 1.0,
+        comment: Some("test replacement".to_string()),
+    }];
+
+    merge_coordinated_structural_replacements(&mut syn, replacements, Some(0), false);
+
+    assert!(
+        syn.coordinated_structural_candidates.is_empty(),
+        "expected coordinated candidates to be truncated to 0 when maxSynapseCandidates=0"
+    );
+    assert_eq!(syn.metadata.candidates_returned, 0);
+}
+
+#[test]
+fn postprocess_truncates_across_all_synapse_buckets_not_just_coordinated() {
+    // Ensure we keep the global cap semantics (helpful + harmful + coordinated <= max).
+
+    let mut syn = shared::AnalyzeSynapsesResult {
+        helpful_synapses: vec![CandidateSynapseJson {
+            from_neuron_uuid: "x".to_string(),
+            to_neuron_uuid: "y".to_string(),
+            from_neuron_index: None,
+            to_neuron_index: None,
+            weight: 0.1,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.1,
+            expected_creature_score_gain: 0.1,
+            improved_count: 1,
+            total_count: 1,
+            target_neuron_stats: None,
+        }],
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: shared::SynapseAnalysisMetadata {
+            candidates_found: 1,
+            candidates_returned: 1,
+            ..Default::default()
+        },
+    };
+
+    let replacements = vec![CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: 2.0, // better than the helpful candidate
+        comment: None,
+    }];
+
+    merge_coordinated_structural_replacements(&mut syn, replacements, Some(1), false);
+
+    let total = syn.helpful_synapses.len()
+        + syn.harmful_synapses.len()
+        + syn.coordinated_structural_candidates.len();
+    assert_eq!(total, 1);
+    assert_eq!(syn.helpful_synapses.len(), 0);
+    assert_eq!(syn.coordinated_structural_candidates.len(), 1);
+    assert_eq!(syn.metadata.candidates_returned, 1);
+}
+
+#[test]
+fn postprocess_updates_candidates_returned_after_merging_neuron_replacements() {
+    // Regression test (7 Jan 2026):
+    // When neuron candidates are converted to coordinated structural replacements during
+    // post-processing, we must update `synapseMetadata.candidatesReturned` to include them.
+    //
+    // This would fail under the old behaviour where we used `extend()` without recomputing
+    // the metadata count.
+
+    let mut syn = shared::AnalyzeSynapsesResult {
+        helpful_synapses: vec![CandidateSynapseJson {
+            from_neuron_uuid: "x".to_string(),
+            to_neuron_uuid: "y".to_string(),
+            from_neuron_index: None,
+            to_neuron_index: None,
+            weight: 0.1,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: 0.1,
+            expected_creature_score_gain: 0.1,
+            improved_count: 1,
+            total_count: 1,
+            target_neuron_stats: None,
+        }],
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: shared::SynapseAnalysisMetadata {
+            candidates_found: 1,
+            candidates_returned: 1,
+            ..Default::default()
+        },
+    };
+
+    let replacements = vec![CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: 1.0,
+        comment: Some("test replacement".to_string()),
+    }];
+
+    merge_coordinated_structural_replacements(&mut syn, replacements, None, false);
+
+    assert_eq!(syn.helpful_synapses.len(), 1);
+    assert_eq!(syn.coordinated_structural_candidates.len(), 1);
+    assert_eq!(
+        syn.metadata.candidates_returned, 2,
+        "expected candidates_returned to include coordinated candidates merged during post-processing"
+    );
+}
+
+#[test]
+fn postprocess_updates_neuron_candidates_returned_after_filtering_replacements() {
+    // Regression test (7-Jan-2026):
+    // When we convert some add-neuron candidates into coordinated structural replacements,
+    // we filter them out of `helpful_neurons`. The metadata must be updated to reflect the
+    // new returned count, otherwise JSON output becomes misleading.
+
+    let cand_a = CandidateNeuronJson {
+        source_neuron_uuid: "s1".to_string(),
+        target_neuron_uuid: "t1".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 0.1,
+        outgoing_weight: 0.2,
+        squash: "relu".to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.01,
+        expected_creature_score_gain: 0.01,
+        improved_count: 1,
+        total_count: 1,
+        target_neuron_stats: None,
+    };
+
+    let cand_b = CandidateNeuronJson {
+        source_neuron_uuid: "s2".to_string(),
+        target_neuron_uuid: "t2".to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 0.1,
+        outgoing_weight: 0.2,
+        squash: "relu".to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.01,
+        expected_creature_score_gain: 0.01,
+        improved_count: 1,
+        total_count: 1,
+        target_neuron_stats: None,
+    };
+
+    let mut neuron = shared::AnalyzeNeuronsResult {
+        helpful_neurons: vec![cand_a.clone(), cand_b],
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: shared::NeuronAnalysisMetadata {
+            candidates_found: 2,
+            candidates_returned: 2,
+            ..Default::default()
+        },
+    };
+
+    apply_kept_neuron_candidates(&mut neuron, vec![cand_a]);
+
+    assert_eq!(neuron.helpful_neurons.len(), 1);
+    assert_eq!(neuron.metadata.candidates_returned, 1);
 }

--- a/tests/coordinated_structural_noisy_vs_trusted_inputs.rs
+++ b/tests/coordinated_structural_noisy_vs_trusted_inputs.rs
@@ -1,0 +1,160 @@
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{analyze_parallel_internal, CreatureJson, NeuronJson, SynapseJson};
+
+/// Regression/integration test for Issue #165 (3-Jan-2026): Coordinated Structural Discovery.
+///
+/// This verifies the "noisy vs trusted" pattern described in the issue:
+/// - Two input signals feed the same target with the same starting weight.
+/// - One input is much noisier (higher activation variance).
+///
+/// The expected coordinated fix is a grouped candidate that:
+/// - removes the noisy synapse
+/// - removes the trusted synapse
+/// - adds the trusted synapse back with a higher weight
+#[test]
+fn coordinated_structural_can_prune_noisy_input_and_reweight_trusted_input() {
+    // Discovery is GPU-only. On machines without GPU, we skip.
+    if !GpuAnalyzer::gpu_is_available() {
+        return;
+    }
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+
+    // Two input synapses into one output with equal starting weights.
+    let creature = CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(), // trusted (low variance)
+                to_uuid: "output-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".to_string(), // noisy (high variance)
+                to_uuid: "output-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+    };
+
+    // Deterministic dataset:
+    // - trusted signal has a small variance (low amplitude), mean ~0
+    // - noisy signal has a much larger variance (high amplitude), mean ~0
+    //
+    // This is the strict "simple case" the coordinated-noise logic targets:
+    // - same synapse weights
+    // - same activation means
+    // - large variance ratio (noisy/trusted >= 10×)
+    //
+    // Desired output is ~0.0 (mean-preserving). Current output is polluted by the noisy input,
+    // so removing noisy and moving its weight onto the trusted input reduces error magnitude.
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for obs_index in 0..128u32 {
+        let trusted = if (obs_index % 2) == 0 { 0.1 } else { -0.1 };
+        let noisy = if (obs_index % 2) == 0 { 1.0 } else { -1.0 };
+
+        let current = 0.5 * trusted + 0.5 * noisy;
+        let desired = 0.0;
+        let error = desired - current;
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(trusted),
+            trusted,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(noisy),
+            noisy,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![error],
+        ));
+    }
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write discovery records");
+
+    let input_json = serde_json::json!({
+        "parquetFile": parquet_file,
+        "creature": creature,
+        "focusNeurons": ["output-0"],
+        // Coordinated structural candidates are part of the synapse candidate budget.
+        "maxSynapseCandidates": 64,
+        "maxNeuronCandidates": 0,
+        "randomSeed": 42
+    })
+    .to_string();
+
+    let output_json =
+        analyze_parallel_internal(&input_json).expect("parallel analysis should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    assert_eq!(output["success"], true);
+
+    let groups = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .expect("should include coordinatedStructuralCandidates array");
+    assert!(
+        !groups.is_empty(),
+        "expected at least one coordinated structural candidate"
+    );
+
+    // We expect a group with:
+    // - removeSynapse(input-1 -> output-0) (noisy)
+    // - removeSynapse(input-0 -> output-0) (trusted)
+    // - addSynapse(input-0 -> output-0, weight ~= 1.0)
+    let found = groups.iter().any(|g| {
+        let Some(ops) = g["operations"].as_array() else {
+            return false;
+        };
+
+        let remove_noisy = ops.iter().any(|op| {
+            op["type"] == "removeSynapse"
+                && op["fromNeuronUuid"] == "input-1"
+                && op["toNeuronUuid"] == "output-0"
+        });
+        let remove_trusted = ops.iter().any(|op| {
+            op["type"] == "removeSynapse"
+                && op["fromNeuronUuid"] == "input-0"
+                && op["toNeuronUuid"] == "output-0"
+        });
+        let add_trusted_higher = ops.iter().any(|op| {
+            op["type"] == "addSynapse"
+                && op["fromNeuronUuid"] == "input-0"
+                && op["toNeuronUuid"] == "output-0"
+                && (op["weight"].as_f64().unwrap_or(0.0) - 1.0).abs() < 1e-6
+        });
+
+        remove_noisy && remove_trusted && add_trusted_higher
+    });
+
+    assert!(
+        found,
+        "expected a coordinated candidate that prunes the noisy input and reweights the trusted input"
+    );
+}

--- a/tests/coordinated_structural_replace_synapse_with_relu.rs
+++ b/tests/coordinated_structural_replace_synapse_with_relu.rs
@@ -80,7 +80,8 @@ fn coordinated_structural_can_replace_synapse_with_hidden_relu_neuron() {
         "parquetFile": parquet_file,
         "creature": creature,
         "focusNeurons": ["output-0"],
-        "maxSynapseCandidates": 0,
+        // Coordinated structural candidates are part of the synapse candidate budget.
+        "maxSynapseCandidates": 32,
         "maxNeuronCandidates": 32,
         "randomSeed": 1
     })


### PR DESCRIPTION
- Introduce a new function `merge_coordinated_structural_replacements` to manage the merging of coordinated structural candidates and ensure proper truncation of synapse candidates based on a global cap.
- Update `truncate_combined_synapse_candidate_sets` to include detailed documentation on its role in preserving ordering semantics during candidate assembly.
- Add regression tests to validate the correct behavior of candidate truncation and metadata updates after merging neuron replacements, ensuring accurate reporting of candidates returned.
- Modify analysis functions to utilize the new merging logic, improving the overall integrity of synapse analysis.

These changes enhance the robustness and accuracy of synapse candidate management in the analysis process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens candidate post-processing and budgeting for coordinated structural discovery.
> 
> - New `merge_coordinated_structural_replacements` merges `coordinatedStructuralCandidates`, preserves ordering (non-diversified), re-applies `maxSynapseCandidates` across `helpfulSynapses` + `harmfulSynapses` + `coordinatedStructuralCandidates`, and updates `synapseMetadata.candidatesReturned`
> - `truncate_combined_synapse_candidate_sets` is documented and reused (now `pub(crate)`) to keep global cap/ordering semantics stable
> - `analyze_all` converts certain add-neuron candidates into coordinated replacements, applies truncation via the new helper, and updates neuron metadata with `apply_kept_neuron_candidates`
> - Tests: unit regressions for truncation/metadata semantics; integration tests for coordinated patterns (noisy-vs-trusted inputs; replace synapse with hidden ReLU)
> - README adds **Coordinated Structural Discovery** section; version bumped to `0.5.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaa27b2105d81b581346e187e64f838517aa1faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->