### PR TITLE
Fix: Please check #217 and adjust (#306)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.35"
+version = "0.7.36"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.36"
+version = "0.7.37"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-306.md
+++ b/docs/pr-summary-306.md
@@ -1,0 +1,41 @@
+## Summary
+
+Implements Issue #306: Constant-value neuron detection with bias adjustment for removal candidates.
+
+When a hidden neuron has near-zero activation variance (constant output), it can be removed and its effect folded into bias adjustments for downstream neurons. This is a behaviour-preserving simplification that reduces network complexity.
+
+### Key Changes
+
+1. **Added `constant_neuron_removals` field** to `RankFocusStats` and `RankFocusNeuronsOutput` - returns coordinated structural candidates for removing constant neurons with bias adjustments.
+
+2. **Added `activation_mean_and_variance_from_records()` function** in `focus.rs` - computes mean and variance of neuron activations to detect constant neurons.
+
+3. **Constant neuron detection logic** - Hidden neurons with variance below `1e-10` (as proposed in Issue #217) are identified as constant and returned as removal candidates.
+
+4. **Bias adjustment calculation** - For each downstream neuron, the bias is adjusted by `weight × mean_activation` to preserve network behaviour when the constant neuron is removed.
+
+### How It Works
+
+When `rank_focus_neurons` is called, it now:
+1. Computes activation variance for each selectable neuron
+2. Identifies hidden neurons with variance below `CONSTANT_VARIANCE_THRESHOLD` (1e-10)
+3. For each constant neuron, creates a `CoordinatedStructuralCandidateJson` containing:
+   - `SetBias` operations for all downstream neurons (with adjusted bias values)
+   - `RemoveNeuron` operation for the constant neuron
+
+This addresses Issue #217's proposal that "dead neurons" (neurons with near-zero variance) waste computation and should be candidates for removal with bias adjustments.
+
+## Evidence
+
+This is a backend change with no UI. The feature is verified through automated tests.
+
+## Test Plan
+
+Added 4 new tests in `tests/issue_306_constant_neuron_removal_with_bias_adjustment.rs`:
+
+- `issue_306_constant_neuron_creates_removal_candidate_with_bias_adjustment` - Verifies constant neurons are detected and returned with correct bias adjustments
+- `issue_306_varying_neuron_not_treated_as_constant` - Ensures neurons with normal variance are not incorrectly flagged
+- `issue_306_constant_neuron_adjusts_multiple_downstream_biases` - Tests bias adjustments for neurons with multiple downstream connections
+- `issue_306_near_zero_variance_treated_as_constant` - Verifies the 1e-10 threshold correctly identifies near-constant neurons
+
+All existing tests continue to pass (576 tests total).

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -1,7 +1,10 @@
 use crate::analysis::{check_memory_for_parquet, verbose_enabled};
 use crate::parquet_format::{read_all_records_grouped_by_neuron, read_records_from_parquet};
 use crate::types::DiscoverRecord;
-use crate::{CreatureJson, NeuronJson, SynapseJson};
+use crate::{
+    CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson, NeuronJson,
+    SynapseJson,
+};
 use anyhow::{anyhow, Context, Result};
 use rayon::prelude::*;
 use std::cmp::Ordering;
@@ -587,6 +590,13 @@ pub struct RankFocusStats {
     pub neurons: Vec<RankedNeuron>,
     /// Neurons with impact below costOfGrowth - candidates for removal
     pub removal_candidates: Vec<RemovalCandidate>,
+    /// Issue #306: Coordinated structural candidates for removing constant-value neurons.
+    /// When a hidden neuron has near-zero activation variance (constant output), it can be
+    /// removed and its effect folded into bias adjustments for downstream neurons.
+    /// Each candidate contains:
+    /// - A RemoveNeuron operation for the constant neuron
+    /// - SetBias operations for all downstream neurons with adjusted biases
+    pub constant_neuron_removals: Vec<CoordinatedStructuralCandidateJson>,
     pub max_output_error: f32,
     pub processed_neurons: usize,
     pub total_neurons: usize,
@@ -695,6 +705,54 @@ fn mean_absolute_activation_from_records(records: &[DiscoverRecord]) -> f32 {
         sum / count as f32
     }
 }
+
+/// Compute activation variance and mean from discovery records.
+///
+/// Issue #306: Used to detect constant-value neurons for removal with bias adjustments.
+/// A neuron with near-zero variance has constant activation and can be removed,
+/// with its effect folded into bias adjustments for downstream neurons.
+///
+/// # Returns
+/// A tuple of (mean_activation, variance) where:
+/// - `mean_activation` is the arithmetic mean (NOT absolute value)
+/// - `variance` is the statistical variance of activations
+///
+/// Returns (0.0, 0.0) if there are insufficient records.
+fn activation_mean_and_variance_from_records(records: &[DiscoverRecord]) -> (f32, f32) {
+    if records.len() < 2 {
+        return (0.0, 0.0);
+    }
+
+    let mut sum = 0.0f64;
+    let mut sum_sq = 0.0f64;
+    let mut count = 0u32;
+
+    for record in records {
+        if record.activation.is_finite() {
+            let a = record.activation as f64;
+            sum += a;
+            sum_sq += a * a;
+            count += 1;
+        }
+    }
+
+    if count < 2 {
+        return (0.0, 0.0);
+    }
+
+    let n = count as f64;
+    let mean = sum / n;
+    let variance = (sum_sq / n) - (mean * mean);
+
+    (mean as f32, variance.max(0.0) as f32)
+}
+
+/// Threshold for considering a neuron as "constant" (near-zero variance).
+/// Issue #217/306: Neurons with variance below this threshold are treated as constant
+/// and can be removed with bias adjustments for downstream neurons.
+///
+/// Value 1e-10 is from Issue #217's proposal for DEAD_VARIANCE_THRESHOLD.
+const CONSTANT_VARIANCE_THRESHOLD: f32 = 1e-10;
 
 fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)>> {
     let mut adjacency: HashMap<String, Vec<(String, f32)>> = HashMap::new();
@@ -1346,6 +1404,7 @@ pub fn rank_focus_neurons(
         return Ok(RankFocusStats {
             neurons: Vec::new(),
             removal_candidates: Vec::new(),
+            constant_neuron_removals: Vec::new(),
             max_output_error: 0.0,
             processed_neurons: 0,
             total_neurons: 0,
@@ -1642,9 +1701,113 @@ pub fn rank_focus_neurons(
         }
     }
 
+    // Issue #306: Detect constant-value neurons and create coordinated structural candidates
+    // that remove the neuron and adjust downstream biases.
+    //
+    // A neuron with near-zero activation variance is "constant" - it always outputs roughly
+    // the same value regardless of input. Removing it is equivalent to adjusting the biases
+    // of downstream neurons by: bias_adjustment = synapse_weight × mean_activation
+    //
+    // This is a win because:
+    // 1. We reduce complexity (one less neuron and its synapses)
+    // 2. We preserve the network's behaviour (downstream biases compensate)
+    // 3. The constant neuron wasn't contributing useful signal anyway
+    let neuron_types: HashMap<&str, &str> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.neuron_type.as_str()))
+        .collect();
+
+    let neuron_biases: HashMap<&str, f32> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.bias))
+        .collect();
+
+    // Build outgoing synapse map: from_uuid -> [(to_uuid, weight)]
+    let outgoing_synapses: HashMap<&str, Vec<(&str, f32)>> =
+        creature
+            .synapses
+            .iter()
+            .fold(HashMap::new(), |mut map, syn| {
+                map.entry(syn.from_uuid.as_str())
+                    .or_default()
+                    .push((syn.to_uuid.as_str(), syn.weight));
+                map
+            });
+
+    // Find constant hidden neurons and create coordinated removal candidates
+    let constant_neuron_removals: Vec<CoordinatedStructuralCandidateJson> = selectable
+        .par_iter()
+        .filter_map(|neuron| {
+            // Only consider hidden neurons for constant removal
+            let neuron_type = neuron_types.get(neuron.uuid.as_str())?;
+            if *neuron_type != "hidden" {
+                return None;
+            }
+
+            // Get records and compute variance
+            let records = get_records_or_error(records_provider.as_ref(), &neuron.uuid).ok()?;
+            let (mean_activation, variance) = activation_mean_and_variance_from_records(&records);
+
+            // Check if variance is below threshold (constant neuron)
+            if variance > CONSTANT_VARIANCE_THRESHOLD {
+                return None;
+            }
+
+            // Get outgoing synapses for this neuron
+            let outgoing = outgoing_synapses.get(neuron.uuid.as_str())?;
+            if outgoing.is_empty() {
+                return None;
+            }
+
+            // Build coordinated structural candidate:
+            // 1. SetBias operations for all downstream neurons
+            // 2. RemoveNeuron operation
+            let mut operations = Vec::with_capacity(outgoing.len() + 1);
+
+            // Add SetBias operations for all downstream neurons
+            for (to_uuid, weight) in outgoing {
+                let old_bias = neuron_biases.get(to_uuid).copied().unwrap_or(0.0);
+                let bias_adjustment = weight * mean_activation;
+                let new_bias = old_bias + bias_adjustment;
+
+                if new_bias.is_finite() {
+                    operations.push(CoordinatedStructuralOpJson::SetBias {
+                        neuron_uuid: to_uuid.to_string(),
+                        bias: new_bias,
+                    });
+                }
+            }
+
+            // Add RemoveNeuron operation (must be last so bias adjustments happen first)
+            operations.push(CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: neuron.uuid.clone(),
+            });
+
+            // Calculate expected improvement: removal savings (complexity reduction)
+            let (incoming_count, outgoing_count) =
+                count_synapses_for_neuron(&neuron.uuid, creature);
+            let removal_savings =
+                calculate_removal_savings(incoming_count, outgoing_count, cost_of_growth_threshold);
+
+            Some(CoordinatedStructuralCandidateJson {
+                operations,
+                expected_creature_score_gain: removal_savings,
+                comment: Some(format!(
+                    "Issue #306: Constant neuron removal with bias adjustments. \
+                     mean_activation={mean_activation:.6}, variance={variance:.2e}, \
+                     {} downstream neurons, savings={removal_savings:.2e}",
+                    outgoing.len()
+                )),
+            })
+        })
+        .collect();
+
     Ok(RankFocusStats {
         neurons,
         removal_candidates,
+        constant_neuron_removals,
         max_output_error,
         processed_neurons: total_neurons,
         total_neurons,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,6 +745,14 @@ pub struct RankFocusNeuronsOutput {
     /// Neurons with high error but very low impact - candidates for removal
     #[serde(skip_serializing_if = "Option::is_none")]
     pub removal_candidates: Option<Vec<RemovalCandidateJson>>,
+    /// Issue #306: Coordinated structural candidates for removing constant-value neurons.
+    /// When a hidden neuron has near-zero activation variance (constant output), it can be
+    /// removed and its effect folded into bias adjustments for downstream neurons.
+    /// Each candidate contains:
+    /// - A RemoveNeuron operation for the constant neuron
+    /// - SetBias operations for all downstream neurons with adjusted biases
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub constant_neuron_removals: Option<Vec<CoordinatedStructuralCandidateJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_output_error: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1328,6 +1336,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 success: false,
                 neurons: None,
                 removal_candidates: None,
+                constant_neuron_removals: None,
                 max_output_error: None,
                 processed_neurons: None,
                 total_neurons: None,
@@ -1380,6 +1389,12 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 } else {
                     Some(removal_candidates)
                 },
+                // Issue #306: Return constant neuron removal candidates
+                constant_neuron_removals: if stats.constant_neuron_removals.is_empty() {
+                    None
+                } else {
+                    Some(stats.constant_neuron_removals)
+                },
                 max_output_error: Some(stats.max_output_error),
                 processed_neurons: Some(stats.processed_neurons),
                 total_neurons: Some(stats.total_neurons),
@@ -1393,6 +1408,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 success: false,
                 neurons: None,
                 removal_candidates: None,
+                constant_neuron_removals: None,
                 max_output_error: None,
                 processed_neurons: None,
                 total_neurons: None,
@@ -2046,6 +2062,7 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
                     success: false,
                     neurons: None,
                     removal_candidates: None,
+                    constant_neuron_removals: None,
                     max_output_error: None,
                     processed_neurons: None,
                     total_neurons: None,

--- a/tests/issue_306_constant_neuron_removal_with_bias_adjustment.rs
+++ b/tests/issue_306_constant_neuron_removal_with_bias_adjustment.rs
@@ -1,0 +1,386 @@
+//! Issue #306: Constant-value neurons should be removal candidates with bias adjustments.
+//!
+//! When a hidden neuron has near-constant activation (very low variance), removing it
+//! is equivalent to adjusting the biases of all downstream neurons by:
+//!   bias_adjustment = synapse_weight * mean_activation
+//!
+//! This test verifies that such neurons are identified and returned as coordinated
+//! structural candidates containing:
+//! - RemoveNeuron operation for the constant neuron
+//! - SetBias operations for all downstream neurons with adjusted biases
+
+mod common;
+
+use neat_ai_discovery::focus::rank_focus_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CoordinatedStructuralOpJson, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Helper to create a simple creature with specified neurons and synapses.
+fn create_creature(
+    neurons: Vec<(&str, &str, f32)>,  // (uuid, type, bias)
+    synapses: Vec<(&str, &str, f32)>, // (from, to, weight)
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t, _)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t, _)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .filter(|(_, neuron_type, _)| *neuron_type != "input")
+            .map(|(uuid, neuron_type, bias)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: neuron_type.to_string(),
+                squash: "IDENTITY".to_string(),
+                bias,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, weight)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight,
+                synapse_type: None,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Helper to create parquet records for neurons with specified errors, activations,
+/// and optional variance in the activation.
+fn create_records_with_variance(
+    neuron_data: Vec<(&str, f32, f32, f32)>, // (uuid, error, mean_activation, variance)
+    sample_count: u32,
+) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for (uuid, error, mean_activation, variance) in neuron_data {
+        let std_dev = variance.sqrt();
+        for i in 0..sample_count {
+            // Create varying activations based on variance
+            // Use a simple pattern: alternate above and below mean
+            let activation = if std_dev > 0.0 {
+                if i % 2 == 0 {
+                    mean_activation + std_dev
+                } else {
+                    mean_activation - std_dev
+                }
+            } else {
+                mean_activation // Constant activation when variance is 0
+            };
+            records.push(DiscoverRecord::new(
+                i,
+                uuid.to_string(),
+                Some(activation),
+                activation,
+                vec![error],
+            ));
+        }
+    }
+    records
+}
+
+/// Issue #306: A hidden neuron with constant (zero variance) activation should be
+/// identified as a candidate for removal with bias adjustments.
+///
+/// Network:
+///   input-0 → constant-hidden (always outputs 1.0) → output-0
+///
+/// When constant-hidden is removed, output-0's bias should be adjusted by:
+///   bias_adjustment = synapse_weight × mean_activation = 0.5 × 1.0 = 0.5
+#[test]
+fn issue_306_constant_neuron_creates_removal_candidate_with_bias_adjustment() {
+    // Create a creature with a hidden neuron that has constant activation
+    let creature = create_creature(
+        vec![
+            ("input-0", "input", 0.0),
+            ("constant-hidden", "hidden", 0.0),
+            ("output-0", "output", 0.1), // Initial bias
+        ],
+        vec![
+            ("input-0", "constant-hidden", 1.0),
+            ("constant-hidden", "output-0", 0.5), // This weight becomes bias adjustment
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records where constant-hidden has ZERO variance (always 1.0)
+    // and some error in the output neuron
+    let records = create_records_with_variance(
+        vec![
+            // (uuid, error, mean_activation, variance)
+            ("constant-hidden", 0.1, 1.0, 0.0), // Zero variance = constant
+            ("output-0", 0.3, 0.5, 0.01),       // Normal variance
+        ],
+        32,
+    );
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Use a reasonable cost_of_growth to allow removal candidates
+    let result = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    // The constant-hidden neuron should be identified as a candidate
+    // Check if we have coordinated structural candidates with bias adjustments
+    assert!(
+        !result.constant_neuron_removals.is_empty(),
+        "Expected constant_neuron_removals to be present. \
+         Removal candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| &c.neuron_uuid)
+            .collect::<Vec<_>>()
+    );
+
+    let constant_removals = &result.constant_neuron_removals;
+    assert!(
+        !constant_removals.is_empty(),
+        "Expected at least one constant neuron removal candidate"
+    );
+
+    // Find the candidate for constant-hidden
+    let candidate = constant_removals
+        .iter()
+        .find(|c| {
+            c.operations.iter().any(|op| matches!(
+                op,
+                CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "constant-hidden"
+            ))
+        })
+        .expect("Should have a removal candidate for constant-hidden");
+
+    // Verify it contains both RemoveNeuron and SetBias operations
+    let has_remove = candidate.operations.iter().any(|op| {
+        matches!(
+            op,
+            CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "constant-hidden"
+        )
+    });
+    assert!(
+        has_remove,
+        "Candidate should include RemoveNeuron operation"
+    );
+
+    // Check the SetBias operation
+    let set_bias_op = candidate.operations.iter().find_map(|op| {
+        if let CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias } = op {
+            if neuron_uuid == "output-0" {
+                Some(*bias)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    });
+    assert!(
+        set_bias_op.is_some(),
+        "Candidate should include SetBias operation for output-0"
+    );
+
+    let new_bias = set_bias_op.unwrap();
+    // Expected: old_bias (0.1) + weight (0.5) × mean_activation (1.0) = 0.6
+    let expected_bias = 0.1 + 0.5 * 1.0;
+    assert!(
+        (new_bias - expected_bias).abs() < 0.01,
+        "New bias should be {expected_bias:.3}, got {new_bias:.3}"
+    );
+}
+
+/// Issue #306: Verify that neurons with non-zero variance are NOT treated as constant.
+#[test]
+fn issue_306_varying_neuron_not_treated_as_constant() {
+    let creature = create_creature(
+        vec![
+            ("input-0", "input", 0.0),
+            ("varying-hidden", "hidden", 0.0),
+            ("output-0", "output", 0.0),
+        ],
+        vec![
+            ("input-0", "varying-hidden", 1.0),
+            ("varying-hidden", "output-0", 0.5),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records where varying-hidden has SIGNIFICANT variance
+    let records = create_records_with_variance(
+        vec![
+            ("varying-hidden", 0.1, 0.5, 0.25), // std_dev = 0.5, significant variance
+            ("output-0", 0.3, 0.5, 0.01),
+        ],
+        32,
+    );
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    // varying-hidden should NOT be in constant_neuron_removals
+    let has_varying = result.constant_neuron_removals.iter().any(|c| {
+        c.operations.iter().any(|op| {
+            matches!(
+                op,
+                CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "varying-hidden"
+            )
+        })
+    });
+    assert!(
+        !has_varying,
+        "varying-hidden should NOT be in constant_neuron_removals"
+    );
+}
+
+/// Issue #306: Multiple downstream neurons should all get bias adjustments.
+#[test]
+fn issue_306_constant_neuron_adjusts_multiple_downstream_biases() {
+    // Network: constant-hidden feeds into both output-0 and output-1
+    let creature = create_creature(
+        vec![
+            ("input-0", "input", 0.0),
+            ("constant-hidden", "hidden", 0.0),
+            ("output-0", "output", 0.1),
+            ("output-1", "output", 0.2),
+        ],
+        vec![
+            ("input-0", "constant-hidden", 1.0),
+            ("constant-hidden", "output-0", 0.3), // bias adjustment = 0.3 × 2.0 = 0.6
+            ("constant-hidden", "output-1", 0.4), // bias adjustment = 0.4 × 2.0 = 0.8
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = create_records_with_variance(
+        vec![
+            ("constant-hidden", 0.1, 2.0, 0.0), // Zero variance, mean = 2.0
+            ("output-0", 0.3, 0.5, 0.01),
+            ("output-1", 0.3, 0.5, 0.01),
+        ],
+        32,
+    );
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    // Should have constant neuron removal with bias adjustments for both outputs
+    assert!(
+        !result.constant_neuron_removals.is_empty(),
+        "Expected constant_neuron_removals"
+    );
+
+    let candidate = result.constant_neuron_removals
+        .iter()
+        .find(|c| {
+            c.operations.iter().any(|op| matches!(
+                op,
+                CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "constant-hidden"
+            ))
+        })
+        .expect("Should have removal candidate for constant-hidden");
+
+    // Count SetBias operations
+    let set_bias_count = candidate
+        .operations
+        .iter()
+        .filter(|op| matches!(op, CoordinatedStructuralOpJson::SetBias { .. }))
+        .count();
+
+    assert_eq!(
+        set_bias_count, 2,
+        "Should have 2 SetBias operations (one for each downstream neuron)"
+    );
+
+    // Verify output-0 bias adjustment
+    let output_0_bias = candidate.operations.iter().find_map(|op| {
+        if let CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias } = op {
+            if neuron_uuid == "output-0" {
+                Some(*bias)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    });
+    let expected_0 = 0.1 + 0.3 * 2.0; // 0.7
+    assert!(
+        (output_0_bias.unwrap() - expected_0).abs() < 0.01,
+        "output-0 bias should be {expected_0:.3}"
+    );
+
+    // Verify output-1 bias adjustment
+    let output_1_bias = candidate.operations.iter().find_map(|op| {
+        if let CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias } = op {
+            if neuron_uuid == "output-1" {
+                Some(*bias)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    });
+    let expected_1 = 0.2 + 0.4 * 2.0; // 1.0
+    assert!(
+        (output_1_bias.unwrap() - expected_1).abs() < 0.01,
+        "output-1 bias should be {expected_1:.3}"
+    );
+}
+
+/// Issue #306: Very low (but non-zero) variance should still be treated as constant.
+/// Uses the same threshold as Issue #217 proposes: 1e-10 for "dead" neurons.
+#[test]
+fn issue_306_near_zero_variance_treated_as_constant() {
+    let creature = create_creature(
+        vec![
+            ("input-0", "input", 0.0),
+            ("near-constant", "hidden", 0.0),
+            ("output-0", "output", 0.0),
+        ],
+        vec![
+            ("input-0", "near-constant", 1.0),
+            ("near-constant", "output-0", 0.5),
+        ],
+    );
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Create records with very small variance (below threshold)
+    let records = create_records_with_variance(
+        vec![
+            ("near-constant", 0.1, 1.0, 1e-12), // Variance below 1e-10 threshold
+            ("output-0", 0.3, 0.5, 0.01),
+        ],
+        32,
+    );
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, Some(0.01)).unwrap();
+
+    // near-constant should be in constant_neuron_removals
+    assert!(
+        !result.constant_neuron_removals.is_empty(),
+        "Expected constant_neuron_removals to be present for near-zero variance"
+    );
+
+    let has_near_constant = result.constant_neuron_removals.iter().any(|c| {
+        c.operations.iter().any(|op| {
+            matches!(
+                op,
+                CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "near-constant"
+            )
+        })
+    });
+    assert!(
+        has_near_constant,
+        "near-constant neuron should be in constant_neuron_removals"
+    );
+}


### PR DESCRIPTION
## Summary

Implements Issue #306: Constant-value neuron detection with bias adjustment for removal candidates.

When a hidden neuron has near-zero activation variance (constant output), it can be removed and its effect folded into bias adjustments for downstream neurons. This is a behaviour-preserving simplification that reduces network complexity.

### Key Changes

1. **Added `constant_neuron_removals` field** to `RankFocusStats` and `RankFocusNeuronsOutput` - returns coordinated structural candidates for removing constant neurons with bias adjustments.

2. **Added `activation_mean_and_variance_from_records()` function** in `focus.rs` - computes mean and variance of neuron activations to detect constant neurons.

3. **Constant neuron detection logic** - Hidden neurons with variance below `1e-10` (as proposed in Issue #217) are identified as constant and returned as removal candidates.

4. **Bias adjustment calculation** - For each downstream neuron, the bias is adjusted by `weight × mean_activation` to preserve network behaviour when the constant neuron is removed.

### How It Works

When `rank_focus_neurons` is called, it now:
1. Computes activation variance for each selectable neuron
2. Identifies hidden neurons with variance below `CONSTANT_VARIANCE_THRESHOLD` (1e-10)
3. For each constant neuron, creates a `CoordinatedStructuralCandidateJson` containing:
   - `SetBias` operations for all downstream neurons (with adjusted bias values)
   - `RemoveNeuron` operation for the constant neuron

This addresses Issue #217's proposal that "dead neurons" (neurons with near-zero variance) waste computation and should be candidates for removal with bias adjustments.

## Evidence

This is a backend change with no UI. The feature is verified through automated tests.

## Test Plan

Added 4 new tests in `tests/issue_306_constant_neuron_removal_with_bias_adjustment.rs`:

- `issue_306_constant_neuron_creates_removal_candidate_with_bias_adjustment` - Verifies constant neurons are detected and returned with correct bias adjustments
- `issue_306_varying_neuron_not_treated_as_constant` - Ensures neurons with normal variance are not incorrectly flagged
- `issue_306_constant_neuron_adjusts_multiple_downstream_biases` - Tests bias adjustments for neurons with multiple downstream connections
- `issue_306_near_zero_variance_treated_as_constant` - Verifies the 1e-10 threshold correctly identifies near-constant neurons

All existing tests continue to pass (576 tests total).

---

## Automated Fix Details
This PR addresses issue #306: **Please check #217 and adjust**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #306