### PR TITLE
Fix: Check candidate implementation in NEAT-AI (#337)

### DIFF
--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -47,7 +47,7 @@ NEAT-AI-Discovery (Rust)          NEAT-AI (TypeScript)
 |----------------|-------------|------------|------------|--------------|--------|
 | **add-neurons** | Add a new hidden neuron between existing neurons | 556 | 8,944 | 5.9% | 🟢 Active |
 | **add-synapses** | Add a new synapse connection | 1 | 9 | 10.0% | ⚠️ Low volume |
-| **coordinated-structural** | Apply a *group* of dependent edits as a single candidate | — | — | — | 🟠 Not tested |
+| **coordinated-structural** | Apply a *group* of dependent edits as a single candidate | — | — | — | 🟢 Active |
 | **change-squash** | Change a neuron's activation function | 2 | 9 | 18.2% | ⚠️ Low volume |
 | **remove-low-impact** | Remove neurons with activation_weighted_impact < costOfGrowth | 65 | 304 | 17.6% | 🟢 Active |
 | **remove-harmful-synapse** | Remove synapses that increase error | — | — | — | 🟠 Not tested |
@@ -167,13 +167,14 @@ This discovery type exists to escape neutral plateaus and handle interference ca
 }
 ```
 
-**Operation vocabulary** (7-Jan-2026):
+**Operation vocabulary** (29-Jan-2026):
 - `removeSynapse(fromNeuronUuid,toNeuronUuid)`
 - `addSynapse(fromNeuronUuid,toNeuronUuid,weight)`
 - `addNeuron(neuronUuid,neuronType,squash,bias,insertBeforeNeuronUuid?)`
 - `removeNeuron(neuronUuid)`
 - `changeSquash(neuronUuid,squash)`
 - `setBias(neuronUuid,bias)`
+- `setWeight(fromNeuronUuid,toNeuronUuid,weight)` — Issue #180: direct weight adjustment replacing the previous `removeSynapse` + `addSynapse` pattern
 
 **Forward-only note**: for forward-only creatures, `addNeuron.insertBeforeNeuronUuid` is used to place the neuron in the `neurons[]` array before the target neuron so subsequent `addSynapse(newNeuron -> target)` respects the forward-only ordering constraint.
 
@@ -215,7 +216,9 @@ This discovery type exists to escape neutral plateaus and handle interference ca
 }
 ```
 
-**Current status**: 🟢 **Active and tested** – Rust emits ordered groups; NEAT-AI applies the full ordered operation list atomically and re-scores on the full training set.
+**Current status**: 🟢 **Active and tested** – Rust emits ordered groups; NEAT-AI applies the full ordered operation list atomically and re-scores on the full training set. All 7 operation types are implemented in NEAT-AI's `ApplyCoordinatedStructuralCandidate.ts` (verified Issue #337).
+
+**Synergistic discovery** (Issue #189): Cross-neuron interactions (e.g., XOR-like patterns) are detected via residual analysis and emitted as coordinated candidates containing paired `addSynapse` operations. No new operation type is needed — NEAT-AI handles these through the existing coordinated-structural path.
 
 ---
 
@@ -412,10 +415,10 @@ review.
 
 ### Not Implemented / Not Tested
 
-1. **coordinated-structural** 🟠 – Produced by Rust, needs TypeScript validation support
-   - Rust returns `coordinatedStructuralCandidates[]`
-   - TypeScript must apply a group of operations to a clone then rescore (single ablation run)
-   - Enables epistatic changes (dependent edits) to be validated as one unit
+1. **coordinated-structural** 🟢 – **Verified** (Issue #337): NEAT-AI implements all 7 operation types
+   (`removeSynapse`, `addSynapse`, `addNeuron`, `removeNeuron`, `changeSquash`, `setBias`, `setWeight`)
+   in `ApplyCoordinatedStructuralCandidate.ts`. Synergistic candidates (Issue #189) use existing
+   `addSynapse` operations and require no additional NEAT-AI changes.
 
 2. **remove-harmful-synapse** 🟠 – Rust produces, no samples recorded
    - Rust returns `harmful_synapses[]` array
@@ -427,7 +430,7 @@ review.
 
 | Priority | Action | Rationale |
 |----------|--------|-----------|
-| 🔴 High | Implement coordinated-structural (grouped candidates) | Needed for epistatic changes where only a set of edits improves fitness |
+| ✅ Done | Verify coordinated-structural implementation (Issue #337) | NEAT-AI implements all 7 operation types; no gaps found |
 | 🔴 High | Investigate why harmful_synapses aren't recorded | Mapping exists but no samples in discovery folder |
 | 🔴 High | Investigate add-synapses prediction inversion | 10 samples show consistent wrong-direction predictions |
 | 🔴 High | Disable or fix remove-neuron | 0% success rate, wasting validation cycles |

--- a/docs/pr-summary-337.md
+++ b/docs/pr-summary-337.md
@@ -1,0 +1,62 @@
+## Summary
+
+Verified that NEAT-AI implements all candidate types returned by NEAT-AI-Discovery,
+including those introduced by Issue #189 (synergistic discovery / cross-neuron interactions).
+
+### Findings
+
+**No gaps found.** NEAT-AI already handles all 7 `CoordinatedStructuralOpJson` operation
+types in `ApplyCoordinatedStructuralCandidate.ts`:
+
+| Operation | Rust Variant | NEAT-AI Status |
+|-----------|-------------|----------------|
+| `removeSynapse` | `RemoveSynapse` | Implemented |
+| `addSynapse` | `AddSynapse` | Implemented |
+| `addNeuron` | `AddNeuron` | Implemented (with `insertBeforeNeuronUuid`) |
+| `removeNeuron` | `RemoveNeuron` | Implemented |
+| `changeSquash` | `ChangeSquash` | Implemented |
+| `setBias` | `SetBias` | Implemented |
+| `setWeight` | `SetWeight` | Implemented (Issue #180) |
+
+The synergistic discovery feature (Issue #189 / PR #336) uses existing `addSynapse`
+operations within `CoordinatedStructuralCandidateJson` — no new operation type was
+introduced, so no NEAT-AI changes are needed.
+
+### Changes Made
+
+1. **Added contract tests** (`tests/issue_337_candidate_type_contract.rs`):
+   15 tests verifying all candidate types serialise to the JSON format NEAT-AI expects.
+   This includes all 7 operation variants, the coordinated candidate wrapper,
+   synergistic candidate structure, `SynapseWeightUpdateCandidateJson`,
+   `AnalyzeParallelOutput`, and `RankFocusNeuronsOutput`.
+
+2. **Updated documentation** (`docs/DISCOVERY_TYPES.md`):
+   - Added missing `setWeight` operation to the operation vocabulary (Issue #180).
+   - Updated `coordinated-structural` status from "Not tested" to "Active".
+   - Added note about synergistic discovery (Issue #189).
+   - Updated recommended actions to reflect verification is complete.
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+The contract is verified by automated serialisation tests.
+
+## Test Plan
+
+- Added 15 tests in `tests/issue_337_candidate_type_contract.rs`:
+  - `coordinated_op_remove_synapse_serialises_for_neat_ai`
+  - `coordinated_op_add_synapse_serialises_for_neat_ai`
+  - `coordinated_op_add_neuron_serialises_for_neat_ai`
+  - `coordinated_op_add_neuron_omits_insert_before_when_none`
+  - `coordinated_op_remove_neuron_serialises_for_neat_ai`
+  - `coordinated_op_change_squash_serialises_for_neat_ai`
+  - `coordinated_op_set_bias_serialises_for_neat_ai`
+  - `coordinated_op_set_weight_serialises_for_neat_ai`
+  - `coordinated_candidate_serialises_with_all_required_fields`
+  - `coordinated_candidate_omits_comment_when_none`
+  - `synergistic_candidate_uses_add_synapse_operations`
+  - `synapse_weight_update_candidate_serialises_for_neat_ai`
+  - `analyze_parallel_output_contains_all_candidate_fields`
+  - `rank_focus_neurons_output_contains_removal_candidate_fields`
+  - `all_operation_types_match_neat_ai_type_discriminator`
+- All existing tests continue to pass (verified via `quality.sh`).

--- a/tests/issue_337_candidate_type_contract.rs
+++ b/tests/issue_337_candidate_type_contract.rs
@@ -1,0 +1,460 @@
+//! Issue #337: Verify that all candidate types returned by NEAT-AI-Discovery
+//! match the contract expected by the NEAT-AI TypeScript consumer.
+//!
+//! NEAT-AI (TypeScript) must implement all candidate types that this library can
+//! return. This test suite verifies:
+//!
+//! 1. All 7 `CoordinatedStructuralOpJson` variants serialise to the JSON format
+//!    that NEAT-AI's `ApplyCoordinatedStructuralCandidate.ts` expects.
+//! 2. The top-level `AnalyzeParallelOutput` contains all candidate fields that
+//!    NEAT-AI's `DiscoverResult.ts` consumes.
+//! 3. The `RankFocusNeuronsOutput` contains all fields that NEAT-AI expects,
+//!    including `constantNeuronRemovals` (Issue #306).
+//! 4. `SynapseWeightUpdateCandidateJson` serialises correctly for NEAT-AI.
+//!
+//! If a new candidate type or operation variant is added to the Rust library,
+//! a corresponding test MUST be added here and NEAT-AI must be updated.
+
+use neat_ai_discovery::{
+    CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson,
+    SynapseWeightUpdateCandidateJson,
+};
+
+// ---------------------------------------------------------------------------
+// 1. CoordinatedStructuralOpJson — all 7 variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coordinated_op_remove_synapse_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::RemoveSynapse {
+        from_neuron_uuid: "input-0".to_string(),
+        to_neuron_uuid: "output-0".to_string(),
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "removeSynapse");
+    assert_eq!(json["fromNeuronUuid"], "input-0");
+    assert_eq!(json["toNeuronUuid"], "output-0");
+    // NEAT-AI's ApplyCoordinatedStructuralCandidate.ts checks op.type === "removeSynapse"
+    // and reads fromNeuronUuid + toNeuronUuid.
+}
+
+#[test]
+fn coordinated_op_add_synapse_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::AddSynapse {
+        from_neuron_uuid: "input-1".to_string(),
+        to_neuron_uuid: "output-0".to_string(),
+        weight: 0.42,
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "addSynapse");
+    assert_eq!(json["fromNeuronUuid"], "input-1");
+    assert_eq!(json["toNeuronUuid"], "output-0");
+    assert!(
+        (json["weight"].as_f64().unwrap() - 0.42).abs() < 1e-6,
+        "weight should be approximately 0.42"
+    );
+}
+
+#[test]
+fn coordinated_op_add_neuron_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::AddNeuron {
+        neuron_uuid: "coordinated-hidden-abc123".to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: "ReLU".to_string(),
+        bias: 0.5,
+        insert_before_neuron_uuid: Some("output-0".to_string()),
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "addNeuron");
+    assert_eq!(json["neuronUuid"], "coordinated-hidden-abc123");
+    assert_eq!(json["neuronType"], "hidden");
+    assert_eq!(json["squash"], "ReLU");
+    assert!((json["bias"].as_f64().unwrap() - 0.5).abs() < 1e-6);
+    assert_eq!(json["insertBeforeNeuronUuid"], "output-0");
+}
+
+#[test]
+fn coordinated_op_add_neuron_omits_insert_before_when_none() {
+    let op = CoordinatedStructuralOpJson::AddNeuron {
+        neuron_uuid: "hidden-1".to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: "TANH".to_string(),
+        bias: 0.0,
+        insert_before_neuron_uuid: None,
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "addNeuron");
+    // insertBeforeNeuronUuid should be absent (skip_serializing_if = "Option::is_none")
+    assert!(
+        json.get("insertBeforeNeuronUuid").is_none() || json["insertBeforeNeuronUuid"].is_null(),
+        "insertBeforeNeuronUuid should be absent when None"
+    );
+}
+
+#[test]
+fn coordinated_op_remove_neuron_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::RemoveNeuron {
+        neuron_uuid: "hidden-0".to_string(),
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "removeNeuron");
+    assert_eq!(json["neuronUuid"], "hidden-0");
+}
+
+#[test]
+fn coordinated_op_change_squash_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::ChangeSquash {
+        neuron_uuid: "hidden-0".to_string(),
+        squash: "GELU".to_string(),
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "changeSquash");
+    assert_eq!(json["neuronUuid"], "hidden-0");
+    assert_eq!(json["squash"], "GELU");
+}
+
+#[test]
+fn coordinated_op_set_bias_serialises_for_neat_ai() {
+    let op = CoordinatedStructuralOpJson::SetBias {
+        neuron_uuid: "hidden-0".to_string(),
+        bias: -1.5,
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "setBias");
+    assert_eq!(json["neuronUuid"], "hidden-0");
+    assert!((json["bias"].as_f64().unwrap() - (-1.5)).abs() < 1e-6);
+}
+
+#[test]
+fn coordinated_op_set_weight_serialises_for_neat_ai() {
+    // Issue #180: SetWeight replaces the remove+add pattern for weight adjustments.
+    // NEAT-AI's ApplyCoordinatedStructuralCandidate.ts handles op.type === "setWeight".
+    let op = CoordinatedStructuralOpJson::SetWeight {
+        from_neuron_uuid: "input-0".to_string(),
+        to_neuron_uuid: "output-0".to_string(),
+        weight: 0.006,
+    };
+
+    let json: serde_json::Value = serde_json::to_value(&op).expect("serialisation should succeed");
+
+    assert_eq!(json["type"], "setWeight");
+    assert_eq!(json["fromNeuronUuid"], "input-0");
+    assert_eq!(json["toNeuronUuid"], "output-0");
+    assert!((json["weight"].as_f64().unwrap() - 0.006).abs() < 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// 2. CoordinatedStructuralCandidateJson — wrapper shape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn coordinated_candidate_serialises_with_all_required_fields() {
+    let candidate = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+                weight: 0.5,
+            },
+        ],
+        expected_creature_score_gain: 0.001,
+        comment: Some("Epistatic pair: remove noisy, add trusted".to_string()),
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&candidate).expect("serialisation should succeed");
+
+    // NEAT-AI's CoordinatedStructuralCandidate.ts expects:
+    //   operations: CoordinatedStructuralOperation[]
+    //   expectedCreatureScoreGain: number
+    //   comment?: string
+    assert!(json["operations"].is_array());
+    assert_eq!(json["operations"].as_array().unwrap().len(), 2);
+    assert!(json["expectedCreatureScoreGain"].as_f64().is_some());
+    assert_eq!(json["comment"], "Epistatic pair: remove noisy, add trusted");
+}
+
+#[test]
+fn coordinated_candidate_omits_comment_when_none() {
+    let candidate = CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: "h-1".to_string(),
+            bias: 0.0,
+        }],
+        expected_creature_score_gain: 0.0,
+        comment: None,
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&candidate).expect("serialisation should succeed");
+
+    assert!(
+        json.get("comment").is_none() || json["comment"].is_null(),
+        "comment should be absent when None"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Synergistic discovery (Issue #189) produces valid coordinated candidates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn synergistic_candidate_uses_add_synapse_operations() {
+    // Issue #189: Synergistic discovery detects cross-neuron interactions
+    // (e.g., XOR-like patterns) and returns them as CoordinatedStructuralCandidateJson
+    // with AddSynapse operations. NEAT-AI handles these via the existing
+    // coordinated-structural path — no new operation type is needed.
+    let candidate = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+                weight: 0.3,
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-1".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+                weight: -0.3,
+            },
+        ],
+        expected_creature_score_gain: 0.005,
+        comment: Some("Synergistic: XOR-like pattern".to_string()),
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&candidate).expect("serialisation should succeed");
+
+    let ops = json["operations"].as_array().unwrap();
+    assert_eq!(ops.len(), 2);
+    assert_eq!(ops[0]["type"], "addSynapse");
+    assert_eq!(ops[1]["type"], "addSynapse");
+    assert!(json["expectedCreatureScoreGain"].as_f64().unwrap() > 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// 4. SynapseWeightUpdateCandidateJson — standalone weight update
+// ---------------------------------------------------------------------------
+
+#[test]
+fn synapse_weight_update_candidate_serialises_for_neat_ai() {
+    let candidate = SynapseWeightUpdateCandidateJson {
+        from_neuron_uuid: "input-0".to_string(),
+        to_neuron_uuid: "output-0".to_string(),
+        from_neuron_index: Some(0),
+        to_neuron_index: Some(1),
+        old_weight: 0.1,
+        new_weight: 0.3,
+        delta_weight: 0.2,
+        target_neuron_impact: 0.5,
+        expected_creature_error_reduction: 0.01,
+        expected_creature_score_gain: 0.001,
+        improved_count: 40,
+        total_count: 100,
+        target_neuron_stats: None,
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&candidate).expect("serialisation should succeed");
+
+    // NEAT-AI expects camelCase field names
+    assert_eq!(json["fromNeuronUuid"], "input-0");
+    assert_eq!(json["toNeuronUuid"], "output-0");
+    assert_eq!(json["fromNeuronIndex"], 0);
+    assert_eq!(json["toNeuronIndex"], 1);
+    assert!((json["oldWeight"].as_f64().unwrap() - 0.1).abs() < 1e-6);
+    assert!((json["newWeight"].as_f64().unwrap() - 0.3).abs() < 1e-6);
+    assert!((json["deltaWeight"].as_f64().unwrap() - 0.2).abs() < 1e-6);
+    assert!(json["targetNeuronImpact"].as_f64().is_some());
+    assert!(json["expectedCreatureErrorReduction"].as_f64().is_some());
+    assert!(json["expectedCreatureScoreGain"].as_f64().is_some());
+    assert_eq!(json["improvedCount"], 40);
+    assert_eq!(json["totalCount"], 100);
+}
+
+// ---------------------------------------------------------------------------
+// 5. AnalyzeParallelOutput — all candidate fields present
+// ---------------------------------------------------------------------------
+
+#[test]
+fn analyze_parallel_output_contains_all_candidate_fields() {
+    // Verify that AnalyzeParallelOutput serialises all candidate type fields
+    // that NEAT-AI's DiscoverResult.ts and DiscoveryCandidates.ts consume.
+    let output = neat_ai_discovery::AnalyzeParallelOutput {
+        success: true,
+        helpful_synapses: Some(vec![]),
+        harmful_synapses: Some(vec![]),
+        synapse_diagnostics: None,
+        synapse_gpu_used: Some(true),
+        synapse_metadata: None,
+        helpful_neurons: Some(vec![]),
+        synapse_weight_updates: Some(vec![]),
+        coordinated_structural_candidates: Some(vec![]),
+        neuron_diagnostics: None,
+        neuron_gpu_used: Some(true),
+        neuron_metadata: None,
+        error: None,
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&output).expect("serialisation should succeed");
+
+    // Fields consumed by NEAT-AI DiscoverResult.ts / DiscoveryCandidates.ts:
+    assert_eq!(json["success"], true);
+    assert!(
+        json["helpfulSynapses"].is_array(),
+        "helpfulSynapses must be present for add-synapses candidates"
+    );
+    assert!(
+        json["harmfulSynapses"].is_array(),
+        "harmfulSynapses must be present for remove-harmful-synapse candidates"
+    );
+    assert!(
+        json["helpfulNeurons"].is_array(),
+        "helpfulNeurons must be present for add-neurons candidates"
+    );
+    assert!(
+        json["synapseWeightUpdates"].is_array(),
+        "synapseWeightUpdates must be present (v0.2.18+)"
+    );
+    assert!(
+        json["coordinatedStructuralCandidates"].is_array(),
+        "coordinatedStructuralCandidates must be present for coordinated-structural candidates"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. RankFocusNeuronsOutput — removal and constant neuron fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rank_focus_neurons_output_contains_removal_candidate_fields() {
+    // Verify that RankFocusNeuronsOutput serialises all fields NEAT-AI expects,
+    // including constantNeuronRemovals (Issue #306).
+    let output = neat_ai_discovery::RankFocusNeuronsOutput {
+        success: true,
+        neurons: Some(vec![]),
+        removal_candidates: Some(vec![]),
+        constant_neuron_removals: Some(vec![]),
+        max_output_error: Some(0.01),
+        processed_neurons: Some(5),
+        total_neurons: Some(10),
+        duration_ms: Some(100),
+        error: None,
+    };
+
+    let json: serde_json::Value =
+        serde_json::to_value(&output).expect("serialisation should succeed");
+
+    assert_eq!(json["success"], true);
+    assert!(json["neurons"].is_array());
+    assert!(
+        json["removalCandidates"].is_array(),
+        "removalCandidates must be present for remove-low-impact candidates"
+    );
+    assert!(
+        json["constantNeuronRemovals"].is_array(),
+        "constantNeuronRemovals must be present (Issue #306)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. All 7 operation type strings match NEAT-AI's switch/if checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_operation_types_match_neat_ai_type_discriminator() {
+    // NEAT-AI's ApplyCoordinatedStructuralCandidate.ts uses op.type to dispatch.
+    // This test ensures every variant produces the exact string NEAT-AI expects.
+    let ops_and_expected_types = vec![
+        (
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "a".to_string(),
+                to_neuron_uuid: "b".to_string(),
+            },
+            "removeSynapse",
+        ),
+        (
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "a".to_string(),
+                to_neuron_uuid: "b".to_string(),
+                weight: 1.0,
+            },
+            "addSynapse",
+        ),
+        (
+            CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: "n".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "ReLU".to_string(),
+                bias: 0.0,
+                insert_before_neuron_uuid: None,
+            },
+            "addNeuron",
+        ),
+        (
+            CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "n".to_string(),
+            },
+            "removeNeuron",
+        ),
+        (
+            CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: "n".to_string(),
+                squash: "TANH".to_string(),
+            },
+            "changeSquash",
+        ),
+        (
+            CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: "n".to_string(),
+                bias: 0.0,
+            },
+            "setBias",
+        ),
+        (
+            CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid: "a".to_string(),
+                to_neuron_uuid: "b".to_string(),
+                weight: 1.0,
+            },
+            "setWeight",
+        ),
+    ];
+
+    for (op, expected_type) in &ops_and_expected_types {
+        let json: serde_json::Value =
+            serde_json::to_value(op).expect("serialisation should succeed");
+        assert_eq!(
+            json["type"].as_str().unwrap(),
+            *expected_type,
+            "Operation variant should serialise type as \"{expected_type}\""
+        );
+    }
+
+    // Ensure we tested all 7 variants — if a new variant is added, this count
+    // must be updated and a corresponding NEAT-AI implementation must be verified.
+    assert_eq!(
+        ops_and_expected_types.len(),
+        7,
+        "Expected exactly 7 CoordinatedStructuralOpJson variants. \
+         If a new variant was added, update this test AND verify NEAT-AI handles it."
+    );
+}


### PR DESCRIPTION
## Summary

Verified that NEAT-AI implements all candidate types returned by NEAT-AI-Discovery,
including those introduced by Issue #189 (synergistic discovery / cross-neuron interactions).

### Findings

**No gaps found.** NEAT-AI already handles all 7 `CoordinatedStructuralOpJson` operation
types in `ApplyCoordinatedStructuralCandidate.ts`:

| Operation | Rust Variant | NEAT-AI Status |
|-----------|-------------|----------------|
| `removeSynapse` | `RemoveSynapse` | Implemented |
| `addSynapse` | `AddSynapse` | Implemented |
| `addNeuron` | `AddNeuron` | Implemented (with `insertBeforeNeuronUuid`) |
| `removeNeuron` | `RemoveNeuron` | Implemented |
| `changeSquash` | `ChangeSquash` | Implemented |
| `setBias` | `SetBias` | Implemented |
| `setWeight` | `SetWeight` | Implemented (Issue #180) |

The synergistic discovery feature (Issue #189 / PR #336) uses existing `addSynapse`
operations within `CoordinatedStructuralCandidateJson` — no new operation type was
introduced, so no NEAT-AI changes are needed.

### Changes Made

1. **Added contract tests** (`tests/issue_337_candidate_type_contract.rs`):
   15 tests verifying all candidate types serialise to the JSON format NEAT-AI expects.
   This includes all 7 operation variants, the coordinated candidate wrapper,
   synergistic candidate structure, `SynapseWeightUpdateCandidateJson`,
   `AnalyzeParallelOutput`, and `RankFocusNeuronsOutput`.

2. **Updated documentation** (`docs/DISCOVERY_TYPES.md`):
   - Added missing `setWeight` operation to the operation vocabulary (Issue #180).
   - Updated `coordinated-structural` status from "Not tested" to "Active".
   - Added note about synergistic discovery (Issue #189).
   - Updated recommended actions to reflect verification is complete.

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.
The contract is verified by automated serialisation tests.

## Test Plan

- Added 15 tests in `tests/issue_337_candidate_type_contract.rs`:
  - `coordinated_op_remove_synapse_serialises_for_neat_ai`
  - `coordinated_op_add_synapse_serialises_for_neat_ai`
  - `coordinated_op_add_neuron_serialises_for_neat_ai`
  - `coordinated_op_add_neuron_omits_insert_before_when_none`
  - `coordinated_op_remove_neuron_serialises_for_neat_ai`
  - `coordinated_op_change_squash_serialises_for_neat_ai`
  - `coordinated_op_set_bias_serialises_for_neat_ai`
  - `coordinated_op_set_weight_serialises_for_neat_ai`
  - `coordinated_candidate_serialises_with_all_required_fields`
  - `coordinated_candidate_omits_comment_when_none`
  - `synergistic_candidate_uses_add_synapse_operations`
  - `synapse_weight_update_candidate_serialises_for_neat_ai`
  - `analyze_parallel_output_contains_all_candidate_fields`
  - `rank_focus_neurons_output_contains_removal_candidate_fields`
  - `all_operation_types_match_neat_ai_type_discriminator`
- All existing tests continue to pass (verified via `quality.sh`).

---

## Automated Fix Details
This PR addresses issue #337: **Check candidate implementation in NEAT-AI**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #337