### PR TITLE
Fix: Discovery: Detect correlated error patterns for shared-cause identification (#344)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -646,6 +646,31 @@ training and inference without contributing useful information to the network's 
 `removeNeuron` operations. No new candidate types are needed — this reuses the existing
 coordinated structural change mechanism.
 
+#### Correlated Error Pattern Detection (Issue #344)
+
+When multiple output neurons consistently err in the same direction on the same samples,
+it suggests a missing input feature or hidden representation that would benefit all of them.
+Rather than treating each output independently and potentially creating redundant candidates,
+this analysis identifies shared causes and recommends a single structural change.
+
+**Detection method**:
+1. **Error correlation matrix**: Pearson correlation of per-sample errors between all output pairs
+2. **Complete-linkage clustering**: Groups outputs with pairwise correlation > 0.7
+3. **Shared error samples**: Counts samples where all neurons in a group err in the same direction
+4. **Predictive input identification**: Finds input neuron activations that predict the shared error
+
+**Skip optimisation**: This analysis is skipped when there is only one output neuron, since
+there is nothing to correlate.
+
+**Recommended action**:
+- **Add shared hidden neuron**: A single new hidden neuron that connects predictive inputs
+  to all outputs in the correlated group, addressing the shared missing cause as an atomic
+  coordinated structural change
+
+**Output**: Correlated error groups appear in `coordinatedStructuralCandidates` with
+`addNeuron` and `addSynapse` operations. No new candidate types are needed — this reuses
+the existing coordinated structural change mechanism.
+
 ### Discrete activation function handling
 
 The standard discovery algorithm uses a **linear error model** to predict improvement:

--- a/docs/pr-summary-344.md
+++ b/docs/pr-summary-344.md
@@ -1,0 +1,45 @@
+## Summary
+
+Implements correlated error pattern detection for shared-cause identification (Issue #344).
+
+When multiple output neurons consistently err in the same direction on the same samples, it suggests a missing input feature or hidden representation that would benefit all of them. This new analysis detects such correlated error groups and recommends adding a shared hidden neuron that connects predictive inputs to all affected outputs as a single coordinated structural change.
+
+### Changes
+
+- **New module**: `src/analysis/correlated_error.rs` — Detection logic including:
+  - Pearson correlation computation between output neuron error vectors
+  - Complete-linkage clustering to group correlated outputs (threshold > 0.7)
+  - Shared error sample counting (same-direction errors)
+  - Predictive input identification (which inputs predict the shared error)
+  - Coordinated structural candidate generation (AddNeuron + AddSynapse operations)
+- **Pipeline integration**: `src/analysis/mod.rs` — Correlated error detection runs after dead neuron detection in the analysis pipeline. Skipped when only one output neuron exists (nothing to correlate).
+- **Documentation**: `README.md` — Added section describing the detection method, skip optimisation, and candidate output format.
+
+### Key design decisions
+
+- **Output neurons only**: Only output neuron errors are correlated (hidden/input neurons excluded from groups)
+- **First error value**: When neurons have multiple error values, the primary (first) error is used
+- **Complete-linkage clustering**: All pairwise correlations in a group must exceed 0.7 (prevents spurious groupings)
+- **Skip optimisation**: Single output neuron networks skip this analysis entirely, as noted in the issue
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+Added 13 tests in `tests/issue_344_correlated_error_detection.rs`:
+
+1. `test_detects_strongly_correlated_output_errors` — Verifies strongly correlated errors across three outputs are detected
+2. `test_independent_errors_no_groups` — Independent error patterns do not form groups
+3. `test_single_output_skips` — Single output neuron produces no groups
+4. `test_insufficient_samples_no_detection` — Too few samples (< 20) do not trigger detection
+5. `test_candidates_produce_coordinated_operations` — Groups produce AddNeuron + AddSynapse coordinated operations
+6. `test_two_independent_correlated_groups` — Two separate correlated groups are detected independently
+7. `test_negatively_correlated_errors_no_group` — Negative correlation does not form groups
+8. `test_predictive_inputs_identified` — Input neurons predictive of the shared error are correctly identified
+9. `test_shared_error_sample_count` — Shared error sample count is correctly computed
+10. `test_estimated_improvement_positive` — Estimated improvement is always positive for detected groups
+11. `test_empty_records_no_groups` — Empty records produce no groups
+12. `test_only_output_neurons_in_groups` — Hidden neurons excluded from correlated groups
+13. `test_multi_error_outputs_use_first_error` — Multi-error outputs use first (primary) error for correlation

--- a/src/analysis/correlated_error.rs
+++ b/src/analysis/correlated_error.rs
@@ -1,0 +1,627 @@
+//! Correlated error pattern detection module (Issue #344).
+//!
+//! Identifies groups of output neurons that exhibit correlated error patterns across
+//! samples, suggesting they share a common missing cause. Recommends structural changes
+//! that address the shared cause rather than treating each output independently.
+//!
+//! ## Detection Method
+//!
+//! 1. **Compute error correlation matrix**: For each pair of output neurons, compute the
+//!    Pearson correlation of their per-sample errors.
+//! 2. **Cluster correlated outputs**: Group outputs with correlation > threshold (0.7).
+//! 3. **Identify shared error samples**: Find samples where all neurons in a cluster err
+//!    in the same direction.
+//! 4. **Find predictive inputs**: Identify which input neuron activations predict the
+//!    shared error pattern.
+//!
+//! ## Recommended Actions
+//!
+//! When correlated errors are detected, we recommend:
+//! 1. **Add shared hidden neuron**: A new neuron connecting predictive inputs to all outputs
+//!    in the correlated group, addressing the shared missing cause.
+//!
+//! These are emitted as `CoordinatedStructuralCandidateJson` with `AddNeuron` and
+//! `AddSynapse` operations.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable correlation estimation.
+const MIN_SAMPLES_FOR_CORRELATION: usize = 20;
+
+/// Minimum Pearson correlation to consider two outputs as correlated.
+const CORRELATION_THRESHOLD: f32 = 0.7;
+
+/// Minimum absolute correlation between an input activation and the shared error
+/// to consider the input "predictive".
+const PREDICTIVE_INPUT_THRESHOLD: f32 = 0.4;
+
+/// Minimum fraction of samples where the group's errors share the same sign
+/// to count as "shared error samples".
+const SHARED_ERROR_SIGN_THRESHOLD: f32 = 0.0;
+
+/// Result of detecting a correlated error group among output neurons.
+#[derive(Debug, Clone)]
+pub struct CorrelatedErrorGroup {
+    /// UUIDs of output neurons in this correlated group.
+    pub output_neuron_uuids: Vec<String>,
+    /// Mean pairwise Pearson correlation within the group.
+    pub mean_correlation: f32,
+    /// Number of samples where all neurons in the group err in the same direction.
+    pub shared_error_sample_count: usize,
+    /// Total number of samples analysed.
+    pub total_sample_count: usize,
+    /// UUIDs of input neurons whose activations predict the shared error pattern.
+    pub predictive_input_uuids: Vec<String>,
+    /// Estimated creature score improvement from addressing the shared cause.
+    pub estimated_improvement: f32,
+}
+
+/// Detect correlated error patterns among output neurons.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations
+///   and errors. Should include both output and input neuron records.
+///
+/// # Returns
+/// A list of `CorrelatedErrorGroup` for groups of output neurons with correlated errors,
+/// sorted by estimated improvement (best first).
+pub fn detect_correlated_error_patterns(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<CorrelatedErrorGroup> {
+    // Identify output neuron UUIDs
+    let output_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Skip if only one output neuron — nothing to correlate
+    if output_uuids.len() < 2 {
+        return Vec::new();
+    }
+
+    // Identify input neuron UUIDs (for predictive input analysis)
+    let input_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Collect output neurons that have sufficient records with errors
+    let mut output_neurons_with_errors: Vec<&str> = Vec::new();
+    for uuid in &output_uuids {
+        if let Some(records) = records_map.get(uuid) {
+            if records.len() >= MIN_SAMPLES_FOR_CORRELATION
+                && records.iter().any(|r| !r.errors.is_empty())
+            {
+                output_neurons_with_errors.push(uuid);
+            }
+        }
+    }
+    output_neurons_with_errors.sort(); // deterministic ordering
+
+    if output_neurons_with_errors.len() < 2 {
+        return Vec::new();
+    }
+
+    // Build per-sample error vectors for each output neuron, indexed by obs_index.
+    // Use the first (primary) error value for correlation.
+    let mut error_by_obs: HashMap<&str, HashMap<u32, f32>> = HashMap::new();
+    for &uuid in &output_neurons_with_errors {
+        if let Some(records) = records_map.get(uuid) {
+            let mut obs_map = HashMap::new();
+            for r in records.iter() {
+                if let Some(&err) = r.errors.first() {
+                    obs_map.insert(r.obs_index, err);
+                }
+            }
+            error_by_obs.insert(uuid, obs_map);
+        }
+    }
+
+    // Find shared obs_indices across all output pairs
+    // Build pairwise correlation matrix
+    let n_outputs = output_neurons_with_errors.len();
+    let mut correlation_matrix: Vec<Vec<f32>> = vec![vec![0.0; n_outputs]; n_outputs];
+
+    for i in 0..n_outputs {
+        correlation_matrix[i][i] = 1.0; // self-correlation
+        for j in (i + 1)..n_outputs {
+            let uuid_i = output_neurons_with_errors[i];
+            let uuid_j = output_neurons_with_errors[j];
+
+            let corr = compute_pearson_correlation(
+                error_by_obs.get(uuid_i).unwrap(),
+                error_by_obs.get(uuid_j).unwrap(),
+            );
+
+            correlation_matrix[i][j] = corr;
+            correlation_matrix[j][i] = corr;
+        }
+    }
+
+    // Cluster correlated outputs using greedy single-linkage:
+    // Start from each pair above threshold, merge into groups where all pairwise
+    // correlations exceed the threshold (complete-linkage criterion).
+    let groups = cluster_correlated_outputs(
+        &output_neurons_with_errors,
+        &correlation_matrix,
+        CORRELATION_THRESHOLD,
+    );
+
+    // For each group, compute statistics and find predictive inputs
+    let mut results: Vec<CorrelatedErrorGroup> = Vec::new();
+
+    for group_indices in &groups {
+        let group_uuids: Vec<&str> = group_indices
+            .iter()
+            .map(|&i| output_neurons_with_errors[i])
+            .collect();
+
+        // Compute mean pairwise correlation within the group
+        let mut corr_sum = 0.0;
+        let mut corr_count = 0;
+        for (pos_i, &i) in group_indices.iter().enumerate() {
+            for &j in group_indices.iter().skip(pos_i + 1) {
+                corr_sum += correlation_matrix[i][j];
+                corr_count += 1;
+            }
+        }
+        let mean_correlation = if corr_count > 0 {
+            corr_sum / corr_count as f32
+        } else {
+            0.0
+        };
+
+        // Find shared obs_indices across all neurons in the group
+        let shared_obs = find_shared_obs_indices(&group_uuids, &error_by_obs);
+        let total_sample_count = shared_obs.len();
+
+        if total_sample_count < MIN_SAMPLES_FOR_CORRELATION {
+            continue;
+        }
+
+        // Count samples where all neurons err in the same direction
+        let shared_error_sample_count =
+            count_shared_error_samples(&group_uuids, &error_by_obs, &shared_obs);
+
+        if (shared_error_sample_count as f32 / total_sample_count as f32)
+            <= SHARED_ERROR_SIGN_THRESHOLD
+        {
+            continue;
+        }
+
+        // Find predictive input neurons
+        let predictive_inputs = find_predictive_inputs(
+            &group_uuids,
+            &input_uuids,
+            &records_map,
+            &error_by_obs,
+            &shared_obs,
+        );
+
+        // Estimate improvement: based on correlation strength, group size, and error magnitude
+        let mean_abs_error = compute_mean_abs_error(&group_uuids, &error_by_obs, &shared_obs);
+        let estimated_improvement =
+            mean_correlation * mean_abs_error * (group_uuids.len() as f32) * 0.01;
+
+        results.push(CorrelatedErrorGroup {
+            output_neuron_uuids: group_uuids.iter().map(|s| s.to_string()).collect(),
+            mean_correlation,
+            shared_error_sample_count,
+            total_sample_count,
+            predictive_input_uuids: predictive_inputs,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    results.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+/// Compute Pearson correlation between two error vectors indexed by obs_index.
+fn compute_pearson_correlation(errors_a: &HashMap<u32, f32>, errors_b: &HashMap<u32, f32>) -> f32 {
+    // Find shared obs_indices
+    let shared: Vec<u32> = errors_a
+        .keys()
+        .filter(|k| errors_b.contains_key(k))
+        .copied()
+        .collect();
+
+    let n = shared.len();
+    if n < MIN_SAMPLES_FOR_CORRELATION {
+        return 0.0;
+    }
+
+    let n_f = n as f32;
+
+    // Compute means
+    let mean_a: f32 = shared.iter().map(|k| errors_a[k]).sum::<f32>() / n_f;
+    let mean_b: f32 = shared.iter().map(|k| errors_b[k]).sum::<f32>() / n_f;
+
+    // Compute covariance and standard deviations
+    let mut cov = 0.0_f32;
+    let mut var_a = 0.0_f32;
+    let mut var_b = 0.0_f32;
+
+    for &k in &shared {
+        let da = errors_a[&k] - mean_a;
+        let db = errors_b[&k] - mean_b;
+        cov += da * db;
+        var_a += da * da;
+        var_b += db * db;
+    }
+
+    let denom = (var_a * var_b).sqrt();
+    if denom < 1e-10 {
+        return 0.0; // No variance — undefined correlation
+    }
+
+    cov / denom
+}
+
+/// Cluster correlated outputs using complete-linkage clustering.
+///
+/// Returns groups of indices into `output_uuids` where all pairwise correlations
+/// within each group exceed `threshold`.
+fn cluster_correlated_outputs(
+    output_uuids: &[&str],
+    correlation_matrix: &[Vec<f32>],
+    threshold: f32,
+) -> Vec<Vec<usize>> {
+    let n = output_uuids.len();
+    let mut assigned: Vec<bool> = vec![false; n];
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+
+    for i in 0..n {
+        if assigned[i] {
+            continue;
+        }
+
+        // Start a new potential group with neuron i
+        let mut group = vec![i];
+        assigned[i] = true;
+
+        // Try to add other unassigned neurons that correlate with ALL current members
+        for j in (i + 1)..n {
+            if assigned[j] {
+                continue;
+            }
+
+            // Check complete-linkage: j must correlate above threshold with all in group
+            let all_correlated = group
+                .iter()
+                .all(|&member| correlation_matrix[member][j] >= threshold);
+
+            if all_correlated {
+                group.push(j);
+                assigned[j] = true;
+            }
+        }
+
+        // Only keep groups with at least 2 members
+        if group.len() >= 2 {
+            groups.push(group);
+        } else {
+            // Unassign the single neuron so it can be picked up by another group
+            assigned[i] = false;
+        }
+    }
+
+    groups
+}
+
+/// Find obs_indices shared across all neurons in the group.
+fn find_shared_obs_indices(
+    group_uuids: &[&str],
+    error_by_obs: &HashMap<&str, HashMap<u32, f32>>,
+) -> Vec<u32> {
+    if group_uuids.is_empty() {
+        return Vec::new();
+    }
+
+    let first = error_by_obs.get(group_uuids[0]);
+    if first.is_none() {
+        return Vec::new();
+    }
+
+    let mut shared: HashSet<u32> = first.unwrap().keys().copied().collect();
+
+    for &uuid in &group_uuids[1..] {
+        if let Some(obs_map) = error_by_obs.get(uuid) {
+            shared.retain(|k| obs_map.contains_key(k));
+        } else {
+            return Vec::new();
+        }
+    }
+
+    let mut result: Vec<u32> = shared.into_iter().collect();
+    result.sort();
+    result
+}
+
+/// Count samples where all neurons in the group err in the same direction.
+fn count_shared_error_samples(
+    group_uuids: &[&str],
+    error_by_obs: &HashMap<&str, HashMap<u32, f32>>,
+    shared_obs: &[u32],
+) -> usize {
+    shared_obs
+        .iter()
+        .filter(|&&obs| {
+            let errors: Vec<f32> = group_uuids
+                .iter()
+                .filter_map(|uuid| error_by_obs.get(uuid)?.get(&obs).copied())
+                .collect();
+
+            if errors.len() < group_uuids.len() {
+                return false;
+            }
+
+            // All errors have the same sign (all positive or all negative)
+            let all_positive = errors.iter().all(|&e| e > 0.0);
+            let all_negative = errors.iter().all(|&e| e < 0.0);
+            all_positive || all_negative
+        })
+        .count()
+}
+
+/// Find input neurons whose activations predict the shared error pattern.
+///
+/// For each input neuron, compute the correlation between its activation and the
+/// average error across the correlated group. Inputs with |correlation| > threshold
+/// are considered predictive.
+fn find_predictive_inputs(
+    group_uuids: &[&str],
+    input_uuids: &HashSet<&str>,
+    records_map: &HashMap<&str, &Vec<DiscoverRecord>>,
+    error_by_obs: &HashMap<&str, HashMap<u32, f32>>,
+    shared_obs: &[u32],
+) -> Vec<String> {
+    if shared_obs.is_empty() {
+        return Vec::new();
+    }
+
+    // Compute average error across the group for each shared obs_index
+    let mut avg_error: HashMap<u32, f32> = HashMap::new();
+    for &obs in shared_obs {
+        let mut sum = 0.0;
+        let mut count = 0;
+        for &uuid in group_uuids {
+            if let Some(err) = error_by_obs.get(uuid).and_then(|m| m.get(&obs)) {
+                sum += err;
+                count += 1;
+            }
+        }
+        if count > 0 {
+            avg_error.insert(obs, sum / count as f32);
+        }
+    }
+
+    // For each input neuron, compute correlation with the average error
+    let mut predictive: Vec<(String, f32)> = Vec::new();
+
+    for &input_uuid in input_uuids {
+        let Some(input_records) = records_map.get(input_uuid) else {
+            continue;
+        };
+
+        // Build activation-by-obs map for this input
+        let input_activations: HashMap<u32, f32> = input_records
+            .iter()
+            .map(|r| (r.obs_index, r.activation))
+            .collect();
+
+        // Compute correlation between input activation and average error
+        let corr = compute_pearson_correlation_vecs(&input_activations, &avg_error);
+
+        if corr.abs() >= PREDICTIVE_INPUT_THRESHOLD {
+            predictive.push((input_uuid.to_string(), corr.abs()));
+        }
+    }
+
+    // Sort by correlation strength (strongest first)
+    predictive.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    predictive.into_iter().map(|(uuid, _)| uuid).collect()
+}
+
+/// Compute Pearson correlation between two f32 vectors indexed by u32 keys.
+fn compute_pearson_correlation_vecs(vec_a: &HashMap<u32, f32>, vec_b: &HashMap<u32, f32>) -> f32 {
+    let shared: Vec<u32> = vec_a
+        .keys()
+        .filter(|k| vec_b.contains_key(k))
+        .copied()
+        .collect();
+
+    let n = shared.len();
+    if n < MIN_SAMPLES_FOR_CORRELATION {
+        return 0.0;
+    }
+
+    let n_f = n as f32;
+
+    let mean_a: f32 = shared.iter().map(|k| vec_a[k]).sum::<f32>() / n_f;
+    let mean_b: f32 = shared.iter().map(|k| vec_b[k]).sum::<f32>() / n_f;
+
+    let mut cov = 0.0_f32;
+    let mut var_a = 0.0_f32;
+    let mut var_b = 0.0_f32;
+
+    for &k in &shared {
+        let da = vec_a[&k] - mean_a;
+        let db = vec_b[&k] - mean_b;
+        cov += da * db;
+        var_a += da * da;
+        var_b += db * db;
+    }
+
+    let denom = (var_a * var_b).sqrt();
+    if denom < 1e-10 {
+        return 0.0;
+    }
+
+    cov / denom
+}
+
+/// Compute mean absolute error across all neurons in the group for shared samples.
+fn compute_mean_abs_error(
+    group_uuids: &[&str],
+    error_by_obs: &HashMap<&str, HashMap<u32, f32>>,
+    shared_obs: &[u32],
+) -> f32 {
+    if shared_obs.is_empty() || group_uuids.is_empty() {
+        return 0.0;
+    }
+
+    let mut sum = 0.0_f32;
+    let mut count = 0_usize;
+
+    for &obs in shared_obs {
+        for &uuid in group_uuids {
+            if let Some(err) = error_by_obs.get(uuid).and_then(|m| m.get(&obs)) {
+                sum += err.abs();
+                count += 1;
+            }
+        }
+    }
+
+    if count > 0 {
+        sum / count as f32
+    } else {
+        0.0
+    }
+}
+
+/// Generate a deterministic UUID for a shared hidden neuron.
+fn shared_neuron_uuid(group_uuids: &[String], index: usize) -> String {
+    let mut key = format!("correlated-shared|{index}");
+    for uuid in group_uuids {
+        key.push('|');
+        key.push_str(uuid);
+    }
+    // FNV-1a 64-bit
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("cs-{hash:016x}")
+}
+
+/// Convert correlated error groups into coordinated structural candidates.
+///
+/// Each group produces a candidate that adds a shared hidden neuron connecting
+/// predictive inputs to all correlated outputs, addressing the shared missing cause.
+///
+/// # Arguments
+/// * `groups` - Detected correlated error groups.
+/// * `creature` - The creature topology (needed for neuron lookup).
+pub fn correlated_errors_to_coordinated_candidates(
+    groups: &[CorrelatedErrorGroup],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    // Find the first output neuron UUID for insert_before placement
+    let first_output_uuid = creature
+        .neurons
+        .iter()
+        .find(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone());
+
+    let mut results = Vec::new();
+
+    for (idx, group) in groups.iter().enumerate() {
+        let new_uuid = shared_neuron_uuid(&group.output_neuron_uuids, idx);
+
+        let mut operations = Vec::new();
+
+        // Add the shared hidden neuron (placed before the first output neuron)
+        operations.push(CoordinatedStructuralOpJson::AddNeuron {
+            neuron_uuid: new_uuid.clone(),
+            neuron_type: "hidden".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+            insert_before_neuron_uuid: first_output_uuid.clone(),
+        });
+
+        // Connect predictive inputs to the new shared neuron
+        let input_sources: &[String] = if group.predictive_input_uuids.is_empty() {
+            // If no predictive inputs found, use the first input neuron as fallback
+            &[]
+        } else {
+            &group.predictive_input_uuids
+        };
+
+        for input_uuid in input_sources {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: input_uuid.clone(),
+                to_neuron_uuid: new_uuid.clone(),
+                weight: 0.5,
+            });
+        }
+
+        // If no predictive inputs, connect from a generic input
+        if input_sources.is_empty() {
+            if let Some(first_input) = creature.neurons.iter().find(|n| n.neuron_type == "input") {
+                operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: first_input.uuid.clone(),
+                    to_neuron_uuid: new_uuid.clone(),
+                    weight: 0.5,
+                });
+            }
+        }
+
+        // Connect the shared neuron to all correlated outputs
+        for output_uuid in &group.output_neuron_uuids {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: new_uuid.clone(),
+                to_neuron_uuid: output_uuid.clone(),
+                weight: 0.1, // Start with a small weight — ablation testing will validate
+            });
+        }
+
+        let output_list = group.output_neuron_uuids.join(", ");
+        let input_list = if group.predictive_input_uuids.is_empty() {
+            "auto-selected".to_string()
+        } else {
+            group.predictive_input_uuids.join(", ")
+        };
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: group.estimated_improvement,
+            comment: Some(format!(
+                "Correlated error group [{}]: mean correlation {:.2}, {}/{} shared error samples → add shared hidden neuron from [{}]",
+                output_list, group.mean_correlation, group.shared_error_sample_count, group.total_sample_count, input_list
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -18,12 +18,14 @@
 //! - `saturation.rs` - Saturated neuron detection for activation function changes (Issue #342)
 //! - `bottleneck.rs` - Bottleneck neuron detection for information flow widening (Issue #343)
 //! - `dead_neuron.rs` - Dead neuron detection for removal candidates (Issue #341)
+//! - `correlated_error.rs` - Correlated error pattern detection for shared-cause identification (Issue #344)
 //! - `early_termination.rs` - SPRT-based early termination for GPU evaluation (Issue #219)
 
 pub mod activation;
 pub mod bottleneck;
 pub mod cache;
 pub mod confidence;
+pub mod correlated_error;
 pub mod dead_neuron;
 pub mod diagnostics;
 pub mod early_termination;
@@ -724,6 +726,75 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
 
         crate::watchdog::beat("analysis::analyze_all → dead neuron detection finished");
+
+        // Issue #344: Detect correlated error patterns for shared-cause identification.
+        // When multiple output neurons consistently err in the same direction on the same
+        // samples, it suggests a missing input feature or hidden representation that would
+        // benefit all of them. We recommend adding a shared hidden neuron.
+        crate::watchdog::beat("analysis::analyze_all → correlated error detection starting");
+        let _correlated_timer = PhaseTimer::new("correlated_error_detection");
+
+        // Only run if there are multiple output neurons (nothing to correlate otherwise)
+        let output_count = input
+            .creature
+            .neurons
+            .iter()
+            .filter(|n| n.neuron_type == "output")
+            .count();
+
+        if output_count >= 2 {
+            // Collect records for output and input neurons
+            let correlated_neuron_uuids: Vec<String> = input
+                .creature
+                .neurons
+                .iter()
+                .filter(|n| n.neuron_type == "output" || n.neuron_type == "input")
+                .map(|n| n.uuid.clone())
+                .collect();
+
+            let correlated_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
+                correlated_neuron_uuids
+                    .iter()
+                    .filter_map(|uuid| {
+                        shared_cache
+                            .get(uuid)
+                            .ok()
+                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
+                    })
+                    .collect();
+
+            let correlated_groups = correlated_error::detect_correlated_error_patterns(
+                &input.creature,
+                &correlated_records,
+            );
+
+            if !correlated_groups.is_empty() {
+                let coordinated_correlated =
+                    correlated_error::correlated_errors_to_coordinated_candidates(
+                        &correlated_groups,
+                        &input.creature,
+                    );
+
+                if !coordinated_correlated.is_empty() {
+                    if utils::verbose_enabled() {
+                        eprintln!(
+                            "[NEAT-AI-Discovery][verbose] Correlated error detection: found {} group(s), {} candidate(s)",
+                            correlated_groups.len(),
+                            coordinated_correlated.len()
+                        );
+                    }
+
+                    merge_coordinated_structural_replacements(
+                        syn,
+                        coordinated_correlated,
+                        input.max_synapse_candidates,
+                        input.analysis_deadline_ms.is_some(),
+                    );
+                }
+            }
+        }
+
+        crate::watchdog::beat("analysis::analyze_all → correlated error detection finished");
     }
 
     // Collect final profile data (Issue #214)

--- a/tests/issue_344_correlated_error_detection.rs
+++ b/tests/issue_344_correlated_error_detection.rs
@@ -1,0 +1,648 @@
+//! Tests for Issue #344: Detect correlated error patterns for shared-cause identification.
+//!
+//! When multiple output neurons consistently err in the same direction on the same samples,
+//! it suggests a missing input feature or hidden representation that would benefit all of them.
+//! This module detects correlated error groups and recommends shared structural changes.
+//!
+//! ## TDD Plan
+//! 1. Create test network where multiple outputs depend on a missing feature
+//! 2. Generate samples showing correlated errors
+//! 3. Verify detection identifies the correlated group
+//! 4. Verify recommended structural change addresses the shared cause
+//! 5. Test with independent errors (should not form groups)
+//! 6. Test single output neuron (should skip — nothing to correlate)
+
+use neat_ai_discovery::analysis::correlated_error::{
+    correlated_errors_to_coordinated_candidates, detect_correlated_error_patterns,
+    CorrelatedErrorGroup,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord for a neuron with given activation and errors.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature with neurons and synapses.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Helper: build a NeuronJson.
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Helper: build a SynapseJson.
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Test 1: Strongly correlated errors across three output neurons are detected.
+///
+/// All three outputs err positively on the same samples, suggesting a shared
+/// missing cause.
+#[test]
+fn test_detects_strongly_correlated_output_errors() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-2", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+            neuron("output-3", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+            synapse("input-2", "output-3", 0.4),
+        ],
+    );
+
+    // Generate correlated errors: all three outputs err similarly on the same samples
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2", "output-3"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                // All outputs have correlated positive error on even samples,
+                // correlated negative error on odd samples
+                let base_error = if i % 2 == 0 { 0.5 } else { -0.3 };
+                let noise = (i as f32 * 0.001) % 0.01; // tiny noise
+                record(output_id, i, 0.5, vec![base_error + noise])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        !groups.is_empty(),
+        "Should detect at least one correlated error group"
+    );
+    let group = &groups[0];
+    assert!(
+        group.output_neuron_uuids.len() >= 2,
+        "Group should contain at least 2 output neurons"
+    );
+    assert!(
+        group.mean_correlation >= 0.7,
+        "Mean correlation should be high, got {}",
+        group.mean_correlation
+    );
+}
+
+/// Test 2: Independent (uncorrelated) errors do NOT form groups.
+#[test]
+fn test_independent_errors_no_groups() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+            neuron("output-3", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+            synapse("input-1", "output-3", 0.4),
+        ],
+    );
+
+    // Generate independent errors: each output has a different pattern
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // output-1: positive on even, negative on odd
+    let records_1: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 2 == 0 { 0.5 } else { -0.5 };
+            record("output-1", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("output-1".to_string(), records_1));
+
+    // output-2: positive on multiples of 3, negative otherwise (different pattern)
+    let records_2: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 3 == 0 { 0.5 } else { -0.5 };
+            record("output-2", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("output-2".to_string(), records_2));
+
+    // output-3: positive on multiples of 7, negative otherwise (different pattern)
+    let records_3: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 7 == 0 { 0.5 } else { -0.5 };
+            record("output-3", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("output-3".to_string(), records_3));
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        groups.is_empty(),
+        "Independent errors should not form correlated groups"
+    );
+}
+
+/// Test 3: Single output neuron — should skip (nothing to correlate).
+#[test]
+fn test_single_output_skips() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("output-1", i, 0.5, vec![0.3]))
+        .collect();
+
+    let groups = detect_correlated_error_patterns(&creature, &[("output-1".to_string(), records)]);
+
+    assert!(
+        groups.is_empty(),
+        "Single output neuron should not form any groups"
+    );
+}
+
+/// Test 4: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_no_detection() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    // Only 5 samples — not enough
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..5)
+            .map(|i| record(output_id, i, 0.5, vec![0.3]))
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        groups.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 5: Correlated error group produces coordinated structural candidate
+/// with AddNeuron and AddSynapse operations.
+#[test]
+fn test_candidates_produce_coordinated_operations() {
+    let group = CorrelatedErrorGroup {
+        output_neuron_uuids: vec![
+            "output-1".to_string(),
+            "output-2".to_string(),
+            "output-3".to_string(),
+        ],
+        mean_correlation: 0.85,
+        shared_error_sample_count: 60,
+        total_sample_count: 100,
+        predictive_input_uuids: vec!["input-1".to_string(), "input-4".to_string()],
+        estimated_improvement: 0.02,
+    };
+
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-4", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+            neuron("output-3", "output", "IDENTITY"),
+        ],
+        vec![],
+    );
+
+    let coordinated = correlated_errors_to_coordinated_candidates(&[group], &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the recommendation"
+    );
+
+    // Check that operations include AddNeuron and AddSynapse
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("addNeuron"),
+        "Should include addNeuron operation, got: {ops_json}"
+    );
+    assert!(
+        ops_json.contains("addSynapse"),
+        "Should include addSynapse operation, got: {ops_json}"
+    );
+}
+
+/// Test 6: Two separate correlated groups are detected independently.
+#[test]
+fn test_two_independent_correlated_groups() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+            neuron("output-3", "output", "IDENTITY"),
+            neuron("output-4", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+            synapse("input-1", "output-3", 0.4),
+            synapse("input-1", "output-4", 0.2),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Group A: output-1 and output-2 correlate (even/odd pattern)
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i % 2 == 0 { 0.5 } else { -0.5 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    // Group B: output-3 and output-4 correlate (multiples of 5 pattern — different from A)
+    for output_id in &["output-3", "output-4"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i % 5 == 0 { 0.8 } else { -0.2 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        groups.len() >= 2,
+        "Should detect at least 2 separate groups, got {}",
+        groups.len()
+    );
+}
+
+/// Test 7: Negatively correlated errors should NOT form a group.
+/// Negative correlation means errors go in opposite directions — not a shared cause.
+#[test]
+fn test_negatively_correlated_errors_no_group() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", -0.5),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // output-1: positive on even, negative on odd
+    let records_1: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 2 == 0 { 0.5 } else { -0.5 };
+            record("output-1", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("output-1".to_string(), records_1));
+
+    // output-2: OPPOSITE pattern — negative on even, positive on odd
+    let records_2: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 2 == 0 { -0.5 } else { 0.5 };
+            record("output-2", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("output-2".to_string(), records_2));
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        groups.is_empty(),
+        "Negatively correlated errors should not form groups"
+    );
+}
+
+/// Test 8: Predictive input identification — the detection should find which
+/// input neuron activations predict the shared error.
+#[test]
+fn test_predictive_inputs_identified() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-2", "input", "IDENTITY"),
+            neuron("input-3", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-2", "output-1", 0.3),
+            synapse("input-3", "output-2", 0.4),
+        ],
+    );
+
+    // input-1 is predictive: when input-1 is high, both outputs err high
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                // Error correlates with a hidden pattern
+                let error = if i < 50 { 0.5 } else { -0.3 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    // input records: input-1 activation correlates with the error pattern
+    output_records.push((
+        "input-1".to_string(),
+        (0..100)
+            .map(|i| {
+                let activation = if i < 50 { 0.9 } else { 0.1 };
+                record("input-1", i, activation, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-2: random, not predictive
+    output_records.push((
+        "input-2".to_string(),
+        (0..100)
+            .map(|i| {
+                let activation = ((i as f32) * 0.7).sin() * 0.5 + 0.5;
+                record("input-2", i, activation, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-3: random, not predictive
+    output_records.push((
+        "input-3".to_string(),
+        (0..100)
+            .map(|i| {
+                let activation = ((i as f32) * 1.3).cos() * 0.5 + 0.5;
+                record("input-3", i, activation, vec![])
+            })
+            .collect(),
+    ));
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(!groups.is_empty(), "Should detect correlated error group");
+    let group = &groups[0];
+    assert!(
+        !group.predictive_input_uuids.is_empty(),
+        "Should identify at least one predictive input"
+    );
+    assert!(
+        group
+            .predictive_input_uuids
+            .contains(&"input-1".to_string()),
+        "input-1 should be identified as predictive, got: {:?}",
+        group.predictive_input_uuids
+    );
+}
+
+/// Test 9: Shared error sample count is correctly computed.
+#[test]
+fn test_shared_error_sample_count() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                // Same error pattern: positive on first 60, negative on last 40
+                let error = if i < 60 { 0.5 } else { -0.3 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(!groups.is_empty(), "Should detect correlated error group");
+    let group = &groups[0];
+    assert_eq!(
+        group.total_sample_count, 100,
+        "Total sample count should match"
+    );
+    assert!(
+        group.shared_error_sample_count > 0,
+        "Should have shared error samples"
+    );
+}
+
+/// Test 10: Estimated improvement is positive for detected groups.
+#[test]
+fn test_estimated_improvement_positive() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i % 2 == 0 { 0.5 } else { -0.3 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(!groups.is_empty(), "Should detect correlated error group");
+    for group in &groups {
+        assert!(
+            group.estimated_improvement > 0.0,
+            "Estimated improvement should be positive, got {}",
+            group.estimated_improvement
+        );
+    }
+}
+
+/// Test 11: Empty records produce no groups.
+#[test]
+fn test_empty_records_no_groups() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![],
+    );
+
+    let groups: Vec<CorrelatedErrorGroup> = detect_correlated_error_patterns(&creature, &[]);
+
+    assert!(groups.is_empty(), "Empty records should produce no groups");
+}
+
+/// Test 12: Only output neurons are included in correlated groups (hidden neurons excluded).
+#[test]
+fn test_only_output_neurons_in_groups() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.5),
+            synapse("hidden-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Correlated output errors
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i % 2 == 0 { 0.5 } else { -0.3 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    // Hidden neuron records (should not be in any group)
+    let hidden_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i % 2 == 0 { 0.5 } else { -0.3 };
+            record("hidden-1", i, 0.5, vec![error])
+        })
+        .collect();
+    output_records.push(("hidden-1".to_string(), hidden_records));
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(!groups.is_empty(), "Should detect correlated group");
+    for group in &groups {
+        for uuid in &group.output_neuron_uuids {
+            assert!(
+                !uuid.starts_with("hidden"),
+                "Hidden neurons should not appear in correlated error groups"
+            );
+        }
+    }
+}
+
+/// Test 13: Multi-error outputs — correlation computed per error index.
+/// When output neurons have multiple error values, we correlate based on the
+/// first (primary) error value.
+#[test]
+fn test_multi_error_outputs_use_first_error() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut output_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let primary_error = if i % 2 == 0 { 0.5 } else { -0.3 };
+                // Second error is uncorrelated noise
+                let secondary_error = ((i as f32) * 0.37).sin();
+                record(output_id, i, 0.5, vec![primary_error, secondary_error])
+            })
+            .collect();
+        output_records.push((output_id.to_string(), records));
+    }
+
+    let groups = detect_correlated_error_patterns(&creature, &output_records);
+
+    assert!(
+        !groups.is_empty(),
+        "Should detect correlated group from primary error"
+    );
+}


### PR DESCRIPTION
## Summary

Implements correlated error pattern detection for shared-cause identification (Issue #344).

When multiple output neurons consistently err in the same direction on the same samples, it suggests a missing input feature or hidden representation that would benefit all of them. This new analysis detects such correlated error groups and recommends adding a shared hidden neuron that connects predictive inputs to all affected outputs as a single coordinated structural change.

### Changes

- **New module**: `src/analysis/correlated_error.rs` — Detection logic including:
  - Pearson correlation computation between output neuron error vectors
  - Complete-linkage clustering to group correlated outputs (threshold > 0.7)
  - Shared error sample counting (same-direction errors)
  - Predictive input identification (which inputs predict the shared error)
  - Coordinated structural candidate generation (AddNeuron + AddSynapse operations)
- **Pipeline integration**: `src/analysis/mod.rs` — Correlated error detection runs after dead neuron detection in the analysis pipeline. Skipped when only one output neuron exists (nothing to correlate).
- **Documentation**: `README.md` — Added section describing the detection method, skip optimisation, and candidate output format.

### Key design decisions

- **Output neurons only**: Only output neuron errors are correlated (hidden/input neurons excluded from groups)
- **First error value**: When neurons have multiple error values, the primary (first) error is used
- **Complete-linkage clustering**: All pairwise correlations in a group must exceed 0.7 (prevents spurious groupings)
- **Skip optimisation**: Single output neuron networks skip this analysis entirely, as noted in the issue

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

Added 13 tests in `tests/issue_344_correlated_error_detection.rs`:

1. `test_detects_strongly_correlated_output_errors` — Verifies strongly correlated errors across three outputs are detected
2. `test_independent_errors_no_groups` — Independent error patterns do not form groups
3. `test_single_output_skips` — Single output neuron produces no groups
4. `test_insufficient_samples_no_detection` — Too few samples (< 20) do not trigger detection
5. `test_candidates_produce_coordinated_operations` — Groups produce AddNeuron + AddSynapse coordinated operations
6. `test_two_independent_correlated_groups` — Two separate correlated groups are detected independently
7. `test_negatively_correlated_errors_no_group` — Negative correlation does not form groups
8. `test_predictive_inputs_identified` — Input neurons predictive of the shared error are correctly identified
9. `test_shared_error_sample_count` — Shared error sample count is correctly computed
10. `test_estimated_improvement_positive` — Estimated improvement is always positive for detected groups
11. `test_empty_records_no_groups` — Empty records produce no groups
12. `test_only_output_neurons_in_groups` — Hidden neurons excluded from correlated groups
13. `test_multi_error_outputs_use_first_error` — Multi-error outputs use first (primary) error for correlation

---

## Automated Fix Details
This PR addresses issue #344: **Discovery: Detect correlated error patterns for shared-cause identification**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #344