### PR TITLE
Fix: GPU detection failed on a Mac (#326)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.59"
+version = "0.7.60"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.7.60"
+version = "0.7.61"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-326.md
+++ b/docs/pr-summary-326.md
@@ -1,0 +1,51 @@
+## Summary
+
+Fixed GPU detection failing on macOS due to an overly strict memory availability check.
+
+The bug occurred when a Mac reported low "available" memory (e.g., 1.0GB on an 8GB system) due to macOS's aggressive file caching. The library's 1GB minimum threshold would fail even though macOS can quickly reclaim this cached memory when needed.
+
+### Root Cause
+
+1. **macOS memory reporting**: macOS aggressively caches files in RAM, making "available" memory appear artificially low
+2. **Strict threshold**: The library used a 1GB minimum on all platforms
+3. **Misleading error**: Memory check failure returned `is_error: false`, so NEAT-AI reported "no usable GPU detected" instead of the actual memory issue
+
+### Changes
+
+1. **Platform-specific memory thresholds**:
+   - macOS: 0.5GB minimum (down from 1GB) - safe due to unified memory and quick cache reclamation
+   - Linux: 1GB minimum (unchanged) - conservative for headless servers
+
+2. **Error status on macOS**: Memory check failure now sets `is_error: true` on macOS so callers receive proper error messaging about the memory issue, not "no usable GPU"
+
+3. **Improved precision**: Available memory now displayed with 2 decimal places (e.g., `0.95GB` instead of `1.0GB`) to avoid confusion when values are near thresholds
+
+### Files Changed
+
+- `src/analysis/utils/memory.rs` - Platform-specific `MINIMUM_AVAILABLE_MEMORY_GB` constant and improved documentation
+- `src/analysis/gpu/analyzer.rs` - Platform-specific `is_error` flag in `check_minimum_system_requirements()`
+- `src/analysis/utils/memory_tests.rs` - Platform-specific tests for memory thresholds
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI/library tool with no visual interface.
+
+The fix addresses the root cause identified in the issue logs:
+```
+[NEAT-AI-Discovery] Memory check failed: 1.0GB available / 8.0GB total. Discovery disabled.
+```
+
+With this fix:
+- Macs with 0.5-1GB reported available memory will pass the memory check
+- If memory check still fails, the error message will correctly identify it as a memory issue, not "no usable GPU"
+
+## Test Plan
+
+Added platform-specific tests to verify the memory threshold behaviour:
+
+- `test_system_requirements_low_available_memory` - Updated to use 400MB (below all thresholds)
+- `test_system_requirements_macos_lower_threshold` - Verifies 0.6GB passes on macOS
+- `test_system_requirements_macos_edge_case` - Verifies edge cases at 0.51GB and 0.49GB
+- `test_system_requirements_linux_stricter_threshold` - Verifies Linux still uses 1GB threshold
+
+All existing tests continue to pass. Run `./quality.sh` to verify.

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -207,6 +207,16 @@ impl GpuEvaluator for GpuAnalyzer {
 /// without risking hangs from memory pressure. This check runs before GPU
 /// initialisation to allow discovery to be disabled gracefully.
 ///
+/// # Platform Differences
+///
+/// - **macOS**: Memory check failure is treated as an error (`is_error: true`) because
+///   macOS should always have working GPU (Metal) and sufficient reclaimable memory.
+///   This ensures callers don't just report "no GPU" when the issue is memory.
+/// - **Linux**: Memory check failure is graceful (`is_error: false`) because
+///   headless servers may genuinely lack GPU hardware.
+///
+/// Issue #326: On macOS, memory check failure was misleadingly reported as "no usable GPU".
+///
 /// Returns `Some(GpuAvailabilityResult)` if requirements are NOT met (discovery disabled).
 /// Returns `None` if requirements ARE met (continue with GPU check).
 fn check_minimum_system_requirements() -> Option<GpuAvailabilityResult> {
@@ -217,12 +227,23 @@ fn check_minimum_system_requirements() -> Option<GpuAvailabilityResult> {
         let available_gb = available as f64 / (1024.0 * 1024.0 * 1024.0);
         let total_gb = total as f64 / (1024.0 * 1024.0 * 1024.0);
         eprintln!(
-            "[NEAT-AI-Discovery] Memory check failed: {available_gb:.1}GB available / {total_gb:.1}GB total. Discovery disabled."
+            "[NEAT-AI-Discovery] Memory check failed: {available_gb:.2}GB available / {total_gb:.1}GB total. Discovery disabled."
         );
+
+        // On macOS, memory failure should be treated as an error because:
+        // 1. macOS always has working GPU (Metal)
+        // 2. macOS can quickly reclaim cached memory
+        // 3. We want callers to know this is a memory issue, not "no GPU"
+        // Issue #326: Prevent misleading "no usable GPU" messages on Mac.
+        #[cfg(target_os = "macos")]
+        let is_error = true;
+        #[cfg(not(target_os = "macos"))]
+        let is_error = false; // Graceful disable on Linux (may not have GPU)
+
         return Some(GpuAvailabilityResult {
             available: false,
             reason: Some(reason),
-            is_error: false, // Not an error - graceful disable
+            is_error,
         });
     }
 

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -29,7 +29,19 @@ const STANDARD_MEMORY_THRESHOLD_GB: f64 = 16.0;
 /// Minimum total system memory required for discovery (4GB).
 const MINIMUM_TOTAL_MEMORY_GB: f64 = 4.0;
 
-/// Minimum available memory required for discovery (1GB).
+/// Minimum available memory required for discovery.
+///
+/// Platform-specific thresholds:
+/// - **macOS (0.5GB)**: macOS aggressively caches files, so "available" memory appears low.
+///   The kernel can quickly reclaim this cached memory when needed. Apple Silicon also has
+///   unified memory where GPU shares system RAM.
+/// - **Linux (1GB)**: Standard threshold for headless servers without aggressive file caching.
+///
+/// Issue #326: GPU detection failed on Mac due to overly strict memory check.
+#[cfg(target_os = "macos")]
+const MINIMUM_AVAILABLE_MEMORY_GB: f64 = 0.5;
+
+#[cfg(not(target_os = "macos"))]
 const MINIMUM_AVAILABLE_MEMORY_GB: f64 = 1.0;
 
 // =============================================================================
@@ -359,6 +371,15 @@ pub fn check_memory_for_parquet(parquet_file: &str) -> Result<()> {
 ///
 /// Returns `Some(reason)` if requirements are NOT met.
 /// Returns `None` if requirements ARE met.
+///
+/// # Platform Differences
+///
+/// On macOS, we use a lower threshold for available memory because:
+/// - macOS aggressively caches files in memory (appears as "inactive" or "purgeable")
+/// - The kernel can instantly reclaim this cached memory when needed
+/// - Apple Silicon has unified memory, so GPU shares system RAM efficiently
+///
+/// Issue #326: GPU detection failed on Mac due to overly strict memory check.
 pub fn check_system_memory_requirements(available_bytes: u64, total_bytes: u64) -> Option<String> {
     let available_gb = available_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
     let total_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
@@ -372,10 +393,11 @@ pub fn check_system_memory_requirements(available_bytes: u64, total_bytes: u64) 
         ));
     }
 
-    // Check available memory
+    // Check available memory - MINIMUM_AVAILABLE_MEMORY_GB is platform-specific
+    // (0.5GB on macOS, 1GB on Linux). See constant definition for rationale.
     if available_gb < MINIMUM_AVAILABLE_MEMORY_GB {
         return Some(format!(
-            "Insufficient available memory: {available_gb:.1}GB available (minimum: {MINIMUM_AVAILABLE_MEMORY_GB}GB required). \
+            "Insufficient available memory: {available_gb:.2}GB available (minimum: {MINIMUM_AVAILABLE_MEMORY_GB}GB required). \
              Discovery is disabled to prevent hangs from memory pressure. \
              Try closing other applications or reboot to free memory."
         ));

--- a/src/analysis/utils/memory_tests.rs
+++ b/src/analysis/utils/memory_tests.rs
@@ -125,8 +125,9 @@ fn test_system_requirements_low_total_memory() {
 
 #[test]
 fn test_system_requirements_low_available_memory() {
+    // 400MB should fail on all platforms (below both 0.5GB macOS and 1GB Linux thresholds)
     let result = check_system_memory_requirements(
-        500 * 1024 * 1024,      // 500MB available (below 1GB minimum)
+        400 * 1024 * 1024,      // 400MB available (below all minimum thresholds)
         8 * 1024 * 1024 * 1024, // 8GB total
     );
     assert!(
@@ -135,6 +136,77 @@ fn test_system_requirements_low_available_memory() {
     );
     let reason = result.unwrap();
     assert!(reason.contains("Insufficient available memory"));
+}
+
+/// Test that macOS uses a lower memory threshold (0.5GB) vs Linux (1GB).
+///
+/// Issue #326: macOS aggressively caches files, so "available" memory appears low.
+/// The kernel can quickly reclaim this memory, so we use a more lenient threshold.
+#[cfg(target_os = "macos")]
+#[test]
+fn test_system_requirements_macos_lower_threshold() {
+    // 0.6GB should pass on macOS (above 0.5GB threshold)
+    let result = check_system_memory_requirements(
+        (0.6 * 1024.0 * 1024.0 * 1024.0) as u64, // 0.6GB available
+        8 * 1024 * 1024 * 1024,                  // 8GB total
+    );
+    assert!(
+        result.is_none(),
+        "macOS should allow 0.6GB available (threshold is 0.5GB)"
+    );
+}
+
+/// Test edge case where memory is just above the macOS threshold.
+///
+/// Issue #326: The original bug showed "1.0GB available" but failed because
+/// the actual value was slightly below 1.0GB (e.g., 0.95GB displayed as 1.0GB).
+#[cfg(target_os = "macos")]
+#[test]
+fn test_system_requirements_macos_edge_case() {
+    // 0.51GB should pass on macOS (just above 0.5GB threshold)
+    let result = check_system_memory_requirements(
+        (0.51 * 1024.0 * 1024.0 * 1024.0) as u64, // 0.51GB available
+        8 * 1024 * 1024 * 1024,                   // 8GB total
+    );
+    assert!(
+        result.is_none(),
+        "macOS should allow 0.51GB available (just above 0.5GB threshold)"
+    );
+
+    // 0.49GB should fail on macOS (just below 0.5GB threshold)
+    let result = check_system_memory_requirements(
+        (0.49 * 1024.0 * 1024.0 * 1024.0) as u64, // 0.49GB available
+        8 * 1024 * 1024 * 1024,                   // 8GB total
+    );
+    assert!(
+        result.is_some(),
+        "macOS should reject 0.49GB available (below 0.5GB threshold)"
+    );
+}
+
+/// Test that Linux uses the stricter 1GB threshold.
+#[cfg(target_os = "linux")]
+#[test]
+fn test_system_requirements_linux_stricter_threshold() {
+    // 0.6GB should fail on Linux (below 1GB threshold)
+    let result = check_system_memory_requirements(
+        (0.6 * 1024.0 * 1024.0 * 1024.0) as u64, // 0.6GB available
+        8 * 1024 * 1024 * 1024,                  // 8GB total
+    );
+    assert!(
+        result.is_some(),
+        "Linux should reject 0.6GB available (threshold is 1GB)"
+    );
+
+    // 1.1GB should pass on Linux (above 1GB threshold)
+    let result = check_system_memory_requirements(
+        (1.1 * 1024.0 * 1024.0 * 1024.0) as u64, // 1.1GB available
+        8 * 1024 * 1024 * 1024,                  // 8GB total
+    );
+    assert!(
+        result.is_none(),
+        "Linux should allow 1.1GB available (above 1GB threshold)"
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixed GPU detection failing on macOS due to an overly strict memory availability check.

The bug occurred when a Mac reported low "available" memory (e.g., 1.0GB on an 8GB system) due to macOS's aggressive file caching. The library's 1GB minimum threshold would fail even though macOS can quickly reclaim this cached memory when needed.

### Root Cause

1. **macOS memory reporting**: macOS aggressively caches files in RAM, making "available" memory appear artificially low
2. **Strict threshold**: The library used a 1GB minimum on all platforms
3. **Misleading error**: Memory check failure returned `is_error: false`, so NEAT-AI reported "no usable GPU detected" instead of the actual memory issue

### Changes

1. **Platform-specific memory thresholds**:
   - macOS: 0.5GB minimum (down from 1GB) - safe due to unified memory and quick cache reclamation
   - Linux: 1GB minimum (unchanged) - conservative for headless servers

2. **Error status on macOS**: Memory check failure now sets `is_error: true` on macOS so callers receive proper error messaging about the memory issue, not "no usable GPU"

3. **Improved precision**: Available memory now displayed with 2 decimal places (e.g., `0.95GB` instead of `1.0GB`) to avoid confusion when values are near thresholds

### Files Changed

- `src/analysis/utils/memory.rs` - Platform-specific `MINIMUM_AVAILABLE_MEMORY_GB` constant and improved documentation
- `src/analysis/gpu/analyzer.rs` - Platform-specific `is_error` flag in `check_minimum_system_requirements()`
- `src/analysis/utils/memory_tests.rs` - Platform-specific tests for memory thresholds

## Evidence

Unable to generate screenshot: This is a CLI/library tool with no visual interface.

The fix addresses the root cause identified in the issue logs:
```
[NEAT-AI-Discovery] Memory check failed: 1.0GB available / 8.0GB total. Discovery disabled.
```

With this fix:
- Macs with 0.5-1GB reported available memory will pass the memory check
- If memory check still fails, the error message will correctly identify it as a memory issue, not "no usable GPU"

## Test Plan

Added platform-specific tests to verify the memory threshold behaviour:

- `test_system_requirements_low_available_memory` - Updated to use 400MB (below all thresholds)
- `test_system_requirements_macos_lower_threshold` - Verifies 0.6GB passes on macOS
- `test_system_requirements_macos_edge_case` - Verifies edge cases at 0.51GB and 0.49GB
- `test_system_requirements_linux_stricter_threshold` - Verifies Linux still uses 1GB threshold

All existing tests continue to pass. Run `./quality.sh` to verify.

---

## Automated Fix Details
This PR addresses issue #326: **GPU detection failed on a Mac**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #326