### PR TITLE
Fix: Discovery: Detect dead neurons for removal candidates (#341)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -621,6 +621,31 @@ range must encode all upstream information.
 `addNeuron` and/or `addSynapse` operations. No new candidate types are needed — this
 reuses the existing coordinated structural change mechanism.
 
+#### Dead Neuron Detection (Issue #341)
+
+As NEAT networks evolve, some neurons may become dead through weight changes that push
+their inputs to always land in the zero region of their activation function (e.g., RELU
+neurons that never receive positive input). Dead neurons consume GPU resources during both
+training and inference without contributing useful information to the network's output.
+
+**Detection criteria**:
+- **Near-zero activation**: Mean absolute activation < 1e-6 across all samples
+- **Zero variance**: Activation standard deviation ≈ 0 (always outputs the same value)
+- **No meaningful activity**: Fewer than 1% of samples show activation above 0.01
+- **Hidden neurons only**: Output and input neurons are excluded
+
+**Removal confidence** combines:
+- **Activation factor** (40%): How close mean absolute activation is to zero
+- **Variance factor** (40%): How close standard deviation is to zero
+- **Sample size factor** (20%): More samples increase confidence (plateaus at 1000)
+
+**Recommended action**:
+- **Remove neuron**: Emit a `RemoveNeuron` operation to eliminate wasted computation
+
+**Output**: Dead neuron candidates appear in `coordinatedStructuralCandidates` with
+`removeNeuron` operations. No new candidate types are needed — this reuses the existing
+coordinated structural change mechanism.
+
 ### Discrete activation function handling
 
 The standard discovery algorithm uses a **linear error model** to predict improvement:

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -54,6 +54,7 @@ NEAT-AI-Discovery (Rust)          NEAT-AI (TypeScript)
 | **remove-harmful-synapse** | Remove synapses that increase error | — | — | — | 🟠 Not tested |
 | **remove-neuron** | Remove harmful neurons (high error magnitude) | 0 | 2 | 0.0% | 🔴 Not working |
 | **redundant-path-pruning** | Prune redundant paths and renormalise survivor weight (Issue #164) | — | — | — | 🟢 Active |
+| **dead-neuron-removal** | Remove dead neurons with near-zero activation (Issue #341) | — | — | — | 🟢 Active |
 | **combo-successful** | Apply multiple successful changes together | 0 | 8 | 0.0% | 🔴 Not working |
 
 **Total**: 624 successes / 9,276 failures (6.3% overall success rate)
@@ -395,6 +396,34 @@ but applies a filter requiring `expectedCreatureScoreGain < 0` (line 1917-1919).
 **Current status**: 🔴 **Not working** – 0 successes from 2 attempts. The massive discrepancy
 between predicted improvement (0.41) and actual result (-0.00003) suggests the error
 magnitude calculation may not translate to actual score improvement.
+
+---
+
+### dead-neuron-removal
+
+🧹 **Purpose**: Remove dead neurons that always output zero or near-zero activation (Issue #341).
+
+**How it works**:
+1. Rust analyses recorded activations for each hidden neuron
+2. Identifies neurons with mean absolute activation < 1e-6 and near-zero standard deviation
+3. Verifies the neuron is not rarely but meaningfully active (< 1% of samples above 0.01)
+4. Emits a `RemoveNeuron` coordinated structural candidate
+
+**Detection criteria**:
+- Mean absolute activation < 1e-6
+- Activation standard deviation < 1e-6
+- Fewer than 1% of samples show activation above 0.01
+- Minimum 20 samples required
+- Hidden neurons only (output/input neurons excluded)
+
+**Removal confidence** combines activation proximity to zero (40%), variance proximity to
+zero (40%), and sample count (20%, plateaus at 1000 samples).
+
+**Output**: Dead neuron candidates appear in `coordinatedStructuralCandidates` with
+`removeNeuron` operations, reusing the existing coordinated structural change mechanism.
+
+**Current status**: 🟢 **Active** – New discovery category. Dead neurons waste computation
+without contributing to the network's output, so removal reduces overhead.
 
 ---
 

--- a/docs/pr-summary-341.md
+++ b/docs/pr-summary-341.md
@@ -1,0 +1,50 @@
+## Summary
+
+Implements dead neuron detection (Issue #341) — a new discovery category that identifies
+hidden neurons with near-zero activation across all samples and recommends their removal.
+
+Dead neurons waste GPU computation during both training and inference without contributing
+useful information to the network's output. This commonly occurs when weight changes push
+a neuron's inputs to always land in the zero region of its activation function (e.g., RELU
+neurons that never receive positive input).
+
+### Detection Criteria
+
+A neuron is considered "dead" if:
+1. **Near-zero activation**: Mean absolute activation < 1e-6 across all samples
+2. **Zero variance**: Activation standard deviation < 1e-6
+3. **No meaningful activity**: Fewer than 1% of samples show activation above 0.01
+4. **Minimum samples**: At least 20 samples required for reliable detection
+5. **Hidden neurons only**: Output and input neurons are excluded
+
+### Implementation
+
+- New module `src/analysis/dead_neuron.rs` following the established pattern from
+  saturated neuron detection (Issue #342) and bottleneck detection (Issue #343)
+- Integrated as a post-processing pass in `analyze_all()` after bottleneck detection
+- Emits `RemoveNeuron` operations via `CoordinatedStructuralCandidateJson`
+- No new candidate types needed — reuses existing coordinated structural mechanism
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+Added 13 tests in `tests/issue_341_dead_neuron_detection.rs`:
+
+1. `test_detects_all_zero_activation_neuron` — All-zero activation detected as dead
+2. `test_detects_near_zero_activation_neuron` — Near-zero (1e-8) activation detected
+3. `test_does_not_flag_active_neuron` — Active neuron (mean ~0.5) not flagged
+4. `test_rarely_active_neuron_not_flagged` — Neuron active on 5% of samples not flagged (false positive prevention)
+5. `test_constant_tiny_activation_is_dead` — Constant 1e-8 activation detected
+6. `test_output_neurons_not_flagged` — Output neurons excluded from detection
+7. `test_insufficient_samples_not_flagged` — Fewer than 20 samples skipped
+8. `test_mixed_neurons_only_dead_detected` — Only dead neurons detected in mixed set
+9. `test_candidates_produce_coordinated_removal_operations` — Correct `removeNeuron` operation emitted
+10. `test_detects_negative_near_zero_activation` — Negative near-zero (LeakyRELU) detected
+11. `test_zero_mean_high_variance_not_dead` — Bipolar activation (zero mean, high variance) not flagged
+12. `test_sample_count_recorded` — Sample count correctly recorded in candidate
+13. `test_connected_outputs_identified` — Downstream output neurons correctly found via BFS
+
+All existing tests continue to pass. `./quality.sh` passes cleanly.

--- a/src/analysis/dead_neuron.rs
+++ b/src/analysis/dead_neuron.rs
@@ -1,0 +1,281 @@
+//! Dead neuron detection module (Issue #341).
+//!
+//! Identifies neurons that have become effectively dead (always outputting zero or
+//! near-zero activation) and recommends their removal. Dead neurons waste computation
+//! without contributing to the network's output.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron is "dead" if:
+//! 1. **Near-zero activation**: Mean absolute activation < threshold (e.g., 1e-6) across
+//!    all samples.
+//! 2. **Zero variance**: Standard deviation of activation ≈ 0 (always outputs the same value).
+//! 3. **Only hidden neurons**: Output and input neurons are excluded.
+//!
+//! ## Recommended Actions
+//!
+//! When a dead neuron is detected, we recommend:
+//! 1. **Remove the neuron**: Emit a `RemoveNeuron` operation via `CoordinatedStructuralCandidateJson`.
+//!
+//! Dead neurons consume GPU resources during both training and inference without contributing
+//! useful information, so removal is the primary recommendation.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable dead neuron detection.
+const MIN_SAMPLES_FOR_DEAD_DETECTION: usize = 20;
+
+/// Threshold for mean absolute activation to consider a neuron dead.
+/// Activations below this are effectively zero.
+const DEAD_ACTIVATION_THRESHOLD: f32 = 1e-6;
+
+/// Maximum activation standard deviation for a dead neuron.
+/// If output varies significantly, the neuron is not truly dead.
+const MAX_DEAD_STD_DEV: f32 = 1e-6;
+
+/// Minimum fraction of samples where a neuron must be active to avoid being
+/// flagged as dead. A neuron active on even a small fraction of samples with
+/// meaningful activation is not dead.
+const MIN_ACTIVE_FRACTION: f32 = 0.01;
+
+/// Activation magnitude threshold for considering a single sample "active".
+const ACTIVE_SAMPLE_THRESHOLD: f32 = 0.01;
+
+/// Result of detecting a dead neuron.
+#[derive(Debug, Clone)]
+pub struct DeadNeuronCandidate {
+    /// UUID of the dead neuron.
+    pub neuron_uuid: String,
+    /// Mean absolute activation across all samples.
+    pub mean_abs_activation: f32,
+    /// Standard deviation of activation across samples.
+    pub activation_std_dev: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// UUIDs of output neurons reachable from this neuron.
+    pub connected_outputs: Vec<String>,
+    /// Confidence that removing this neuron is safe (0.0 to 1.0).
+    pub removal_confidence: f32,
+    /// Estimated creature score improvement from removing this neuron.
+    pub estimated_improvement: f32,
+}
+
+/// Detect dead neurons from the creature topology and recorded activations.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `DeadNeuronCandidate` for neurons that are dead,
+/// sorted by removal confidence (highest first).
+pub fn detect_dead_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<DeadNeuronCandidate> {
+    // Identify hidden neurons only
+    let hidden_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Identify output neuron UUIDs
+    let output_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Build fan-out map for finding connected outputs
+    let mut fan_out_map: HashMap<&str, Vec<&str>> = HashMap::new();
+    for synapse in &creature.synapses {
+        fan_out_map
+            .entry(synapse.from_uuid.as_str())
+            .or_default()
+            .push(synapse.to_uuid.as_str());
+    }
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for uuid in &hidden_uuids {
+        let Some(records) = records_map.get(uuid) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES_FOR_DEAD_DETECTION {
+            continue;
+        }
+
+        let n = records.len() as f32;
+
+        // Compute mean absolute activation
+        let sum_abs_activation: f32 = records.iter().map(|r| r.activation.abs()).sum();
+        let mean_abs_activation = sum_abs_activation / n;
+
+        // Compute activation standard deviation
+        let mean_activation: f32 = records.iter().map(|r| r.activation).sum::<f32>() / n;
+        let variance: f32 = records
+            .iter()
+            .map(|r| {
+                let diff = r.activation - mean_activation;
+                diff * diff
+            })
+            .sum::<f32>()
+            / n;
+        let activation_std_dev = variance.sqrt();
+
+        // Check if neuron is dead: near-zero mean absolute activation AND low variance
+        if mean_abs_activation >= DEAD_ACTIVATION_THRESHOLD {
+            continue;
+        }
+
+        if activation_std_dev >= MAX_DEAD_STD_DEV {
+            continue;
+        }
+
+        // Check active fraction: if the neuron fires meaningfully on even a small
+        // fraction of samples, it is not dead (prevents false positives).
+        let active_count = records
+            .iter()
+            .filter(|r| r.activation.abs() >= ACTIVE_SAMPLE_THRESHOLD)
+            .count();
+        let active_fraction = active_count as f32 / n;
+
+        if active_fraction >= MIN_ACTIVE_FRACTION {
+            continue;
+        }
+
+        // Find output neurons reachable from this neuron (BFS)
+        let connected_outputs = find_connected_outputs(uuid, &fan_out_map, &output_uuids);
+
+        // Compute removal confidence based on how dead the neuron is
+        let confidence = compute_removal_confidence(mean_abs_activation, activation_std_dev, n);
+
+        // Estimated improvement: removing a dead neuron saves computation.
+        // The improvement is small but positive (reduced overhead).
+        let estimated_improvement = confidence * 0.001;
+
+        candidates.push(DeadNeuronCandidate {
+            neuron_uuid: uuid.to_string(),
+            mean_abs_activation,
+            activation_std_dev,
+            sample_count: records.len(),
+            connected_outputs,
+            removal_confidence: confidence,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by removal confidence (highest first)
+    candidates.sort_by(|a, b| {
+        b.removal_confidence
+            .partial_cmp(&a.removal_confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Find output neurons reachable from a given neuron via BFS through the fan-out map.
+fn find_connected_outputs<'a>(
+    start_uuid: &str,
+    fan_out_map: &HashMap<&'a str, Vec<&'a str>>,
+    output_uuids: &HashSet<&str>,
+) -> Vec<String> {
+    let mut visited = HashSet::new();
+    let mut queue = vec![start_uuid];
+    let mut connected = Vec::new();
+
+    while let Some(current) = queue.pop() {
+        if !visited.insert(current.to_string()) {
+            continue;
+        }
+
+        if let Some(downstream) = fan_out_map.get(current) {
+            for &next in downstream {
+                if output_uuids.contains(next) {
+                    connected.push(next.to_string());
+                }
+                if !visited.contains(next) {
+                    queue.push(next);
+                }
+            }
+        }
+    }
+
+    connected.sort();
+    connected.dedup();
+    connected
+}
+
+/// Compute removal confidence based on activation statistics.
+///
+/// Higher confidence when:
+/// - Mean absolute activation is closer to zero
+/// - Standard deviation is closer to zero
+/// - More samples were analysed
+fn compute_removal_confidence(
+    mean_abs_activation: f32,
+    activation_std_dev: f32,
+    sample_count: f32,
+) -> f32 {
+    // Base confidence from how dead the neuron is (closer to zero = higher confidence)
+    let activation_factor = 1.0 - (mean_abs_activation / DEAD_ACTIVATION_THRESHOLD).min(1.0);
+
+    // Variance factor (lower variance = higher confidence)
+    let variance_factor = 1.0 - (activation_std_dev / MAX_DEAD_STD_DEV).min(1.0);
+
+    // Sample size factor (more samples = higher confidence, plateaus at 1000)
+    let sample_factor = (sample_count / 1000.0).min(1.0);
+
+    // Combine: all factors contribute to confidence
+    let raw_confidence = activation_factor * 0.4 + variance_factor * 0.4 + sample_factor * 0.2;
+
+    // Scale to [0.5, 1.0] range since we already passed the threshold checks
+    0.5 + raw_confidence * 0.5
+}
+
+/// Convert dead neuron candidates into coordinated structural candidates.
+///
+/// Each dead neuron produces a `RemoveNeuron` coordinated candidate.
+/// The NEAT-AI controller will validate the removal through ablation testing
+/// before actually applying it.
+pub fn dead_neurons_to_coordinated_candidates(
+    candidates: &[DeadNeuronCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: c.neuron_uuid.clone(),
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Dead neuron {}: mean abs activation {:.2e}, std dev {:.2e}, {} samples → remove to reduce wasted computation",
+                c.neuron_uuid, c.mean_abs_activation, c.activation_std_dev, c.sample_count
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -17,12 +17,14 @@
 //! - `streaming.rs` - Streaming parquet loading with block-based caching (Issue #193)
 //! - `saturation.rs` - Saturated neuron detection for activation function changes (Issue #342)
 //! - `bottleneck.rs` - Bottleneck neuron detection for information flow widening (Issue #343)
+//! - `dead_neuron.rs` - Dead neuron detection for removal candidates (Issue #341)
 //! - `early_termination.rs` - SPRT-based early termination for GPU evaluation (Issue #219)
 
 pub mod activation;
 pub mod bottleneck;
 pub mod cache;
 pub mod confidence;
+pub mod dead_neuron;
 pub mod diagnostics;
 pub mod early_termination;
 pub mod epistatic;
@@ -676,6 +678,52 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
 
         crate::watchdog::beat("analysis::analyze_all → bottleneck detection finished");
+
+        // Issue #341: Detect dead neurons for removal candidates.
+        // Dead neurons always output zero or near-zero activation, wasting computation.
+        // We recommend removing them via CoordinatedStructuralCandidateJson with RemoveNeuron.
+        crate::watchdog::beat("analysis::analyze_all → dead neuron detection starting");
+        let _dead_neuron_timer = PhaseTimer::new("dead_neuron_detection");
+
+        if !hidden_neurons.is_empty() {
+            let dead_neuron_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
+                hidden_neurons
+                    .iter()
+                    .filter_map(|(uuid, _, _)| {
+                        shared_cache
+                            .get(uuid)
+                            .ok()
+                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
+                    })
+                    .collect();
+
+            let dead_candidates =
+                dead_neuron::detect_dead_neurons(&input.creature, &dead_neuron_records);
+
+            if !dead_candidates.is_empty() {
+                let coordinated_dead =
+                    dead_neuron::dead_neurons_to_coordinated_candidates(&dead_candidates);
+
+                if !coordinated_dead.is_empty() {
+                    if utils::verbose_enabled() {
+                        eprintln!(
+                            "[NEAT-AI-Discovery][verbose] Dead neuron detection: found {} dead neuron(s), {} candidate(s)",
+                            dead_candidates.len(),
+                            coordinated_dead.len()
+                        );
+                    }
+
+                    merge_coordinated_structural_replacements(
+                        syn,
+                        coordinated_dead,
+                        input.max_synapse_candidates,
+                        input.analysis_deadline_ms.is_some(),
+                    );
+                }
+            }
+        }
+
+        crate::watchdog::beat("analysis::analyze_all → dead neuron detection finished");
     }
 
     // Collect final profile data (Issue #214)

--- a/tests/issue_341_dead_neuron_detection.rs
+++ b/tests/issue_341_dead_neuron_detection.rs
@@ -1,0 +1,437 @@
+//! Tests for Issue #341: Detect dead neurons for removal candidates.
+//!
+//! Dead neurons always output zero or near-zero activation, wasting computation
+//! without contributing to the network's output. This module detects them and
+//! recommends their removal.
+//!
+//! ## TDD Plan
+//! 1. Create test network with intentionally dead neurons
+//! 2. Verify detection identifies them with correct statistics
+//! 3. Verify active neurons are not flagged
+//! 4. Test edge cases: rarely active neurons, tiny but nonzero activation
+//! 5. Test coordinated structural candidate conversion
+
+use neat_ai_discovery::analysis::dead_neuron::{
+    dead_neurons_to_coordinated_candidates, detect_dead_neurons, DeadNeuronCandidate,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord for a neuron with given activation.
+fn record(
+    neuron_uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    value: Option<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value,
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+/// Helper: build a minimal creature with neurons and synapses.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 2,
+        output: 1,
+    }
+}
+
+/// Helper: build a NeuronJson.
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Helper: build a SynapseJson.
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Test 1: Neuron with all-zero activations is detected as dead.
+#[test]
+fn test_detects_all_zero_activation_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-dead", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-dead", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-dead", i, 0.0, Some(-5.0)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-dead".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect one dead neuron");
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "hidden-dead");
+    assert!(
+        c.mean_abs_activation < 1e-6,
+        "Mean abs activation should be near zero"
+    );
+    assert!(c.activation_std_dev < 1e-6, "Std dev should be near zero");
+    assert!(c.removal_confidence > 0.9, "Confidence should be high");
+}
+
+/// Test 2: Neuron with near-zero but nonzero activations is detected.
+#[test]
+fn test_detects_near_zero_activation_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-tiny", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-tiny", "output-1", 0.3)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-tiny", i, 1e-8 * (i as f32), Some(1e-9)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-tiny".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect near-zero neuron");
+    assert!(candidates[0].mean_abs_activation < 1e-6);
+}
+
+/// Test 3: Active neuron is NOT flagged as dead.
+#[test]
+fn test_does_not_flag_active_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-active", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-active", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = 0.5 + 0.3 * ((i as f32 * 0.1).sin());
+            record("hidden-active", i, activation, Some(0.5))
+        })
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-active".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Active neuron should not be flagged as dead"
+    );
+}
+
+/// Test 4: Neuron that is rarely but meaningfully active is NOT flagged.
+/// This tests the false-positive prevention: a neuron active on only 5% of samples
+/// but with significant activation when active should not be considered dead.
+#[test]
+fn test_rarely_active_neuron_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-rare", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-rare", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            // Active on 5% of samples with significant activation (0.8)
+            let activation = if i % 20 == 0 { 0.8 } else { 0.0 };
+            record(
+                "hidden-rare",
+                i,
+                activation,
+                Some(if i % 20 == 0 { 1.0 } else { -1.0 }),
+            )
+        })
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-rare".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Rarely but meaningfully active neuron should not be flagged"
+    );
+}
+
+/// Test 5: Neuron with constant tiny activation and zero variance is dead.
+#[test]
+fn test_constant_tiny_activation_is_dead() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-const", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-const", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-const", i, 1e-8, Some(1e-9)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-const".to_string(), records)]);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Constant tiny activation neuron is dead"
+    );
+    assert!(candidates[0].activation_std_dev < 1e-6);
+}
+
+/// Test 6: Output neurons should never be flagged as dead.
+#[test]
+fn test_output_neurons_not_flagged() {
+    let creature = make_creature(vec![neuron("output-1", "output", "IDENTITY")], vec![]);
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("output-1", i, 0.0, Some(0.0)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("output-1".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Output neurons should not be flagged"
+    );
+}
+
+/// Test 7: Too few samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-few", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-few", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| record("hidden-few", i, 0.0, Some(-5.0)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-few".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 8: Mixed neurons — only dead ones are detected.
+#[test]
+fn test_mixed_neurons_only_dead_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("dead-1", "hidden", "RELU"),
+            neuron("dead-2", "hidden", "TANH"),
+            neuron("alive-1", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("dead-1", "output-1", 0.5),
+            synapse("dead-2", "output-1", 0.3),
+            synapse("alive-1", "output-1", 0.8),
+        ],
+    );
+
+    let dead_records_1: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("dead-1", i, 0.0, Some(-3.0)))
+        .collect();
+    let dead_records_2: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("dead-2", i, 1e-9, Some(1e-10)))
+        .collect();
+    let alive_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = 0.5 + 0.2 * ((i as f32 * 0.1).sin());
+            record("alive-1", i, activation, Some(1.0))
+        })
+        .collect();
+
+    let candidates = detect_dead_neurons(
+        &creature,
+        &[
+            ("dead-1".to_string(), dead_records_1),
+            ("dead-2".to_string(), dead_records_2),
+            ("alive-1".to_string(), alive_records),
+        ],
+    );
+
+    assert_eq!(candidates.len(), 2, "Should detect exactly 2 dead neurons");
+    let uuids: Vec<&str> = candidates.iter().map(|c| c.neuron_uuid.as_str()).collect();
+    assert!(uuids.contains(&"dead-1"), "Should detect dead-1");
+    assert!(uuids.contains(&"dead-2"), "Should detect dead-2");
+}
+
+/// Test 9: Dead neuron candidates produce correct coordinated structural operations.
+#[test]
+fn test_candidates_produce_coordinated_removal_operations() {
+    let candidate = DeadNeuronCandidate {
+        neuron_uuid: "hidden-dead".to_string(),
+        mean_abs_activation: 1e-8,
+        activation_std_dev: 0.0,
+        sample_count: 1000,
+        connected_outputs: vec!["output-1".to_string(), "output-3".to_string()],
+        removal_confidence: 0.99,
+        estimated_improvement: 0.001,
+    };
+
+    let coordinated = dead_neurons_to_coordinated_candidates(&[candidate]);
+
+    assert_eq!(
+        coordinated.len(),
+        1,
+        "Should produce one coordinated candidate"
+    );
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the removal"
+    );
+
+    // Check that operations include a RemoveNeuron
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("removeNeuron"),
+        "Should include removeNeuron operation, got: {ops_json}"
+    );
+}
+
+/// Test 10: Neuron with negative near-zero activation (e.g., leaky RELU) is detected.
+#[test]
+fn test_detects_negative_near_zero_activation() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-neg", "hidden", "LEAKYRELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-neg", "output-1", 0.5)],
+    );
+
+    // LeakyRELU with very small negative outputs (dead-like behaviour)
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-neg", i, -1e-8, Some(-1e-7)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-neg".to_string(), records)]);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect near-zero negative activation"
+    );
+}
+
+/// Test 11: Neuron with zero mean but high variance is NOT dead (bipolar activation).
+#[test]
+fn test_zero_mean_high_variance_not_dead() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-bipolar", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-bipolar", "output-1", 0.5)],
+    );
+
+    // Activation alternates between +0.5 and -0.5 → mean ≈ 0 but high variance
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = if i % 2 == 0 { 0.5 } else { -0.5 };
+            record("hidden-bipolar", i, activation, Some(0.0))
+        })
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-bipolar".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Zero-mean but high-variance neuron is not dead"
+    );
+}
+
+/// Test 12: Sample count is correctly recorded in the candidate.
+#[test]
+fn test_sample_count_recorded() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-dead", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-dead", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..200)
+        .map(|i| record("hidden-dead", i, 0.0, Some(-5.0)))
+        .collect();
+
+    let candidates = detect_dead_neurons(&creature, &[("hidden-dead".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates[0].sample_count, 200,
+        "Sample count should match record count"
+    );
+}
+
+/// Test 13: Connected outputs are correctly identified.
+#[test]
+fn test_connected_outputs_identified() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-dead", "hidden", "RELU"),
+            neuron("hidden-mid", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("hidden-dead", "hidden-mid", 0.5),
+            synapse("hidden-dead", "output-1", 0.3),
+            synapse("hidden-mid", "output-2", 0.4),
+        ],
+    );
+
+    let dead_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-dead", i, 0.0, Some(-5.0)))
+        .collect();
+    let mid_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-mid", i, 0.5, Some(1.0)))
+        .collect();
+
+    let candidates = detect_dead_neurons(
+        &creature,
+        &[
+            ("hidden-dead".to_string(), dead_records),
+            ("hidden-mid".to_string(), mid_records),
+        ],
+    );
+
+    assert_eq!(candidates.len(), 1);
+    // The dead neuron connects directly to output-1 and indirectly to output-2 via hidden-mid
+    assert!(
+        !candidates[0].connected_outputs.is_empty(),
+        "Should identify connected outputs"
+    );
+}


### PR DESCRIPTION
## Summary

Implements dead neuron detection (Issue #341) — a new discovery category that identifies
hidden neurons with near-zero activation across all samples and recommends their removal.

Dead neurons waste GPU computation during both training and inference without contributing
useful information to the network's output. This commonly occurs when weight changes push
a neuron's inputs to always land in the zero region of its activation function (e.g., RELU
neurons that never receive positive input).

### Detection Criteria

A neuron is considered "dead" if:
1. **Near-zero activation**: Mean absolute activation < 1e-6 across all samples
2. **Zero variance**: Activation standard deviation < 1e-6
3. **No meaningful activity**: Fewer than 1% of samples show activation above 0.01
4. **Minimum samples**: At least 20 samples required for reliable detection
5. **Hidden neurons only**: Output and input neurons are excluded

### Implementation

- New module `src/analysis/dead_neuron.rs` following the established pattern from
  saturated neuron detection (Issue #342) and bottleneck detection (Issue #343)
- Integrated as a post-processing pass in `analyze_all()` after bottleneck detection
- Emits `RemoveNeuron` operations via `CoordinatedStructuralCandidateJson`
- No new candidate types needed — reuses existing coordinated structural mechanism

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

Added 13 tests in `tests/issue_341_dead_neuron_detection.rs`:

1. `test_detects_all_zero_activation_neuron` — All-zero activation detected as dead
2. `test_detects_near_zero_activation_neuron` — Near-zero (1e-8) activation detected
3. `test_does_not_flag_active_neuron` — Active neuron (mean ~0.5) not flagged
4. `test_rarely_active_neuron_not_flagged` — Neuron active on 5% of samples not flagged (false positive prevention)
5. `test_constant_tiny_activation_is_dead` — Constant 1e-8 activation detected
6. `test_output_neurons_not_flagged` — Output neurons excluded from detection
7. `test_insufficient_samples_not_flagged` — Fewer than 20 samples skipped
8. `test_mixed_neurons_only_dead_detected` — Only dead neurons detected in mixed set
9. `test_candidates_produce_coordinated_removal_operations` — Correct `removeNeuron` operation emitted
10. `test_detects_negative_near_zero_activation` — Negative near-zero (LeakyRELU) detected
11. `test_zero_mean_high_variance_not_dead` — Bipolar activation (zero mean, high variance) not flagged
12. `test_sample_count_recorded` — Sample count correctly recorded in candidate
13. `test_connected_outputs_identified` — Downstream output neurons correctly found via BFS

All existing tests continue to pass. `./quality.sh` passes cleanly.

---

## Automated Fix Details
This PR addresses issue #341: **Discovery: Detect dead neurons for removal candidates**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #341