### PR TITLE
Fix: Performance: Pre-compute synapse counts to eliminate O(n×m) complexity (#208)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.39"
+version = "0.7.40"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.40"
+version = "0.7.41"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,9 @@ signal-hook = "0.3"  # Signal handling (SIGUSR1 for thread dumps)
 [dev-dependencies]
 tempfile = "3.8"
 serial_test = "3.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "synapse_counts"
+harness = false
 

--- a/benches/synapse_counts.rs
+++ b/benches/synapse_counts.rs
@@ -1,0 +1,152 @@
+//! Benchmark for Issue #208: Pre-compute synapse counts performance.
+//!
+//! This benchmark compares the performance of:
+//! - Old approach: O(n×m) - scanning all synapses for each neuron lookup
+//! - New approach: O(n+m) - pre-compute HashMaps, then O(1) lookup
+//!
+//! Expected improvement: ~1000x for large creatures (500 neurons, 10,000 synapses).
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use neat_ai_discovery::focus::SynapseCounts;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Create a test creature with specified number of neurons and synapses.
+///
+/// The synapse connectivity is randomised but deterministic (based on indices).
+fn create_test_creature(num_neurons: usize, num_synapses: usize) -> CreatureJson {
+    // Create neurons: 1 input, (num_neurons - 2) hidden, 1 output
+    let mut neurons = Vec::with_capacity(num_neurons);
+
+    // Hidden neurons (input neurons are not in the neurons list per NEAT-AI model)
+    for i in 0..(num_neurons - 1) {
+        neurons.push(NeuronJson {
+            uuid: format!("hidden-{i}"),
+            neuron_type: "hidden".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        });
+    }
+
+    // Output neuron
+    neurons.push(NeuronJson {
+        uuid: "output-0".to_string(),
+        neuron_type: "output".to_string(),
+        squash: "IDENTITY".to_string(),
+        bias: 0.0,
+    });
+
+    // Create synapses with pseudo-random connectivity
+    let mut synapses = Vec::with_capacity(num_synapses);
+    for i in 0..num_synapses {
+        // Deterministic "random" from/to selection based on index
+        let from_idx = i % num_neurons;
+        let to_idx = (i * 7 + 3) % num_neurons;
+
+        let from_uuid = if from_idx == 0 {
+            "input-0".to_string()
+        } else if from_idx == num_neurons - 1 {
+            "output-0".to_string()
+        } else {
+            format!("hidden-{}", from_idx - 1)
+        };
+
+        let to_uuid = if to_idx == num_neurons - 1 {
+            "output-0".to_string()
+        } else {
+            format!("hidden-{to_idx}")
+        };
+
+        synapses.push(SynapseJson {
+            from_uuid,
+            to_uuid,
+            weight: 0.5,
+            synapse_type: None,
+        });
+    }
+
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 1,
+        output: 1,
+    }
+}
+
+/// Simulate the OLD approach: O(m) scan for each neuron lookup.
+/// This is what count_synapses_for_neuron used to do.
+fn old_count_synapses_for_neuron(neuron_uuid: &str, creature: &CreatureJson) -> (usize, usize) {
+    let incoming = creature
+        .synapses
+        .iter()
+        .filter(|s| s.to_uuid == neuron_uuid)
+        .count();
+    let outgoing = creature
+        .synapses
+        .iter()
+        .filter(|s| s.from_uuid == neuron_uuid)
+        .count();
+    (incoming, outgoing)
+}
+
+/// Benchmark: Count synapses for ALL neurons using the old O(n×m) approach.
+fn bench_old_approach(creature: &CreatureJson) -> Vec<(usize, usize)> {
+    let all_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .map(|n| n.uuid.as_str())
+        .chain(std::iter::once("input-0"))
+        .collect();
+
+    all_uuids
+        .iter()
+        .map(|uuid| old_count_synapses_for_neuron(uuid, creature))
+        .collect()
+}
+
+/// Benchmark: Count synapses for ALL neurons using the new O(n+m) approach.
+fn bench_new_approach(creature: &CreatureJson) -> Vec<(usize, usize)> {
+    let synapse_counts = SynapseCounts::new(creature);
+
+    let all_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .map(|n| n.uuid.as_str())
+        .chain(std::iter::once("input-0"))
+        .collect();
+
+    all_uuids
+        .iter()
+        .map(|uuid| synapse_counts.get(uuid))
+        .collect()
+}
+
+fn bench_synapse_counts(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synapse_counts");
+
+    // Test different creature sizes as specified in the issue
+    let sizes: Vec<(usize, usize)> = vec![
+        (100, 500),     // Small: 100 neurons, 500 synapses
+        (500, 10_000),  // Medium: 500 neurons, 10,000 synapses (issue example)
+        (1000, 50_000), // Large: 1000 neurons, 50,000 synapses
+    ];
+
+    for (num_neurons, num_synapses) in sizes {
+        let creature = create_test_creature(num_neurons, num_synapses);
+        let id = format!("{num_neurons}n_{num_synapses}s");
+
+        // Benchmark old approach
+        group.bench_with_input(BenchmarkId::new("old_O(n×m)", &id), &creature, |b, c| {
+            b.iter(|| bench_old_approach(black_box(c)))
+        });
+
+        // Benchmark new approach
+        group.bench_with_input(BenchmarkId::new("new_O(n+m)", &id), &creature, |b, c| {
+            b.iter(|| bench_new_approach(black_box(c)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_synapse_counts);
+criterion_main!(benches);

--- a/docs/pr-summary-208.md
+++ b/docs/pr-summary-208.md
@@ -1,0 +1,73 @@
+## Summary
+
+Fixed performance issue in `rank_focus_neurons` where synapse counting had O(n×m) complexity. The `count_synapses_for_neuron` function was scanning all synapses twice (incoming + outgoing) for each neuron being ranked.
+
+**Solution**: Pre-compute synapse counts into HashMaps during initialisation, reducing complexity to O(n+m).
+
+### Changes
+
+1. **Added `SynapseCounts` struct** (`src/focus.rs:658-705`)
+   - Pre-computes incoming and outgoing synapse counts in O(m) time
+   - Provides O(1) lookup via `get(neuron_uuid)` method
+   - Used in three places within `rank_focus_neurons`:
+     - Removal candidates filtering
+     - High-error exploratory ablation candidates
+     - Constant neuron removal candidates
+
+2. **Removed deprecated `count_synapses_for_neuron` function**
+   - Was performing O(m) iteration per call
+   - All usages replaced with `SynapseCounts::get()`
+
+3. **Updated `quality.sh`**
+   - Exclude benchmarks from test runs (criterion benchmarks use custom harness)
+
+## Evidence
+
+### Benchmark Results
+
+```
+synapse_counts/old_O(n×m)/100n_500s
+                        time:   [155.72 µs 155.93 µs 156.14 µs]
+synapse_counts/new_O(n+m)/100n_500s
+                        time:   [27.854 µs 27.898 µs 27.944 µs]
+
+synapse_counts/old_O(n×m)/500n_10000s
+                        time:   [14.089 ms 14.115 ms 14.140 ms]
+synapse_counts/new_O(n+m)/500n_10000s
+                        time:   [486.51 µs 487.53 µs 488.57 µs]
+
+synapse_counts/old_O(n×m)/1000n_50000s
+                        time:   [147.67 ms 147.81 ms 147.94 ms]
+synapse_counts/new_O(n+m)/1000n_50000s
+                        time:   [2.4810 ms 2.4890 ms 2.4974 ms]
+```
+
+| Creature Size | Old O(n×m) | New O(n+m) | Speedup |
+|---------------|------------|------------|---------|
+| 100 neurons, 500 synapses | 155.9 µs | 27.9 µs | **5.6x** |
+| 500 neurons, 10,000 synapses | 14.1 ms | 487.5 µs | **29x** |
+| 1000 neurons, 50,000 synapses | 147.8 ms | 2.49 ms | **59x** |
+
+The improvement scales with creature size as expected from the complexity analysis.
+
+## Test Plan
+
+### New Tests Added
+- `tests/issue_208_synapse_counts.rs`:
+  - `test_synapse_counts_basic` - Basic incoming/outgoing counts
+  - `test_synapse_counts_multiple_connections` - Multiple connections per neuron
+  - `test_synapse_counts_neuron_with_no_synapses` - Orphan neuron handling
+  - `test_synapse_counts_self_loop` - Self-referential synapses
+  - `test_synapse_counts_empty_creature` - Empty creature edge case
+  - `test_synapse_counts_nonexistent_neuron` - Missing neuron lookup
+  - `test_synapse_counts_complex_network` - Complex topology verification
+  - `test_synapse_counts_matches_original_implementation` - Correctness against original
+
+### Benchmarks Added
+- `benches/synapse_counts.rs`:
+  - Compares old O(n×m) vs new O(n+m) approach
+  - Tests three creature sizes: 100/500, 500/10000, 1000/50000 neurons/synapses
+  - Run with: `cargo bench --bench synapse_counts`
+
+### Existing Tests
+All 200+ existing tests continue to pass, verifying no regressions in functionality.

--- a/quality.sh
+++ b/quality.sh
@@ -29,7 +29,8 @@ cargo check --all-targets --all-features
 
 echo "🧪 Running tests..."
 # Run tests sequentially to avoid interference from shared global state (deadline override, GPU failure guard, env vars)
-cargo test --all-targets --all-features -- --test-threads=1
+# Note: Exclude benchmarks (--benches) since criterion benchmarks use custom harness and fail with --test-threads
+cargo test --lib --tests --all-features -- --test-threads=1
 
 echo "🏗️ Building release library..."
 cargo build --release --lib

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -637,26 +637,62 @@ pub fn calculate_removal_savings(
     growth_cost * (1.0 + total_synapses as f32 / 10.0)
 }
 
-/// Count the incoming and outgoing synapses for a neuron.
+/// Pre-computed synapse counts for efficient O(1) lookup.
 ///
-/// # Arguments
-/// * `neuron_uuid` - The UUID of the neuron to count synapses for
-/// * `creature` - The creature containing the synapses
+/// Issue #208: Pre-compute synapse counts to eliminate O(n×m) complexity.
 ///
-/// # Returns
-/// A tuple of (incoming_count, outgoing_count)
-fn count_synapses_for_neuron(neuron_uuid: &str, creature: &CreatureJson) -> (usize, usize) {
-    let incoming = creature
-        .synapses
-        .iter()
-        .filter(|s| s.to_uuid == neuron_uuid)
-        .count();
-    let outgoing = creature
-        .synapses
-        .iter()
-        .filter(|s| s.from_uuid == neuron_uuid)
-        .count();
-    (incoming, outgoing)
+/// Previously, `count_synapses_for_neuron` performed a linear O(m) scan through ALL synapses
+/// twice (incoming + outgoing) for each neuron being ranked. With n neurons and m synapses,
+/// this was O(n × m) complexity.
+///
+/// This struct pre-builds two HashMaps during initialisation in O(m) time, then provides
+/// O(1) lookup for any neuron's synapse counts. Total complexity is O(n + m).
+///
+/// # Example performance improvement
+///
+/// For a creature with 500 neurons and 10,000 synapses:
+/// - Previous: 500 × 10,000 × 2 = **10 million** iterations
+/// - With SynapseCounts: 10,000 + 500 = **10,500** iterations
+/// - **~1000x improvement**
+#[derive(Debug)]
+pub struct SynapseCounts {
+    /// Map from neuron UUID to count of synapses pointing TO that neuron
+    incoming: HashMap<String, usize>,
+    /// Map from neuron UUID to count of synapses pointing FROM that neuron
+    outgoing: HashMap<String, usize>,
+}
+
+impl SynapseCounts {
+    /// Create a new SynapseCounts by scanning all synapses once.
+    ///
+    /// Time complexity: O(m) where m is the number of synapses.
+    /// Space complexity: O(n) where n is the number of unique neurons with synapses.
+    pub fn new(creature: &CreatureJson) -> Self {
+        let mut incoming: HashMap<String, usize> = HashMap::new();
+        let mut outgoing: HashMap<String, usize> = HashMap::new();
+
+        for synapse in &creature.synapses {
+            *incoming.entry(synapse.to_uuid.clone()).or_default() += 1;
+            *outgoing.entry(synapse.from_uuid.clone()).or_default() += 1;
+        }
+
+        Self { incoming, outgoing }
+    }
+
+    /// Get the synapse counts for a neuron in O(1) time.
+    ///
+    /// # Arguments
+    /// * `neuron_uuid` - The UUID of the neuron to look up
+    ///
+    /// # Returns
+    /// A tuple of (incoming_count, outgoing_count). Returns (0, 0) if the neuron
+    /// has no synapses or doesn't exist in the creature.
+    pub fn get(&self, neuron_uuid: &str) -> (usize, usize) {
+        (
+            self.incoming.get(neuron_uuid).copied().unwrap_or(0),
+            self.outgoing.get(neuron_uuid).copied().unwrap_or(0),
+        )
+    }
 }
 
 fn average_absolute_error_from_records(records: &[DiscoverRecord]) -> f32 {
@@ -1469,6 +1505,12 @@ pub fn rank_focus_neurons(
     // Use activation-based impact calculation for more accurate MIN/MAX/IF statistics
     let impact_map = compute_impacts_with_activations(creature, records_provider.as_ref())?;
 
+    // Issue #208: Pre-compute synapse counts to eliminate O(n×m) complexity.
+    // Previously, count_synapses_for_neuron scanned ALL synapses twice (incoming + outgoing)
+    // for each neuron being ranked. With n neurons and m synapses, this was O(n × m).
+    // By pre-computing counts into HashMaps, we reduce to O(m) for init + O(1) per lookup.
+    let synapse_counts = SynapseCounts::new(creature);
+
     // Now we can safely unwrap since we've verified all selectable neurons have records
     // Use parallel iteration for faster processing on multi-core systems
     let mut neurons: Vec<RankedNeuron> = selectable
@@ -1559,7 +1601,8 @@ pub fn rank_focus_neurons(
     let mut removal_candidates: Vec<RemovalCandidate> = neurons
         .par_iter()
         .filter_map(|n| {
-            let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
+            // Issue #208: Use pre-computed synapse counts for O(1) lookup
+            let (incoming, outgoing) = synapse_counts.get(&n.neuron_uuid);
             let savings = calculate_removal_savings(incoming, outgoing, cost_of_growth_threshold);
 
             // Issue #235: Filter on savings > impact (removal improves score)
@@ -1645,7 +1688,8 @@ pub fn rank_focus_neurons(
         high_error_neurons.truncate(EXPLORATORY_ABLATION_MAX);
 
         for n in high_error_neurons {
-            let (incoming, outgoing) = count_synapses_for_neuron(&n.neuron_uuid, creature);
+            // Issue #208: Use pre-computed synapse counts for O(1) lookup
+            let (incoming, outgoing) = synapse_counts.get(&n.neuron_uuid);
             let savings = calculate_removal_savings(incoming, outgoing, cost_of_growth_threshold);
 
             removal_candidates.push(RemovalCandidate {
@@ -1786,8 +1830,8 @@ pub fn rank_focus_neurons(
             });
 
             // Calculate expected improvement: removal savings (complexity reduction)
-            let (incoming_count, outgoing_count) =
-                count_synapses_for_neuron(&neuron.uuid, creature);
+            // Issue #208: Use pre-computed synapse counts for O(1) lookup
+            let (incoming_count, outgoing_count) = synapse_counts.get(&neuron.uuid);
             let removal_savings =
                 calculate_removal_savings(incoming_count, outgoing_count, cost_of_growth_threshold);
 

--- a/tests/issue_208_synapse_counts.rs
+++ b/tests/issue_208_synapse_counts.rs
@@ -1,0 +1,336 @@
+//! Tests for Issue #208: Pre-compute synapse counts to eliminate O(n×m) complexity.
+//!
+//! The `count_synapses_for_neuron` function previously scanned ALL synapses twice
+//! (incoming + outgoing) for each neuron being ranked. With n neurons and m synapses,
+//! this was O(n × m) complexity.
+//!
+//! The fix pre-computes synapse counts into HashMaps, reducing complexity to O(n + m).
+//!
+//! These tests verify:
+//! - Correct synapse counts match the original implementation
+//! - Edge cases: neurons with 0 synapses, self-loops
+//! - Empty creatures are handled correctly
+
+mod common;
+
+use neat_ai_discovery::focus::SynapseCounts;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper to create a simple creature with specified neurons and synapses
+fn create_creature(
+    neurons: Vec<(&str, &str)>,       // (uuid, type)
+    synapses: Vec<(&str, &str, f32)>, // (from, to, weight)
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .filter(|(_, neuron_type)| *neuron_type != "input")
+            .map(|(uuid, neuron_type)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: neuron_type.to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, weight)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight,
+                synapse_type: None,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+#[test]
+fn test_synapse_counts_basic() {
+    // Simple network: input-0 -> hidden-1 -> output-0
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("hidden-1", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "hidden-1", 1.0),  // hidden-1 has 1 incoming
+            ("hidden-1", "output-0", 1.0), // hidden-1 has 1 outgoing, output-0 has 1 incoming
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // Check hidden-1: 1 incoming (from input-0), 1 outgoing (to output-0)
+    let (incoming, outgoing) = counts.get("hidden-1");
+    assert_eq!(incoming, 1, "hidden-1 should have 1 incoming synapse");
+    assert_eq!(outgoing, 1, "hidden-1 should have 1 outgoing synapse");
+
+    // Check output-0: 1 incoming (from hidden-1), 0 outgoing
+    let (incoming, outgoing) = counts.get("output-0");
+    assert_eq!(incoming, 1, "output-0 should have 1 incoming synapse");
+    assert_eq!(outgoing, 0, "output-0 should have 0 outgoing synapses");
+
+    // Check input-0: 0 incoming, 1 outgoing (to hidden-1)
+    let (incoming, outgoing) = counts.get("input-0");
+    assert_eq!(incoming, 0, "input-0 should have 0 incoming synapses");
+    assert_eq!(outgoing, 1, "input-0 should have 1 outgoing synapse");
+}
+
+#[test]
+fn test_synapse_counts_multiple_connections() {
+    // Network with multiple connections:
+    // input-0 -> hidden-1 -> output-0
+    // input-1 -> hidden-1
+    // hidden-1 -> output-1
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("input-1", "input"),
+            ("hidden-1", "hidden"),
+            ("output-0", "output"),
+            ("output-1", "output"),
+        ],
+        vec![
+            ("input-0", "hidden-1", 1.0),
+            ("input-1", "hidden-1", 1.0),
+            ("hidden-1", "output-0", 1.0),
+            ("hidden-1", "output-1", 1.0),
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // hidden-1: 2 incoming (from input-0, input-1), 2 outgoing (to output-0, output-1)
+    let (incoming, outgoing) = counts.get("hidden-1");
+    assert_eq!(incoming, 2, "hidden-1 should have 2 incoming synapses");
+    assert_eq!(outgoing, 2, "hidden-1 should have 2 outgoing synapses");
+}
+
+#[test]
+fn test_synapse_counts_neuron_with_no_synapses() {
+    // A neuron with no connections (orphan)
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("orphan", "hidden"), // No connections
+            ("connected", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "connected", 1.0),
+            ("connected", "output-0", 1.0),
+            // Note: orphan has no synapses
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // orphan: 0 incoming, 0 outgoing
+    let (incoming, outgoing) = counts.get("orphan");
+    assert_eq!(incoming, 0, "orphan should have 0 incoming synapses");
+    assert_eq!(outgoing, 0, "orphan should have 0 outgoing synapses");
+}
+
+#[test]
+fn test_synapse_counts_self_loop() {
+    // A neuron with a self-loop (synapse from itself to itself)
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("self-loop", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "self-loop", 1.0),
+            ("self-loop", "self-loop", 0.5), // Self-loop
+            ("self-loop", "output-0", 1.0),
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // self-loop: 2 incoming (from input-0 + itself), 2 outgoing (to output-0 + itself)
+    let (incoming, outgoing) = counts.get("self-loop");
+    assert_eq!(
+        incoming, 2,
+        "self-loop should have 2 incoming synapses (input + self)"
+    );
+    assert_eq!(
+        outgoing, 2,
+        "self-loop should have 2 outgoing synapses (output + self)"
+    );
+}
+
+#[test]
+fn test_synapse_counts_empty_creature() {
+    // Empty creature with no neurons or synapses
+    let creature = CreatureJson {
+        neurons: vec![],
+        synapses: vec![],
+        input: 0,
+        output: 0,
+    };
+
+    let counts = SynapseCounts::new(&creature);
+
+    // Any neuron lookup should return (0, 0)
+    let (incoming, outgoing) = counts.get("nonexistent");
+    assert_eq!(incoming, 0, "nonexistent neuron should have 0 incoming");
+    assert_eq!(outgoing, 0, "nonexistent neuron should have 0 outgoing");
+}
+
+#[test]
+fn test_synapse_counts_nonexistent_neuron() {
+    // Lookup a neuron that doesn't exist in the creature
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("hidden-1", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![("input-0", "hidden-1", 1.0), ("hidden-1", "output-0", 1.0)],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // Lookup nonexistent neuron should return (0, 0)
+    let (incoming, outgoing) = counts.get("nonexistent-uuid");
+    assert_eq!(incoming, 0, "nonexistent neuron should have 0 incoming");
+    assert_eq!(outgoing, 0, "nonexistent neuron should have 0 outgoing");
+}
+
+#[test]
+fn test_synapse_counts_complex_network() {
+    // A more complex network to test cumulative counting
+    //
+    // input-0 ─┬─> hidden-1 ─┬─> output-0
+    //          │             │
+    // input-1 ─┴─> hidden-2 ─┴─> output-1
+    //                 │
+    //                 └─> hidden-3 ─> output-0
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("input-1", "input"),
+            ("hidden-1", "hidden"),
+            ("hidden-2", "hidden"),
+            ("hidden-3", "hidden"),
+            ("output-0", "output"),
+            ("output-1", "output"),
+        ],
+        vec![
+            ("input-0", "hidden-1", 1.0),  // hidden-1: 1 incoming
+            ("input-1", "hidden-1", 1.0),  // hidden-1: 2 incoming
+            ("input-0", "hidden-2", 1.0),  // hidden-2: 1 incoming
+            ("input-1", "hidden-2", 1.0),  // hidden-2: 2 incoming
+            ("hidden-1", "output-0", 1.0), // hidden-1: 1 outgoing, output-0: 1 incoming
+            ("hidden-1", "output-1", 1.0), // hidden-1: 2 outgoing, output-1: 1 incoming
+            ("hidden-2", "output-0", 1.0), // hidden-2: 1 outgoing, output-0: 2 incoming
+            ("hidden-2", "output-1", 1.0), // hidden-2: 2 outgoing, output-1: 2 incoming
+            ("hidden-2", "hidden-3", 1.0), // hidden-2: 3 outgoing, hidden-3: 1 incoming
+            ("hidden-3", "output-0", 1.0), // hidden-3: 1 outgoing, output-0: 3 incoming
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // Verify hidden-1: 2 incoming (from input-0, input-1), 2 outgoing (to output-0, output-1)
+    let (incoming, outgoing) = counts.get("hidden-1");
+    assert_eq!(incoming, 2, "hidden-1 should have 2 incoming synapses");
+    assert_eq!(outgoing, 2, "hidden-1 should have 2 outgoing synapses");
+
+    // Verify hidden-2: 2 incoming, 3 outgoing (output-0, output-1, hidden-3)
+    let (incoming, outgoing) = counts.get("hidden-2");
+    assert_eq!(incoming, 2, "hidden-2 should have 2 incoming synapses");
+    assert_eq!(outgoing, 3, "hidden-2 should have 3 outgoing synapses");
+
+    // Verify hidden-3: 1 incoming (from hidden-2), 1 outgoing (to output-0)
+    let (incoming, outgoing) = counts.get("hidden-3");
+    assert_eq!(incoming, 1, "hidden-3 should have 1 incoming synapse");
+    assert_eq!(outgoing, 1, "hidden-3 should have 1 outgoing synapse");
+
+    // Verify output-0: 3 incoming (from hidden-1, hidden-2, hidden-3), 0 outgoing
+    let (incoming, outgoing) = counts.get("output-0");
+    assert_eq!(incoming, 3, "output-0 should have 3 incoming synapses");
+    assert_eq!(outgoing, 0, "output-0 should have 0 outgoing synapses");
+
+    // Verify output-1: 2 incoming (from hidden-1, hidden-2), 0 outgoing
+    let (incoming, outgoing) = counts.get("output-1");
+    assert_eq!(incoming, 2, "output-1 should have 2 incoming synapses");
+    assert_eq!(outgoing, 0, "output-1 should have 0 outgoing synapses");
+
+    // Verify input-0: 0 incoming, 2 outgoing (to hidden-1, hidden-2)
+    let (incoming, outgoing) = counts.get("input-0");
+    assert_eq!(incoming, 0, "input-0 should have 0 incoming synapses");
+    assert_eq!(outgoing, 2, "input-0 should have 2 outgoing synapses");
+}
+
+#[test]
+fn test_synapse_counts_matches_original_implementation() {
+    // Verify that SynapseCounts produces the same results as the original
+    // O(n) implementation for a variety of neurons.
+    //
+    // This test ensures the optimised implementation is a drop-in replacement.
+    let creature = create_creature(
+        vec![
+            ("input-0", "input"),
+            ("input-1", "input"),
+            ("hidden-1", "hidden"),
+            ("hidden-2", "hidden"),
+            ("hidden-3", "hidden"),
+            ("output-0", "output"),
+        ],
+        vec![
+            ("input-0", "hidden-1", 1.0),
+            ("input-0", "hidden-2", 0.5),
+            ("input-1", "hidden-1", 0.8),
+            ("hidden-1", "hidden-2", 0.3),
+            ("hidden-1", "hidden-3", 0.4),
+            ("hidden-2", "output-0", 0.6),
+            ("hidden-3", "output-0", 0.7),
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    // Helper function mimicking the original implementation
+    fn count_original(neuron_uuid: &str, creature: &CreatureJson) -> (usize, usize) {
+        let incoming = creature
+            .synapses
+            .iter()
+            .filter(|s| s.to_uuid == neuron_uuid)
+            .count();
+        let outgoing = creature
+            .synapses
+            .iter()
+            .filter(|s| s.from_uuid == neuron_uuid)
+            .count();
+        (incoming, outgoing)
+    }
+
+    // Test all neurons
+    let neurons_to_test = vec![
+        "input-0",
+        "input-1",
+        "hidden-1",
+        "hidden-2",
+        "hidden-3",
+        "output-0",
+        "nonexistent",
+    ];
+
+    for neuron_uuid in neurons_to_test {
+        let (expected_in, expected_out) = count_original(neuron_uuid, &creature);
+        let (actual_in, actual_out) = counts.get(neuron_uuid);
+        assert_eq!(
+            (actual_in, actual_out),
+            (expected_in, expected_out),
+            "SynapseCounts.get({neuron_uuid}) should match original implementation"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixed performance issue in `rank_focus_neurons` where synapse counting had O(n×m) complexity. The `count_synapses_for_neuron` function was scanning all synapses twice (incoming + outgoing) for each neuron being ranked.

**Solution**: Pre-compute synapse counts into HashMaps during initialisation, reducing complexity to O(n+m).

### Changes

1. **Added `SynapseCounts` struct** (`src/focus.rs:658-705`)
   - Pre-computes incoming and outgoing synapse counts in O(m) time
   - Provides O(1) lookup via `get(neuron_uuid)` method
   - Used in three places within `rank_focus_neurons`:
     - Removal candidates filtering
     - High-error exploratory ablation candidates
     - Constant neuron removal candidates

2. **Removed deprecated `count_synapses_for_neuron` function**
   - Was performing O(m) iteration per call
   - All usages replaced with `SynapseCounts::get()`

3. **Updated `quality.sh`**
   - Exclude benchmarks from test runs (criterion benchmarks use custom harness)

## Evidence

### Benchmark Results

```
synapse_counts/old_O(n×m)/100n_500s
                        time:   [155.72 µs 155.93 µs 156.14 µs]
synapse_counts/new_O(n+m)/100n_500s
                        time:   [27.854 µs 27.898 µs 27.944 µs]

synapse_counts/old_O(n×m)/500n_10000s
                        time:   [14.089 ms 14.115 ms 14.140 ms]
synapse_counts/new_O(n+m)/500n_10000s
                        time:   [486.51 µs 487.53 µs 488.57 µs]

synapse_counts/old_O(n×m)/1000n_50000s
                        time:   [147.67 ms 147.81 ms 147.94 ms]
synapse_counts/new_O(n+m)/1000n_50000s
                        time:   [2.4810 ms 2.4890 ms 2.4974 ms]
```

| Creature Size | Old O(n×m) | New O(n+m) | Speedup |
|---------------|------------|------------|---------|
| 100 neurons, 500 synapses | 155.9 µs | 27.9 µs | **5.6x** |
| 500 neurons, 10,000 synapses | 14.1 ms | 487.5 µs | **29x** |
| 1000 neurons, 50,000 synapses | 147.8 ms | 2.49 ms | **59x** |

The improvement scales with creature size as expected from the complexity analysis.

## Test Plan

### New Tests Added
- `tests/issue_208_synapse_counts.rs`:
  - `test_synapse_counts_basic` - Basic incoming/outgoing counts
  - `test_synapse_counts_multiple_connections` - Multiple connections per neuron
  - `test_synapse_counts_neuron_with_no_synapses` - Orphan neuron handling
  - `test_synapse_counts_self_loop` - Self-referential synapses
  - `test_synapse_counts_empty_creature` - Empty creature edge case
  - `test_synapse_counts_nonexistent_neuron` - Missing neuron lookup
  - `test_synapse_counts_complex_network` - Complex topology verification
  - `test_synapse_counts_matches_original_implementation` - Correctness against original

### Benchmarks Added
- `benches/synapse_counts.rs`:
  - Compares old O(n×m) vs new O(n+m) approach
  - Tests three creature sizes: 100/500, 500/10000, 1000/50000 neurons/synapses
  - Run with: `cargo bench --bench synapse_counts`

### Existing Tests
All 200+ existing tests continue to pass, verifying no regressions in functionality.

---

## Automated Fix Details
This PR addresses issue #208: **Performance: Pre-compute synapse counts to eliminate O(n×m) complexity**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #208