### PR TITLE
Add unit tests for discovery detection modules (#376)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.9.28"
+version = "0.9.29"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-376.md
+++ b/docs/pr-summary-376.md
@@ -1,0 +1,41 @@
+## Summary
+
+Add inline unit tests (`#[cfg(test)]`) to all 9 discovery detection modules in `src/analysis/`. These tests exercise internal helper functions and private logic that cannot be tested through the public API alone, complementing the existing integration tests in `tests/`.
+
+Closes #376.
+
+## Changes
+
+Added `#[cfg(test)] mod tests` blocks to each of the 9 detection modules:
+
+| Module | Unit tests added | Coverage areas |
+|--------|-----------------|----------------|
+| `saturation.rs` | 21 | `is_bounded_squash`, `check_bounded_saturation`, `compute_saturation_severity`, `compute_input_std_dev`, `recommend_fix`, detection thresholds, conversion |
+| `bottleneck.rs` | 8 | `bottleneck_parallel_neuron_uuid` determinism, fan-in/fan-out ratio filtering, output exclusion, conversion |
+| `dead_neuron.rs` | 9 | `compute_removal_confidence`, `find_connected_outputs` (direct + transitive), active/output exclusion, conversion |
+| `correlated_error.rs` | 11 | `compute_pearson_correlation` (positive/negative/zero-variance/no-overlap), `cluster_correlated_outputs`, `count_shared_error_samples`, `shared_neuron_uuid` |
+| `multi_hop.rs` | 9 | `compute_activation_error_correlation`, `compute_activation_activation_correlation`, `compute_mean_abs_error`, `multi_hop_relay_uuid` determinism |
+| `oscillating_neuron.rs` | 12 | `recommend_squash_for_oscillation`, `recommend_bias_for_oscillation`, stable/dead/insufficient exclusion, conversion |
+| `dormant_synapse.rs` | 5 | Near-zero weight detection, active weight exclusion, sole connection protection, insufficient samples, conversion |
+| `opposing_synapse.rs` | 7 | `pearson_correlation` (positive/negative/single/zero-variance), hidden target exclusion, removal vs weight flip conversion |
+| `output_bias_drift.rs` | 6 | Positive/balanced error detection, hidden neuron exclusion, noise threshold, insufficient samples, conversion bias value |
+
+**Total: 88 new unit tests** (test count increased from 434 to 522).
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+All 522 tests pass and `./quality.sh` completes successfully (fmt, clippy, check, test, release build).
+
+## Test Plan
+
+- 88 new `#[cfg(test)]` unit tests across the 9 detection modules
+- Each module has at least 5 unit tests covering:
+  - **Detection criteria**: Verify neurons/synapses meeting threshold criteria are detected
+  - **Exclusion criteria**: Verify neurons/synapses that should NOT be detected are excluded
+  - **Edge cases**: Insufficient samples, boundary threshold values, zero-variance inputs
+  - **Conversion**: Verify `*_to_coordinated_candidates()` produces correct operation types
+- All tests use Australian English in names and comments
+- Tests verify outcomes, not implementation details
+- `./quality.sh` passes cleanly

--- a/src/analysis/bottleneck.rs
+++ b/src/analysis/bottleneck.rs
@@ -402,3 +402,233 @@ pub fn bottleneck_neurons_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+    use crate::{NeuronJson, SynapseJson};
+
+    fn make_neuron(uuid: &str, ntype: &str) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: ntype.to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+        }
+    }
+
+    fn make_synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+        SynapseJson {
+            from_uuid: from.to_string(),
+            to_uuid: to.to_string(),
+            weight,
+            synapse_type: None,
+        }
+    }
+
+    fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+        CreatureJson {
+            neurons,
+            synapses,
+            input: 1,
+            output: 1,
+        }
+    }
+
+    fn make_record(uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord::new(obs_index, uuid.to_string(), None, activation, vec![0.1])
+    }
+
+    // ── bottleneck_parallel_neuron_uuid ─────────────────────────────────
+
+    #[test]
+    fn parallel_neuron_uuid_is_deterministic() {
+        let uuid1 = bottleneck_parallel_neuron_uuid("bottleneck-1", 0);
+        let uuid2 = bottleneck_parallel_neuron_uuid("bottleneck-1", 0);
+        assert_eq!(uuid1, uuid2, "Same inputs should produce the same UUID");
+    }
+
+    #[test]
+    fn parallel_neuron_uuid_differs_by_index() {
+        let uuid1 = bottleneck_parallel_neuron_uuid("bottleneck-1", 0);
+        let uuid2 = bottleneck_parallel_neuron_uuid("bottleneck-1", 1);
+        assert_ne!(
+            uuid1, uuid2,
+            "Different indices should produce different UUIDs"
+        );
+    }
+
+    #[test]
+    fn parallel_neuron_uuid_has_bp_prefix() {
+        let uuid = bottleneck_parallel_neuron_uuid("test", 0);
+        assert!(
+            uuid.starts_with("bp-"),
+            "UUID should start with 'bp-' prefix"
+        );
+    }
+
+    // ── detect_bottleneck_neurons ──────────────────────────────────────
+
+    #[test]
+    fn low_fan_in_neuron_not_flagged() {
+        // Fan-in 2, fan-out 1: ratio is 2.0 but fan-in < MIN_FAN_IN_FOR_BOTTLENECK (3)
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("h-1", "hidden"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "h-1", 1.0),
+                make_synapse("in-2", "h-1", 1.0),
+                make_synapse("h-1", "out-1", 1.0),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "h-1".to_string(),
+            (0..30).map(|i| make_record("h-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_bottleneck_neurons(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Fan-in 2 should not trigger bottleneck detection"
+        );
+    }
+
+    #[test]
+    fn balanced_fan_in_fan_out_not_flagged() {
+        // Fan-in 3, fan-out 3: ratio is 1.0 < MIN_FAN_IN_FAN_OUT_RATIO (2.0)
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("in-3", "input"),
+                make_neuron("h-1", "hidden"),
+                make_neuron("out-1", "output"),
+                make_neuron("out-2", "output"),
+                make_neuron("out-3", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "h-1", 1.0),
+                make_synapse("in-2", "h-1", 1.0),
+                make_synapse("in-3", "h-1", 1.0),
+                make_synapse("h-1", "out-1", 1.0),
+                make_synapse("h-1", "out-2", 1.0),
+                make_synapse("h-1", "out-3", 1.0),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "h-1".to_string(),
+            (0..30).map(|i| make_record("h-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_bottleneck_neurons(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Balanced fan-in/fan-out should not trigger bottleneck detection"
+        );
+    }
+
+    #[test]
+    fn high_fan_in_to_single_output_detected() {
+        // Fan-in 4, fan-out 1: ratio is 4.0 >= MIN_FAN_IN_FAN_OUT_RATIO
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("in-3", "input"),
+                make_neuron("in-4", "input"),
+                make_neuron("h-1", "hidden"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "h-1", 1.0),
+                make_synapse("in-2", "h-1", 1.0),
+                make_synapse("in-3", "h-1", 1.0),
+                make_synapse("in-4", "h-1", 1.0),
+                make_synapse("h-1", "out-1", 1.0),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "h-1".to_string(),
+            (0..30).map(|i| make_record("h-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_bottleneck_neurons(&creature, &records);
+        assert_eq!(result.len(), 1, "Should detect one bottleneck neuron");
+        assert_eq!(result[0].fan_in, 4);
+        assert_eq!(result[0].fan_out, 1);
+    }
+
+    #[test]
+    fn output_neurons_excluded_from_bottleneck_detection() {
+        // Even if output neuron has high fan-in, it should not be flagged
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("in-3", "input"),
+                make_neuron("in-4", "input"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "out-1", 1.0),
+                make_synapse("in-2", "out-1", 1.0),
+                make_synapse("in-3", "out-1", 1.0),
+                make_synapse("in-4", "out-1", 1.0),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..30).map(|i| make_record("out-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_bottleneck_neurons(&creature, &records);
+        assert!(result.is_empty(), "Output neurons should be excluded");
+    }
+
+    // ── bottleneck_neurons_to_coordinated_candidates ───────────────────
+
+    #[test]
+    fn conversion_includes_add_neuron_and_add_synapse_ops() {
+        let candidate = BottleneckNeuronCandidate {
+            neuron_uuid: "h-1".to_string(),
+            fan_in: 4,
+            fan_out: 1,
+            error_contribution_ratio: 0.5,
+            bottleneck_score: 0.3,
+            estimated_improvement: 0.003,
+            recommended_actions: vec!["addParallelNeuron".to_string()],
+            upstream_uuids: vec!["in-1".to_string(), "in-2".to_string()],
+            downstream_uuids: vec!["out-1".to_string()],
+        };
+
+        let creature = make_creature(
+            vec![make_neuron("h-1", "hidden"), make_neuron("out-1", "output")],
+            vec![
+                make_synapse("in-1", "h-1", 0.5),
+                make_synapse("in-2", "h-1", 0.8),
+                make_synapse("h-1", "out-1", 1.0),
+            ],
+        );
+
+        let coordinated = bottleneck_neurons_to_coordinated_candidates(&[candidate], &creature);
+        assert!(
+            !coordinated.is_empty(),
+            "Should produce at least one candidate"
+        );
+
+        let ops = &coordinated[0].operations;
+        let has_add_neuron = ops
+            .iter()
+            .any(|op| matches!(op, CoordinatedStructuralOpJson::AddNeuron { .. }));
+        assert!(has_add_neuron, "Should include AddNeuron operation");
+    }
+}

--- a/src/analysis/correlated_error.rs
+++ b/src/analysis/correlated_error.rs
@@ -627,3 +627,128 @@ pub fn correlated_errors_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── compute_pearson_correlation ─────────────────────────────────────
+
+    #[test]
+    fn perfect_positive_correlation() {
+        let a: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32)).collect();
+        let b: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32 * 2.0)).collect();
+        let corr = compute_pearson_correlation(&a, &b);
+        assert!(
+            (corr - 1.0).abs() < 0.01,
+            "Perfectly correlated vectors should have r ≈ 1.0, got {corr}"
+        );
+    }
+
+    #[test]
+    fn perfect_negative_correlation() {
+        let a: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32)).collect();
+        let b: HashMap<u32, f32> = (0..30).map(|i| (i, -(i as f32))).collect();
+        let corr = compute_pearson_correlation(&a, &b);
+        assert!(
+            (corr + 1.0).abs() < 0.01,
+            "Perfectly anti-correlated vectors should have r ≈ -1.0, got {corr}"
+        );
+    }
+
+    #[test]
+    fn insufficient_shared_samples_returns_zero() {
+        let a: HashMap<u32, f32> = (0..5).map(|i| (i, i as f32)).collect();
+        let b: HashMap<u32, f32> = (0..5).map(|i| (i, i as f32)).collect();
+        let corr = compute_pearson_correlation(&a, &b);
+        assert_eq!(corr, 0.0, "Should return 0.0 with insufficient samples");
+    }
+
+    #[test]
+    fn no_overlap_returns_zero() {
+        let a: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32)).collect();
+        let b: HashMap<u32, f32> = (100..130).map(|i| (i, i as f32)).collect();
+        let corr = compute_pearson_correlation(&a, &b);
+        assert_eq!(corr, 0.0, "No overlapping obs indices should return 0.0");
+    }
+
+    #[test]
+    fn zero_variance_returns_zero() {
+        let a: HashMap<u32, f32> = (0..30).map(|i| (i, 5.0)).collect();
+        let b: HashMap<u32, f32> = (0..30).map(|i| (i, 5.0)).collect();
+        let corr = compute_pearson_correlation(&a, &b);
+        assert_eq!(
+            corr, 0.0,
+            "Zero variance should return 0.0 (undefined correlation)"
+        );
+    }
+
+    // ── cluster_correlated_outputs ─────────────────────────────────────
+
+    #[test]
+    fn two_highly_correlated_outputs_form_one_group() {
+        let output_uuids = vec!["out-1", "out-2"];
+        let corr_matrix = vec![vec![1.0, 0.9], vec![0.9, 1.0]];
+        let groups = cluster_correlated_outputs(&output_uuids, &corr_matrix, 0.7);
+        assert_eq!(groups.len(), 1, "Should form one group");
+        assert_eq!(groups[0].len(), 2, "Group should contain both outputs");
+    }
+
+    #[test]
+    fn independent_outputs_form_no_group() {
+        let output_uuids = vec!["out-1", "out-2"];
+        let corr_matrix = vec![vec![1.0, 0.1], vec![0.1, 1.0]];
+        let groups = cluster_correlated_outputs(&output_uuids, &corr_matrix, 0.7);
+        assert!(
+            groups.is_empty(),
+            "Independent outputs should form no groups"
+        );
+    }
+
+    // ── count_shared_error_samples ─────────────────────────────────────
+
+    #[test]
+    fn all_same_sign_errors_counted() {
+        let group_uuids = vec!["out-1", "out-2"];
+        let error_by_obs: HashMap<&str, HashMap<u32, f32>> = [
+            ("out-1", [(0_u32, 1.0), (1, 2.0)].into_iter().collect()),
+            ("out-2", [(0_u32, 0.5), (1, 1.5)].into_iter().collect()),
+        ]
+        .into_iter()
+        .collect();
+        let shared_obs = vec![0, 1];
+        let count = count_shared_error_samples(&group_uuids, &error_by_obs, &shared_obs);
+        assert_eq!(count, 2, "Both samples have all-positive errors");
+    }
+
+    #[test]
+    fn mixed_sign_errors_not_counted() {
+        let group_uuids = vec!["out-1", "out-2"];
+        let error_by_obs: HashMap<&str, HashMap<u32, f32>> = [
+            ("out-1", [(0_u32, 1.0)].into_iter().collect()),
+            ("out-2", [(0_u32, -0.5)].into_iter().collect()),
+        ]
+        .into_iter()
+        .collect();
+        let shared_obs = vec![0];
+        let count = count_shared_error_samples(&group_uuids, &error_by_obs, &shared_obs);
+        assert_eq!(count, 0, "Mixed-sign errors should not be counted");
+    }
+
+    // ── shared_neuron_uuid ─────────────────────────────────────────────
+
+    #[test]
+    fn shared_neuron_uuid_is_deterministic() {
+        let uuids = vec!["out-1".to_string(), "out-2".to_string()];
+        let id1 = shared_neuron_uuid(&uuids, 0);
+        let id2 = shared_neuron_uuid(&uuids, 0);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn shared_neuron_uuid_has_cs_prefix() {
+        let uuids = vec!["out-1".to_string()];
+        let id = shared_neuron_uuid(&uuids, 0);
+        assert!(id.starts_with("cs-"), "Should start with 'cs-' prefix");
+    }
+}

--- a/src/analysis/dead_neuron.rs
+++ b/src/analysis/dead_neuron.rs
@@ -281,3 +281,162 @@ pub fn dead_neurons_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+    use crate::{NeuronJson, SynapseJson};
+
+    fn make_neuron(uuid: &str, ntype: &str) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: ntype.to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+        }
+    }
+
+    fn make_synapse(from: &str, to: &str) -> SynapseJson {
+        SynapseJson {
+            from_uuid: from.to_string(),
+            to_uuid: to.to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }
+    }
+
+    fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+        CreatureJson {
+            neurons,
+            synapses,
+            input: 1,
+            output: 1,
+        }
+    }
+
+    fn make_record(uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord::new(obs_index, uuid.to_string(), None, activation, vec![0.01])
+    }
+
+    // ── compute_removal_confidence ─────────────────────────────────────
+
+    #[test]
+    fn perfect_dead_neuron_has_high_confidence() {
+        // Zero activation, zero std dev, many samples → high confidence
+        let confidence = compute_removal_confidence(0.0, 0.0, 1000.0);
+        assert!(
+            confidence > 0.8,
+            "Perfectly dead neuron should have high confidence, got {confidence}"
+        );
+    }
+
+    #[test]
+    fn more_samples_increase_confidence() {
+        let c_few = compute_removal_confidence(0.0, 0.0, 20.0);
+        let c_many = compute_removal_confidence(0.0, 0.0, 500.0);
+        assert!(
+            c_many > c_few,
+            "More samples should increase confidence: {c_many} vs {c_few}"
+        );
+    }
+
+    #[test]
+    fn confidence_never_exceeds_one() {
+        let confidence = compute_removal_confidence(0.0, 0.0, 100_000.0);
+        assert!(
+            confidence <= 1.0,
+            "Confidence should not exceed 1.0, got {confidence}"
+        );
+    }
+
+    // ── find_connected_outputs ─────────────────────────────────────────
+
+    #[test]
+    fn finds_directly_connected_output() {
+        let fan_out_map: HashMap<&str, Vec<&str>> = [("h-1", vec!["out-1"])].into_iter().collect();
+        let output_uuids: HashSet<&str> = ["out-1"].into_iter().collect();
+
+        let connected = find_connected_outputs("h-1", &fan_out_map, &output_uuids);
+        assert_eq!(connected, vec!["out-1".to_string()]);
+    }
+
+    #[test]
+    fn finds_transitively_connected_output() {
+        let fan_out_map: HashMap<&str, Vec<&str>> = [("h-1", vec!["h-2"]), ("h-2", vec!["out-1"])]
+            .into_iter()
+            .collect();
+        let output_uuids: HashSet<&str> = ["out-1"].into_iter().collect();
+
+        let connected = find_connected_outputs("h-1", &fan_out_map, &output_uuids);
+        assert_eq!(connected, vec!["out-1".to_string()]);
+    }
+
+    #[test]
+    fn no_connected_outputs_returns_empty() {
+        let fan_out_map: HashMap<&str, Vec<&str>> = HashMap::new();
+        let output_uuids: HashSet<&str> = ["out-1"].into_iter().collect();
+
+        let connected = find_connected_outputs("h-1", &fan_out_map, &output_uuids);
+        assert!(connected.is_empty());
+    }
+
+    // ── detect_dead_neurons ────────────────────────────────────────────
+
+    #[test]
+    fn active_neuron_not_flagged_as_dead() {
+        let creature = make_creature(
+            vec![make_neuron("h-1", "hidden"), make_neuron("out-1", "output")],
+            vec![make_synapse("h-1", "out-1")],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "h-1".to_string(),
+            (0..30).map(|i| make_record("h-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_dead_neurons(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Active neuron should not be flagged as dead"
+        );
+    }
+
+    #[test]
+    fn output_neuron_never_flagged() {
+        let creature = make_creature(vec![make_neuron("out-1", "output")], vec![]);
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..30).map(|i| make_record("out-1", i, 0.0)).collect(),
+        )];
+
+        let result = detect_dead_neurons(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Output neurons should never be flagged as dead"
+        );
+    }
+
+    // ── dead_neurons_to_coordinated_candidates ─────────────────────────
+
+    #[test]
+    fn conversion_produces_remove_neuron_op() {
+        let candidate = DeadNeuronCandidate {
+            neuron_uuid: "dead-1".to_string(),
+            mean_abs_activation: 0.0,
+            activation_std_dev: 0.0,
+            sample_count: 100,
+            connected_outputs: vec!["out-1".to_string()],
+            removal_confidence: 0.95,
+            estimated_improvement: 0.001,
+        };
+
+        let coordinated = dead_neurons_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        assert!(matches!(
+            &coordinated[0].operations[0],
+            CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } if neuron_uuid == "dead-1"
+        ));
+    }
+}

--- a/src/analysis/dormant_synapse.rs
+++ b/src/analysis/dormant_synapse.rs
@@ -179,3 +179,161 @@ pub fn dormant_synapses_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+    use crate::{NeuronJson, SynapseJson};
+
+    fn make_neuron(uuid: &str, ntype: &str) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: ntype.to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+        }
+    }
+
+    fn make_synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+        SynapseJson {
+            from_uuid: from.to_string(),
+            to_uuid: to.to_string(),
+            weight,
+            synapse_type: None,
+        }
+    }
+
+    fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+        CreatureJson {
+            neurons,
+            synapses,
+            input: 1,
+            output: 1,
+        }
+    }
+
+    fn make_record(uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord::new(obs_index, uuid.to_string(), None, activation, vec![])
+    }
+
+    // ── detect_dormant_synapses ────────────────────────────────────────
+
+    #[test]
+    fn near_zero_weight_synapse_detected() {
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "out-1", 1e-5), // dormant
+                make_synapse("in-2", "out-1", 1.0),  // active (ensures fan-in > 1)
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+            (
+                "in-1".to_string(),
+                (0..30).map(|i| make_record("in-1", i, 0.5)).collect(),
+            ),
+            (
+                "in-2".to_string(),
+                (0..30).map(|i| make_record("in-2", i, 0.5)).collect(),
+            ),
+        ];
+
+        let result = detect_dormant_synapses(&creature, &records);
+        assert_eq!(result.len(), 1, "Should detect one dormant synapse");
+        assert_eq!(result[0].from_neuron_uuid, "in-1");
+    }
+
+    #[test]
+    fn active_weight_synapse_not_flagged() {
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "out-1", 0.5),
+                make_synapse("in-2", "out-1", 0.8),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "in-1".to_string(),
+            (0..30).map(|i| make_record("in-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_dormant_synapses(&creature, &records);
+        assert!(result.is_empty(), "Active synapse should not be flagged");
+    }
+
+    #[test]
+    fn sole_connection_not_flagged() {
+        // Only one synapse to target — removal would be destructive
+        let creature = make_creature(
+            vec![make_neuron("in-1", "input"), make_neuron("out-1", "output")],
+            vec![make_synapse("in-1", "out-1", 1e-5)],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "in-1".to_string(),
+            (0..30).map(|i| make_record("in-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_dormant_synapses(&creature, &records);
+        assert!(result.is_empty(), "Sole connection should not be flagged");
+    }
+
+    #[test]
+    fn insufficient_samples_not_flagged() {
+        let creature = make_creature(
+            vec![
+                make_neuron("in-1", "input"),
+                make_neuron("in-2", "input"),
+                make_neuron("out-1", "output"),
+            ],
+            vec![
+                make_synapse("in-1", "out-1", 1e-5),
+                make_synapse("in-2", "out-1", 1.0),
+            ],
+        );
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "in-1".to_string(),
+            (0..5).map(|i| make_record("in-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_dormant_synapses(&creature, &records);
+        assert!(result.is_empty(), "Should require minimum sample count");
+    }
+
+    // ── dormant_synapses_to_coordinated_candidates ─────────────────────
+
+    #[test]
+    fn conversion_produces_remove_synapse_op() {
+        let candidate = DormantSynapseCandidate {
+            from_neuron_uuid: "in-1".to_string(),
+            to_neuron_uuid: "out-1".to_string(),
+            weight: 1e-5,
+            mean_abs_contribution: 1e-6,
+            other_fan_in: 2,
+            sample_count: 100,
+            estimated_improvement: 0.001,
+        };
+
+        let coordinated = dormant_synapses_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        assert!(matches!(
+            &coordinated[0].operations[0],
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+            } if from_neuron_uuid == "in-1" && to_neuron_uuid == "out-1"
+        ));
+    }
+}

--- a/src/analysis/multi_hop.rs
+++ b/src/analysis/multi_hop.rs
@@ -548,3 +548,96 @@ pub fn multi_hop_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── compute_activation_error_correlation ────────────────────────────
+
+    #[test]
+    fn perfect_activation_error_correlation() {
+        let activations: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32)).collect();
+        let errors: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32 * 3.0)).collect();
+        let corr = compute_activation_error_correlation(&activations, &errors);
+        assert!(
+            (corr - 1.0).abs() < 0.01,
+            "Linearly related values should have r ≈ 1.0, got {corr}"
+        );
+    }
+
+    #[test]
+    fn zero_variance_activation_returns_zero() {
+        let activations: HashMap<u32, f32> = (0..30).map(|i| (i, 5.0)).collect();
+        let errors: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32)).collect();
+        let corr = compute_activation_error_correlation(&activations, &errors);
+        assert_eq!(
+            corr, 0.0,
+            "Zero-variance activation should produce 0.0 correlation"
+        );
+    }
+
+    #[test]
+    fn insufficient_shared_returns_zero() {
+        let activations: HashMap<u32, f32> = (0..5).map(|i| (i, i as f32)).collect();
+        let errors: HashMap<u32, f32> = (0..5).map(|i| (i, i as f32)).collect();
+        let corr = compute_activation_error_correlation(&activations, &errors);
+        assert_eq!(corr, 0.0);
+    }
+
+    // ── compute_activation_activation_correlation ───────────────────────
+
+    #[test]
+    fn identical_activations_have_perfect_correlation() {
+        let a: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32 * 0.1)).collect();
+        let b: HashMap<u32, f32> = (0..30).map(|i| (i, i as f32 * 0.1)).collect();
+        let corr = compute_activation_activation_correlation(&a, &b);
+        assert!(
+            (corr - 1.0).abs() < 0.01,
+            "Identical activations should have r ≈ 1.0, got {corr}"
+        );
+    }
+
+    // ── compute_mean_abs_error ──────────────────────────────────────────
+
+    #[test]
+    fn mean_abs_error_of_empty_map_is_zero() {
+        let errors: HashMap<u32, f32> = HashMap::new();
+        assert_eq!(compute_mean_abs_error(&errors), 0.0);
+    }
+
+    #[test]
+    fn mean_abs_error_uses_absolute_values() {
+        let errors: HashMap<u32, f32> = [(0, -1.0), (1, 1.0)].into_iter().collect();
+        let mae = compute_mean_abs_error(&errors);
+        assert!(
+            (mae - 1.0).abs() < 0.01,
+            "Mean absolute error of [-1, 1] should be 1.0, got {mae}"
+        );
+    }
+
+    // ── multi_hop_relay_uuid ───────────────────────────────────────────
+
+    #[test]
+    fn relay_uuid_is_deterministic() {
+        let path = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let id1 = multi_hop_relay_uuid(&path, 0);
+        let id2 = multi_hop_relay_uuid(&path, 0);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn relay_uuid_has_mh_prefix() {
+        let path = vec!["a".to_string()];
+        let id = multi_hop_relay_uuid(&path, 0);
+        assert!(id.starts_with("mh-"), "Should start with 'mh-' prefix");
+    }
+
+    #[test]
+    fn relay_uuid_differs_by_index() {
+        let path = vec!["a".to_string(), "b".to_string()];
+        let id1 = multi_hop_relay_uuid(&path, 0);
+        let id2 = multi_hop_relay_uuid(&path, 1);
+        assert_ne!(id1, id2);
+    }
+}

--- a/src/analysis/opposing_synapse.rs
+++ b/src/analysis/opposing_synapse.rs
@@ -263,3 +263,144 @@ pub fn opposing_synapses_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── pearson_correlation ─────────────────────────────────────────────
+
+    #[test]
+    fn pearson_perfect_positive() {
+        let x: Vec<f32> = (0..30).map(|i| i as f32).collect();
+        let y: Vec<f32> = (0..30).map(|i| i as f32 * 2.0 + 1.0).collect();
+        let corr = pearson_correlation(&x, &y);
+        assert!(
+            (corr - 1.0).abs() < 0.01,
+            "Perfectly correlated should give r ≈ 1.0, got {corr}"
+        );
+    }
+
+    #[test]
+    fn pearson_perfect_negative() {
+        let x: Vec<f32> = (0..30).map(|i| i as f32).collect();
+        let y: Vec<f32> = (0..30).map(|i| -(i as f32)).collect();
+        let corr = pearson_correlation(&x, &y);
+        assert!(
+            (corr + 1.0).abs() < 0.01,
+            "Perfectly anti-correlated should give r ≈ -1.0, got {corr}"
+        );
+    }
+
+    #[test]
+    fn pearson_single_element_returns_zero() {
+        let corr = pearson_correlation(&[1.0], &[2.0]);
+        assert_eq!(corr, 0.0, "Single element should return 0.0");
+    }
+
+    #[test]
+    fn pearson_zero_variance_returns_zero() {
+        let x: Vec<f32> = vec![5.0; 30];
+        let y: Vec<f32> = (0..30).map(|i| i as f32).collect();
+        let corr = pearson_correlation(&x, &y);
+        assert_eq!(corr, 0.0, "Zero variance in x should return 0.0");
+    }
+
+    // ── detect_opposing_synapses ───────────────────────────────────────
+
+    #[test]
+    fn non_output_target_synapses_excluded() {
+        use crate::types::DiscoverRecord;
+        use crate::{CreatureJson, NeuronJson, SynapseJson};
+
+        let creature = CreatureJson {
+            neurons: vec![
+                NeuronJson {
+                    uuid: "in-1".to_string(),
+                    neuron_type: "input".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+                NeuronJson {
+                    uuid: "h-1".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "TANH".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: vec![SynapseJson {
+                from_uuid: "in-1".to_string(),
+                to_uuid: "h-1".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            }],
+            input: 1,
+            output: 0,
+        };
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+            (
+                "in-1".to_string(),
+                (0..30)
+                    .map(|i| DiscoverRecord::new(i, "in-1".to_string(), None, i as f32, vec![]))
+                    .collect(),
+            ),
+            (
+                "h-1".to_string(),
+                (0..30)
+                    .map(|i| DiscoverRecord::new(i, "h-1".to_string(), None, 0.0, vec![i as f32]))
+                    .collect(),
+            ),
+        ];
+
+        let result = detect_opposing_synapses(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Synapses targeting hidden neurons should be excluded"
+        );
+    }
+
+    // ── opposing_synapses_to_coordinated_candidates ────────────────────
+
+    #[test]
+    fn strong_opposition_produces_remove_synapse() {
+        let candidate = OpposingSynapseCandidate {
+            from_neuron_uuid: "in-1".to_string(),
+            to_neuron_uuid: "out-1".to_string(),
+            weight: 0.5,
+            contribution_error_correlation: 0.8,
+            mean_abs_contribution: 0.1,
+            sample_count: 100,
+            recommend_removal: true,
+            estimated_improvement: 0.004,
+        };
+
+        let coordinated = opposing_synapses_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        assert!(matches!(
+            &coordinated[0].operations[0],
+            CoordinatedStructuralOpJson::RemoveSynapse { .. }
+        ));
+    }
+
+    #[test]
+    fn moderate_opposition_produces_set_weight() {
+        let candidate = OpposingSynapseCandidate {
+            from_neuron_uuid: "in-1".to_string(),
+            to_neuron_uuid: "out-1".to_string(),
+            weight: 0.5,
+            contribution_error_correlation: 0.35,
+            mean_abs_contribution: 0.1,
+            sample_count: 100,
+            recommend_removal: false,
+            estimated_improvement: 0.002,
+        };
+
+        let coordinated = opposing_synapses_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        assert!(matches!(
+            &coordinated[0].operations[0],
+            CoordinatedStructuralOpJson::SetWeight { weight, .. } if (*weight + 0.5_f32).abs() < 0.01
+        ));
+    }
+}

--- a/src/analysis/oscillating_neuron.rs
+++ b/src/analysis/oscillating_neuron.rs
@@ -246,3 +246,137 @@ pub fn oscillating_neurons_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+
+    fn make_record(obs_index: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord::new(
+            obs_index,
+            "test-neuron".to_string(),
+            None,
+            activation,
+            vec![],
+        )
+    }
+
+    // ── recommend_squash_for_oscillation ────────────────────────────────
+
+    #[test]
+    fn tanh_recommends_absolute() {
+        assert_eq!(recommend_squash_for_oscillation("TANH"), "ABSOLUTE");
+    }
+
+    #[test]
+    fn identity_recommends_absolute() {
+        assert_eq!(recommend_squash_for_oscillation("IDENTITY"), "ABSOLUTE");
+    }
+
+    #[test]
+    fn logistic_recommends_relu() {
+        assert_eq!(recommend_squash_for_oscillation("LOGISTIC"), "RELU");
+    }
+
+    #[test]
+    fn softsign_recommends_absolute() {
+        assert_eq!(recommend_squash_for_oscillation("SOFTSIGN"), "ABSOLUTE");
+    }
+
+    #[test]
+    fn recommendation_is_case_insensitive() {
+        assert_eq!(recommend_squash_for_oscillation("tanh"), "ABSOLUTE");
+    }
+
+    // ── recommend_bias_for_oscillation ──────────────────────────────────
+
+    #[test]
+    fn majority_positive_recommends_negative_bias() {
+        let delta = recommend_bias_for_oscillation(0.7, 0.0);
+        assert!(
+            delta.is_some() && delta.unwrap() < 0.0,
+            "Should recommend negative bias when mostly positive"
+        );
+    }
+
+    #[test]
+    fn majority_negative_recommends_positive_bias() {
+        let delta = recommend_bias_for_oscillation(0.3, 0.0);
+        assert!(
+            delta.is_some() && delta.unwrap() > 0.0,
+            "Should recommend positive bias when mostly negative"
+        );
+    }
+
+    #[test]
+    fn balanced_oscillation_no_bias_change() {
+        let delta = recommend_bias_for_oscillation(0.5, 0.0);
+        assert!(
+            delta.is_none(),
+            "Balanced oscillation should not adjust bias"
+        );
+    }
+
+    // ── detect_oscillating_neurons ─────────────────────────────────────
+
+    #[test]
+    fn stable_positive_neuron_not_detected() {
+        let neurons = vec![("n1".to_string(), "TANH".to_string(), 0.0)];
+        let records: Vec<DiscoverRecord> = (0..30).map(|i| make_record(i, 0.5)).collect();
+        let result = detect_oscillating_neurons(&neurons, &[("n1".to_string(), records)]);
+        assert!(
+            result.is_empty(),
+            "Stable positive neuron should not be detected as oscillating"
+        );
+    }
+
+    #[test]
+    fn dead_neuron_not_detected_as_oscillating() {
+        let neurons = vec![("n1".to_string(), "TANH".to_string(), 0.0)];
+        let records: Vec<DiscoverRecord> = (0..30).map(|i| make_record(i, 0.0)).collect();
+        let result = detect_oscillating_neurons(&neurons, &[("n1".to_string(), records)]);
+        assert!(
+            result.is_empty(),
+            "Dead neuron (zero activation) should not be flagged as oscillating"
+        );
+    }
+
+    #[test]
+    fn insufficient_samples_not_detected() {
+        let neurons = vec![("n1".to_string(), "TANH".to_string(), 0.0)];
+        // Alternating sign but only 10 samples
+        let records: Vec<DiscoverRecord> = (0..10)
+            .map(|i| {
+                let sign = if i % 2 == 0 { 1.0 } else { -1.0 };
+                make_record(i, 0.5 * sign)
+            })
+            .collect();
+        let result = detect_oscillating_neurons(&neurons, &[("n1".to_string(), records)]);
+        assert!(result.is_empty(), "Should require minimum sample count");
+    }
+
+    // ── oscillating_neurons_to_coordinated_candidates ──────────────────
+
+    #[test]
+    fn conversion_includes_change_squash_op() {
+        let candidate = OscillatingNeuronCandidate {
+            neuron_uuid: "osc-1".to_string(),
+            current_squash: "TANH".to_string(),
+            sign_change_fraction: 0.5,
+            positive_fraction: 0.5,
+            mean_abs_activation: 0.3,
+            sample_count: 100,
+            recommended_squash: "ABSOLUTE".to_string(),
+            recommended_bias_delta: None,
+            estimated_improvement: 0.005,
+        };
+
+        let coordinated = oscillating_neurons_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        let has_change_squash = coordinated[0].operations.iter().any(|op| {
+            matches!(op, CoordinatedStructuralOpJson::ChangeSquash { squash, .. } if squash == "ABSOLUTE")
+        });
+        assert!(has_change_squash, "Should include ChangeSquash to ABSOLUTE");
+    }
+}

--- a/src/analysis/output_bias_drift.rs
+++ b/src/analysis/output_bias_drift.rs
@@ -192,3 +192,151 @@ pub fn output_bias_drift_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+    use crate::NeuronJson;
+
+    fn make_output_neuron(uuid: &str, bias: f32) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias,
+        }
+    }
+
+    fn make_creature(neurons: Vec<NeuronJson>) -> CreatureJson {
+        CreatureJson {
+            neurons,
+            synapses: vec![],
+            input: 0,
+            output: 1,
+        }
+    }
+
+    fn make_record(uuid: &str, obs_index: u32, error: f32) -> DiscoverRecord {
+        DiscoverRecord::new(obs_index, uuid.to_string(), None, 0.0, vec![error])
+    }
+
+    // ── detect_output_bias_drift ───────────────────────────────────────
+
+    #[test]
+    fn consistent_positive_errors_detected() {
+        let creature = make_creature(vec![make_output_neuron("out-1", 0.0)]);
+        // 80% positive errors with meaningful magnitude
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..100)
+                .map(|i| {
+                    let err = if i < 80 { 0.5 } else { -0.2 };
+                    make_record("out-1", i, err)
+                })
+                .collect(),
+        )];
+
+        let result = detect_output_bias_drift(&creature, &records);
+        assert_eq!(result.len(), 1, "Should detect bias drift");
+        assert!(
+            result[0].recommended_bias_delta < 0.0,
+            "Should recommend negative delta for positive error bias"
+        );
+    }
+
+    #[test]
+    fn balanced_errors_not_flagged() {
+        let creature = make_creature(vec![make_output_neuron("out-1", 0.0)]);
+        // 50/50 positive/negative errors
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..100)
+                .map(|i| {
+                    let err = if i % 2 == 0 { 0.5 } else { -0.5 };
+                    make_record("out-1", i, err)
+                })
+                .collect(),
+        )];
+
+        let result = detect_output_bias_drift(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Balanced errors should not trigger bias drift"
+        );
+    }
+
+    #[test]
+    fn hidden_neurons_excluded() {
+        let creature = CreatureJson {
+            neurons: vec![NeuronJson {
+                uuid: "h-1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            }],
+            synapses: vec![],
+            input: 0,
+            output: 0,
+        };
+
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "h-1".to_string(),
+            (0..100).map(|i| make_record("h-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_output_bias_drift(&creature, &records);
+        assert!(result.is_empty(), "Hidden neurons should be excluded");
+    }
+
+    #[test]
+    fn noise_level_errors_not_flagged() {
+        let creature = make_creature(vec![make_output_neuron("out-1", 0.0)]);
+        // All positive but very small magnitude (below MIN_MEAN_ERROR_MAGNITUDE)
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..100).map(|i| make_record("out-1", i, 0.001)).collect(),
+        )];
+
+        let result = detect_output_bias_drift(&creature, &records);
+        assert!(
+            result.is_empty(),
+            "Tiny errors should not trigger bias drift"
+        );
+    }
+
+    #[test]
+    fn insufficient_samples_not_detected() {
+        let creature = make_creature(vec![make_output_neuron("out-1", 0.0)]);
+        let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+            "out-1".to_string(),
+            (0..10).map(|i| make_record("out-1", i, 0.5)).collect(),
+        )];
+
+        let result = detect_output_bias_drift(&creature, &records);
+        assert!(result.is_empty(), "Should require minimum sample count");
+    }
+
+    // ── output_bias_drift_to_coordinated_candidates ────────────────────
+
+    #[test]
+    fn conversion_produces_set_bias_with_correct_value() {
+        let candidate = OutputBiasDriftCandidate {
+            neuron_uuid: "out-1".to_string(),
+            current_bias: 0.5,
+            mean_error: 0.3,
+            positive_error_fraction: 0.8,
+            sample_count: 100,
+            recommended_bias_delta: -0.3,
+            estimated_improvement: 0.006,
+        };
+
+        let coordinated = output_bias_drift_to_coordinated_candidates(&[candidate]);
+        assert_eq!(coordinated.len(), 1);
+        assert!(matches!(
+            &coordinated[0].operations[0],
+            CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias }
+                if neuron_uuid == "out-1" && (*bias - 0.2).abs() < 0.01
+        ));
+    }
+}

--- a/src/analysis/saturation.rs
+++ b/src/analysis/saturation.rs
@@ -384,3 +384,213 @@ pub fn saturated_neurons_to_coordinated_candidates(
 
     results
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+
+    fn make_record(obs_index: u32, activation: f32, value: Option<f32>) -> DiscoverRecord {
+        DiscoverRecord::new(
+            obs_index,
+            "test-neuron".to_string(),
+            value,
+            activation,
+            vec![],
+        )
+    }
+
+    // ── is_bounded_squash ──────────────────────────────────────────────
+
+    #[test]
+    fn bounded_squash_includes_tanh_and_logistic() {
+        assert!(is_bounded_squash("TANH"));
+        assert!(is_bounded_squash("LOGISTIC"));
+        assert!(is_bounded_squash("HARD_TANH"));
+        assert!(is_bounded_squash("CLIPPED"));
+        assert!(is_bounded_squash("SOFTSIGN"));
+        assert!(is_bounded_squash("RELU6"));
+    }
+
+    #[test]
+    fn bounded_squash_is_case_insensitive() {
+        assert!(is_bounded_squash("tanh"));
+        assert!(is_bounded_squash("Logistic"));
+    }
+
+    #[test]
+    fn unbounded_squash_excluded() {
+        assert!(!is_bounded_squash("RELU"));
+        assert!(!is_bounded_squash("IDENTITY"));
+        assert!(!is_bounded_squash("ELU"));
+    }
+
+    // ── can_have_dead_zone ─────────────────────────────────────────────
+
+    #[test]
+    fn relu_family_can_have_dead_zone() {
+        assert!(can_have_dead_zone("RELU"));
+        assert!(can_have_dead_zone("LEAKYRELU"));
+        assert!(can_have_dead_zone("ELU"));
+        assert!(can_have_dead_zone("SELU"));
+    }
+
+    #[test]
+    fn tanh_cannot_have_dead_zone() {
+        assert!(!can_have_dead_zone("TANH"));
+        assert!(!can_have_dead_zone("IDENTITY"));
+    }
+
+    // ── check_bounded_saturation ───────────────────────────────────────
+
+    #[test]
+    fn tanh_above_threshold_is_saturated() {
+        assert!(check_bounded_saturation("TANH", 0.96, 0.01));
+        assert!(check_bounded_saturation("TANH", -0.96, 0.01));
+    }
+
+    #[test]
+    fn tanh_below_threshold_is_not_saturated() {
+        assert!(!check_bounded_saturation("TANH", 0.5, 0.01));
+        assert!(!check_bounded_saturation("TANH", 0.0, 0.01));
+    }
+
+    #[test]
+    fn high_std_dev_prevents_saturation_detection() {
+        // Even with high mean activation, high variance means not truly saturated
+        assert!(!check_bounded_saturation("TANH", 0.99, 0.10));
+    }
+
+    #[test]
+    fn logistic_near_one_is_saturated() {
+        assert!(check_bounded_saturation("LOGISTIC", 0.98, 0.01));
+    }
+
+    #[test]
+    fn logistic_near_zero_is_saturated() {
+        assert!(check_bounded_saturation("LOGISTIC", 0.02, 0.01));
+    }
+
+    #[test]
+    fn logistic_mid_range_is_not_saturated() {
+        assert!(!check_bounded_saturation("LOGISTIC", 0.5, 0.01));
+    }
+
+    // ── compute_saturation_severity ────────────────────────────────────
+
+    #[test]
+    fn severity_at_threshold_is_zero() {
+        let severity = compute_saturation_severity("TANH", 0.95);
+        assert!(
+            severity < 0.01,
+            "Severity at threshold should be near zero, got {severity}"
+        );
+    }
+
+    #[test]
+    fn severity_at_max_is_one() {
+        let severity = compute_saturation_severity("TANH", 1.0);
+        assert!(
+            (severity - 1.0).abs() < 0.01,
+            "Severity at max should be 1.0, got {severity}"
+        );
+    }
+
+    #[test]
+    fn severity_between_threshold_and_max_is_proportional() {
+        let s1 = compute_saturation_severity("TANH", 0.96);
+        let s2 = compute_saturation_severity("TANH", 0.99);
+        assert!(s2 > s1, "Higher activation should produce higher severity");
+    }
+
+    // ── compute_input_std_dev ──────────────────────────────────────────
+
+    #[test]
+    fn input_std_dev_with_no_values_returns_zero() {
+        let records: Vec<DiscoverRecord> = (0..5).map(|i| make_record(i, 0.5, None)).collect();
+        assert_eq!(compute_input_std_dev(&records), 0.0);
+    }
+
+    #[test]
+    fn input_std_dev_with_constant_values_returns_zero() {
+        let records: Vec<DiscoverRecord> =
+            (0..10).map(|i| make_record(i, 0.5, Some(1.0))).collect();
+        assert!(
+            compute_input_std_dev(&records) < 1e-6,
+            "Constant inputs should have zero std dev"
+        );
+    }
+
+    // ── recommend_fix ──────────────────────────────────────────────────
+
+    #[test]
+    fn recommend_fix_suggests_identity_for_tanh() {
+        let (squash, _bias) = recommend_fix("TANH", 0.99, 0.5);
+        assert_eq!(squash, Some("IDENTITY".to_string()));
+    }
+
+    #[test]
+    fn recommend_fix_bias_direction_matches_saturation_side() {
+        // Positive saturation: bias delta should be negative
+        let (_, bias_delta) = recommend_fix("TANH", 0.99, 0.5);
+        assert!(
+            bias_delta.unwrap() < 0.0,
+            "Positive saturation should recommend negative bias delta"
+        );
+        // Negative saturation: bias delta should be positive
+        let (_, bias_delta) = recommend_fix("TANH", -0.99, 0.5);
+        assert!(
+            bias_delta.unwrap() > 0.0,
+            "Negative saturation should recommend positive bias delta"
+        );
+    }
+
+    // ── detect_saturated_neurons (integration within unit scope) ──────
+
+    #[test]
+    fn insufficient_samples_returns_empty() {
+        let neurons = vec![("n1".to_string(), "TANH".to_string(), 0.0)];
+        let records: Vec<DiscoverRecord> = (0..5).map(|i| make_record(i, 0.99, None)).collect();
+        let result = detect_saturated_neurons(&neurons, &[("n1".to_string(), records)]);
+        assert!(result.is_empty(), "Should require at least 20 samples");
+    }
+
+    #[test]
+    fn identity_neuron_not_flagged() {
+        let neurons = vec![("n1".to_string(), "IDENTITY".to_string(), 0.0)];
+        let records: Vec<DiscoverRecord> = (0..30).map(|i| make_record(i, 100.0, None)).collect();
+        let result = detect_saturated_neurons(&neurons, &[("n1".to_string(), records)]);
+        assert!(result.is_empty(), "IDENTITY neurons cannot saturate");
+    }
+
+    // ── saturated_neurons_to_coordinated_candidates ────────────────────
+
+    #[test]
+    fn conversion_produces_change_squash_and_set_bias_ops() {
+        let candidate = SaturatedNeuronCandidate {
+            neuron_uuid: "sat-1".to_string(),
+            current_squash: "TANH".to_string(),
+            mean_activation: 0.99,
+            activation_std_dev: 0.01,
+            input_std_dev: 0.5,
+            recommended_squash: Some("IDENTITY".to_string()),
+            recommended_bias_delta: Some(-1.0),
+            estimated_improvement: 0.005,
+        };
+        let coordinated = saturated_neurons_to_coordinated_candidates(&[candidate]);
+        assert!(
+            coordinated.len() >= 2,
+            "Should produce both a squash+bias candidate and a bias-only candidate"
+        );
+        // First candidate should contain ChangeSquash
+        let first = &coordinated[0];
+        let has_change_squash = first
+            .operations
+            .iter()
+            .any(|op| matches!(op, CoordinatedStructuralOpJson::ChangeSquash { .. }));
+        assert!(
+            has_change_squash,
+            "First candidate should include ChangeSquash operation"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Added inline `#[cfg(test)]` unit tests to all 9 discovery detection modules in `src/analysis/`
- 88 new unit tests exercising internal helper functions and private logic
- Complements existing integration tests in `tests/`

## Test plan
- [x] Each of the 9 modules has at least 5 unit tests (88 total)
- [x] Tests cover detection criteria, exclusion criteria, edge cases, and conversion
- [x] All tests use Australian English in names and comments
- [x] Tests verify outcomes, not implementation details
- [x] `./quality.sh` passes cleanly (all 522 tests green)

See `docs/pr-summary-376.md` for full details.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)