### PR TITLE
Fix: Discovery: Add gradient flow analysis for focus neuron selection (#206)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.51"
+version = "0.7.52"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.52"
+version = "0.7.53"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-206.md
+++ b/docs/pr-summary-206.md
@@ -1,0 +1,107 @@
+## Summary
+
+This PR implements gradient flow analysis for focus neuron selection (Issue #206), enhancing the discovery algorithm's ability to identify neurons with high learning potential.
+
+### Problem
+
+Previously, focus neurons were ranked solely by `error × impact`, which could miss neurons that are "stuck" in saturation or have "dead" ReLU neurons with zero gradient. These neurons cannot effectively learn, making them poor candidates for discovery analysis.
+
+### Solution
+
+Added gradient flow metrics to the focus neuron ranking:
+
+1. **GradientFlowStats struct**: New struct containing three metrics:
+   - `avg_gradient_magnitude`: Average |f'(value)| across samples - higher values indicate better error signal propagation
+   - `saturation_ratio`: Fraction of samples in saturated region (gradient near zero)
+   - `dead_ratio`: Fraction of samples with zero gradient (ReLU dead zones)
+
+2. **Activation-specific gradient computation**: Implemented `compute_activation_gradient()` supporting 30+ activation functions including:
+   - ReLU family: RELU, RELU6, LEAKYRELU, ELU, SELU
+   - Sigmoid family: TANH, LOGISTIC, HARD_TANH, BIPOLAR_SIGMOID, SOFTSIGN
+   - Other: GELU, SWISH, MISH, SOFTPLUS, IDENTITY, and more
+
+3. **Saturation detection**: Function-specific thresholds:
+   - TANH: |value| > 3 (gradient < 0.01)
+   - LOGISTIC: |value| > 5
+   - HARD_TANH: |value| >= 1 (clamped)
+   - ARCTAN/SOFTSIGN: |value| > 10
+
+4. **Dead neuron detection**: Identifies ReLU neurons with negative inputs that produce zero output and zero gradient.
+
+5. **Ranking integration**: The new `compute_gradient_flow_factor()` adjusts ranking scores:
+   ```
+   factor = (1 - saturation_ratio) × (1 - dead_ratio) × gradient_boost
+   ```
+   Where `gradient_boost = 0.5 + 0.5 × clamp(avg_gradient_magnitude, 0, 1)`
+
+### Key Changes
+
+- `src/focus.rs`:
+  - Added `GradientFlowStats` struct with documentation
+  - Added `compute_activation_gradient()` for 30+ activation functions
+  - Added `is_saturated()` with function-specific thresholds
+  - Added `compute_gradient_flow_stats()` for parquet file analysis
+  - Added `compute_gradient_flow_for_neuron()` for per-neuron stats
+  - Added `compute_gradient_flow_factor()` for ranking adjustment
+  - Updated `RankedNeuron` to include `gradient_flow` field
+  - Updated `rank_focus_neurons()` and `rank_focus_neurons_with_history()` to use gradient flow in ranking
+
+- `tests/issue_206_gradient_flow_analysis.rs`:
+  - 12 comprehensive tests covering:
+    - TANH saturation detection (high/low)
+    - ReLU dead neuron detection
+    - LeakyReLU never-dead behaviour
+    - Gradient magnitude calculation
+    - LOGISTIC saturation detection
+    - Integration with focus ranking
+    - Edge cases (IDENTITY, aggregate neurons)
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface. The changes are validated through comprehensive unit tests.
+
+### Test Results
+
+All 12 new tests pass, plus all 372 existing tests continue to pass:
+
+```
+test test_tanh_saturation_detection_high_saturation ... ok
+test test_tanh_saturation_detection_low_saturation ... ok
+test test_relu_dead_neuron_detection_mostly_dead ... ok
+test test_relu_active_neuron_detection ... ok
+test test_leaky_relu_never_dead ... ok
+test test_gradient_magnitude_calculation ... ok
+test test_logistic_saturation_detection ... ok
+test test_gradient_flow_integration_with_ranking ... ok
+test test_dead_relu_deprioritised_in_ranking ... ok
+test test_gradient_flow_stats_struct_fields ... ok
+test test_identity_always_full_gradient ... ok
+test test_aggregate_neurons_handled_gracefully ... ok
+```
+
+### Expected Impact
+
+- **Better discovery targeting**: Neurons with high learning potential (good gradient flow) are prioritised
+- **Avoid wasted analysis**: Saturated or dead neurons that cannot meaningfully change are de-prioritised
+- **Complement existing ranking**: Gradient flow factor works alongside error × impact ranking
+
+## Test Plan
+
+1. **Unit tests added** (`tests/issue_206_gradient_flow_analysis.rs`):
+   - `test_tanh_saturation_detection_high_saturation`: Verifies TANH neurons with |value| > 3 are detected as saturated
+   - `test_tanh_saturation_detection_low_saturation`: Verifies TANH neurons in linear region have low saturation ratio
+   - `test_relu_dead_neuron_detection_mostly_dead`: Verifies ReLU with negative inputs has high dead ratio
+   - `test_relu_active_neuron_detection`: Verifies active ReLU has low dead ratio
+   - `test_leaky_relu_never_dead`: Verifies LeakyReLU always has zero dead ratio (never truly dead)
+   - `test_gradient_magnitude_calculation`: Verifies gradient magnitude is higher for non-saturated neurons
+   - `test_logistic_saturation_detection`: Verifies LOGISTIC saturation detection at |value| > 5
+   - `test_gradient_flow_integration_with_ranking`: Verifies saturated neurons rank lower than active ones
+   - `test_dead_relu_deprioritised_in_ranking`: Verifies dead ReLU neurons rank lower than active ones
+   - `test_gradient_flow_stats_struct_fields`: Verifies struct field access
+   - `test_identity_always_full_gradient`: Verifies IDENTITY has gradient=1.0, never saturated/dead
+   - `test_aggregate_neurons_handled_gracefully`: Verifies aggregate neurons (MINIMUM) get neutral stats
+
+2. **Quality checks passed**:
+   - All 384 tests pass (372 existing + 12 new)
+   - Clippy lints pass with `-D warnings`
+   - Release build succeeds

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -565,6 +565,13 @@ pub struct RankedNeuron {
     /// Activation-weighted impact = structural_impact × mean_activation
     /// This reflects the actual contribution the neuron makes during inference
     pub activation_weighted_impact: f32,
+    /// Issue #206: Gradient flow statistics for this neuron.
+    ///
+    /// These metrics help identify neurons with high learning potential:
+    /// - `avg_gradient_magnitude`: How much error signal can flow through
+    /// - `saturation_ratio`: % of samples in saturated activation region
+    /// - `dead_ratio`: % of samples with zero gradient (ReLU dead zones)
+    pub gradient_flow: GradientFlowStats,
 }
 
 /// A neuron with activation-weighted impact below removal savings threshold - candidate for removal.
@@ -798,6 +805,569 @@ fn activation_mean_and_variance_from_records(records: &[DiscoverRecord]) -> (f32
 ///
 /// Value 1e-10 is from Issue #217's proposal for DEAD_VARIANCE_THRESHOLD.
 const CONSTANT_VARIANCE_THRESHOLD: f32 = 1e-10;
+
+// =============================================================================
+// Gradient Flow Analysis (Issue #206)
+// =============================================================================
+
+/// Statistics about gradient flow through a neuron.
+///
+/// These metrics help identify neurons with high learning potential by analysing:
+/// 1. How much error signal can flow through the neuron (gradient magnitude)
+/// 2. Whether the neuron is stuck in a saturated region (saturation ratio)
+/// 3. Whether the neuron is effectively dead (dead ratio for ReLU-family)
+///
+/// # Usage in Focus Ranking
+///
+/// Neurons with high gradient magnitude and low saturation/dead ratios have higher
+/// learning potential and should be prioritised for discovery analysis.
+///
+/// # Example
+///
+/// ```ignore
+/// let stats = GradientFlowStats {
+///     avg_gradient_magnitude: 0.75,  // Good gradient flow
+///     saturation_ratio: 0.1,          // 10% saturated samples
+///     dead_ratio: 0.0,                // No dead samples (not ReLU)
+/// };
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct GradientFlowStats {
+    /// Average gradient magnitude across all samples.
+    ///
+    /// For a neuron with activation function f(x), this is the average of |f'(x)|
+    /// weighted by the error magnitude. Higher values indicate the neuron can
+    /// effectively propagate error signals for learning.
+    pub avg_gradient_magnitude: f32,
+
+    /// Ratio of samples where the neuron is in a saturated region (0.0 to 1.0).
+    ///
+    /// Saturation thresholds by activation:
+    /// - TANH: |value| > 3 (gradient < 0.01)
+    /// - LOGISTIC: |value| > 5 (output near 0 or 1)
+    /// - HARD_TANH: |value| > 1 (clamped to ±1)
+    ///
+    /// High saturation ratio means the neuron cannot effectively learn because
+    /// the gradient is near zero in the saturated region.
+    pub saturation_ratio: f32,
+
+    /// Ratio of samples where the neuron has zero gradient (0.0 to 1.0).
+    ///
+    /// Primarily relevant for ReLU-family activations:
+    /// - ReLU: value < 0 (completely dead - zero output and gradient)
+    /// - RELU6: value < 0 or value > 6 (dead at both ends)
+    /// - SELU: value < 0 has reduced but non-zero gradient
+    ///
+    /// High dead ratio means the neuron cannot learn from most samples.
+    /// For non-ReLU activations, this will typically be 0.0.
+    pub dead_ratio: f32,
+}
+
+impl Default for GradientFlowStats {
+    fn default() -> Self {
+        Self {
+            avg_gradient_magnitude: 1.0, // Assume full gradient for unknown activations
+            saturation_ratio: 0.0,       // Assume not saturated
+            dead_ratio: 0.0,             // Assume not dead
+        }
+    }
+}
+
+/// Saturation thresholds for various activation functions.
+/// These thresholds define when the gradient becomes effectively zero.
+mod saturation_thresholds {
+    /// TANH: |x| > 3 means tanh'(x) < 0.01 (effectively saturated)
+    pub const TANH_THRESHOLD: f32 = 3.0;
+
+    /// LOGISTIC: |x| > 5 means sigmoid'(x) < 0.007 (effectively saturated)
+    pub const LOGISTIC_THRESHOLD: f32 = 5.0;
+
+    /// HARD_TANH: |x| >= 1 means output is clamped (gradient = 0)
+    pub const HARD_TANH_THRESHOLD: f32 = 1.0;
+
+    /// ARCTAN: |x| > 10 means arctan'(x) < 0.01
+    pub const ARCTAN_THRESHOLD: f32 = 10.0;
+
+    /// SOFTSIGN: |x| > 10 means softsign'(x) < 0.008
+    pub const SOFTSIGN_THRESHOLD: f32 = 10.0;
+
+    /// Gradient threshold below which we consider the sample "saturated"
+    pub const GRADIENT_SATURATION_THRESHOLD: f32 = 0.01;
+}
+
+/// Compute the gradient (derivative) of an activation function at a given input value.
+///
+/// Returns (gradient, is_dead) where:
+/// - gradient: The derivative f'(value)
+/// - is_dead: True if this is a "dead" neuron sample (zero gradient AND zero output)
+///
+/// # Arguments
+/// * `squash` - Uppercase squash function name
+/// * `value` - Pre-activation input value
+fn compute_activation_gradient(squash: &str, value: f32) -> (f32, bool) {
+    match squash {
+        // ReLU family - can have dead neurons
+        "RELU" => {
+            if value > 0.0 {
+                (1.0, false)
+            } else {
+                (0.0, true) // Dead: zero gradient AND zero output
+            }
+        }
+        "RELU6" => {
+            if value <= 0.0 {
+                (0.0, true) // Dead at negative end
+            } else if value >= 6.0 {
+                (0.0, false) // Saturated but not "dead" (output is 6)
+            } else {
+                (1.0, false)
+            }
+        }
+        "LEAKYRELU" => {
+            // LeakyReLU never truly dead - always has 0.01 gradient for negative inputs
+            if value >= 0.0 {
+                (1.0, false)
+            } else {
+                (0.01, false)
+            }
+        }
+        "ELU" => {
+            if value >= 0.0 {
+                (1.0, false)
+            } else {
+                // ELU'(x) = exp(x) for x < 0
+                (value.exp(), false)
+            }
+        }
+        "SELU" => {
+            const ALPHA: f32 = 1.673_263_2;
+            const LAMBDA: f32 = 1.050_701;
+            if value >= 0.0 {
+                (LAMBDA, false)
+            } else {
+                (LAMBDA * ALPHA * value.exp(), false)
+            }
+        }
+
+        // Sigmoid-family - can saturate
+        "TANH" => {
+            let tanh_val = value.tanh();
+            let gradient = 1.0 - tanh_val * tanh_val;
+            (gradient, false)
+        }
+        "LOGISTIC" => {
+            let sigmoid = if value >= 0.0 {
+                1.0 / (1.0 + (-value).exp())
+            } else {
+                let exp_x = value.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            let gradient = sigmoid * (1.0 - sigmoid);
+            (gradient, false)
+        }
+        "HARD_TANH" | "CLIPPED" => {
+            if value.abs() >= saturation_thresholds::HARD_TANH_THRESHOLD {
+                (0.0, false) // Saturated but not "dead"
+            } else {
+                (1.0, false)
+            }
+        }
+        "BIPOLAR_SIGMOID" => {
+            // 2 * sigmoid(x) - 1, derivative = 2 * sigmoid(x) * (1 - sigmoid(x))
+            let sigmoid = if value >= 0.0 {
+                1.0 / (1.0 + (-value).exp())
+            } else {
+                let exp_x = value.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            (2.0 * sigmoid * (1.0 - sigmoid), false)
+        }
+        "SOFTSIGN" => {
+            // softsign'(x) = 1 / (1 + |x|)^2
+            let denom = 1.0 + value.abs();
+            (1.0 / (denom * denom), false)
+        }
+
+        // Other activations
+        "IDENTITY" => (1.0, false),
+        "ABSOLUTE" | "ABS" => {
+            if value != 0.0 {
+                (1.0, false) // |gradient| = 1 everywhere except at 0
+            } else {
+                (0.0, false) // Technically undefined at 0
+            }
+        }
+        "ARCTAN" => {
+            // arctan'(x) = 1 / (1 + x^2)
+            (1.0 / (1.0 + value * value), false)
+        }
+        "BENT_IDENTITY" => {
+            // bent_identity'(x) = x / (2 * sqrt(x^2 + 1)) + 1
+            ((value / (2.0 * (value * value + 1.0).sqrt())) + 1.0, false)
+        }
+        "CUBE" => {
+            // cube'(x) = 3x^2
+            (3.0 * value * value, false)
+        }
+        "SQUARE" => {
+            // square'(x) = 2x
+            (2.0 * value, false)
+        }
+        "GAUSSIAN" => {
+            // gaussian(x) = exp(-x^2), gaussian'(x) = -2x * exp(-x^2)
+            let safe_x = value.abs().min(100.0);
+            ((-2.0 * value * (-safe_x * safe_x).exp()).abs(), false)
+        }
+        "GELU" => {
+            // GELU gradient approximation
+            let x3 = value * value * value;
+            let tanh_arg = 0.797_884_6_f32 * (value + 0.044_715_f32 * x3);
+            let tanh_val = tanh_arg.tanh();
+            let sech2 = 1.0 - tanh_val * tanh_val;
+            let inner_deriv = 0.797_884_6_f32 * (1.0 + 3.0 * 0.044_715_f32 * value * value);
+            let gradient = 0.5 * (1.0 + tanh_val) + 0.5 * value * sech2 * inner_deriv;
+            (gradient, false)
+        }
+        "ISRU" => {
+            // ISRU(x) = x / sqrt(1 + x^2)
+            // ISRU'(x) = 1 / (1 + x^2)^(3/2)
+            let denom = (1.0 + value * value).powf(1.5);
+            (1.0 / denom, false)
+        }
+        "MISH" => {
+            // Mish(x) = x * tanh(softplus(x))
+            // Derivative is complex, approximate with numerical stability
+            let sp = if value > 20.0 {
+                value
+            } else {
+                (1.0 + value.exp()).ln()
+            };
+            let tanh_sp = sp.tanh();
+            let sech2_sp = 1.0 - tanh_sp * tanh_sp;
+            let sp_deriv = if value > 20.0 {
+                1.0
+            } else {
+                value.exp() / (1.0 + value.exp())
+            };
+            (tanh_sp + value * sech2_sp * sp_deriv, false)
+        }
+        "SOFTPLUS" => {
+            // softplus(x) = ln(1 + exp(x)), softplus'(x) = sigmoid(x)
+            let sigmoid = if value >= 0.0 {
+                1.0 / (1.0 + (-value).exp())
+            } else {
+                let exp_x = value.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            (sigmoid, false)
+        }
+        "SWISH" => {
+            // Swish(x) = x * sigmoid(x)
+            // Swish'(x) = sigmoid(x) + x * sigmoid(x) * (1 - sigmoid(x))
+            let sigmoid = if value >= 0.0 {
+                1.0 / (1.0 + (-value).exp())
+            } else {
+                let exp_x = value.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            (sigmoid + value * sigmoid * (1.0 - sigmoid), false)
+        }
+        "SINE" | "SINUSOID" => (value.cos().abs(), false),
+        "COSINE" => (value.sin().abs(), false),
+        "TAN" => {
+            let cos_val = value.cos();
+            if cos_val.abs() < 1e-6 {
+                (100.0, false) // Near asymptote, very high gradient
+            } else {
+                (1.0 / (cos_val * cos_val), false)
+            }
+        }
+        "EXPONENTIAL" => {
+            if value >= 88.0 {
+                (f32::MAX, false)
+            } else {
+                (value.exp(), false)
+            }
+        }
+        "LOGSIGMOID" => {
+            // logsigmoid(x) = -ln(1 + exp(-x))
+            // logsigmoid'(x) = 1 / (1 + exp(x)) = 1 - sigmoid(x)
+            let sigmoid = if value >= 0.0 {
+                1.0 / (1.0 + (-value).exp())
+            } else {
+                let exp_x = value.exp();
+                exp_x / (1.0 + exp_x)
+            };
+            (1.0 - sigmoid, false)
+        }
+        "SQRT" => {
+            if value > 0.0 {
+                (0.5 / value.sqrt(), false)
+            } else {
+                (0.0, false) // Undefined for negative, zero at boundary
+            }
+        }
+        "STDINVERSE" => {
+            // 1/x, derivative = -1/x^2
+            let eps = 1e-15_f32;
+            let safe_x = if value.abs() < eps { eps } else { value.abs() };
+            (1.0 / (safe_x * safe_x), false)
+        }
+        "COMPLEMENT" | "INVERSE" => {
+            // 1 - x, derivative = -1 (absolute value = 1)
+            (1.0, false)
+        }
+
+        // Threshold functions - gradient is zero almost everywhere
+        // but can still propagate useful information at the threshold
+        "STEP" | "BIPOLAR" => {
+            // Technically gradient = 0 everywhere except at threshold
+            // For gradient flow analysis, treat as having small gradient
+            (0.0, false)
+        }
+
+        // Aggregate functions - cannot compute scalar gradient
+        "MINIMUM" | "MAXIMUM" | "IF" | "MEAN" | "HYPOT" | "HYPOTV2" => {
+            // For aggregate functions, assume gradient passes through
+            // The actual gradient depends on which input "wins"
+            (1.0, false)
+        }
+
+        // Unknown activation - assume identity-like behaviour
+        _ => (1.0, false),
+    }
+}
+
+/// Check if a neuron sample is in a saturated region based on its activation function.
+///
+/// Saturation means the gradient is effectively zero, preventing learning.
+fn is_saturated(squash: &str, value: f32, gradient: f32) -> bool {
+    use saturation_thresholds::*;
+
+    // Use function-specific thresholds for common activations
+    let saturated_by_threshold = match squash {
+        "TANH" => value.abs() > TANH_THRESHOLD,
+        "LOGISTIC" => value.abs() > LOGISTIC_THRESHOLD,
+        "HARD_TANH" | "CLIPPED" => value.abs() >= HARD_TANH_THRESHOLD,
+        "ARCTAN" => value.abs() > ARCTAN_THRESHOLD,
+        "SOFTSIGN" => value.abs() > SOFTSIGN_THRESHOLD,
+        "RELU6" => !(0.0..=6.0).contains(&value),
+        // For other functions, rely on gradient threshold
+        _ => false,
+    };
+
+    // Also check gradient magnitude as a fallback
+    saturated_by_threshold || gradient < GRADIENT_SATURATION_THRESHOLD
+}
+
+/// Compute gradient flow statistics for all neurons in a creature.
+///
+/// This function analyses discovery records to compute gradient flow metrics
+/// for each selectable neuron. The metrics help identify neurons with high
+/// learning potential by measuring:
+///
+/// 1. **Gradient magnitude**: Average |f'(value)| across samples
+/// 2. **Saturation ratio**: Fraction of samples in saturated region
+/// 3. **Dead ratio**: Fraction of samples with zero gradient (ReLU-family)
+///
+/// # Arguments
+/// * `parquet_file` - Path to parquet file containing discovery records
+/// * `creature` - The creature to analyse
+///
+/// # Returns
+/// Map from neuron UUID to GradientFlowStats
+///
+/// # Example
+///
+/// ```ignore
+/// let stats = compute_gradient_flow_stats("records.parquet", &creature)?;
+/// for (uuid, flow_stats) in &stats {
+///     println!("{}: gradient={:.3}, saturated={:.1}%, dead={:.1}%",
+///         uuid,
+///         flow_stats.avg_gradient_magnitude,
+///         flow_stats.saturation_ratio * 100.0,
+///         flow_stats.dead_ratio * 100.0
+///     );
+/// }
+/// ```
+pub fn compute_gradient_flow_stats(
+    parquet_file: &str,
+    creature: &CreatureJson,
+) -> Result<HashMap<String, GradientFlowStats>> {
+    // Build squash map for efficient lookup
+    let squash_map = build_squash_map(creature);
+
+    // Load records grouped by neuron
+    let records = read_all_records_grouped_by_neuron(parquet_file)
+        .context("Failed to read discovery records for gradient flow analysis")?;
+
+    // Compute stats for each neuron
+    let stats: HashMap<String, GradientFlowStats> = creature
+        .neurons
+        .iter()
+        .filter(|n| is_selectable_type(&n.neuron_type))
+        .filter_map(|neuron| {
+            let squash = squash_map.get(&neuron.uuid)?;
+            let neuron_records = records.get(&neuron.uuid)?;
+
+            if neuron_records.is_empty() {
+                return Some((neuron.uuid.clone(), GradientFlowStats::default()));
+            }
+
+            let mut total_gradient = 0.0f64;
+            let mut saturated_count = 0u32;
+            let mut dead_count = 0u32;
+            let mut valid_count = 0u32;
+
+            for record in neuron_records.iter() {
+                // Use pre-activation value if available, otherwise skip
+                let value = match record.value {
+                    Some(v) if v.is_finite() => v,
+                    _ => continue,
+                };
+
+                let (gradient, is_dead) = compute_activation_gradient(squash, value);
+
+                if !gradient.is_finite() {
+                    continue;
+                }
+
+                valid_count += 1;
+                total_gradient += gradient as f64;
+
+                if is_dead {
+                    dead_count += 1;
+                }
+
+                if is_saturated(squash, value, gradient) {
+                    saturated_count += 1;
+                }
+            }
+
+            if valid_count == 0 {
+                return Some((neuron.uuid.clone(), GradientFlowStats::default()));
+            }
+
+            let avg_gradient_magnitude = (total_gradient / valid_count as f64) as f32;
+            let saturation_ratio = saturated_count as f32 / valid_count as f32;
+            let dead_ratio = dead_count as f32 / valid_count as f32;
+
+            Some((
+                neuron.uuid.clone(),
+                GradientFlowStats {
+                    avg_gradient_magnitude,
+                    saturation_ratio,
+                    dead_ratio,
+                },
+            ))
+        })
+        .collect();
+
+    Ok(stats)
+}
+
+/// Compute gradient flow stats for a single neuron from its discovery records.
+///
+/// This is a helper function for use within `rank_focus_neurons` where records
+/// are already loaded and we want to avoid re-loading the parquet file.
+///
+/// # Arguments
+/// * `neuron_uuid` - UUID of the neuron
+/// * `squash_map` - Map from neuron UUID to uppercase squash name
+/// * `records` - Discovery records for this neuron
+///
+/// # Returns
+/// GradientFlowStats for the neuron
+fn compute_gradient_flow_for_neuron(
+    neuron_uuid: &str,
+    squash_map: &HashMap<String, String>,
+    records: &[DiscoverRecord],
+) -> GradientFlowStats {
+    let squash = match squash_map.get(neuron_uuid) {
+        Some(s) => s.as_str(),
+        None => return GradientFlowStats::default(),
+    };
+
+    if records.is_empty() {
+        return GradientFlowStats::default();
+    }
+
+    let mut total_gradient = 0.0f64;
+    let mut saturated_count = 0u32;
+    let mut dead_count = 0u32;
+    let mut valid_count = 0u32;
+
+    for record in records {
+        // Use pre-activation value if available, otherwise skip
+        let value = match record.value {
+            Some(v) if v.is_finite() => v,
+            _ => continue,
+        };
+
+        let (gradient, is_dead) = compute_activation_gradient(squash, value);
+
+        if !gradient.is_finite() {
+            continue;
+        }
+
+        valid_count += 1;
+        total_gradient += gradient as f64;
+
+        if is_dead {
+            dead_count += 1;
+        }
+
+        if is_saturated(squash, value, gradient) {
+            saturated_count += 1;
+        }
+    }
+
+    if valid_count == 0 {
+        return GradientFlowStats::default();
+    }
+
+    let avg_gradient_magnitude = (total_gradient / valid_count as f64) as f32;
+    let saturation_ratio = saturated_count as f32 / valid_count as f32;
+    let dead_ratio = dead_count as f32 / valid_count as f32;
+
+    GradientFlowStats {
+        avg_gradient_magnitude,
+        saturation_ratio,
+        dead_ratio,
+    }
+}
+
+/// Compute a ranking factor from gradient flow statistics.
+///
+/// This factor adjusts the base ranking score (error × impact) to prioritise
+/// neurons with high learning potential:
+///
+/// ```text
+/// factor = (1 - saturation_ratio) × (1 - dead_ratio) × gradient_boost
+/// ```
+///
+/// where `gradient_boost = 0.5 + 0.5 × clamp(avg_gradient_magnitude, 0, 1)`
+/// ensures the factor is always positive and rewards higher gradient magnitudes.
+///
+/// # Returns
+/// A factor in range (0.0, 1.0] that multiplies the base ranking score.
+fn compute_gradient_flow_factor(stats: &GradientFlowStats) -> f32 {
+    // Factor for saturation: 1.0 when no saturation, 0.0 when fully saturated
+    let saturation_factor = (1.0 - stats.saturation_ratio).max(0.0);
+
+    // Factor for dead neurons: 1.0 when no dead samples, 0.0 when fully dead
+    let dead_factor = (1.0 - stats.dead_ratio).max(0.0);
+
+    // Factor for gradient magnitude: boost neurons with higher gradient
+    // Clamp to [0, 1] range for consistent scaling, then apply 0.5 + 0.5*x
+    // This ensures factor is always >= 0.5 (never completely kills the score)
+    let clamped_gradient = stats.avg_gradient_magnitude.clamp(0.0, 1.0);
+    let gradient_boost = 0.5 + 0.5 * clamped_gradient;
+
+    // Combine factors multiplicatively
+    // Minimum factor is ~0.01 to ensure neurons aren't completely hidden
+    (saturation_factor * dead_factor * gradient_boost).max(0.01)
+}
 
 fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)>> {
     let mut adjacency: HashMap<String, Vec<(String, f32)>> = HashMap::new();
@@ -1529,6 +2099,9 @@ pub fn rank_focus_neurons(
     // By pre-computing counts into HashMaps, we reduce to O(m) for init + O(1) per lookup.
     let synapse_counts = SynapseCounts::new(creature);
 
+    // Issue #206: Build squash map for gradient flow analysis
+    let squash_map = build_squash_map(creature);
+
     // Now we can safely unwrap since we've verified all selectable neurons have records
     // Use parallel iteration for faster processing on multi-core systems
     let mut neurons: Vec<RankedNeuron> = selectable
@@ -1552,6 +2125,11 @@ pub fn rank_focus_neurons(
             } else {
                 raw_error
             };
+
+            // Issue #206: Compute gradient flow stats for this neuron
+            let gradient_flow =
+                compute_gradient_flow_for_neuron(&neuron.uuid, &squash_map, &records);
+
             Ok(RankedNeuron {
                 neuron_uuid: neuron.uuid.clone(),
                 total_error,
@@ -1559,24 +2137,43 @@ pub fn rank_focus_neurons(
                 impact: structural_impact,
                 mean_activation,
                 activation_weighted_impact,
+                gradient_flow,
             })
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // Sort by weighted score (error × impact) to prioritise neurons that:
+    // Sort by weighted score (error × impact × gradient_factor) to prioritise neurons that:
     // 1. Have high error (potential for improvement)
     // 2. Have high impact (changes will affect output)
-    // This ensures output neurons and neurons close to outputs are prioritised
-    // over high-error hidden neurons with minimal impact on the creature's score.
+    // 3. Have good gradient flow (can actually learn - Issue #206)
     //
     // Dec 2025: We deliberately soften (but do not remove) the output bias by applying a
     // sub-linear exponent to impact. This increases exploration of hidden neurons without
     // letting low-impact neurons dominate purely due to noisy per-neuron errors.
+    //
+    // Jan 2026 (Issue #206): We further adjust ranking by gradient flow factor:
+    // - Neurons stuck in saturation (high saturation_ratio) are de-prioritised
+    // - Dead ReLU neurons (high dead_ratio) are de-prioritised
+    // - Neurons with good gradient flow get higher priority
     const IMPACT_EPSILON: f32 = 0.0001;
     const IMPACT_GAMMA: f32 = 0.8;
     neurons.sort_by(|a, b| {
-        let a_weighted = a.total_error * (a.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
-        let b_weighted = b.total_error * (b.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
+        // Base weighted score: error × impact^gamma
+        let a_base = a.total_error * (a.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
+        let b_base = b.total_error * (b.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
+
+        // Issue #206: Apply gradient flow factor
+        // Factor = (1 - saturation_ratio) × (1 - dead_ratio) × (0.5 + avg_gradient_magnitude/2)
+        // This gives higher scores to neurons with:
+        // - Low saturation (more room to learn)
+        // - Low dead ratio (not stuck at zero)
+        // - Higher gradient magnitude (better error propagation)
+        let a_gradient_factor = compute_gradient_flow_factor(&a.gradient_flow);
+        let b_gradient_factor = compute_gradient_flow_factor(&b.gradient_flow);
+
+        let a_weighted = a_base * a_gradient_factor;
+        let b_weighted = b_base * b_gradient_factor;
+
         b_weighted
             .partial_cmp(&a_weighted)
             .unwrap_or(Ordering::Equal)
@@ -2015,6 +2612,9 @@ pub fn rank_focus_neurons_with_history(
     // Pre-compute synapse counts for O(1) lookup
     let synapse_counts = SynapseCounts::new(creature);
 
+    // Issue #206: Build squash map for gradient flow analysis
+    let squash_map = build_squash_map(creature);
+
     // Build neurons with base metrics
     let mut neurons: Vec<RankedNeuron> = selectable
         .par_iter()
@@ -2030,6 +2630,11 @@ pub fn rank_focus_neurons_with_history(
             } else {
                 raw_error
             };
+
+            // Issue #206: Compute gradient flow stats for this neuron
+            let gradient_flow =
+                compute_gradient_flow_for_neuron(&neuron.uuid, &squash_map, &records);
+
             Ok(RankedNeuron {
                 neuron_uuid: neuron.uuid.clone(),
                 total_error,
@@ -2037,18 +2642,27 @@ pub fn rank_focus_neurons_with_history(
                 impact: structural_impact,
                 mean_activation,
                 activation_weighted_impact,
+                gradient_flow,
             })
         })
         .collect::<Result<Vec<_>>>()?;
 
-    // Sort by weighted score with optional history factor
+    // Sort by weighted score with optional history factor and gradient flow factor
     // Issue #227: Incorporate historical success rate into ranking
+    // Issue #206: Incorporate gradient flow analysis into ranking
     const IMPACT_EPSILON: f32 = 0.0001;
     const IMPACT_GAMMA: f32 = 0.8;
 
     neurons.sort_by(|a, b| {
         let a_base = a.total_error * (a.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
         let b_base = b.total_error * (b.impact + IMPACT_EPSILON).powf(IMPACT_GAMMA);
+
+        // Issue #206: Apply gradient flow factor
+        let a_gradient_factor = compute_gradient_flow_factor(&a.gradient_flow);
+        let b_gradient_factor = compute_gradient_flow_factor(&b.gradient_flow);
+
+        let a_with_gradient = a_base * a_gradient_factor;
+        let b_with_gradient = b_base * b_gradient_factor;
 
         // Apply history factor if available
         // History factor is in [0, 1], where 0.5 is neutral
@@ -2062,9 +2676,12 @@ pub fn rank_focus_neurons_with_history(
             let b_history = h.bayesian_score_for(&b.neuron_uuid) as f32;
             let a_multiplier = 0.5 + a_history;
             let b_multiplier = 0.5 + b_history;
-            (a_base * a_multiplier, b_base * b_multiplier)
+            (
+                a_with_gradient * a_multiplier,
+                b_with_gradient * b_multiplier,
+            )
         } else {
-            (a_base, b_base)
+            (a_with_gradient, b_with_gradient)
         };
 
         b_weighted

--- a/tests/issue_206_gradient_flow_analysis.rs
+++ b/tests/issue_206_gradient_flow_analysis.rs
@@ -1,0 +1,797 @@
+//! Tests for gradient flow analysis in focus neuron selection (Issue #206)
+//!
+//! ## Overview
+//!
+//! This module tests the gradient flow analysis feature which enhances focus neuron
+//! selection by analysing gradient flow through the network to identify neurons with
+//! high learning potential.
+//!
+//! ## Key Metrics
+//!
+//! 1. **Gradient magnitude**: How much error signal flows through this neuron
+//! 2. **Saturation ratio**: Percentage of samples in saturated activation region
+//! 3. **Dead neuron ratio**: Percentage of samples with zero gradient (ReLU dead zones)
+//!
+//! ## Test Strategy (TDD)
+//!
+//! 1. Test saturation detection for TANH near ±1
+//! 2. Test dead neuron detection for ReLU with negative inputs
+//! 3. Test gradient magnitude ranking
+//! 4. Verify integration with existing focus selection
+
+mod common;
+
+use neat_ai_discovery::focus::{
+    compute_gradient_flow_stats, rank_focus_neurons, GradientFlowStats,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Helper to create a neuron with specified squash function
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Helper to create a synapse
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Helper to create a simple creature with specified neurons and synapses
+fn create_creature(
+    neurons: Vec<NeuronJson>,
+    synapses: Vec<SynapseJson>,
+    input: usize,
+) -> CreatureJson {
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input,
+        output: output_count,
+    }
+}
+
+/// Sample data: (value, activation, error) triple.
+type Sample = (f32, f32, f32);
+
+/// Neuron sample data: (uuid, samples) pair.
+type NeuronSamples<'a> = (&'a str, Vec<Sample>);
+
+/// Create discovery records with specific pre-activation values
+///
+/// The `value` field represents pre-activation (before squash function).
+/// The `activation` field represents post-squash output.
+fn create_records_with_values(data: Vec<NeuronSamples<'_>>) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for (uuid, samples) in data {
+        for (obs_idx, (value, activation, error)) in samples.into_iter().enumerate() {
+            records.push(DiscoverRecord::new(
+                obs_idx as u32,
+                uuid.to_string(),
+                Some(value),
+                activation,
+                vec![error],
+            ));
+        }
+    }
+    records
+}
+
+// =============================================================================
+// Test: Saturation Detection for TANH
+// =============================================================================
+
+/// Test that TANH neurons with activations near ±1 are detected as saturated.
+///
+/// TANH saturation:
+/// - At |input| > 3: output ≈ ±1, derivative ≈ 0
+/// - The saturation ratio should be high when most samples have |value| > 3
+#[test]
+fn test_tanh_saturation_detection_high_saturation() {
+    // Create a network with a TANH neuron
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records where hidden-1 is heavily saturated (|value| > 3)
+    // TANH(5) ≈ 0.9999, TANH(-5) ≈ -0.9999
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (5.0, 0.9999, 0.1),   // Saturated positive
+                (-5.0, -0.9999, 0.1), // Saturated negative
+                (4.0, 0.9993, 0.1),   // Saturated positive
+                (-4.0, -0.9993, 0.1), // Saturated negative
+                (0.5, 0.462, 0.1),    // Not saturated
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (0.9999, 0.9999, 0.1),
+                (-0.9999, -0.9999, 0.1),
+                (0.9993, 0.9993, 0.1),
+                (-0.9993, -0.9993, 0.1),
+                (0.462, 0.462, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Compute gradient flow stats
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    // hidden-1 should have high saturation ratio (4/5 = 80%)
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.saturation_ratio >= 0.7,
+        "TANH hidden-1 should have saturation_ratio >= 0.7, got {}",
+        hidden_stats.saturation_ratio
+    );
+}
+
+/// Test that TANH neurons operating in linear region have low saturation.
+#[test]
+fn test_tanh_saturation_detection_low_saturation() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records where hidden-1 operates in linear region (|value| < 1)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (0.1, 0.0997, 0.1),  // Linear region
+                (-0.2, -0.197, 0.1), // Linear region
+                (0.5, 0.462, 0.1),   // Linear region
+                (-0.3, -0.291, 0.1), // Linear region
+                (0.8, 0.664, 0.1),   // Slightly non-linear but not saturated
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (0.0997, 0.0997, 0.1),
+                (-0.197, -0.197, 0.1),
+                (0.462, 0.462, 0.1),
+                (-0.291, -0.291, 0.1),
+                (0.664, 0.664, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.saturation_ratio <= 0.2,
+        "TANH hidden-1 in linear region should have saturation_ratio <= 0.2, got {}",
+        hidden_stats.saturation_ratio
+    );
+}
+
+// =============================================================================
+// Test: Dead Neuron Detection for ReLU
+// =============================================================================
+
+/// Test that ReLU neurons with mostly negative inputs are detected as "dead".
+///
+/// A dead ReLU:
+/// - Has output = 0 for all negative inputs
+/// - Has gradient = 0 for negative inputs (cannot learn)
+/// - The dead_ratio represents % of samples with zero gradient
+#[test]
+fn test_relu_dead_neuron_detection_mostly_dead() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "RELU"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records where hidden-1 has mostly negative inputs (dead zone)
+    // ReLU(x) = max(0, x), so negative inputs produce 0 output and 0 gradient
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (-5.0, 0.0, 0.1), // Dead (negative input)
+                (-2.0, 0.0, 0.1), // Dead
+                (-1.0, 0.0, 0.1), // Dead
+                (-0.5, 0.0, 0.1), // Dead
+                (0.5, 0.5, 0.1),  // Active
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (0.0, 0.0, 0.1),
+                (0.0, 0.0, 0.1),
+                (0.0, 0.0, 0.1),
+                (0.0, 0.0, 0.1),
+                (0.5, 0.5, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.dead_ratio >= 0.7,
+        "ReLU hidden-1 with mostly negative inputs should have dead_ratio >= 0.7, got {}",
+        hidden_stats.dead_ratio
+    );
+}
+
+/// Test that active ReLU neurons have low dead ratio.
+#[test]
+fn test_relu_active_neuron_detection() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "RELU"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records where hidden-1 has mostly positive inputs (active)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (1.0, 1.0, 0.1),  // Active
+                (2.0, 2.0, 0.1),  // Active
+                (0.5, 0.5, 0.1),  // Active
+                (3.0, 3.0, 0.1),  // Active
+                (-0.1, 0.0, 0.1), // Dead (but only one sample)
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (1.0, 1.0, 0.1),
+                (2.0, 2.0, 0.1),
+                (0.5, 0.5, 0.1),
+                (3.0, 3.0, 0.1),
+                (0.0, 0.0, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.dead_ratio <= 0.3,
+        "ReLU hidden-1 with mostly positive inputs should have dead_ratio <= 0.3, got {}",
+        hidden_stats.dead_ratio
+    );
+}
+
+// =============================================================================
+// Test: LeakyReLU Never Dead
+// =============================================================================
+
+/// Test that LeakyReLU neurons are never considered "dead" since they always have non-zero gradient.
+#[test]
+fn test_leaky_relu_never_dead() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "LEAKYRELU"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records with negative inputs - LeakyReLU still has gradient (0.01)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (-5.0, -0.05, 0.1), // Leaky output
+                (-2.0, -0.02, 0.1), // Leaky output
+                (-1.0, -0.01, 0.1), // Leaky output
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (-0.05, -0.05, 0.1),
+                (-0.02, -0.02, 0.1),
+                (-0.01, -0.01, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.dead_ratio == 0.0,
+        "LeakyReLU should never have dead neurons, got dead_ratio {}",
+        hidden_stats.dead_ratio
+    );
+}
+
+// =============================================================================
+// Test: Gradient Magnitude Calculation
+// =============================================================================
+
+/// Test that gradient magnitude is correctly computed from error and activation gradient.
+///
+/// For a target neuron with squash function f, the gradient magnitude through
+/// a neuron should reflect |error × f'(value)|.
+#[test]
+fn test_gradient_magnitude_calculation() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("hidden-2", "hidden", "TANH"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("input-0", "hidden-2", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+            synapse("hidden-2", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // hidden-1: operates in linear region (high gradient)
+    // hidden-2: operates in saturated region (low gradient)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (0.5, 0.462, 0.5), // TANH'(0.5) ≈ 0.786
+                (0.3, 0.291, 0.5), // TANH'(0.3) ≈ 0.915
+            ],
+        ),
+        (
+            "hidden-2",
+            vec![
+                (5.0, 0.9999, 0.5), // TANH'(5.0) ≈ 0.0 (saturated)
+                (4.0, 0.9993, 0.5), // TANH'(4.0) ≈ 0.0007
+            ],
+        ),
+        ("output-0", vec![(1.461, 1.461, 0.5), (1.290, 1.290, 0.5)]),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden1_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    let hidden2_stats = stats.get("hidden-2").expect("hidden-2 stats should exist");
+
+    // hidden-1 should have higher gradient magnitude than hidden-2
+    assert!(
+        hidden1_stats.avg_gradient_magnitude > hidden2_stats.avg_gradient_magnitude,
+        "hidden-1 (linear region) should have higher gradient than hidden-2 (saturated). \
+         hidden-1: {}, hidden-2: {}",
+        hidden1_stats.avg_gradient_magnitude,
+        hidden2_stats.avg_gradient_magnitude
+    );
+}
+
+// =============================================================================
+// Test: LOGISTIC Saturation Detection
+// =============================================================================
+
+/// Test saturation detection for LOGISTIC activation function.
+///
+/// LOGISTIC(x) = 1 / (1 + exp(-x))
+/// - At x > 5 or x < -5: output approaches 0 or 1, gradient approaches 0
+#[test]
+fn test_logistic_saturation_detection() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Create records where hidden-1 is saturated (|value| > 5)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (10.0, 0.99995, 0.1),  // Saturated high
+                (-10.0, 0.00005, 0.1), // Saturated low
+                (6.0, 0.9975, 0.1),    // Saturated
+                (-6.0, 0.0025, 0.1),   // Saturated
+                (0.0, 0.5, 0.1),       // Not saturated (linear region)
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (0.99995, 0.99995, 0.1),
+                (0.00005, 0.00005, 0.1),
+                (0.9975, 0.9975, 0.1),
+                (0.0025, 0.0025, 0.1),
+                (0.5, 0.5, 0.1),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.saturation_ratio >= 0.7,
+        "LOGISTIC hidden-1 should have saturation_ratio >= 0.7, got {}",
+        hidden_stats.saturation_ratio
+    );
+}
+
+// =============================================================================
+// Test: Integration with Focus Neuron Ranking
+// =============================================================================
+
+/// Test that gradient flow stats are incorporated into focus neuron ranking.
+///
+/// Neurons with high error × impact but stuck in saturation should be
+/// de-prioritised compared to neurons that can actually learn.
+#[test]
+fn test_gradient_flow_integration_with_ranking() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-saturated", "hidden", "TANH"),
+            neuron("hidden-active", "hidden", "TANH"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-saturated", 1.0),
+            synapse("input-0", "hidden-active", 1.0),
+            synapse("hidden-saturated", "output-0", 1.0),
+            synapse("hidden-active", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Both neurons have same error and impact, but:
+    // - hidden-saturated is in saturation (cannot learn)
+    // - hidden-active is in linear region (can learn)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-saturated",
+            vec![
+                (5.0, 0.9999, 0.5),  // Saturated
+                (6.0, 0.99998, 0.5), // Saturated
+                (4.0, 0.9993, 0.5),  // Saturated
+                (5.5, 0.99995, 0.5), // Saturated
+                (7.0, 0.99999, 0.5), // Saturated
+            ],
+        ),
+        (
+            "hidden-active",
+            vec![
+                (0.3, 0.291, 0.5),   // Active (gradient ~0.92)
+                (0.5, 0.462, 0.5),   // Active (gradient ~0.79)
+                (-0.2, -0.197, 0.5), // Active
+                (0.1, 0.0997, 0.5),  // Active
+                (-0.4, -0.38, 0.5),  // Active
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (1.29, 1.29, 0.5),
+                (1.46, 1.46, 0.5),
+                (0.79, 0.79, 0.5),
+                (1.10, 1.10, 0.5),
+                (0.62, 0.62, 0.5),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    // Rank with gradient flow analysis enabled
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    // Find positions of both neurons
+    let saturated_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "hidden-saturated");
+    let active_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "hidden-active");
+
+    assert!(
+        saturated_pos.is_some() && active_pos.is_some(),
+        "Both hidden neurons should be in ranking"
+    );
+
+    // hidden-active should rank HIGHER (lower position index) than hidden-saturated
+    // because it has higher learning potential (not stuck in saturation)
+    assert!(
+        active_pos.unwrap() < saturated_pos.unwrap(),
+        "hidden-active (rank {}) should rank higher than hidden-saturated (rank {})",
+        active_pos.unwrap(),
+        saturated_pos.unwrap()
+    );
+}
+
+/// Test that dead ReLU neurons are de-prioritised in ranking.
+#[test]
+fn test_dead_relu_deprioritised_in_ranking() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-dead", "hidden", "RELU"),
+            neuron("hidden-active", "hidden", "RELU"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-dead", 1.0),
+            synapse("input-0", "hidden-active", 1.0),
+            synapse("hidden-dead", "output-0", 1.0),
+            synapse("hidden-active", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    // Both have same structural impact, but:
+    // - hidden-dead always receives negative inputs (dead)
+    // - hidden-active receives positive inputs (active)
+    let records = create_records_with_values(vec![
+        (
+            "hidden-dead",
+            vec![
+                (-2.0, 0.0, 0.5), // Dead
+                (-1.0, 0.0, 0.5), // Dead
+                (-3.0, 0.0, 0.5), // Dead
+                (-0.5, 0.0, 0.5), // Dead
+                (-1.5, 0.0, 0.5), // Dead
+            ],
+        ),
+        (
+            "hidden-active",
+            vec![
+                (1.0, 1.0, 0.5), // Active
+                (2.0, 2.0, 0.5), // Active
+                (0.5, 0.5, 0.5), // Active
+                (1.5, 1.5, 0.5), // Active
+                (3.0, 3.0, 0.5), // Active
+            ],
+        ),
+        (
+            "output-0",
+            vec![
+                (1.0, 1.0, 0.5),
+                (2.0, 2.0, 0.5),
+                (0.5, 0.5, 0.5),
+                (1.5, 1.5, 0.5),
+                (3.0, 3.0, 0.5),
+            ],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    let dead_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "hidden-dead");
+    let active_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "hidden-active");
+
+    assert!(
+        dead_pos.is_some() && active_pos.is_some(),
+        "Both hidden neurons should be in ranking"
+    );
+
+    // hidden-active should rank higher than hidden-dead
+    assert!(
+        active_pos.unwrap() < dead_pos.unwrap(),
+        "hidden-active (rank {}) should rank higher than hidden-dead (rank {})",
+        active_pos.unwrap(),
+        dead_pos.unwrap()
+    );
+}
+
+// =============================================================================
+// Test: GradientFlowStats struct fields
+// =============================================================================
+
+/// Test that GradientFlowStats contains the expected fields.
+#[test]
+fn test_gradient_flow_stats_struct_fields() {
+    let stats = GradientFlowStats {
+        avg_gradient_magnitude: 0.5,
+        saturation_ratio: 0.2,
+        dead_ratio: 0.0,
+    };
+
+    assert!((stats.avg_gradient_magnitude - 0.5).abs() < f32::EPSILON);
+    assert!((stats.saturation_ratio - 0.2).abs() < f32::EPSILON);
+    assert!((stats.dead_ratio - 0.0).abs() < f32::EPSILON);
+}
+
+// =============================================================================
+// Test: Edge Cases
+// =============================================================================
+
+/// Test gradient flow with IDENTITY activation (gradient always 1.0).
+#[test]
+fn test_identity_always_full_gradient() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "IDENTITY"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        1,
+    );
+
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (100.0, 100.0, 0.1), // IDENTITY passes through
+                (-100.0, -100.0, 0.1),
+                (0.0, 0.0, 0.1),
+            ],
+        ),
+        (
+            "output-0",
+            vec![(100.0, 100.0, 0.1), (-100.0, -100.0, 0.1), (0.0, 0.0, 0.1)],
+        ),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+
+    // IDENTITY: gradient = 1.0, never saturated, never dead
+    assert!(
+        hidden_stats.saturation_ratio == 0.0,
+        "IDENTITY should never be saturated, got {}",
+        hidden_stats.saturation_ratio
+    );
+    assert!(
+        hidden_stats.dead_ratio == 0.0,
+        "IDENTITY should never be dead, got {}",
+        hidden_stats.dead_ratio
+    );
+}
+
+/// Test gradient flow with aggregate neurons (MINIMUM/MAXIMUM/IF).
+///
+/// Aggregate neurons cannot compute scalar gradients - they should
+/// be handled gracefully with default values.
+#[test]
+fn test_aggregate_neurons_handled_gracefully() {
+    let creature = create_creature(
+        vec![
+            neuron("hidden-1", "hidden", "MINIMUM"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+        2,
+    );
+
+    let records = create_records_with_values(vec![
+        (
+            "hidden-1",
+            vec![
+                (0.5, 0.3, 0.1), // MINIMUM selects one input
+                (0.8, 0.2, 0.1),
+            ],
+        ),
+        ("output-0", vec![(0.3, 0.3, 0.1), (0.2, 0.2, 0.1)]),
+    ]);
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let stats = compute_gradient_flow_stats(file_path, &creature).unwrap();
+
+    // Aggregate neurons should have default/neutral gradient stats
+    // (neither saturated nor dead - they just pass through winning input)
+    let hidden_stats = stats.get("hidden-1").expect("hidden-1 stats should exist");
+    assert!(
+        hidden_stats.saturation_ratio <= 0.1,
+        "MINIMUM should have low saturation, got {}",
+        hidden_stats.saturation_ratio
+    );
+}


### PR DESCRIPTION
## Summary

This PR implements gradient flow analysis for focus neuron selection (Issue #206), enhancing the discovery algorithm's ability to identify neurons with high learning potential.

### Problem

Previously, focus neurons were ranked solely by `error × impact`, which could miss neurons that are "stuck" in saturation or have "dead" ReLU neurons with zero gradient. These neurons cannot effectively learn, making them poor candidates for discovery analysis.

### Solution

Added gradient flow metrics to the focus neuron ranking:

1. **GradientFlowStats struct**: New struct containing three metrics:
   - `avg_gradient_magnitude`: Average |f'(value)| across samples - higher values indicate better error signal propagation
   - `saturation_ratio`: Fraction of samples in saturated region (gradient near zero)
   - `dead_ratio`: Fraction of samples with zero gradient (ReLU dead zones)

2. **Activation-specific gradient computation**: Implemented `compute_activation_gradient()` supporting 30+ activation functions including:
   - ReLU family: RELU, RELU6, LEAKYRELU, ELU, SELU
   - Sigmoid family: TANH, LOGISTIC, HARD_TANH, BIPOLAR_SIGMOID, SOFTSIGN
   - Other: GELU, SWISH, MISH, SOFTPLUS, IDENTITY, and more

3. **Saturation detection**: Function-specific thresholds:
   - TANH: |value| > 3 (gradient < 0.01)
   - LOGISTIC: |value| > 5
   - HARD_TANH: |value| >= 1 (clamped)
   - ARCTAN/SOFTSIGN: |value| > 10

4. **Dead neuron detection**: Identifies ReLU neurons with negative inputs that produce zero output and zero gradient.

5. **Ranking integration**: The new `compute_gradient_flow_factor()` adjusts ranking scores:
   ```
   factor = (1 - saturation_ratio) × (1 - dead_ratio) × gradient_boost
   ```
   Where `gradient_boost = 0.5 + 0.5 × clamp(avg_gradient_magnitude, 0, 1)`

### Key Changes

- `src/focus.rs`:
  - Added `GradientFlowStats` struct with documentation
  - Added `compute_activation_gradient()` for 30+ activation functions
  - Added `is_saturated()` with function-specific thresholds
  - Added `compute_gradient_flow_stats()` for parquet file analysis
  - Added `compute_gradient_flow_for_neuron()` for per-neuron stats
  - Added `compute_gradient_flow_factor()` for ranking adjustment
  - Updated `RankedNeuron` to include `gradient_flow` field
  - Updated `rank_focus_neurons()` and `rank_focus_neurons_with_history()` to use gradient flow in ranking

- `tests/issue_206_gradient_flow_analysis.rs`:
  - 12 comprehensive tests covering:
    - TANH saturation detection (high/low)
    - ReLU dead neuron detection
    - LeakyReLU never-dead behaviour
    - Gradient magnitude calculation
    - LOGISTIC saturation detection
    - Integration with focus ranking
    - Edge cases (IDENTITY, aggregate neurons)

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface. The changes are validated through comprehensive unit tests.

### Test Results

All 12 new tests pass, plus all 372 existing tests continue to pass:

```
test test_tanh_saturation_detection_high_saturation ... ok
test test_tanh_saturation_detection_low_saturation ... ok
test test_relu_dead_neuron_detection_mostly_dead ... ok
test test_relu_active_neuron_detection ... ok
test test_leaky_relu_never_dead ... ok
test test_gradient_magnitude_calculation ... ok
test test_logistic_saturation_detection ... ok
test test_gradient_flow_integration_with_ranking ... ok
test test_dead_relu_deprioritised_in_ranking ... ok
test test_gradient_flow_stats_struct_fields ... ok
test test_identity_always_full_gradient ... ok
test test_aggregate_neurons_handled_gracefully ... ok
```

### Expected Impact

- **Better discovery targeting**: Neurons with high learning potential (good gradient flow) are prioritised
- **Avoid wasted analysis**: Saturated or dead neurons that cannot meaningfully change are de-prioritised
- **Complement existing ranking**: Gradient flow factor works alongside error × impact ranking

## Test Plan

1. **Unit tests added** (`tests/issue_206_gradient_flow_analysis.rs`):
   - `test_tanh_saturation_detection_high_saturation`: Verifies TANH neurons with |value| > 3 are detected as saturated
   - `test_tanh_saturation_detection_low_saturation`: Verifies TANH neurons in linear region have low saturation ratio
   - `test_relu_dead_neuron_detection_mostly_dead`: Verifies ReLU with negative inputs has high dead ratio
   - `test_relu_active_neuron_detection`: Verifies active ReLU has low dead ratio
   - `test_leaky_relu_never_dead`: Verifies LeakyReLU always has zero dead ratio (never truly dead)
   - `test_gradient_magnitude_calculation`: Verifies gradient magnitude is higher for non-saturated neurons
   - `test_logistic_saturation_detection`: Verifies LOGISTIC saturation detection at |value| > 5
   - `test_gradient_flow_integration_with_ranking`: Verifies saturated neurons rank lower than active ones
   - `test_dead_relu_deprioritised_in_ranking`: Verifies dead ReLU neurons rank lower than active ones
   - `test_gradient_flow_stats_struct_fields`: Verifies struct field access
   - `test_identity_always_full_gradient`: Verifies IDENTITY has gradient=1.0, never saturated/dead
   - `test_aggregate_neurons_handled_gracefully`: Verifies aggregate neurons (MINIMUM) get neutral stats

2. **Quality checks passed**:
   - All 384 tests pass (372 existing + 12 new)
   - Clippy lints pass with `-D warnings`
   - Release build succeeds

---

## Automated Fix Details
This PR addresses issue #206: **Discovery: Add gradient flow analysis for focus neuron selection**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #206