### PR TITLE
Extract generic discovery module dispatch pattern (DRY) (#375)

### DIFF
--- a/docs/pr-summary-375.md
+++ b/docs/pr-summary-375.md
@@ -1,0 +1,40 @@
+## Summary
+
+Extract the generic discovery module dispatch pattern (DRY) from `analyze_all()` in `src/analysis/mod.rs`.
+
+The function previously contained 9 nearly identical code blocks (~500 lines of boilerplate) for dispatching discovery detection modules (saturation, bottleneck, dead neuron, correlated error, multi-hop, oscillating neuron, dormant synapse, opposing synapse, and output bias drift). Each block repeated the same pipeline: watchdog beat → phase timer → record collection → detection → conversion → verbose logging → merge.
+
+This PR introduces `src/analysis/discovery_dispatch.rs` with:
+- `dispatch_discovery_module()` — a generic function handling all dispatch boilerplate
+- `DiscoveryDispatchConfig` — configuration struct for module name and phase timer
+- `DetectionResult` — standardised detection output (count + candidates)
+- `collect_records_for_uuids()` and `collect_hidden_neuron_records()` — shared record collection helpers
+
+The 9 dispatch blocks in `analyze_all()` are replaced with concise calls to `dispatch_discovery_module()`, each providing only module-specific logic via a closure. This reduces ~500 lines of boilerplate to ~200 lines of focused module-specific code.
+
+Adding a new detection module now requires only a single `dispatch_discovery_module()` call with a closure — no boilerplate for watchdog beats, phase timers, verbose logging, or candidate merging.
+
+Closes #375
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+- Added 5 unit tests in `src/analysis/discovery_dispatch.rs` (inline `#[cfg(test)]` module):
+  - `test_dispatch_merges_candidates_into_synapse_result`
+  - `test_dispatch_skips_when_closure_returns_none`
+  - `test_dispatch_skips_when_candidates_empty`
+  - `test_dispatch_respects_max_synapse_candidates_limit`
+  - `test_multiple_dispatches_accumulate_candidates`
+- Added 6 integration tests in `tests/issue_375_discovery_dispatch_pattern.rs`:
+  - `test_dispatch_merges_candidates`
+  - `test_dispatch_skips_on_none`
+  - `test_dispatch_skips_on_empty_candidates`
+  - `test_multiple_dispatches_accumulate`
+  - `test_dispatch_respects_max_candidates_limit`
+  - `test_dispatch_preserves_candidate_details`
+- All 439 existing unit tests pass unchanged
+- All existing integration tests pass unchanged
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -1,0 +1,300 @@
+//! Generic discovery module dispatch pattern (Issue #375).
+//!
+//! Each discovery module follows the same pipeline:
+//! 1. Watchdog beat (starting)
+//! 2. `PhaseTimer` creation
+//! 3. UUID/record collection from the shared cache
+//! 4. Detection function call
+//! 5. Conversion to coordinated candidates
+//! 6. Verbose logging
+//! 7. Merge into synapse results
+//! 8. Watchdog beat (finished)
+//!
+//! This module extracts that boilerplate into a single generic function so that
+//! `analyze_all()` can dispatch each module with minimal repetition.
+
+use crate::analysis::cache::RecordCache;
+use crate::analysis::shared;
+use crate::analysis::utils;
+use crate::observability::PhaseTimer;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CreatureJson};
+use std::sync::Arc;
+
+/// Collects records for a set of UUIDs from the shared cache.
+///
+/// Returns a `Vec<(String, Vec<DiscoverRecord>)>` — one entry per UUID that
+/// was found in the cache.
+pub fn collect_records_for_uuids(
+    uuids: &[String],
+    shared_cache: &Arc<RecordCache>,
+) -> Vec<(String, Vec<DiscoverRecord>)> {
+    uuids
+        .iter()
+        .filter_map(|uuid| {
+            shared_cache
+                .get(uuid)
+                .ok()
+                .map(|records: Arc<Vec<DiscoverRecord>>| (uuid.clone(), records.as_ref().to_vec()))
+        })
+        .collect()
+}
+
+/// Configuration for a single discovery module dispatch.
+pub struct DiscoveryDispatchConfig<'a> {
+    /// Human-readable name for watchdog and logging (e.g. "saturation detection").
+    pub name: &'a str,
+    /// Phase timer name (e.g. "saturation_detection") — must be `'static` for `PhaseTimer`.
+    pub phase_name: &'static str,
+}
+
+/// Result from a detection function, pairing the detected items count with
+/// the coordinated candidates produced from them.
+pub struct DetectionResult {
+    /// Number of raw detections (for verbose logging).
+    pub detected_count: usize,
+    /// Coordinated candidates produced from the detections.
+    pub candidates: Vec<CoordinatedStructuralCandidateJson>,
+}
+
+/// Run a single discovery module through the standard dispatch pipeline.
+///
+/// The `detect_and_convert` closure receives nothing and is expected to perform
+/// the detection and conversion steps, returning a `DetectionResult` (or `None`
+/// if the preconditions for running the module are not met).
+///
+/// This function handles:
+/// - Watchdog beats (starting / finished)
+/// - `PhaseTimer` creation
+/// - Verbose logging with consistent formatting
+/// - Merging candidates via `merge_coordinated_structural_replacements`
+pub fn dispatch_discovery_module(
+    config: &DiscoveryDispatchConfig,
+    syn: &mut shared::AnalyzeSynapsesResult,
+    max_synapse_candidates: Option<usize>,
+    diversify: bool,
+    detect_and_convert: impl FnOnce() -> Option<DetectionResult>,
+) {
+    crate::watchdog::beat(format!(
+        "analysis::analyze_all → {name} starting",
+        name = config.name
+    ));
+    let _timer = PhaseTimer::new(config.phase_name);
+
+    if let Some(result) = detect_and_convert() {
+        if !result.candidates.is_empty() {
+            if utils::verbose_enabled() {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] {name}: found {detected} detection(s), {candidates} candidate(s)",
+                    name = config.name,
+                    detected = result.detected_count,
+                    candidates = result.candidates.len()
+                );
+            }
+
+            super::merge_coordinated_structural_replacements(
+                syn,
+                result.candidates,
+                max_synapse_candidates,
+                diversify,
+            );
+        }
+    }
+
+    crate::watchdog::beat(format!(
+        "analysis::analyze_all → {name} finished",
+        name = config.name
+    ));
+}
+
+/// Collect UUIDs for hidden neurons from the creature and return the `(uuid, squash, bias)` tuples.
+pub fn collect_hidden_neurons(creature: &CreatureJson) -> Vec<(String, String, f32)> {
+    creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect()
+}
+
+/// Collect records for hidden neurons from the shared cache.
+pub fn collect_hidden_neuron_records(
+    hidden_neurons: &[(String, String, f32)],
+    shared_cache: &Arc<RecordCache>,
+) -> Vec<(String, Vec<DiscoverRecord>)> {
+    let uuids: Vec<String> = hidden_neurons
+        .iter()
+        .map(|(uuid, _, _)| uuid.clone())
+        .collect();
+    collect_records_for_uuids(&uuids, shared_cache)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::shared::AnalyzeSynapsesResult;
+
+    /// Helper to create a minimal empty synapse result for testing.
+    fn empty_synapse_result() -> AnalyzeSynapsesResult {
+        AnalyzeSynapsesResult {
+            helpful_synapses: vec![],
+            harmful_synapses: vec![],
+            synapse_weight_updates: vec![],
+            coordinated_structural_candidates: vec![],
+            candidate_clusters: vec![],
+            gpu_used: false,
+            no_candidate_reasons: vec![],
+            metadata: crate::analysis::shared::SynapseAnalysisMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_merges_candidates_into_synapse_result() {
+        let mut syn = empty_synapse_result();
+        let config = DiscoveryDispatchConfig {
+            name: "test module",
+            phase_name: "test_module",
+        };
+
+        dispatch_discovery_module(&config, &mut syn, None, false, || {
+            Some(DetectionResult {
+                detected_count: 2,
+                candidates: vec![
+                    CoordinatedStructuralCandidateJson {
+                        operations: vec![],
+                        expected_creature_score_gain: 0.5,
+                        comment: Some("test candidate 1".to_string()),
+                    },
+                    CoordinatedStructuralCandidateJson {
+                        operations: vec![],
+                        expected_creature_score_gain: 0.3,
+                        comment: Some("test candidate 2".to_string()),
+                    },
+                ],
+            })
+        });
+
+        assert_eq!(syn.coordinated_structural_candidates.len(), 2);
+        assert_eq!(
+            syn.coordinated_structural_candidates[0].expected_creature_score_gain,
+            0.5
+        );
+    }
+
+    #[test]
+    fn test_dispatch_skips_when_closure_returns_none() {
+        let mut syn = empty_synapse_result();
+        let config = DiscoveryDispatchConfig {
+            name: "skipped module",
+            phase_name: "skipped_module",
+        };
+
+        dispatch_discovery_module(&config, &mut syn, None, false, || None);
+
+        assert!(syn.coordinated_structural_candidates.is_empty());
+    }
+
+    #[test]
+    fn test_dispatch_skips_when_candidates_empty() {
+        let mut syn = empty_synapse_result();
+        let config = DiscoveryDispatchConfig {
+            name: "empty module",
+            phase_name: "empty_module",
+        };
+
+        dispatch_discovery_module(&config, &mut syn, None, false, || {
+            Some(DetectionResult {
+                detected_count: 0,
+                candidates: vec![],
+            })
+        });
+
+        assert!(syn.coordinated_structural_candidates.is_empty());
+    }
+
+    #[test]
+    fn test_dispatch_respects_max_synapse_candidates_limit() {
+        let mut syn = empty_synapse_result();
+        let config = DiscoveryDispatchConfig {
+            name: "limited module",
+            phase_name: "limited_module",
+        };
+
+        // Add 5 candidates with a limit of 2
+        let candidates: Vec<CoordinatedStructuralCandidateJson> = (0..5)
+            .map(|i| CoordinatedStructuralCandidateJson {
+                operations: vec![],
+                expected_creature_score_gain: 1.0 - (i as f32 * 0.1),
+                comment: Some(format!("candidate {i}")),
+            })
+            .collect();
+
+        dispatch_discovery_module(&config, &mut syn, Some(2), false, || {
+            Some(DetectionResult {
+                detected_count: 5,
+                candidates,
+            })
+        });
+
+        // merge_coordinated_structural_replacements truncates to the limit
+        assert!(syn.coordinated_structural_candidates.len() <= 2);
+    }
+
+    #[test]
+    fn test_multiple_dispatches_accumulate_candidates() {
+        let mut syn = empty_synapse_result();
+
+        // First dispatch
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "module A",
+                phase_name: "module_a",
+            },
+            &mut syn,
+            None,
+            false,
+            || {
+                Some(DetectionResult {
+                    detected_count: 1,
+                    candidates: vec![CoordinatedStructuralCandidateJson {
+                        operations: vec![],
+                        expected_creature_score_gain: 0.8,
+                        comment: Some("from A".to_string()),
+                    }],
+                })
+            },
+        );
+
+        // Second dispatch
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "module B",
+                phase_name: "module_b",
+            },
+            &mut syn,
+            None,
+            false,
+            || {
+                Some(DetectionResult {
+                    detected_count: 1,
+                    candidates: vec![CoordinatedStructuralCandidateJson {
+                        operations: vec![],
+                        expected_creature_score_gain: 0.6,
+                        comment: Some("from B".to_string()),
+                    }],
+                })
+            },
+        );
+
+        assert_eq!(syn.coordinated_structural_candidates.len(), 2);
+        // Should be sorted by expected gain (highest first) since diversify=false
+        assert_eq!(
+            syn.coordinated_structural_candidates[0].expected_creature_score_gain,
+            0.8
+        );
+        assert_eq!(
+            syn.coordinated_structural_candidates[1].expected_creature_score_gain,
+            0.6
+        );
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -26,6 +26,7 @@
 //! - `dormant_synapse.rs` - Dormant synapse detection for removal candidates (Issue #359)
 //! - `opposing_synapse.rs` - Opposing synapse detection for removal or weight flip candidates (Issue #360)
 //! - `output_bias_drift.rs` - Output bias drift detection for bias adjustment candidates (Issue #361)
+//! - `discovery_dispatch.rs` - Generic discovery module dispatch pattern (Issue #375)
 
 pub mod activation;
 pub mod bottleneck;
@@ -35,6 +36,7 @@ pub mod confidence;
 pub mod correlated_error;
 pub mod dead_neuron;
 pub mod diagnostics;
+pub mod discovery_dispatch;
 pub mod dormant_synapse;
 pub mod early_termination;
 pub mod epistatic;
@@ -587,502 +589,299 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         );
     }
 
-    // Issue #342: Detect saturated neurons and recommend activation function changes.
-    // This runs as a post-processing pass over all hidden neurons in the creature,
-    // using recorded activations from the shared cache to identify neurons that are
-    // stuck at their activation ceiling or floor.
+    // Issue #375: Discovery module dispatch using generic pattern.
+    // Each module follows the same pipeline: watchdog beat → phase timer → record
+    // collection → detection → conversion → verbose logging → merge → watchdog beat.
+    // The `dispatch_discovery_module` function handles all boilerplate.
     if let Some(syn) = synapse_result.as_mut() {
-        crate::watchdog::beat("analysis::analyze_all → saturation detection starting");
-        let _timer = PhaseTimer::new("saturation_detection");
+        use discovery_dispatch::{
+            collect_hidden_neuron_records, collect_hidden_neurons, collect_records_for_uuids,
+            dispatch_discovery_module, DetectionResult, DiscoveryDispatchConfig,
+        };
 
-        // Collect hidden neurons with their squash and bias
-        let hidden_neurons: Vec<(String, String, f32)> = input
-            .creature
-            .neurons
-            .iter()
-            .filter(|n| n.neuron_type == "hidden")
-            .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
-            .collect();
+        let hidden_neurons = collect_hidden_neurons(&input.creature);
+        let max_candidates = input.max_synapse_candidates;
+        let diversify = input.analysis_deadline_ms.is_some();
 
-        if !hidden_neurons.is_empty() {
-            // Retrieve recorded activations for each hidden neuron from the cache
-            let neuron_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> = hidden_neurons
-                .iter()
-                .filter_map(|(uuid, _, _)| {
-                    shared_cache
-                        .get(uuid)
-                        .ok()
-                        .map(|records| (uuid.clone(), records.as_ref().to_vec()))
+        // Issue #342: Saturated neurons → activation function changes
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Saturation detection",
+                phase_name: "saturation_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_neuron_records(&hidden_neurons, &shared_cache);
+                let detected = saturation::detect_saturated_neurons(&hidden_neurons, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = saturation::saturated_neurons_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
                 })
-                .collect();
+            },
+        );
 
-            let saturated = saturation::detect_saturated_neurons(&hidden_neurons, &neuron_records);
-
-            if !saturated.is_empty() {
-                let saturation_candidates =
-                    saturation::saturated_neurons_to_coordinated_candidates(&saturated);
-
-                if !saturation_candidates.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Saturation detection: found {} saturated neuron(s), {} candidate(s)",
-                            saturated.len(),
-                            saturation_candidates.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        saturation_candidates,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
+        // Issue #343: Bottleneck neurons → parallel paths / bypass synapses
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Bottleneck detection",
+                phase_name: "bottleneck_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
                 }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → saturation detection finished");
-
-        // Issue #343: Detect bottleneck neurons limiting information flow.
-        // Bottleneck neurons have high fan-in funnelling through a single hidden neuron.
-        // We recommend adding parallel paths or bypass synapses to widen the bottleneck.
-        crate::watchdog::beat("analysis::analyze_all → bottleneck detection starting");
-        let _bottleneck_timer = PhaseTimer::new("bottleneck_detection");
-
-        if !hidden_neurons.is_empty() {
-            // Retrieve recorded activations for each hidden neuron from the cache
-            let bottleneck_neuron_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                hidden_neurons
-                    .iter()
-                    .filter_map(|(uuid, _, _)| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let bottleneck_candidates =
-                bottleneck::detect_bottleneck_neurons(&input.creature, &bottleneck_neuron_records);
-
-            if !bottleneck_candidates.is_empty() {
-                let coordinated_bottleneck =
-                    bottleneck::bottleneck_neurons_to_coordinated_candidates(
-                        &bottleneck_candidates,
-                        &input.creature,
-                    );
-
-                if !coordinated_bottleneck.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Bottleneck detection: found {} bottleneck neuron(s), {} candidate(s)",
-                            bottleneck_candidates.len(),
-                            coordinated_bottleneck.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_bottleneck,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
+                let records = collect_hidden_neuron_records(&hidden_neurons, &shared_cache);
+                let detected = bottleneck::detect_bottleneck_neurons(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
                 }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → bottleneck detection finished");
-
-        // Issue #341: Detect dead neurons for removal candidates.
-        // Dead neurons always output zero or near-zero activation, wasting computation.
-        // We recommend removing them via CoordinatedStructuralCandidateJson with RemoveNeuron.
-        crate::watchdog::beat("analysis::analyze_all → dead neuron detection starting");
-        let _dead_neuron_timer = PhaseTimer::new("dead_neuron_detection");
-
-        if !hidden_neurons.is_empty() {
-            let dead_neuron_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                hidden_neurons
-                    .iter()
-                    .filter_map(|(uuid, _, _)| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let dead_candidates =
-                dead_neuron::detect_dead_neurons(&input.creature, &dead_neuron_records);
-
-            if !dead_candidates.is_empty() {
-                let coordinated_dead =
-                    dead_neuron::dead_neurons_to_coordinated_candidates(&dead_candidates);
-
-                if !coordinated_dead.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Dead neuron detection: found {} dead neuron(s), {} candidate(s)",
-                            dead_candidates.len(),
-                            coordinated_dead.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_dead,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
-                }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → dead neuron detection finished");
-
-        // Issue #344: Detect correlated error patterns for shared-cause identification.
-        // When multiple output neurons consistently err in the same direction on the same
-        // samples, it suggests a missing input feature or hidden representation that would
-        // benefit all of them. We recommend adding a shared hidden neuron.
-        crate::watchdog::beat("analysis::analyze_all → correlated error detection starting");
-        let _correlated_timer = PhaseTimer::new("correlated_error_detection");
-
-        // Only run if there are multiple output neurons (nothing to correlate otherwise)
-        let output_count = input
-            .creature
-            .neurons
-            .iter()
-            .filter(|n| n.neuron_type == "output")
-            .count();
-
-        if output_count >= 2 {
-            // Collect records for output and input neurons
-            let correlated_neuron_uuids: Vec<String> = input
-                .creature
-                .neurons
-                .iter()
-                .filter(|n| n.neuron_type == "output" || n.neuron_type == "input")
-                .map(|n| n.uuid.clone())
-                .collect();
-
-            let correlated_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                correlated_neuron_uuids
-                    .iter()
-                    .filter_map(|uuid| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let correlated_groups = correlated_error::detect_correlated_error_patterns(
-                &input.creature,
-                &correlated_records,
-            );
-
-            if !correlated_groups.is_empty() {
-                let coordinated_correlated =
-                    correlated_error::correlated_errors_to_coordinated_candidates(
-                        &correlated_groups,
-                        &input.creature,
-                    );
-
-                if !coordinated_correlated.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Correlated error detection: found {} group(s), {} candidate(s)",
-                            correlated_groups.len(),
-                            coordinated_correlated.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_correlated,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
-                }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → correlated error detection finished");
-
-        // Issue #230: Multi-hop candidate analysis for deeper network improvements.
-        // Finds neurons whose activations correlate with target errors but are not directly
-        // connected, and recommends bypass synapses or relay neurons to improve information flow.
-        crate::watchdog::beat("analysis::analyze_all → multi-hop analysis starting");
-        let _multi_hop_timer = PhaseTimer::new("multi_hop_analysis");
-
-        if !hidden_neurons.is_empty() {
-            // Collect records for all neurons (input, hidden, output)
-            let multi_hop_neuron_uuids: Vec<String> = input
-                .creature
-                .neurons
-                .iter()
-                .map(|n| n.uuid.clone())
-                .collect();
-
-            let multi_hop_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                multi_hop_neuron_uuids
-                    .iter()
-                    .filter_map(|uuid| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let multi_hop_candidates =
-                multi_hop::detect_multi_hop_candidates(&input.creature, &multi_hop_records);
-
-            if !multi_hop_candidates.is_empty() {
-                let coordinated_multi_hop = multi_hop::multi_hop_to_coordinated_candidates(
-                    &multi_hop_candidates,
+                let candidates = bottleneck::bottleneck_neurons_to_coordinated_candidates(
+                    &detected,
                     &input.creature,
                 );
-
-                if !coordinated_multi_hop.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Multi-hop analysis: found {} candidate(s), {} coordinated operation(s)",
-                            multi_hop_candidates.len(),
-                            coordinated_multi_hop.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_multi_hop,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
-                }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → multi-hop analysis finished");
-
-        // Issue #356: Detect oscillating neurons for stabilisation candidates.
-        // Oscillating neurons have activations that frequently change sign across samples,
-        // indicating the neuron is fighting between contradictory functions. We recommend
-        // changing the activation function to stabilise the output.
-        crate::watchdog::beat("analysis::analyze_all → oscillating neuron detection starting");
-        let _oscillating_timer = PhaseTimer::new("oscillating_neuron_detection");
-
-        if !hidden_neurons.is_empty() {
-            let oscillating_neuron_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                hidden_neurons
-                    .iter()
-                    .filter_map(|(uuid, _, _)| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let oscillating_candidates = oscillating_neuron::detect_oscillating_neurons(
-                &hidden_neurons,
-                &oscillating_neuron_records,
-            );
-
-            if !oscillating_candidates.is_empty() {
-                let coordinated_oscillating =
-                    oscillating_neuron::oscillating_neurons_to_coordinated_candidates(
-                        &oscillating_candidates,
-                    );
-
-                if !coordinated_oscillating.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Oscillating neuron detection: found {} oscillating neuron(s), {} candidate(s)",
-                            oscillating_candidates.len(),
-                            coordinated_oscillating.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_oscillating,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
-                }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → oscillating neuron detection finished");
-
-        // Issue #359: Detect dormant synapses for removal candidates.
-        // Dormant synapses have near-zero weights that contribute negligible signal.
-        // We recommend removing them to reduce network complexity.
-        crate::watchdog::beat("analysis::analyze_all → dormant synapse detection starting");
-        let _dormant_timer = PhaseTimer::new("dormant_synapse_detection");
-
-        {
-            // Collect records for all source neurons referenced by synapses
-            let source_uuids: Vec<String> = input
-                .creature
-                .synapses
-                .iter()
-                .map(|s| s.from_uuid.clone())
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect();
-
-            let dormant_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> = source_uuids
-                .iter()
-                .filter_map(|uuid| {
-                    shared_cache
-                        .get(uuid)
-                        .ok()
-                        .map(|records| (uuid.clone(), records.as_ref().to_vec()))
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
                 })
-                .collect();
+            },
+        );
 
-            let dormant_candidates =
-                dormant_synapse::detect_dormant_synapses(&input.creature, &dormant_records);
-
-            if !dormant_candidates.is_empty() {
-                let coordinated_dormant =
-                    dormant_synapse::dormant_synapses_to_coordinated_candidates(
-                        &dormant_candidates,
-                    );
-
-                if !coordinated_dormant.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Dormant synapse detection: found {} dormant synapse(s), {} candidate(s)",
-                            dormant_candidates.len(),
-                            coordinated_dormant.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_dormant,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
+        // Issue #341: Dead neurons → removal candidates
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Dead neuron detection",
+                phase_name: "dead_neuron_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
                 }
-            }
-        }
+                let records = collect_hidden_neuron_records(&hidden_neurons, &shared_cache);
+                let detected = dead_neuron::detect_dead_neurons(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = dead_neuron::dead_neurons_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
 
-        crate::watchdog::beat("analysis::analyze_all → dormant synapse detection finished");
-
-        // Issue #360: Detect opposing synapses for removal or weight flip candidates.
-        // Opposing synapses have contributions that correlate positively with target error,
-        // meaning they actively make predictions worse.
-        crate::watchdog::beat("analysis::analyze_all → opposing synapse detection starting");
-        let _opposing_timer = PhaseTimer::new("opposing_synapse_detection");
-
-        {
-            // Collect records for all neurons (sources + output targets)
-            let all_neuron_uuids: Vec<String> = input
-                .creature
-                .neurons
-                .iter()
-                .map(|n| n.uuid.clone())
-                .collect();
-
-            let opposing_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                all_neuron_uuids
+        // Issue #344: Correlated error patterns → shared hidden neuron
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Correlated error detection",
+                phase_name: "correlated_error_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                let output_count = input
+                    .creature
+                    .neurons
                     .iter()
-                    .filter_map(|uuid| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
-                    .collect();
-
-            let opposing_candidates =
-                opposing_synapse::detect_opposing_synapses(&input.creature, &opposing_records);
-
-            if !opposing_candidates.is_empty() {
-                let coordinated_opposing =
-                    opposing_synapse::opposing_synapses_to_coordinated_candidates(
-                        &opposing_candidates,
-                    );
-
-                if !coordinated_opposing.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Opposing synapse detection: found {} opposing synapse(s), {} candidate(s)",
-                            opposing_candidates.len(),
-                            coordinated_opposing.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_opposing,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
+                    .filter(|n| n.neuron_type == "output")
+                    .count();
+                if output_count < 2 {
+                    return None;
                 }
-            }
-        }
-
-        crate::watchdog::beat("analysis::analyze_all → opposing synapse detection finished");
-
-        // Issue #361: Detect output bias drift for bias adjustment candidates.
-        // Output neurons with consistent error sign bias indicate a systematic prediction
-        // offset that can be corrected by adjusting the neuron's bias parameter.
-        crate::watchdog::beat("analysis::analyze_all → output bias drift detection starting");
-        let _bias_drift_timer = PhaseTimer::new("output_bias_drift_detection");
-
-        {
-            let output_neuron_uuids: Vec<String> = input
-                .creature
-                .neurons
-                .iter()
-                .filter(|n| n.neuron_type == "output")
-                .map(|n| n.uuid.clone())
-                .collect();
-
-            let bias_drift_records: Vec<(String, Vec<crate::types::DiscoverRecord>)> =
-                output_neuron_uuids
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
                     .iter()
-                    .filter_map(|uuid| {
-                        shared_cache
-                            .get(uuid)
-                            .ok()
-                            .map(|records| (uuid.clone(), records.as_ref().to_vec()))
-                    })
+                    .filter(|n| n.neuron_type == "output" || n.neuron_type == "input")
+                    .map(|n| n.uuid.clone())
                     .collect();
-
-            let bias_drift_candidates =
-                output_bias_drift::detect_output_bias_drift(&input.creature, &bias_drift_records);
-
-            if !bias_drift_candidates.is_empty() {
-                let coordinated_bias_drift =
-                    output_bias_drift::output_bias_drift_to_coordinated_candidates(
-                        &bias_drift_candidates,
-                    );
-
-                if !coordinated_bias_drift.is_empty() {
-                    if utils::verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Output bias drift detection: found {} biased output(s), {} candidate(s)",
-                            bias_drift_candidates.len(),
-                            coordinated_bias_drift.len()
-                        );
-                    }
-
-                    merge_coordinated_structural_replacements(
-                        syn,
-                        coordinated_bias_drift,
-                        input.max_synapse_candidates,
-                        input.analysis_deadline_ms.is_some(),
-                    );
+                let records = collect_records_for_uuids(&uuids, &shared_cache);
+                let detected =
+                    correlated_error::detect_correlated_error_patterns(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
                 }
-            }
-        }
+                let candidates = correlated_error::correlated_errors_to_coordinated_candidates(
+                    &detected,
+                    &input.creature,
+                );
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
 
-        crate::watchdog::beat("analysis::analyze_all → output bias drift detection finished");
+        // Issue #230: Multi-hop candidates → bypass synapses / relay neurons
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Multi-hop analysis",
+                phase_name: "multi_hop_analysis",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                let records = collect_records_for_uuids(&uuids, &shared_cache);
+                let detected = multi_hop::detect_multi_hop_candidates(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    multi_hop::multi_hop_to_coordinated_candidates(&detected, &input.creature);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #356: Oscillating neurons → stabilisation via activation change
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Oscillating neuron detection",
+                phase_name: "oscillating_neuron_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_neuron_records(&hidden_neurons, &shared_cache);
+                let detected =
+                    oscillating_neuron::detect_oscillating_neurons(&hidden_neurons, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    oscillating_neuron::oscillating_neurons_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #359: Dormant synapses → removal candidates
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Dormant synapse detection",
+                phase_name: "dormant_synapse_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                let source_uuids: Vec<String> = input
+                    .creature
+                    .synapses
+                    .iter()
+                    .map(|s| s.from_uuid.clone())
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
+                    .collect();
+                let records = collect_records_for_uuids(&source_uuids, &shared_cache);
+                let detected = dormant_synapse::detect_dormant_synapses(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    dormant_synapse::dormant_synapses_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #360: Opposing synapses → removal or weight flip candidates
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Opposing synapse detection",
+                phase_name: "opposing_synapse_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                let records = collect_records_for_uuids(&uuids, &shared_cache);
+                let detected =
+                    opposing_synapse::detect_opposing_synapses(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    opposing_synapse::opposing_synapses_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #361: Output bias drift → bias adjustment candidates
+        dispatch_discovery_module(
+            &DiscoveryDispatchConfig {
+                name: "Output bias drift detection",
+                phase_name: "output_bias_drift_detection",
+            },
+            syn,
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "output")
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                let records = collect_records_for_uuids(&uuids, &shared_cache);
+                let detected =
+                    output_bias_drift::detect_output_bias_drift(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
+                Some(DetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
     }
 
     // Issue #224: Candidate clustering to reduce redundant ablation tests.

--- a/tests/issue_375_discovery_dispatch_pattern.rs
+++ b/tests/issue_375_discovery_dispatch_pattern.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the generic discovery module dispatch pattern (Issue #375).
+//!
+//! These tests verify that the dispatch infrastructure correctly:
+//! - Merges candidates into synapse results
+//! - Skips modules when the closure returns `None`
+//! - Skips when candidates are empty
+//! - Accumulates candidates from multiple dispatches
+//! - Respects `max_synapse_candidates` limits
+
+use neat_ai_discovery::analysis::discovery_dispatch::{
+    dispatch_discovery_module, DetectionResult, DiscoveryDispatchConfig,
+};
+use neat_ai_discovery::analysis::shared::{AnalyzeSynapsesResult, SynapseAnalysisMetadata};
+use neat_ai_discovery::CoordinatedStructuralCandidateJson;
+
+/// Helper to create a minimal empty synapse result for testing.
+fn empty_synapse_result() -> AnalyzeSynapsesResult {
+    AnalyzeSynapsesResult {
+        helpful_synapses: vec![],
+        harmful_synapses: vec![],
+        synapse_weight_updates: vec![],
+        coordinated_structural_candidates: vec![],
+        candidate_clusters: vec![],
+        gpu_used: false,
+        no_candidate_reasons: vec![],
+        metadata: SynapseAnalysisMetadata::default(),
+    }
+}
+
+fn make_candidate(gain: f32, comment: &str) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}
+
+#[test]
+fn test_dispatch_merges_candidates() {
+    let mut syn = empty_synapse_result();
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "test module",
+            phase_name: "test_module",
+        },
+        &mut syn,
+        None,
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 2,
+                candidates: vec![make_candidate(0.5, "a"), make_candidate(0.3, "b")],
+            })
+        },
+    );
+
+    assert_eq!(syn.coordinated_structural_candidates.len(), 2);
+}
+
+#[test]
+fn test_dispatch_skips_on_none() {
+    let mut syn = empty_synapse_result();
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "skipped",
+            phase_name: "skipped",
+        },
+        &mut syn,
+        None,
+        false,
+        || None,
+    );
+
+    assert!(syn.coordinated_structural_candidates.is_empty());
+}
+
+#[test]
+fn test_dispatch_skips_on_empty_candidates() {
+    let mut syn = empty_synapse_result();
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "empty",
+            phase_name: "empty",
+        },
+        &mut syn,
+        None,
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 0,
+                candidates: vec![],
+            })
+        },
+    );
+
+    assert!(syn.coordinated_structural_candidates.is_empty());
+}
+
+#[test]
+fn test_multiple_dispatches_accumulate() {
+    let mut syn = empty_synapse_result();
+
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "module A",
+            phase_name: "module_a",
+        },
+        &mut syn,
+        None,
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(0.8, "from A")],
+            })
+        },
+    );
+
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "module B",
+            phase_name: "module_b",
+        },
+        &mut syn,
+        None,
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(0.6, "from B")],
+            })
+        },
+    );
+
+    assert_eq!(syn.coordinated_structural_candidates.len(), 2);
+    // Sorted by expected gain (highest first) since diversify=false
+    assert_eq!(
+        syn.coordinated_structural_candidates[0].expected_creature_score_gain,
+        0.8
+    );
+    assert_eq!(
+        syn.coordinated_structural_candidates[1].expected_creature_score_gain,
+        0.6
+    );
+}
+
+#[test]
+fn test_dispatch_respects_max_candidates_limit() {
+    let mut syn = empty_synapse_result();
+    let candidates: Vec<CoordinatedStructuralCandidateJson> = (0..5)
+        .map(|i| make_candidate(1.0 - (i as f32 * 0.1), &format!("c{i}")))
+        .collect();
+
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "limited",
+            phase_name: "limited",
+        },
+        &mut syn,
+        Some(2),
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 5,
+                candidates,
+            })
+        },
+    );
+
+    assert!(syn.coordinated_structural_candidates.len() <= 2);
+}
+
+#[test]
+fn test_dispatch_preserves_candidate_details() {
+    let mut syn = empty_synapse_result();
+    dispatch_discovery_module(
+        &DiscoveryDispatchConfig {
+            name: "detail check",
+            phase_name: "detail_check",
+        },
+        &mut syn,
+        None,
+        false,
+        || {
+            Some(DetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(0.42, "specific comment")],
+            })
+        },
+    );
+
+    assert_eq!(syn.coordinated_structural_candidates.len(), 1);
+    let c = &syn.coordinated_structural_candidates[0];
+    assert!((c.expected_creature_score_gain - 0.42).abs() < f32::EPSILON);
+    assert_eq!(c.comment.as_deref(), Some("specific comment"));
+}


### PR DESCRIPTION
## Summary

Extract the generic discovery module dispatch pattern (DRY) from `analyze_all()` in `src/analysis/mod.rs`.

The function previously contained 9 nearly identical code blocks (~500 lines of boilerplate) for dispatching discovery detection modules (saturation, bottleneck, dead neuron, correlated error, multi-hop, oscillating neuron, dormant synapse, opposing synapse, and output bias drift). Each block repeated the same pipeline: watchdog beat → phase timer → record collection → detection → conversion → verbose logging → merge.

This PR introduces `src/analysis/discovery_dispatch.rs` with:
- `dispatch_discovery_module()` — a generic function handling all dispatch boilerplate
- `DiscoveryDispatchConfig` — configuration struct for module name and phase timer
- `DetectionResult` — standardised detection output (count + candidates)
- `collect_records_for_uuids()` and `collect_hidden_neuron_records()` — shared record collection helpers

The 9 dispatch blocks in `analyze_all()` are replaced with concise calls to `dispatch_discovery_module()`, each providing only module-specific logic via a closure. This reduces ~500 lines of boilerplate to ~200 lines of focused module-specific code.

Adding a new detection module now requires only a single `dispatch_discovery_module()` call with a closure — no boilerplate for watchdog beats, phase timers, verbose logging, or candidate merging.

Closes #375

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

- Added 5 unit tests in `src/analysis/discovery_dispatch.rs` (inline `#[cfg(test)]` module):
  - `test_dispatch_merges_candidates_into_synapse_result`
  - `test_dispatch_skips_when_closure_returns_none`
  - `test_dispatch_skips_when_candidates_empty`
  - `test_dispatch_respects_max_synapse_candidates_limit`
  - `test_multiple_dispatches_accumulate_candidates`
- Added 6 integration tests in `tests/issue_375_discovery_dispatch_pattern.rs`:
  - `test_dispatch_merges_candidates`
  - `test_dispatch_skips_on_none`
  - `test_dispatch_skips_on_empty_candidates`
  - `test_multiple_dispatches_accumulate`
  - `test_dispatch_respects_max_candidates_limit`
  - `test_dispatch_preserves_candidate_details`
- All 439 existing unit tests pass unchanged
- All existing integration tests pass unchanged
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)