### PR TITLE
Fix: Discovery: Implement candidate clustering to reduce redundant ablation tests (#224)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.15"
+version = "0.9.16"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.14"
+version = "0.9.15"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -671,6 +671,54 @@ there is nothing to correlate.
 `addNeuron` and `addSynapse` operations. No new candidate types are needed — this reuses
 the existing coordinated structural change mechanism.
 
+#### Candidate Clustering for Redundancy Reduction (Issue #224)
+
+When discovery returns many similar candidates (e.g., multiple synapses from the same source
+region targeting the same neuron), the controller would otherwise evaluate each independently,
+wasting CPU on redundant ablation tests. Candidate clustering groups these into clusters so
+the controller can test a representative first and skip the rest if it fails.
+
+**Clustering criteria**:
+1. **Same target neuron** (`toNeuronUuid`) — candidates must target the same neuron
+2. **Same source type** (input vs hidden) — different neuron types have different signal
+   characteristics and should not be mixed
+3. **Similar improvement prediction** — candidates with very different expected improvements
+   (>5× ratio) are split into separate sub-clusters
+
+**JSON output**: Clusters appear in `candidateClusters` (optional field, omitted when empty):
+
+```json
+{
+  "candidateClusters": [
+    {
+      "representativeFromUuid": "input-42",
+      "representativeToUuid": "hidden-5",
+      "representativeImprovement": 0.101,
+      "memberCount": 5,
+      "memberFromUuids": ["input-42", "input-43", "input-44", "input-45", "input-46"],
+      "internalCorrelation": 0.92
+    }
+  ]
+}
+```
+
+**TypeScript usage**:
+
+```typescript
+// Test representative first, skip cluster if it fails:
+for (const cluster of candidateClusters) {
+    const result = testCandidate(cluster.representativeFromUuid, cluster.representativeToUuid);
+    if (!result.improved) {
+        // Representative failed — skip remaining members (high correlation)
+        console.log(`Skipping ${cluster.memberCount - 1} similar candidates`);
+    }
+}
+```
+
+**Backward compatible**: The `candidateClusters` field is optional and only present when
+clusters are detected. Existing consumers that do not read this field continue to work
+unchanged.
+
 ### Discrete activation function handling
 
 The standard discovery algorithm uses a **linear error model** to predict improvement:

--- a/docs/pr-summary-224.md
+++ b/docs/pr-summary-224.md
@@ -1,0 +1,57 @@
+## Summary
+
+Implements candidate clustering to reduce redundant ablation tests (Issue #224).
+
+When discovery returns many similar candidates (e.g., multiple synapses from the same
+source region targeting the same neuron), the TypeScript controller would otherwise test
+each independently, wasting CPU cycles. This change groups similar candidates into
+clusters so the controller can test a representative first and skip redundant tests
+if the representative fails.
+
+### What changed
+
+- **New module `src/analysis/candidate_clustering.rs`**: Groups candidates by target
+  neuron, source type, and improvement similarity. Each cluster identifies a
+  representative (highest improvement) and computes an internal correlation score.
+- **New JSON field `candidateClusters`**: Optional field in `AnalyzeParallelOutput`
+  that lists detected clusters with representative UUID, member count, member UUIDs,
+  and internal correlation.
+- **Post-processing integration**: Clustering runs as a final step in `analyze_all`
+  after all candidates have been gathered, so it sees the complete candidate set.
+- **Backward compatible**: The `candidateClusters` field is `skip_serializing_if`
+  `Option::is_none`, so existing consumers are unaffected.
+
+### Clustering criteria
+
+1. **Same target neuron** — candidates must share `toNeuronUuid`
+2. **Same source type** — input vs hidden neurons are not mixed
+3. **Similar improvement** — candidates with >5x improvement ratio are split into
+   separate sub-clusters
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+No performance benchmark needed — clustering is a lightweight O(n) grouping pass
+over the existing candidate arrays with no GPU involvement.
+
+## Test Plan
+
+- 13 integration tests in `tests/issue_224_candidate_clustering.rs`:
+  - `test_same_target_candidates_clustered` — candidates targeting same neuron cluster
+  - `test_representative_is_best_candidate` — highest improvement is representative
+  - `test_different_targets_separate_clusters` — different targets form different clusters
+  - `test_internal_correlation_range` — correlation is between 0.0 and 1.0
+  - `test_single_candidate_no_cluster` — no cluster for lone candidates
+  - `test_empty_candidates_no_clusters` — empty input produces no clusters
+  - `test_cluster_json_serialisation` — JSON output has expected camelCase fields
+  - `test_mixed_types_sub_clustering` — input vs hidden sources form separate clusters
+  - `test_dissimilar_improvements_separate_clusters` — large improvement differences split
+  - `test_cluster_members_sorted_by_improvement` — members sorted best-first
+  - `test_clusters_sorted_by_best_improvement` — clusters sorted by representative
+  - `test_similar_improvements_yield_high_correlation` — similar values yield high correlation
+  - `test_large_candidate_set` — 100 candidates across 2 targets clustered correctly
+- 2 inline unit tests in `src/analysis/candidate_clustering.rs`:
+  - `test_split_by_improvement_similarity_basic`
+  - `test_compute_internal_correlation_identical`
+- Existing contract test updated: `issue_337_candidate_type_contract.rs`

--- a/src/analysis/candidate_clustering.rs
+++ b/src/analysis/candidate_clustering.rs
@@ -1,0 +1,274 @@
+//! Candidate clustering module (Issue #224).
+//!
+//! Groups similar discovery candidates to reduce redundant ablation tests. When
+//! discovery returns many candidates targeting the same neuron from similar source
+//! regions, clustering identifies these groups so the TypeScript controller can test
+//! a representative candidate first and skip the rest if it fails.
+//!
+//! ## Clustering Criteria
+//!
+//! Candidates are grouped by:
+//! 1. **Same target neuron** (`to_neuron_uuid`) — candidates must target the same neuron.
+//! 2. **Same source type** (input vs hidden) — different neuron types have different
+//!    signal characteristics and should not be mixed.
+//! 3. **Similar improvement prediction** — candidates with very different expected
+//!    improvements are unlikely to be truly redundant.
+//!
+//! ## Output
+//!
+//! Each cluster contains:
+//! - A **representative** (the highest-improvement candidate in the cluster).
+//! - A list of **member UUIDs** (all candidates in the cluster).
+//! - An **internal correlation** score (0.0 to 1.0) indicating how similar the
+//!   members' improvements are.
+//!
+//! The controller tests the representative first. If it fails, all members are
+//! skipped (high correlation implies they would also fail). If it succeeds, the
+//! controller may test additional members with lower priority.
+
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Maximum ratio between the best and worst improvement within a cluster.
+/// Candidates whose improvement differs by more than this factor are split
+/// into separate sub-clusters.
+const IMPROVEMENT_SIMILARITY_RATIO: f32 = 5.0;
+
+/// Minimum number of candidates in a group to form a cluster.
+/// A single candidate has no redundancy to reduce.
+const MIN_CLUSTER_SIZE: usize = 2;
+
+/// Input representation for a candidate that can be clustered.
+///
+/// This is a simplified view of a synapse or structural candidate, containing
+/// only the fields needed for clustering decisions.
+#[derive(Debug, Clone)]
+pub struct ClusterableCandidate {
+    /// UUID of the source neuron.
+    pub from_neuron_uuid: String,
+    /// UUID of the target neuron.
+    pub to_neuron_uuid: String,
+    /// Expected improvement from this candidate.
+    pub expected_improvement: f32,
+    /// Type of the source neuron (e.g., "input", "hidden").
+    pub neuron_type: String,
+}
+
+/// JSON output for a candidate cluster.
+///
+/// Tells the controller which candidates are redundant and can be skipped
+/// if the representative fails the ablation test.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidateClusterJson {
+    /// Source UUID of the representative (highest-improvement) candidate.
+    pub representative_from_uuid: String,
+    /// Target UUID of the representative candidate.
+    pub representative_to_uuid: String,
+    /// Expected improvement of the representative candidate.
+    pub representative_improvement: f32,
+    /// Total number of candidates in this cluster.
+    pub member_count: usize,
+    /// Source UUIDs of all candidates in this cluster (ordered by improvement, best first).
+    pub member_from_uuids: Vec<String>,
+    /// Similarity score within the cluster (0.0 to 1.0).
+    /// Higher values mean the candidates are more likely to share the same outcome.
+    pub internal_correlation: f32,
+}
+
+/// Cluster candidates by target neuron, source type, and improvement similarity.
+///
+/// Returns a list of clusters, each containing at least [`MIN_CLUSTER_SIZE`] members.
+/// Clusters are sorted by representative improvement (best first).
+///
+/// # Arguments
+/// * `candidates` - Slice of clusterable candidates to group.
+///
+/// # Returns
+/// A list of [`CandidateClusterJson`] for groups with ≥ 2 members.
+pub fn cluster_candidates(candidates: &[ClusterableCandidate]) -> Vec<CandidateClusterJson> {
+    if candidates.len() < MIN_CLUSTER_SIZE {
+        return Vec::new();
+    }
+
+    // Step 1: Group by (to_neuron_uuid, neuron_type)
+    let mut groups: HashMap<(&str, &str), Vec<&ClusterableCandidate>> = HashMap::new();
+    for c in candidates {
+        groups
+            .entry((c.to_neuron_uuid.as_str(), c.neuron_type.as_str()))
+            .or_default()
+            .push(c);
+    }
+
+    let mut clusters: Vec<CandidateClusterJson> = Vec::new();
+
+    for group in groups.values() {
+        if group.len() < MIN_CLUSTER_SIZE {
+            continue;
+        }
+
+        // Step 2: Sort by improvement (best first) within each group
+        let mut sorted: Vec<&ClusterableCandidate> = group.clone();
+        sorted.sort_by(|a, b| {
+            b.expected_improvement
+                .partial_cmp(&a.expected_improvement)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Step 3: Sub-cluster by improvement similarity.
+        // Walk through sorted candidates and split when the ratio between the
+        // current best and the next candidate exceeds the threshold.
+        let sub_clusters = split_by_improvement_similarity(&sorted);
+
+        for sub in sub_clusters {
+            if sub.len() < MIN_CLUSTER_SIZE {
+                continue;
+            }
+
+            let representative = sub[0];
+            let internal_correlation = compute_internal_correlation(&sub);
+
+            clusters.push(CandidateClusterJson {
+                representative_from_uuid: representative.from_neuron_uuid.clone(),
+                representative_to_uuid: representative.to_neuron_uuid.clone(),
+                representative_improvement: representative.expected_improvement,
+                member_count: sub.len(),
+                member_from_uuids: sub.iter().map(|c| c.from_neuron_uuid.clone()).collect(),
+                internal_correlation,
+            });
+        }
+    }
+
+    // Sort clusters by representative improvement (best first)
+    clusters.sort_by(|a, b| {
+        b.representative_improvement
+            .partial_cmp(&a.representative_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    clusters
+}
+
+/// Split a sorted (best-first) group of candidates into sub-clusters where
+/// all members have similar improvement values.
+///
+/// Uses a ratio-based criterion: if the best improvement in the current sub-cluster
+/// is more than [`IMPROVEMENT_SIMILARITY_RATIO`]× the worst, a new sub-cluster starts.
+fn split_by_improvement_similarity<'a>(
+    sorted: &[&'a ClusterableCandidate],
+) -> Vec<Vec<&'a ClusterableCandidate>> {
+    if sorted.is_empty() {
+        return Vec::new();
+    }
+
+    let mut result: Vec<Vec<&'a ClusterableCandidate>> = Vec::new();
+    let mut current_sub: Vec<&'a ClusterableCandidate> = vec![sorted[0]];
+    let mut current_best = sorted[0].expected_improvement.abs().max(f32::EPSILON);
+
+    for &c in &sorted[1..] {
+        let c_improvement = c.expected_improvement.abs().max(f32::EPSILON);
+
+        // If the ratio between the sub-cluster's best and this candidate is too large,
+        // start a new sub-cluster.
+        if current_best / c_improvement > IMPROVEMENT_SIMILARITY_RATIO {
+            result.push(std::mem::take(&mut current_sub));
+            current_best = c_improvement;
+        }
+
+        current_sub.push(c);
+    }
+
+    if !current_sub.is_empty() {
+        result.push(current_sub);
+    }
+
+    result
+}
+
+/// Compute the internal correlation score for a sub-cluster.
+///
+/// Uses the coefficient of variation (CV) of improvements to estimate how
+/// similar the candidates are. A low CV (< 0.1) yields correlation ≈ 1.0;
+/// a high CV (> 1.0) yields correlation ≈ 0.0.
+///
+/// Formula: `correlation = 1.0 - min(cv, 1.0)` where `cv = std_dev / mean`.
+fn compute_internal_correlation(candidates: &[&ClusterableCandidate]) -> f32 {
+    if candidates.len() < 2 {
+        return 1.0;
+    }
+
+    let improvements: Vec<f32> = candidates
+        .iter()
+        .map(|c| c.expected_improvement.abs())
+        .collect();
+
+    let n = improvements.len() as f32;
+    let mean = improvements.iter().sum::<f32>() / n;
+
+    if mean < f32::EPSILON {
+        // All near-zero — treat as perfectly correlated
+        return 1.0;
+    }
+
+    let variance = improvements
+        .iter()
+        .map(|&x| (x - mean).powi(2))
+        .sum::<f32>()
+        / n;
+    let std_dev = variance.sqrt();
+    let cv = std_dev / mean;
+
+    // Map CV to correlation: CV=0 → 1.0, CV≥1 → 0.0
+    (1.0 - cv.min(1.0)).max(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_by_improvement_similarity_basic() {
+        let c1 = ClusterableCandidate {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "t".to_string(),
+            expected_improvement: 0.10,
+            neuron_type: "input".to_string(),
+        };
+        let c2 = ClusterableCandidate {
+            from_neuron_uuid: "b".to_string(),
+            to_neuron_uuid: "t".to_string(),
+            expected_improvement: 0.09,
+            neuron_type: "input".to_string(),
+        };
+
+        let sorted = vec![&c1, &c2];
+        let subs = split_by_improvement_similarity(&sorted);
+
+        assert_eq!(subs.len(), 1, "Similar improvements should stay together");
+        assert_eq!(subs[0].len(), 2);
+    }
+
+    #[test]
+    fn test_compute_internal_correlation_identical() {
+        let c1 = ClusterableCandidate {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "t".to_string(),
+            expected_improvement: 0.10,
+            neuron_type: "input".to_string(),
+        };
+        let c2 = ClusterableCandidate {
+            from_neuron_uuid: "b".to_string(),
+            to_neuron_uuid: "t".to_string(),
+            expected_improvement: 0.10,
+            neuron_type: "input".to_string(),
+        };
+
+        let candidates = vec![&c1, &c2];
+        let corr = compute_internal_correlation(&candidates);
+
+        assert!(
+            (corr - 1.0).abs() < f32::EPSILON,
+            "Identical improvements should yield correlation ≈ 1.0"
+        );
+    }
+}

--- a/src/analysis/implementation.rs
+++ b/src/analysis/implementation.rs
@@ -2037,6 +2037,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         // This keeps NEAT-AI's apply/ablate pipeline limited to existing structural ops.
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: coordinated_structural_results,
+        candidate_clusters: Vec::new(), // populated by analyze_all post-processing (Issue #224)
         gpu_used,
         no_candidate_reasons,
         metadata,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -19,11 +19,13 @@
 //! - `bottleneck.rs` - Bottleneck neuron detection for information flow widening (Issue #343)
 //! - `dead_neuron.rs` - Dead neuron detection for removal candidates (Issue #341)
 //! - `correlated_error.rs` - Correlated error pattern detection for shared-cause identification (Issue #344)
+//! - `candidate_clustering.rs` - Candidate clustering to reduce redundant ablation tests (Issue #224)
 //! - `early_termination.rs` - SPRT-based early termination for GPU evaluation (Issue #219)
 
 pub mod activation;
 pub mod bottleneck;
 pub mod cache;
+pub mod candidate_clustering;
 pub mod confidence;
 pub mod correlated_error;
 pub mod dead_neuron;
@@ -795,6 +797,64 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
 
         crate::watchdog::beat("analysis::analyze_all → correlated error detection finished");
+    }
+
+    // Issue #224: Candidate clustering to reduce redundant ablation tests.
+    // Groups similar candidates by target neuron, source type, and improvement
+    // similarity so the controller can test a representative first and skip
+    // redundant tests if it fails.
+    if let Some(syn) = synapse_result.as_mut() {
+        crate::watchdog::beat("analysis::analyze_all → candidate clustering starting");
+        let _clustering_timer = PhaseTimer::new("candidate_clustering");
+
+        // Collect all helpful and harmful synapse candidates as clusterable candidates
+        let mut clusterable: Vec<candidate_clustering::ClusterableCandidate> = Vec::new();
+
+        for c in &syn.helpful_synapses {
+            clusterable.push(candidate_clustering::ClusterableCandidate {
+                from_neuron_uuid: c.from_neuron_uuid.clone(),
+                to_neuron_uuid: c.to_neuron_uuid.clone(),
+                expected_improvement: c.expected_creature_score_gain,
+                neuron_type: input
+                    .creature
+                    .neurons
+                    .iter()
+                    .find(|n| n.uuid == c.from_neuron_uuid)
+                    .map(|n| n.neuron_type.clone())
+                    .unwrap_or_else(|| "input".to_string()),
+            });
+        }
+
+        for c in &syn.harmful_synapses {
+            clusterable.push(candidate_clustering::ClusterableCandidate {
+                from_neuron_uuid: c.from_neuron_uuid.clone(),
+                to_neuron_uuid: c.to_neuron_uuid.clone(),
+                expected_improvement: c.expected_creature_score_gain,
+                neuron_type: input
+                    .creature
+                    .neurons
+                    .iter()
+                    .find(|n| n.uuid == c.from_neuron_uuid)
+                    .map(|n| n.neuron_type.clone())
+                    .unwrap_or_else(|| "input".to_string()),
+            });
+        }
+
+        let clusters = candidate_clustering::cluster_candidates(&clusterable);
+
+        if !clusters.is_empty() && utils::verbose_enabled() {
+            let total_clustered: usize = clusters.iter().map(|c| c.member_count).sum();
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Candidate clustering: {} cluster(s) covering {} candidate(s) of {} total",
+                clusters.len(),
+                total_clustered,
+                clusterable.len()
+            );
+        }
+
+        syn.candidate_clusters = clusters;
+
+        crate::watchdog::beat("analysis::analyze_all → candidate clustering finished");
     }
 
     // Collect final profile data (Issue #214)

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -87,6 +87,7 @@ fn postprocess_reapplies_max_synapse_candidates_after_coordinated_merge() {
         harmful_synapses: Vec::new(),
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
         gpu_used: false,
         no_candidate_reasons: Vec::new(),
         metadata: shared::SynapseAnalysisMetadata {
@@ -138,6 +139,7 @@ fn postprocess_truncates_across_all_synapse_buckets_not_just_coordinated() {
         harmful_synapses: Vec::new(),
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
         gpu_used: false,
         no_candidate_reasons: Vec::new(),
         metadata: shared::SynapseAnalysisMetadata {
@@ -196,6 +198,7 @@ fn postprocess_updates_candidates_returned_after_merging_neuron_replacements() {
         harmful_synapses: Vec::new(),
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
         gpu_used: false,
         no_candidate_reasons: Vec::new(),
         metadata: shared::SynapseAnalysisMetadata {

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -407,6 +407,12 @@ pub struct AnalyzeSynapsesResult {
     pub synapse_weight_updates: Vec<SynapseWeightUpdateCandidateJson>,
     /// Coordinated (grouped) candidates produced from synapse analysis (Issue #165).
     pub coordinated_structural_candidates: Vec<CoordinatedStructuralCandidateJson>,
+    /// Candidate clusters for redundancy reduction (Issue #224).
+    ///
+    /// Groups similar candidates by target neuron, source type, and improvement
+    /// similarity so the controller can test a representative first and skip
+    /// redundant ablation tests.
+    pub candidate_clusters: Vec<super::candidate_clustering::CandidateClusterJson>,
     pub gpu_used: bool,
     pub no_candidate_reasons: Vec<SynapseNoCandidateSummary>,
     /// Metadata about the analysis run for diagnostics (v0.2.17+).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,12 @@ pub struct AnalyzeParallelOutput {
     /// Coordinated (grouped) structural candidates (v0.2.18+).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coordinated_structural_candidates: Option<Vec<CoordinatedStructuralCandidateJson>>,
+    /// Candidate clusters for redundancy reduction (Issue #224).
+    ///
+    /// Groups similar candidates by target neuron so the controller can test a
+    /// representative first and skip redundant ablation tests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidate_clusters: Option<Vec<analysis::candidate_clustering::CandidateClusterJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub neuron_diagnostics: Option<Vec<NeuronDiagnosticJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1224,6 +1230,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 helpful_neurons: None,
                 synapse_weight_updates: None,
                 coordinated_structural_candidates: None,
+                candidate_clusters: None,
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
                 neuron_metadata: None,
@@ -1255,6 +1262,14 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 }
             });
 
+            let candidate_clusters = synapse.as_ref().and_then(|s| {
+                if s.candidate_clusters.is_empty() {
+                    None
+                } else {
+                    Some(s.candidate_clusters.clone())
+                }
+            });
+
             let output = AnalyzeParallelOutput {
                 success: true,
                 helpful_synapses: synapse.as_ref().map(|s| s.helpful_synapses.clone()),
@@ -1279,6 +1294,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 helpful_neurons: neuron.as_ref().map(|n| n.helpful_neurons.clone()),
                 synapse_weight_updates,
                 coordinated_structural_candidates,
+                candidate_clusters,
                 neuron_diagnostics: neuron
                     .as_ref()
                     .and_then(|n| neuron_diagnostics_json(n.no_candidate_reasons.as_slice())),
@@ -1307,6 +1323,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 helpful_neurons: None,
                 synapse_weight_updates: None,
                 coordinated_structural_candidates: None,
+                candidate_clusters: None,
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
                 neuron_metadata: None,
@@ -2180,6 +2197,7 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     helpful_neurons: None,
                     synapse_weight_updates: None,
                     coordinated_structural_candidates: None,
+                    candidate_clusters: None,
                     neuron_diagnostics: None,
                     neuron_gpu_used: None,
                     neuron_metadata: None,

--- a/tests/issue_224_candidate_clustering.rs
+++ b/tests/issue_224_candidate_clustering.rs
@@ -1,0 +1,315 @@
+//! Tests for Issue #224: Candidate clustering to reduce redundant ablation tests.
+//!
+//! When discovery returns many similar candidates (e.g., multiple synapses from the same
+//! source region targeting the same neuron), clustering groups them so the controller can
+//! test a representative first and skip redundant tests if it fails.
+//!
+//! ## TDD Plan
+//! 1. Candidates targeting the same neuron with similar improvements are clustered
+//! 2. Representative is the highest-improvement candidate in each cluster
+//! 3. Independent candidates (different targets) form separate clusters
+//! 4. Internal correlation is computed correctly
+//! 5. Single candidate does not form a cluster (no redundancy to reduce)
+//! 6. Empty input produces no clusters
+//! 7. Cluster JSON output has the expected structure
+
+use neat_ai_discovery::analysis::candidate_clustering::{cluster_candidates, ClusterableCandidate};
+
+/// Helper: create a ClusterableCandidate for testing.
+fn candidate(from: &str, to: &str, improvement: f32) -> ClusterableCandidate {
+    ClusterableCandidate {
+        from_neuron_uuid: from.to_string(),
+        to_neuron_uuid: to.to_string(),
+        expected_improvement: improvement,
+        neuron_type: "input".to_string(),
+    }
+}
+
+/// Test 1: Candidates targeting the same neuron are clustered together.
+#[test]
+fn test_same_target_candidates_clustered() {
+    let candidates = vec![
+        candidate("input-42", "hidden-5", 0.10),
+        candidate("input-43", "hidden-5", 0.098),
+        candidate("input-44", "hidden-5", 0.101),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(
+        clusters.len(),
+        1,
+        "All candidates targeting hidden-5 should form one cluster"
+    );
+    assert_eq!(
+        clusters[0].member_count, 3,
+        "Cluster should contain all 3 candidates"
+    );
+}
+
+/// Test 2: Representative is the highest-improvement candidate.
+#[test]
+fn test_representative_is_best_candidate() {
+    let candidates = vec![
+        candidate("input-42", "hidden-5", 0.10),
+        candidate("input-43", "hidden-5", 0.098),
+        candidate("input-44", "hidden-5", 0.15), // highest
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 1);
+    assert_eq!(
+        clusters[0].representative_from_uuid, "input-44",
+        "Representative should be the candidate with highest improvement"
+    );
+    assert_eq!(clusters[0].representative_to_uuid, "hidden-5");
+}
+
+/// Test 3: Candidates with different targets form separate clusters.
+#[test]
+fn test_different_targets_separate_clusters() {
+    let candidates = vec![
+        candidate("input-1", "hidden-5", 0.10),
+        candidate("input-2", "hidden-5", 0.09),
+        candidate("input-3", "hidden-10", 0.08),
+        candidate("input-4", "hidden-10", 0.07),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(
+        clusters.len(),
+        2,
+        "Two different targets should form two clusters"
+    );
+
+    // Each cluster should have 2 members
+    let mut counts: Vec<usize> = clusters.iter().map(|c| c.member_count).collect();
+    counts.sort();
+    assert_eq!(counts, vec![2, 2]);
+}
+
+/// Test 4: Internal correlation is between 0.0 and 1.0.
+#[test]
+fn test_internal_correlation_range() {
+    let candidates = vec![
+        candidate("input-42", "hidden-5", 0.10),
+        candidate("input-43", "hidden-5", 0.098),
+        candidate("input-44", "hidden-5", 0.101),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 1);
+    assert!(
+        clusters[0].internal_correlation >= 0.0 && clusters[0].internal_correlation <= 1.0,
+        "Internal correlation should be between 0.0 and 1.0, got {}",
+        clusters[0].internal_correlation
+    );
+}
+
+/// Test 5: Single candidate does not form a cluster.
+/// A single candidate targeting a neuron has no redundancy to reduce.
+#[test]
+fn test_single_candidate_no_cluster() {
+    let candidates = vec![candidate("input-1", "hidden-5", 0.10)];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert!(
+        clusters.is_empty(),
+        "Single candidate should not form a cluster (no redundancy)"
+    );
+}
+
+/// Test 6: Empty input produces no clusters.
+#[test]
+fn test_empty_candidates_no_clusters() {
+    let clusters = cluster_candidates(&[]);
+
+    assert!(
+        clusters.is_empty(),
+        "Empty input should produce no clusters"
+    );
+}
+
+/// Test 7: Cluster JSON structure has expected fields.
+#[test]
+fn test_cluster_json_serialisation() {
+    let candidates = vec![
+        candidate("input-42", "hidden-5", 0.10),
+        candidate("input-43", "hidden-5", 0.098),
+        candidate("input-44", "hidden-5", 0.101),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 1);
+    let cluster = &clusters[0];
+
+    // Verify JSON serialisation
+    let json = serde_json::to_value(cluster).unwrap();
+    assert!(json.get("representativeFromUuid").is_some());
+    assert!(json.get("representativeToUuid").is_some());
+    assert!(json.get("memberCount").is_some());
+    assert!(json.get("memberFromUuids").is_some());
+    assert!(json.get("internalCorrelation").is_some());
+
+    // Verify member UUIDs
+    let member_uuids = json["memberFromUuids"].as_array().unwrap();
+    assert_eq!(member_uuids.len(), 3);
+}
+
+/// Test 8: Candidates with very different improvements targeting the same neuron
+/// but from different neuron types form separate sub-clusters.
+#[test]
+fn test_mixed_types_sub_clustering() {
+    let candidates = vec![
+        // Input neurons targeting hidden-5 (similar improvements)
+        ClusterableCandidate {
+            from_neuron_uuid: "input-1".to_string(),
+            to_neuron_uuid: "hidden-5".to_string(),
+            expected_improvement: 0.10,
+            neuron_type: "input".to_string(),
+        },
+        ClusterableCandidate {
+            from_neuron_uuid: "input-2".to_string(),
+            to_neuron_uuid: "hidden-5".to_string(),
+            expected_improvement: 0.098,
+            neuron_type: "input".to_string(),
+        },
+        // Hidden neurons targeting hidden-5 (similar improvements but different type)
+        ClusterableCandidate {
+            from_neuron_uuid: "hidden-1".to_string(),
+            to_neuron_uuid: "hidden-5".to_string(),
+            expected_improvement: 0.05,
+            neuron_type: "hidden".to_string(),
+        },
+        ClusterableCandidate {
+            from_neuron_uuid: "hidden-2".to_string(),
+            to_neuron_uuid: "hidden-5".to_string(),
+            expected_improvement: 0.048,
+            neuron_type: "hidden".to_string(),
+        },
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(
+        clusters.len(),
+        2,
+        "Input and hidden sources should form separate sub-clusters"
+    );
+}
+
+/// Test 9: Candidates with widely different improvements targeting the same neuron
+/// and same type form separate sub-clusters due to improvement dissimilarity.
+#[test]
+fn test_dissimilar_improvements_separate_clusters() {
+    let candidates = vec![
+        candidate("input-1", "hidden-5", 0.001), // very small
+        candidate("input-2", "hidden-5", 0.002), // very small
+        candidate("input-3", "hidden-5", 0.50),  // very large
+        candidate("input-4", "hidden-5", 0.55),  // very large
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert!(
+        clusters.len() >= 2,
+        "Very different improvements should form separate sub-clusters, got {}",
+        clusters.len()
+    );
+}
+
+/// Test 10: Cluster members are sorted by improvement (best first).
+#[test]
+fn test_cluster_members_sorted_by_improvement() {
+    let candidates = vec![
+        candidate("input-1", "hidden-5", 0.05),
+        candidate("input-2", "hidden-5", 0.15),
+        candidate("input-3", "hidden-5", 0.10),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 1);
+    let cluster = &clusters[0];
+
+    // Representative should be the best one
+    assert_eq!(cluster.representative_from_uuid, "input-2");
+
+    // member_from_uuids should be ordered by improvement (best first)
+    assert_eq!(cluster.member_from_uuids[0], "input-2");
+}
+
+/// Test 11: Multiple clusters are sorted by representative improvement (best first).
+#[test]
+fn test_clusters_sorted_by_best_improvement() {
+    let candidates = vec![
+        candidate("input-1", "hidden-5", 0.05),
+        candidate("input-2", "hidden-5", 0.06),
+        candidate("input-3", "hidden-10", 0.20),
+        candidate("input-4", "hidden-10", 0.18),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 2);
+
+    // First cluster should be the one with the best representative
+    assert!(
+        clusters[0].representative_improvement >= clusters[1].representative_improvement,
+        "Clusters should be sorted by representative improvement (best first)"
+    );
+}
+
+/// Test 12: High similarity within cluster yields high internal correlation.
+#[test]
+fn test_similar_improvements_yield_high_correlation() {
+    // All very similar improvements
+    let candidates = vec![
+        candidate("input-1", "hidden-5", 0.100),
+        candidate("input-2", "hidden-5", 0.101),
+        candidate("input-3", "hidden-5", 0.099),
+        candidate("input-4", "hidden-5", 0.100),
+    ];
+
+    let clusters = cluster_candidates(&candidates);
+
+    assert_eq!(clusters.len(), 1);
+    assert!(
+        clusters[0].internal_correlation >= 0.8,
+        "Very similar improvements should yield high internal correlation, got {}",
+        clusters[0].internal_correlation
+    );
+}
+
+/// Test 13: Large number of candidates is correctly clustered.
+#[test]
+fn test_large_candidate_set() {
+    let candidates: Vec<ClusterableCandidate> = (0..100)
+        .map(|i| {
+            let target = if i < 50 { "hidden-5" } else { "hidden-10" };
+            let improvement = 0.1 + (i as f32 * 0.001);
+            candidate(&format!("input-{i}"), target, improvement)
+        })
+        .collect();
+
+    let clusters = cluster_candidates(&candidates);
+
+    // Should form at least 2 clusters (one per target)
+    assert!(
+        clusters.len() >= 2,
+        "100 candidates across 2 targets should form at least 2 clusters, got {}",
+        clusters.len()
+    );
+
+    // Total members across all clusters should equal the input count
+    let total_members: usize = clusters.iter().map(|c| c.member_count).sum();
+    assert_eq!(
+        total_members, 100,
+        "All candidates should be assigned to clusters"
+    );
+}

--- a/tests/issue_337_candidate_type_contract.rs
+++ b/tests/issue_337_candidate_type_contract.rs
@@ -307,6 +307,7 @@ fn analyze_parallel_output_contains_all_candidate_fields() {
         helpful_neurons: Some(vec![]),
         synapse_weight_updates: Some(vec![]),
         coordinated_structural_candidates: Some(vec![]),
+        candidate_clusters: None,
         neuron_diagnostics: None,
         neuron_gpu_used: Some(true),
         neuron_metadata: None,


### PR DESCRIPTION
## Summary

Implements candidate clustering to reduce redundant ablation tests (Issue #224).

When discovery returns many similar candidates (e.g., multiple synapses from the same
source region targeting the same neuron), the TypeScript controller would otherwise test
each independently, wasting CPU cycles. This change groups similar candidates into
clusters so the controller can test a representative first and skip redundant tests
if the representative fails.

### What changed

- **New module `src/analysis/candidate_clustering.rs`**: Groups candidates by target
  neuron, source type, and improvement similarity. Each cluster identifies a
  representative (highest improvement) and computes an internal correlation score.
- **New JSON field `candidateClusters`**: Optional field in `AnalyzeParallelOutput`
  that lists detected clusters with representative UUID, member count, member UUIDs,
  and internal correlation.
- **Post-processing integration**: Clustering runs as a final step in `analyze_all`
  after all candidates have been gathered, so it sees the complete candidate set.
- **Backward compatible**: The `candidateClusters` field is `skip_serializing_if`
  `Option::is_none`, so existing consumers are unaffected.

### Clustering criteria

1. **Same target neuron** — candidates must share `toNeuronUuid`
2. **Same source type** — input vs hidden neurons are not mixed
3. **Similar improvement** — candidates with >5x improvement ratio are split into
   separate sub-clusters

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

No performance benchmark needed — clustering is a lightweight O(n) grouping pass
over the existing candidate arrays with no GPU involvement.

## Test Plan

- 13 integration tests in `tests/issue_224_candidate_clustering.rs`:
  - `test_same_target_candidates_clustered` — candidates targeting same neuron cluster
  - `test_representative_is_best_candidate` — highest improvement is representative
  - `test_different_targets_separate_clusters` — different targets form different clusters
  - `test_internal_correlation_range` — correlation is between 0.0 and 1.0
  - `test_single_candidate_no_cluster` — no cluster for lone candidates
  - `test_empty_candidates_no_clusters` — empty input produces no clusters
  - `test_cluster_json_serialisation` — JSON output has expected camelCase fields
  - `test_mixed_types_sub_clustering` — input vs hidden sources form separate clusters
  - `test_dissimilar_improvements_separate_clusters` — large improvement differences split
  - `test_cluster_members_sorted_by_improvement` — members sorted best-first
  - `test_clusters_sorted_by_best_improvement` — clusters sorted by representative
  - `test_similar_improvements_yield_high_correlation` — similar values yield high correlation
  - `test_large_candidate_set` — 100 candidates across 2 targets clustered correctly
- 2 inline unit tests in `src/analysis/candidate_clustering.rs`:
  - `test_split_by_improvement_similarity_basic`
  - `test_compute_internal_correlation_identical`
- Existing contract test updated: `issue_337_candidate_type_contract.rs`

---

## Automated Fix Details
This PR addresses issue #224: **Discovery: Implement candidate clustering to reduce redundant ablation tests**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #224