### PR TITLE
Update version to 0.6.0 and enhance constant source handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,23 @@ whether discovery should be enabled:
   - `NEAT_AI_DISCOVERY_SOURCE_INPUT_INDEX_BIAS=3`: stronger bias toward the end
 
   Hidden/constant sources keep weight 1.0; only `input-N` sources are biased.
+
+  **Optional folding of constant sources into bias (7-Jan-2026)**: When a source neuron’s
+  activation range is ~0, an add-synapse from that source behaves like a constant offset
+  on the downstream neuron (equivalent to a bias change). To avoid paying complexity cost
+  for a new edge, the library may emit a coordinated-structural candidate containing a
+  single `setBias` operation instead of an `addSynapse`.
+
+  Control this behaviour with `NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD`:
+
+  - unset / empty: enabled with default `1e-7` (matches NEAT-AI’s default cost-of-growth scale)
+  - `0`: disable folding (always emit `addSynapse` when otherwise valid)
+  - `> 0`: enable folding with a custom threshold
+
+  The heuristic compares the predicted contribution range:
+
+  - `effectRange ≈ |weight| × (maxActivation - minActivation)`
+  - fold when `effectRange <= threshold`
 - **Low GPU utilisation**: If you're seeing low GPU utilisation (e.g., 20%) during
   analysis, see the [GPU Performance Tuning](#gpu-performance-tuning) section below.
 - **Deadlock or stuck process**: If the process appears stuck (0% CPU/GPU), see the

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -48,6 +48,18 @@ const MIN_NEURON_SAMPLE_COUNT: usize = 10;
 /// meaning the neuron produces nearly identical output across all samples.
 const MIN_NEURON_OUTPUT_STD_DEV: f32 = 0.01;
 
+/// Default threshold for treating an add-synapse candidate as an effective bias change.
+///
+/// Issue #178 (7-Jan-2026): When the source activation range is ~0, adding a synapse
+/// only contributes a near-constant offset to the target. This is better represented as
+/// a `setBias` coordinated-structural operation than paying complexity cost for a new edge.
+///
+/// The heuristic is based on the *range* of the contribution:
+///   effect_range ≈ |weight| × (max_activation - min_activation)
+///
+/// If `effect_range <= threshold`, we fold the synapse into `setBias`.
+const DEFAULT_CONSTANT_SOURCE_EFFECT_THRESHOLD: f32 = 1e-7;
+
 /// Maximum absolute value for outgoing weights in add-neuron candidates.
 ///
 /// Based on analysis of successful discoveries vs failures:
@@ -200,6 +212,35 @@ fn compute_source_variance_discount(samples: &[HelpfulSample]) -> f32 {
     // Linear discount: full credit at MIN_SOURCE_STD_DEV, zero at 0
     // Values above MIN_SOURCE_STD_DEV get full credit (capped at 1.0)
     (std_dev / MIN_SOURCE_STD_DEV).clamp(0.0, 1.0)
+}
+
+/// Optional threshold for folding constant/near-constant sources into `setBias`.
+///
+/// Controlled via `NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD`:
+/// - unset / empty: enabled with default (`DEFAULT_CONSTANT_SOURCE_EFFECT_THRESHOLD`)
+/// - `0`: disabled (never fold)
+/// - `> 0`: enabled with the configured threshold
+fn constant_source_effect_threshold_from_env() -> Option<f32> {
+    let raw = std::env::var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD").ok();
+    let Some(raw) = raw else {
+        return Some(DEFAULT_CONSTANT_SOURCE_EFFECT_THRESHOLD);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Some(DEFAULT_CONSTANT_SOURCE_EFFECT_THRESHOLD);
+    }
+    match trimmed.parse::<f32>() {
+        Ok(v) if v.is_finite() && v == 0.0 => None,
+        Ok(v) if v.is_finite() && v > 0.0 => Some(v),
+        _ => {
+            if verbose_enabled() {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Ignoring invalid NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD={trimmed:?} (expected 0 or a finite number > 0)"
+                );
+            }
+            Some(DEFAULT_CONSTANT_SOURCE_EFFECT_THRESHOLD)
+        }
+    }
 }
 
 /// Default GPU batch size for GPU operations.
@@ -3336,7 +3377,7 @@ const MIN_WEIGHT_RATIO: f32 = 50.0;
 ///
 /// Coordinated structural candidates emit these ops:
 /// - remove the noisy synapse (full removal), and
-/// - increase the trusted synapse weight, subject to `MAX_OUTGOING_WEIGHT` clamping.
+/// - increase the trusted synapse weight by moving the noisy weight onto it.
 ///
 /// We model the *actual* net delta in target input as:
 /// \[
@@ -3348,9 +3389,11 @@ const MIN_WEIGHT_RATIO: f32 = 50.0;
 /// - `weight = w_noisy`
 /// - `activation = (Δw_trusted / w_noisy)·a_trusted - a_noisy`
 ///
-/// This fixes an overstatement bug (3-Jan-2026): previously we used `activation = a_trusted - a_noisy`
-/// with `weight = w_noisy` *before* clamping the final trusted weight, which assumes
-/// `Δw_trusted == w_noisy` even when clamped.
+/// Notes (7-Jan-2026):
+/// - We intentionally do **not** clamp the trusted weight here. The coordinated candidate is
+///   derived from existing synapse weights, and NEAT-AI will validate the full ablation on the
+///   complete training set. Clamping here changes the candidate semantics and can suppress
+///   valid coordinated candidates.
 fn coordinated_structural_activation_delta(
     trusted_activation: f32,
     noisy_activation: f32,
@@ -3361,8 +3404,7 @@ fn coordinated_structural_activation_delta(
         return None;
     }
 
-    let new_trusted_weight =
-        (trusted_weight + noisy_weight).clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+    let new_trusted_weight = trusted_weight + noisy_weight;
     let delta_trusted_weight = new_trusted_weight - trusted_weight;
 
     let scale = delta_trusted_weight / noisy_weight;
@@ -8546,6 +8588,19 @@ pub(crate) fn analyze_synapses_with_cache(
     let order_map_arc = Arc::new(order_map);
     let neuron_squash_map_arc = Arc::new(neuron_squash_map);
 
+    // Map of neuron UUID -> bias, used when folding constant-source synapses into `setBias`.
+    // Inputs are not present here (they have no bias).
+    let neuron_bias_map: HashMap<String, f32> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.bias))
+        .collect();
+    let neuron_bias_map_arc = Arc::new(neuron_bias_map);
+
+    // Issue #178: threshold for folding constant-ish sources into bias adjustments.
+    let constant_source_effect_threshold = constant_source_effect_threshold_from_env();
+
     // Build a comprehensive map of ALL neuron UUIDs to their types
     // This includes: input neurons, and all neurons from creature.neurons (hidden, output, constant)
     // If a UUID is not in this map, it's an invalid UUID (bug)
@@ -9050,8 +9105,7 @@ pub(crate) fn analyze_synapses_with_cache(
                     }
 
                     best.map(|(noisy, trusted, gain)| {
-                        let new_weight = (trusted.weight + noisy.weight)
-                            .clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                        let new_weight = trusted.weight + noisy.weight;
                         crate::CoordinatedStructuralCandidateJson {
                             operations: vec![
                                 crate::CoordinatedStructuralOpJson::RemoveSynapse {
@@ -9343,6 +9397,55 @@ pub(crate) fn analyze_synapses_with_cache(
                         });
                     } else {
                         diagnostics_selected.push(work.target_uuid.clone());
+                        // Issue #178 (7-Jan-2026): If the source activation is constant/near-constant,
+                        // an add-synapse behaves like a bias shift on the target. Prefer `setBias`
+                        // to avoid paying complexity cost for what is effectively a constant offset.
+                        if let Some(threshold) = constant_source_effect_threshold {
+                            let mut act_min = f32::INFINITY;
+                            let mut act_max = f32::NEG_INFINITY;
+                            let mut act_sum = 0.0f64;
+                            let mut act_count: u32 = 0;
+                            for s in &work.samples {
+                                if s.activation.is_finite() {
+                                    act_min = act_min.min(s.activation);
+                                    act_max = act_max.max(s.activation);
+                                    act_sum += s.activation as f64;
+                                    act_count += 1;
+                                }
+                            }
+
+                            if act_count > 0 {
+                                let mean_activation = (act_sum / act_count as f64) as f32;
+                                let activation_range = (act_max - act_min).abs();
+                                let effect_range = weight.abs() * activation_range;
+
+                                if mean_activation.is_finite()
+                                    && activation_range.is_finite()
+                                    && effect_range.is_finite()
+                                    && effect_range <= threshold
+                                {
+                                    let old_bias = neuron_bias_map_arc
+                                        .get(&work.target_uuid)
+                                        .copied()
+                                        .unwrap_or(0.0);
+                                    let new_bias = old_bias + (weight * mean_activation);
+                                    if new_bias.is_finite() {
+                                        coordinated_to_add.push(crate::CoordinatedStructuralCandidateJson {
+                                            operations: vec![crate::CoordinatedStructuralOpJson::SetBias {
+                                                neuron_uuid: work.target_uuid.clone(),
+                                                bias: new_bias,
+                                            }],
+                                            expected_creature_score_gain: neuron_error_improvement,
+                                            comment: Some(format!(
+                                                "Fold constant source into setBias: old_bias={old_bias:.6}, new_bias={new_bias:.6}, weight={weight:.6}, mean_act={mean_activation:.6}, act_range={activation_range:.6e}, effect_range={effect_range:.6e}"
+                                            )),
+                                        });
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+
                         // Issue #128: Use creature-level metrics (impact discounting applied later)
                         candidates_to_add.push(CandidateSynapseJson {
                             from_neuron_uuid: work.source_uuid.clone(),

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -292,8 +292,9 @@ fn candidate_counts_tracked_correctly() {
     // Synapse metadata
     if let Some(synapse_result) = &result.synapse {
         let metadata = &synapse_result.metadata;
-        let actual_returned =
-            synapse_result.helpful_synapses.len() + synapse_result.harmful_synapses.len();
+        let actual_returned = synapse_result.helpful_synapses.len()
+            + synapse_result.harmful_synapses.len()
+            + synapse_result.coordinated_structural_candidates.len();
 
         assert_eq!(
             metadata.candidates_returned, actual_returned,

--- a/tests/creature_level_metrics.rs
+++ b/tests/creature_level_metrics.rs
@@ -68,6 +68,34 @@ fn output(uuid: &str, squash: &str) -> NeuronJson {
     }
 }
 
+/// Build a minimal set of records that produces synapse candidates without triggering
+/// Issue #178 constant-source folding (7-Jan-2026).
+///
+/// We intentionally make the input activation vary slightly so synapse analysis returns an
+/// `addSynapse` candidate (with creature-level fields) rather than converting it into a
+/// coordinated `setBias` operation.
+fn records_single_output_with_varying_input(error: f32) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for obs_index in 0..10u32 {
+        let input_activation = if (obs_index % 2) == 0 { 0.4 } else { 0.6 };
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_activation),
+            input_activation,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![error],
+        ));
+    }
+    records
+}
+
 // =============================================================================
 // Test: expectedImprovementPercentage field should NOT exist (Issue #128)
 // =============================================================================
@@ -90,29 +118,7 @@ fn test_expected_improvement_percentage_field_removed() {
     let file_path = temp_file.path().to_str().unwrap();
 
     // Create records with error so we get candidates
-    let records = vec![
-        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        // Output with error
-        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-    ];
+    let records = records_single_output_with_varying_input(0.5);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let input_json = serde_json::json!({
@@ -153,28 +159,7 @@ fn test_target_neuron_impact_field_exists() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    let records = vec![
-        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-    ];
+    let records = records_single_output_with_varying_input(0.5);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let input_json = serde_json::json!({
@@ -211,28 +196,7 @@ fn test_expected_creature_error_reduction_field_exists() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    let records = vec![
-        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-    ];
+    let records = records_single_output_with_varying_input(0.5);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let input_json = serde_json::json!({
@@ -268,28 +232,7 @@ fn test_expected_creature_score_gain_field_exists() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    let records = vec![
-        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-    ];
+    let records = records_single_output_with_varying_input(0.5);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let input_json = serde_json::json!({
@@ -328,28 +271,7 @@ fn test_output_neuron_has_impact_one() {
     let temp_file = NamedTempFile::new().unwrap();
     let file_path = temp_file.path().to_str().unwrap();
 
-    let records = vec![
-        DiscoverRecord::new(0, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(1, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(2, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(3, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(4, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(5, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(6, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(7, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(8, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(9, "input-0".to_string(), Some(0.5), 0.5, vec![]),
-        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(2, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(3, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(4, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(5, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(6, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(7, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(8, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-        DiscoverRecord::new(9, "output-0".to_string(), Some(0.0), 0.0, vec![0.5]),
-    ];
+    let records = records_single_output_with_varying_input(0.5);
     write_records_to_parquet(file_path, &records).unwrap();
 
     let input_json = serde_json::json!({

--- a/tests/issue_134_direction_flip.rs
+++ b/tests/issue_134_direction_flip.rs
@@ -112,7 +112,9 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
     let records = vec![
         DiscoverRecord::new(0, "input-0".to_string(), None, arctan_1, Vec::new()),
         DiscoverRecord::new(0, "output-0".to_string(), Some(-10.0), -10.0, vec![2.0]),
-        DiscoverRecord::new(1, "input-0".to_string(), None, arctan_1, Vec::new()),
+        // Vary the input activation slightly so synapse analysis emits an add-synapse candidate
+        // rather than folding the constant source into a `setBias` coordinated candidate (Issue #178).
+        DiscoverRecord::new(1, "input-0".to_string(), None, arctan_1 * 0.9, Vec::new()),
         DiscoverRecord::new(1, "output-0".to_string(), Some(10.0), 10.0, vec![-1.0]),
     ];
 

--- a/tests/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/issue_178_constant_source_folds_to_setbias.rs
@@ -118,4 +118,3 @@ fn issue_178_constant_source_becomes_setbias_candidate() {
         other => panic!("expected setBias op, got {other:?}"),
     }
 }
-

--- a/tests/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/issue_178_constant_source_folds_to_setbias.rs
@@ -1,0 +1,121 @@
+//! Regression test for Issue #178 (7-Jan-2026).
+//!
+//! When a source activation is constant (activation range ≈ 0), an add-synapse from that
+//! source behaves like a bias adjustment on the downstream neuron:
+//!   contribution = weight * activation ≈ constant
+//!
+//! In this case we should emit a coordinated-structural `setBias` operation rather than
+//! proposing a new synapse, which would pay complexity cost for what is effectively an
+//! intercept shift.
+
+mod common;
+
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+#[test]
+fn issue_178_constant_source_becomes_setbias_candidate() {
+    skip_without_gpu!();
+
+    // Minimal creature:
+    // - input-0 (implicit via creature.input)
+    // - output-0 (explicit neuron)
+    //
+    // No existing synapse input-0 → output-0, so synapse analysis would normally propose it.
+    let creature = CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: Vec::<SynapseJson>::new(),
+        input: 1,
+        output: 1,
+    };
+
+    // Records:
+    // - input-0 activation is constant (range = 0)
+    // - output-0 error is constant and positive (so a constant offset helps)
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    let sample_count: u32 = 32;
+    for obs_index in 0..sample_count {
+        let input_activation = 1.0f32; // constant
+        let output_activation = 0.0f32;
+        let output_value = 0.0f32;
+        let error = 0.2f32; // constant VALUE-domain error
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(input_activation),
+            input_activation,
+            Vec::new(),
+        ));
+
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(output_value),
+            output_activation,
+            vec![error],
+        ));
+    }
+
+    let temp_file = NamedTempFile::new().expect("Failed to create temp parquet file");
+    let parquet_file = temp_file
+        .path()
+        .to_str()
+        .expect("temp path should be valid UTF-8")
+        .to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet test data");
+
+    let input = AnalyzeSynapsesInput {
+        parquet_file,
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: Some(30_000),
+        random_seed: None,
+    };
+
+    let result = neat_ai_discovery::analysis::analyze_synapses(&input)
+        .expect("Synapse analysis should succeed");
+
+    // Expected behaviour (post-fix):
+    // - no direct helpful synapse from constant source
+    // - a coordinated-structural candidate that sets output bias instead
+    assert!(
+        result.helpful_synapses.is_empty(),
+        "expected no helpful synapses; constant sources should be folded into setBias"
+    );
+
+    assert_eq!(
+        result.coordinated_structural_candidates.len(),
+        1,
+        "expected a single coordinated candidate"
+    );
+
+    let candidate = &result.coordinated_structural_candidates[0];
+    assert_eq!(
+        candidate.operations.len(),
+        1,
+        "expected a single setBias operation"
+    );
+
+    // Bias should be nudged upward (direction matters); exact value is determined by the
+    // synapse weight calculation and clamping, but must be > 0 for positive error.
+    match &candidate.operations[0] {
+        neat_ai_discovery::CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias } => {
+            assert_eq!(neuron_uuid, "output-0");
+            assert!(
+                *bias > 0.0,
+                "expected positive bias adjustment for positive constant error, got {bias}"
+            );
+        }
+        other => panic!("expected setBias op, got {other:?}"),
+    }
+}
+

--- a/tests/target_map_optimization.rs
+++ b/tests/target_map_optimization.rs
@@ -269,7 +269,9 @@ fn target_map_filters_non_finite_values() {
 
     // Should still find candidates from the valid records
     assert!(
-        !result.helpful_synapses.is_empty() || !result.no_candidate_reasons.is_empty(),
+        !result.helpful_synapses.is_empty()
+            || !result.coordinated_structural_candidates.is_empty()
+            || !result.no_candidate_reasons.is_empty(),
         "Should process valid records despite non-finite values in other records"
     );
 }

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -1107,13 +1107,16 @@ Pages speculative:                        12345.
     }
 
     #[test]
-    fn coordinated_structural_expected_gain_uses_clamped_delta_when_weights_exceed_max() {
-        // Regression test (3-Jan-2026): coordinated structural candidates must compute expected gain
-        // using the *actual* clamped delta on the trusted synapse, otherwise expected gains are
-        // overstated and candidates are mis-prioritised.
+    fn coordinated_structural_expected_gain_matches_unclamped_weight_transfer() {
+        // Regression test (7-Jan-2026): coordinated structural candidates should model the
+        // *actual* “move noisy weight onto trusted” semantics without clamping.
+        //
+        // Rationale: The coordinated candidate is derived from existing synapse weights, and
+        // NEAT-AI validates the ablation on the full training set. Applying a library-local
+        // clamp here changes semantics and can suppress valid coordinated candidates.
 
-        // Both inputs start at 0.06, but MAX_OUTGOING_WEIGHT is 0.1, so the trusted "transfer"
-        // delta cannot be the full 0.06 (it becomes 0.04).
+        // Both inputs start at 0.06. In this synthetic case we deliberately exceed
+        // `MAX_OUTGOING_WEIGHT` to ensure no hidden clamping occurs in the modelling.
         let noisy_weight = 0.06f32;
         let trusted_weight = 0.06f32;
         assert!(trusted_weight + noisy_weight > MAX_OUTGOING_WEIGHT);
@@ -1147,11 +1150,9 @@ Pages speculative:                        12345.
         let (improvement, _improved, _worsened, _total) =
             compute_synapse_improvement_and_count(&samples, noisy_weight, baseline_sq, None);
 
-        // Expected residual error is 0.02 per sample (because 0.06 - 0.04), so:
-        // baseline per sample = 0.06^2 = 0.0036
-        // new per sample      = 0.02^2 = 0.0004
-        // improvement         = (0.0036 - 0.0004) / 0.0036 = 8/9
-        let expected = 8.0f32 / 9.0f32;
+        // With an unclamped weight transfer, the modelled contribution matches `avg_error`,
+        // so the improvement should be 1.0 (perfect cancellation in this synthetic setup).
+        let expected = 1.0f32;
         assert!(
             (improvement - expected).abs() < 1e-4,
             "expected improvement {expected}, got {improvement}"


### PR DESCRIPTION
- Bump version in Cargo.toml from 0.5.1 to 0.6.0.
- Introduce a mechanism to fold constant/near-constant sources into bias adjustments, optimizing synapse operations by reducing complexity.
- Implement a threshold for determining when to treat an add-synapse as a bias change, improving the efficiency of neural network adjustments.
- Update analysis logic to reflect these changes, ensuring accurate modeling of synapse contributions.
- Enhance tests to validate the new behavior and ensure correct functionality in various scenarios.

These updates significantly improve the performance and flexibility of the neural network optimization process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces bias-folding for constant sources and refines coordinated candidate modeling.
> 
> - Adds optional constant-source → bias folding: when `effectRange ≈ |weight| × (maxActivation - minActivation)` ≤ threshold, emit a coordinated `setBias` instead of `addSynapse`; controlled by `NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD` (unset/empty uses default `1e-7`, `0` disables, `>0` custom)
> - Integrates folding in synapse analysis (builds `neuron_bias_map`, computes mean/range, and emits single-op `setBias` candidates)
> - Updates coordinated structural modeling to transfer noisy weight onto trusted without clamping; coordinated op generation now uses `trusted.weight + noisy.weight` (no clamp)
> - README updated with the new folding behavior and env var
> - Tests updated: new regression for Issue #178; candidate count assertions now include `coordinatedStructuralCandidates`; scenarios tweaked to avoid unintended folding; unit test expectations adjusted for unclamped transfer
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90b89de44b8196e6584a5490f059f8d6c2577358. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->