### PR TITLE
Fix: Environment variable to focus on unused observations (#182)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ signal-hook = "0.3"  # Signal handling (SIGUSR1 for thread dumps)
 
 [dev-dependencies]
 tempfile = "3.8"
+serial_test = "3.0"
 

--- a/README.md
+++ b/README.md
@@ -1606,6 +1606,25 @@ whether discovery should be enabled:
 
   Hidden/constant sources keep weight 1.0; only `input-N` sources are biased.
 
+  **Focus on unused observations (10-Jan-2026, Issue #182)**: If you've added new observations
+  (input neurons) to your training data and want discovery to focus on these "unused" inputs
+  before evaluating existing connections, set `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1`.
+
+  When enabled, input neurons that have NO existing outgoing synapses are prioritised
+  (moved to the front of the evaluation queue). This is particularly useful when:
+
+  - You've added a few hundred new observations to the training data
+  - You want to quickly evaluate whether these new inputs improve the network
+  - You're using deadline-constrained runs and want new inputs evaluated first
+
+  Values that enable the feature: `1`, `true`, `yes` (case-insensitive)
+  Values that disable the feature: unset, empty, `0`, `false`, `no`
+
+  Example:
+  ```bash
+  export NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1
+  ```
+
   **Optional folding of constant sources into bias (7-Jan-2026)**: When a source neuron’s
   activation range is ~0, an add-synapse from that source behaves like a constant offset
   on the downstream neuron (equivalent to a bias change). To avoid paying complexity cost

--- a/quality.sh
+++ b/quality.sh
@@ -28,9 +28,8 @@ echo "✅ Running type checks..."
 cargo check --all-targets --all-features
 
 echo "🧪 Running tests..."
-# Run tests sequentially to avoid interference from shared global state (deadline override, GPU failure guard)
-cargo test --all-targets --all-features
-#-- --test-threads=1
+# Run tests sequentially to avoid interference from shared global state (deadline override, GPU failure guard, env vars)
+cargo test --all-targets --all-features -- --test-threads=1
 
 echo "🏗️ Building release library..."
 cargo build --release --lib

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -1152,20 +1152,78 @@ fn source_input_index_bias_from_env() -> Option<f64> {
     }
 }
 
+/// Check if discovery should focus on unused observations (Issue #182).
+///
+/// When enabled via `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1`, input neurons
+/// that have NO existing outgoing synapses are prioritised in the source ordering.
+/// This is useful when new observations have been added to the training data and
+/// the user wants discovery to focus on connecting these new inputs first.
+///
+/// Values that enable the feature: "1", "true", "yes" (case-insensitive)
+/// Values that disable the feature: unset, empty, "0", "false", "no"
+pub fn focus_unused_observations_from_env() -> bool {
+    let raw = match std::env::var("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS") {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let trimmed = raw.trim().to_lowercase();
+    matches!(trimmed.as_str(), "1" | "true" | "yes")
+}
+
 /// Order eligible sources for evaluation.
 ///
 /// - Always respects forward-only candidate constraints (caller must filter by index).
 /// - Default behaviour is a pure random shuffle (no special casing for input indices).
 /// - If `NEAT_AI_DISCOVERY_SOURCE_INPUT_INDEX_BIAS` is set, input sources are ordered
 ///   by a weighted random permutation favouring higher input indices.
+/// - If `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1` is set, input neurons with NO
+///   existing outgoing synapses are prioritised (moved to the front) before any other
+///   ordering is applied (Issue #182).
 fn order_eligible_sources(
     eligible_sources: &mut Vec<&OrderedNeuron>,
     seed: Option<u64>,
     context: &str,
     creature_input_count: usize,
+    used_inputs: Option<&HashSet<String>>,
 ) {
     if eligible_sources.len() <= 1 {
         return;
+    }
+
+    // Issue #182: When NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1 is set,
+    // prioritise input neurons that have NO existing outgoing synapses.
+    // These "unused observations" are moved to the front of the list.
+    if focus_unused_observations_from_env() {
+        if let Some(used) = used_inputs {
+            // Partition: unused inputs first, then others
+            // An input is "unused" if it's an input neuron AND not in the used_inputs set
+            let (mut unused_inputs, mut others): (Vec<_>, Vec<_>) = eligible_sources
+                .drain(..)
+                .partition(|n| parse_input_index(&n.uuid).is_some() && !used.contains(&n.uuid));
+
+            // Log when focusing on unused observations
+            if verbose_enabled() && !unused_inputs.is_empty() {
+                let unused_count = unused_inputs.len();
+                let used_count = others
+                    .iter()
+                    .filter(|n| parse_input_index(&n.uuid).is_some())
+                    .count();
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Focus unused observations: prioritising {} unused inputs over {} used inputs and {} other sources",
+                    unused_count,
+                    used_count,
+                    others.len() - used_count
+                );
+            }
+
+            // Shuffle each partition separately, then concatenate
+            shuffle_slice(&mut unused_inputs, seed, &format!("{context}:unused"));
+            shuffle_slice(&mut others, seed, &format!("{context}:others"));
+
+            eligible_sources.extend(unused_inputs);
+            eligible_sources.extend(others);
+            return;
+        }
     }
 
     let Some(bias) = source_input_index_bias_from_env() else {
@@ -7840,6 +7898,17 @@ pub(crate) fn analyze_neurons_with_cache(
     let order_map_arc = Arc::new(order_map);
     let neuron_squash_map_arc = Arc::new(neuron_squash_map);
 
+    // Issue #182: Build a set of "used" input neurons (those with at least one outgoing synapse)
+    // for the focus_unused_observations feature. Unused inputs will be prioritised in source ordering.
+    let used_inputs: HashSet<String> = input
+        .creature
+        .synapses
+        .iter()
+        .filter(|s| parse_input_index(&s.from_uuid).is_some())
+        .map(|s| s.from_uuid.clone())
+        .collect();
+    let used_inputs_arc = Arc::new(used_inputs);
+
     // Create a shared GPU work queue ONCE before the parallel loop.
     // This eliminates the overhead of creating multiple GPU devices (one per thread).
     // All GPU operations are processed by a single dedicated thread, improving utilisation.
@@ -7924,6 +7993,8 @@ pub(crate) fn analyze_neurons_with_cache(
             // - Candidates must remain forward-only (index < target_index).
             // - Under timeouts we want coverage over time, so we fully shuffle ALL
             //   eligible sources (inputs + hidden + constants).
+            // - If NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1, unused inputs are
+            //   prioritised to the front (Issue #182).
             //
             // If `random_seed` is provided, the shuffle is deterministic for a given
             // target UUID; otherwise it's non-deterministic.
@@ -7933,6 +8004,7 @@ pub(crate) fn analyze_neurons_with_cache(
                 input.random_seed,
                 &context,
                 input.creature.input,
+                Some(&*used_inputs_arc),
             );
 
             // Track total eligible sources for diagnostics
@@ -8588,6 +8660,17 @@ pub(crate) fn analyze_synapses_with_cache(
     let order_map_arc = Arc::new(order_map);
     let neuron_squash_map_arc = Arc::new(neuron_squash_map);
 
+    // Issue #182: Build a set of "used" input neurons (those with at least one outgoing synapse)
+    // for the focus_unused_observations feature. Unused inputs will be prioritised in source ordering.
+    let used_inputs: HashSet<String> = input
+        .creature
+        .synapses
+        .iter()
+        .filter(|s| parse_input_index(&s.from_uuid).is_some())
+        .map(|s| s.from_uuid.clone())
+        .collect();
+    let used_inputs_arc = Arc::new(used_inputs);
+
     // Map of neuron UUID -> bias, used when folding constant-source synapses into `setBias`.
     // Inputs are not present here (they have no bias).
     let neuron_bias_map: HashMap<String, f32> = input
@@ -8780,6 +8863,7 @@ pub(crate) fn analyze_synapses_with_cache(
                 input.random_seed,
                 &context,
                 input.creature.input,
+                Some(&*used_inputs_arc),
             );
 
             // Improved GPU utilisation: Build samples on CPU in parallel, then batch GPU evaluation

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -39,6 +39,9 @@ pub use shared::{NeuronNoCandidateDetail, SynapseNoCandidateDetail};
 // Re-export check_memory_for_parquet and ACTIVATION_SPECS from implementation (hasn't been moved yet)
 pub use implementation::{check_memory_for_parquet, ACTIVATION_SPECS};
 
+// Re-export focus_unused_observations_from_env for tests (Issue #182)
+pub use implementation::focus_unused_observations_from_env;
+
 // Implement analyze_all using the module functions
 use crate::{
     AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput, CandidateNeuronJson,

--- a/tests/issue_182_focus_unused_observations.rs
+++ b/tests/issue_182_focus_unused_observations.rs
@@ -1,0 +1,287 @@
+//! Test for Issue #182: Environment variable to focus on unused observations.
+//!
+//! When `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1` is set, the discovery process
+//! should prioritise input neurons that have NO existing outgoing synapses. These are
+//! "unused observations" - inputs in the training data that haven't been connected to
+//! the network yet.
+//!
+//! This is particularly useful when new observations have been added to the training
+//! data set and the user wants discovery to focus on connecting these new inputs first.
+
+mod common;
+
+use neat_ai_discovery::analysis::{
+    analyze_synapses, focus_unused_observations_from_env, GpuAnalyzer,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Skip test if no GPU available.
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+/// Minimal env var guard so tests remain isolated.
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var(self.key, v),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+/// Create a creature with multiple inputs where some have synapses and some don't.
+///
+/// Layout:
+/// - input-0: HAS synapse to output-0 (weight 1.0) - "used"
+/// - input-1: HAS synapse to output-0 (weight 1.0) - "used"
+/// - input-2: NO synapse - "unused"
+/// - input-3: NO synapse - "unused"
+/// - output-0: target neuron
+fn create_test_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+        input: 4, // 4 inputs: input-0, input-1, input-2, input-3
+        output: 1,
+    }
+}
+
+/// Create parquet records where unused inputs (input-2, input-3) have strong
+/// error correlation that should make them good candidates.
+fn create_test_records() -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+
+    for obs_index in 0..100u32 {
+        let phase = (obs_index as f32) * 0.1;
+
+        // input-0 and input-1 (used) - random activations, weak correlation with error
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-0".to_string(),
+            Some(phase.sin()),
+            phase.sin(),
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-1".to_string(),
+            Some(phase.cos()),
+            phase.cos(),
+            vec![0.0],
+        ));
+
+        // input-2 and input-3 (unused) - activations that correlate with target error
+        // These should be good candidates for new synapses
+        let error = if obs_index % 2 == 0 { 0.5 } else { -0.5 };
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-2".to_string(),
+            Some(error * 2.0), // Strong correlation with error
+            error * 2.0,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "input-3".to_string(),
+            Some(error * 1.5), // Moderate correlation with error
+            error * 1.5,
+            vec![0.0],
+        ));
+
+        // output-0 with error pattern
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![error],
+        ));
+    }
+
+    records
+}
+
+/// Test that the environment variable is correctly parsed when set to "1".
+#[test]
+fn issue_182_env_var_parsing() {
+    // Test with env var set to "1"
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "1");
+    assert!(
+        focus_unused_observations_from_env(),
+        "Should be true when set to '1'"
+    );
+}
+
+#[test]
+fn issue_182_env_var_parsing_not_set() {
+    // Test with env var explicitly removed (using guard to restore)
+    // Note: This test may fail if run in parallel with other tests that set the env var.
+    // quality.sh runs tests with --test-threads=1 to avoid this.
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "");
+    // Empty string should be treated as disabled
+    assert!(
+        !focus_unused_observations_from_env(),
+        "Should be false when empty"
+    );
+}
+
+#[test]
+fn issue_182_env_var_parsing_various_values() {
+    // Test with env var set to "true"
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "true");
+    assert!(
+        focus_unused_observations_from_env(),
+        "Should be true when set to 'true'"
+    );
+}
+
+#[test]
+fn issue_182_env_var_parsing_disabled() {
+    // Test with env var set to "0" - should be disabled
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "0");
+    assert!(
+        !focus_unused_observations_from_env(),
+        "Should be false when set to '0'"
+    );
+}
+
+#[test]
+fn issue_182_focus_unused_observations_prioritises_inputs_without_synapses() {
+    skip_without_gpu!();
+
+    // Enable focus on unused observations
+    let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "1");
+
+    let creature = create_test_creature();
+
+    let temp_file = NamedTempFile::new().expect("temp parquet");
+    let file_path = temp_file.path().to_str().expect("temp path").to_string();
+    let records = create_test_records();
+    write_records_to_parquet(&file_path, &records).expect("write parquet");
+
+    let input = AnalyzeSynapsesInput {
+        parquet_file: file_path,
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: Some(5000), // Short deadline to test prioritisation
+        random_seed: Some(42),
+    };
+
+    let result = analyze_synapses(&input).expect("analysis should succeed");
+
+    // With NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1, the unused inputs
+    // (input-2, input-3) should be prioritised and appear in the results
+    // before the used inputs (input-0, input-1).
+    let helpful = &result.helpful_synapses;
+
+    // We should find candidates from the unused inputs
+    let unused_input_candidates: Vec<_> = helpful
+        .iter()
+        .filter(|c| c.from_neuron_uuid == "input-2" || c.from_neuron_uuid == "input-3")
+        .collect();
+
+    assert!(
+        !unused_input_candidates.is_empty(),
+        "Should find candidates from unused inputs (input-2, input-3). Got {} helpful synapses: {:?}",
+        helpful.len(),
+        helpful.iter().map(|c| &c.from_neuron_uuid).collect::<Vec<_>>()
+    );
+
+    // With short deadline and prioritisation, the unused inputs should be evaluated first.
+    // This means the first few candidates should predominantly be from unused inputs.
+    // Count how many of the first 4 candidates are from unused inputs.
+    let first_four: Vec<_> = helpful.iter().take(4).collect();
+    let unused_in_first_four = first_four
+        .iter()
+        .filter(|c| c.from_neuron_uuid == "input-2" || c.from_neuron_uuid == "input-3")
+        .count();
+
+    // When NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1 is set, unused inputs
+    // should be processed FIRST (moved to the front of the evaluation queue).
+    // Therefore, candidates from unused inputs should dominate the results.
+    assert!(
+        unused_in_first_four >= 2,
+        "With NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1, most early candidates should be from \
+        unused inputs (input-2, input-3). Got {} unused in first 4. First 4: {:?}",
+        unused_in_first_four,
+        first_four
+            .iter()
+            .map(|c| &c.from_neuron_uuid)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn issue_182_without_env_var_no_prioritisation() {
+    skip_without_gpu!();
+
+    // Ensure env var is NOT set
+    std::env::remove_var("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS");
+
+    let creature = create_test_creature();
+
+    let temp_file = NamedTempFile::new().expect("temp parquet");
+    let file_path = temp_file.path().to_str().expect("temp path").to_string();
+    let records = create_test_records();
+    write_records_to_parquet(&file_path, &records).expect("write parquet");
+
+    let input = AnalyzeSynapsesInput {
+        parquet_file: file_path,
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: None, // No deadline - process all
+        random_seed: Some(42),
+    };
+
+    let result = analyze_synapses(&input).expect("analysis should succeed");
+
+    // Without the env var, the default behaviour is random ordering.
+    // We just verify that analysis completes and returns some results.
+    // The exact ordering depends on the random seed.
+    assert!(
+        !result.helpful_synapses.is_empty() || !result.no_candidate_reasons.is_empty(),
+        "Analysis should return either candidates or diagnostic reasons"
+    );
+}

--- a/tests/issue_182_focus_unused_observations.rs
+++ b/tests/issue_182_focus_unused_observations.rs
@@ -16,6 +16,7 @@ use neat_ai_discovery::analysis::{
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 /// Skip test if no GPU available.
@@ -143,6 +144,7 @@ fn create_test_records() -> Vec<DiscoverRecord> {
 
 /// Test that the environment variable is correctly parsed when set to "1".
 #[test]
+#[serial]
 fn issue_182_env_var_parsing() {
     // Test with env var set to "1"
     let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "1");
@@ -153,6 +155,7 @@ fn issue_182_env_var_parsing() {
 }
 
 #[test]
+#[serial]
 fn issue_182_env_var_parsing_not_set() {
     // Test with env var explicitly removed (using guard to restore)
     // Note: This test may fail if run in parallel with other tests that set the env var.
@@ -166,6 +169,7 @@ fn issue_182_env_var_parsing_not_set() {
 }
 
 #[test]
+#[serial]
 fn issue_182_env_var_parsing_various_values() {
     // Test with env var set to "true"
     let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "true");
@@ -176,6 +180,7 @@ fn issue_182_env_var_parsing_various_values() {
 }
 
 #[test]
+#[serial]
 fn issue_182_env_var_parsing_disabled() {
     // Test with env var set to "0" - should be disabled
     let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "0");


### PR DESCRIPTION
## Summary
Automated fix for issue #182

## Changes
This PR addresses the issue: **Environment variable to focus on unused observations**

## Testing
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #182