### PR TITLE
Fix: Extract shared test utilities module (#377)

### DIFF
--- a/docs/pr-summary-377.md
+++ b/docs/pr-summary-377.md
@@ -1,0 +1,34 @@
+## Summary
+
+Extract shared test utilities module to eliminate duplicated helper patterns across
+integration tests. Closes #377.
+
+The `tests/common/mod.rs` module is expanded with reusable builders for neurons,
+synapses, creatures, and discovery records. Four test files are refactored to
+import these shared helpers instead of redefining identical functions locally.
+
+### Changes
+
+- **`tests/common/mod.rs`** — Added `neuron()`, `hidden()`, `hidden_with_bias()`,
+  `output()`, `make_creature()`, and `record()` helpers alongside the existing
+  `synapse()`, `synapse_typed()`, `test_data_dir()`, and `skip_without_gpu!` macro.
+- **`tests/issue_341_dead_neuron_detection.rs`** — Removed 4 local helpers
+  (`record`, `make_creature`, `neuron`, `synapse`); now imports from `common`.
+- **`tests/issue_356_dormant_synapse_detection.rs`** — Removed 3 local helpers
+  (`make_creature`, `neuron`, `synapse`); now imports from `common`. Retains a
+  local `record()` with a different signature (3 args, value derived from activation).
+- **`tests/impact_calculation_production.rs`** — Removed 3 local helpers
+  (`synapse`, `hidden`, `output`); now imports from `common`.
+- **`tests/saturation_detection.rs`** — Removed 3 local helpers
+  (`hidden`, `output`, `synapse`); now imports from `common` including
+  `hidden_with_bias()` for the non-zero-bias case.
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only Rust library with no visual interface.
+
+## Test Plan
+
+- All 4 refactored test files pass with identical behaviour (no test logic changed)
+- `./quality.sh` passes cleanly (build, fmt, clippy, check, tests, release build)
+- No tests were added, removed, or modified — only the helper function source changed

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,11 +1,21 @@
-//! Common test utilities
+//! Shared test utilities for integration tests.
+//!
+//! This module provides common helpers to eliminate boilerplate across test files:
+//! - **GPU skip macro** — `skip_without_gpu!()` for tests requiring GPU access
+//! - **Fixture builders** — `neuron()`, `hidden()`, `output()`, `synapse()`, `make_creature()`
+//! - **Record helpers** — `record()` for creating `DiscoverRecord` instances
 
 #[allow(dead_code)]
 use std::path::PathBuf;
 
-use neat_ai_discovery::SynapseJson;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 
-/// Get the path to test data directory
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// Get the path to test data directory.
 #[allow(dead_code)]
 pub fn test_data_dir() -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -14,29 +24,9 @@ pub fn test_data_dir() -> PathBuf {
     path
 }
 
-/// Helper function to create a SynapseJson with synapse_type defaulting to None.
-/// This avoids having to specify synapse_type: None in every test.
-#[allow(dead_code)]
-pub fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: None,
-    }
-}
-
-/// Helper function to create a SynapseJson with a specific synapse type.
-/// Used for IF neurons with "condition", "positive", or "negative" synapses.
-#[allow(dead_code)]
-pub fn synapse_typed(from: &str, to: &str, weight: f32, stype: &str) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: Some(stype.to_string()),
-    }
-}
+// ---------------------------------------------------------------------------
+// GPU skip macro
+// ---------------------------------------------------------------------------
 
 /// Macro to skip tests that require a GPU when no GPU is available.
 /// Place this at the start of any test that calls GPU-accelerated analysis functions.
@@ -48,4 +38,108 @@ macro_rules! skip_without_gpu {
             return;
         }
     };
+}
+
+// ---------------------------------------------------------------------------
+// Neuron builders
+// ---------------------------------------------------------------------------
+
+/// Build a `NeuronJson` with the given type and activation function.
+#[allow(dead_code)]
+pub fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Build a hidden `NeuronJson` with zero bias.
+#[allow(dead_code)]
+pub fn hidden(uuid: &str, squash: &str) -> NeuronJson {
+    neuron(uuid, "hidden", squash)
+}
+
+/// Build a hidden `NeuronJson` with a specified bias.
+#[allow(dead_code)]
+pub fn hidden_with_bias(uuid: &str, squash: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: squash.to_string(),
+        bias,
+    }
+}
+
+/// Build an output `NeuronJson` with zero bias.
+#[allow(dead_code)]
+pub fn output(uuid: &str, squash: &str) -> NeuronJson {
+    neuron(uuid, "output", squash)
+}
+
+// ---------------------------------------------------------------------------
+// Synapse builders
+// ---------------------------------------------------------------------------
+
+/// Build a `SynapseJson` with `synapse_type` defaulting to `None`.
+#[allow(dead_code)]
+pub fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Build a `SynapseJson` with a specific synapse type.
+/// Used for IF neurons with "condition", "positive", or "negative" synapses.
+#[allow(dead_code)]
+pub fn synapse_typed(from: &str, to: &str, weight: f32, stype: &str) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: Some(stype.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Creature builders
+// ---------------------------------------------------------------------------
+
+/// Build a minimal `CreatureJson` from neurons and synapses.
+///
+/// Sets `input` to 2 and `output` to 1 — suitable for most unit-level
+/// detection tests that only need a small topology.
+#[allow(dead_code)]
+pub fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 2,
+        output: 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Record helpers
+// ---------------------------------------------------------------------------
+
+/// Create a `DiscoverRecord` with a default single-element error vector.
+#[allow(dead_code)]
+pub fn record(
+    neuron_uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    value: Option<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value,
+        activation,
+        errors: vec![0.01],
+    }
 }

--- a/tests/impact_calculation_production.rs
+++ b/tests/impact_calculation_production.rs
@@ -23,41 +23,12 @@
 
 mod common;
 
+use common::{hidden, output, synapse};
 use neat_ai_discovery::focus::{compute_impacts_public, rank_focus_neurons};
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
-use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use neat_ai_discovery::CreatureJson;
 use tempfile::NamedTempFile;
-
-/// Create a synapse helper for cleaner test setup
-fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: None,
-    }
-}
-
-/// Create a hidden neuron helper
-fn hidden(uuid: &str, squash: &str) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: "hidden".to_string(),
-        squash: squash.to_string(),
-        bias: 0.0,
-    }
-}
-
-/// Create an output neuron helper
-fn output(uuid: &str, squash: &str) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: "output".to_string(),
-        squash: squash.to_string(),
-        bias: 0.0,
-    }
-}
 
 /// Production pattern: STEP neuron gets full impact (no normalisation)
 ///

--- a/tests/issue_341_dead_neuron_detection.rs
+++ b/tests/issue_341_dead_neuron_detection.rs
@@ -11,57 +11,13 @@
 //! 4. Test edge cases: rarely active neurons, tiny but nonzero activation
 //! 5. Test coordinated structural candidate conversion
 
+mod common;
+
+use common::{make_creature, neuron, record, synapse};
 use neat_ai_discovery::analysis::dead_neuron::{
     dead_neurons_to_coordinated_candidates, detect_dead_neurons, DeadNeuronCandidate,
 };
 use neat_ai_discovery::types::DiscoverRecord;
-use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
-
-/// Helper: create a DiscoverRecord for a neuron with given activation.
-fn record(
-    neuron_uuid: &str,
-    obs_index: u32,
-    activation: f32,
-    value: Option<f32>,
-) -> DiscoverRecord {
-    DiscoverRecord {
-        obs_index,
-        neuron_uuid: neuron_uuid.to_string(),
-        value,
-        activation,
-        errors: vec![0.01],
-    }
-}
-
-/// Helper: build a minimal creature with neurons and synapses.
-fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
-    CreatureJson {
-        neurons,
-        synapses,
-        input: 2,
-        output: 1,
-    }
-}
-
-/// Helper: build a NeuronJson.
-fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: neuron_type.to_string(),
-        squash: squash.to_string(),
-        bias: 0.0,
-    }
-}
-
-/// Helper: build a SynapseJson.
-fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: None,
-    }
-}
 
 /// Test 1: Neuron with all-zero activations is detected as dead.
 #[test]

--- a/tests/issue_356_dormant_synapse_detection.rs
+++ b/tests/issue_356_dormant_synapse_detection.rs
@@ -10,13 +10,16 @@
 //! 4. Test edge cases: sole connection, zero samples
 //! 5. Test coordinated structural candidate conversion
 
+mod common;
+
+use common::{make_creature, neuron, synapse};
 use neat_ai_discovery::analysis::dormant_synapse::{
     detect_dormant_synapses, dormant_synapses_to_coordinated_candidates,
 };
 use neat_ai_discovery::types::DiscoverRecord;
-use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 
-/// Helper: create a DiscoverRecord.
+/// Helper: create a DiscoverRecord with value derived from activation.
+/// Dormant-synapse tests use `value = activation * 0.8` by convention.
 fn record(neuron_uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord {
     DiscoverRecord {
         obs_index,
@@ -24,36 +27,6 @@ fn record(neuron_uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord 
         value: Some(activation * 0.8),
         activation,
         errors: vec![0.01],
-    }
-}
-
-/// Helper: build a minimal creature.
-fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
-    CreatureJson {
-        neurons,
-        synapses,
-        input: 2,
-        output: 1,
-    }
-}
-
-/// Helper: build a NeuronJson.
-fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: neuron_type.to_string(),
-        squash: squash.to_string(),
-        bias: 0.0,
-    }
-}
-
-/// Helper: build a SynapseJson.
-fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: None,
     }
 }
 

--- a/tests/saturation_detection.rs
+++ b/tests/saturation_detection.rs
@@ -33,35 +33,11 @@
 //! | HARD_TANH | [-1, 1] | |input| > 1 → clamped |
 //! | ArcTan | [-π/2, π/2] | |input| > 10 → ~saturated |
 
+mod common;
+
+use common::{hidden, hidden_with_bias, output, synapse};
 use neat_ai_discovery::focus::compute_impacts_public;
-use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
-
-fn hidden(uuid: &str, squash: &str, bias: f32) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: "hidden".to_string(),
-        squash: squash.to_string(),
-        bias,
-    }
-}
-
-fn output(uuid: &str, squash: &str) -> NeuronJson {
-    NeuronJson {
-        uuid: uuid.to_string(),
-        neuron_type: "output".to_string(),
-        squash: squash.to_string(),
-        bias: 0.0,
-    }
-}
-
-fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
-    SynapseJson {
-        from_uuid: from.to_string(),
-        to_uuid: to.to_string(),
-        weight,
-        synapse_type: None,
-    }
-}
+use neat_ai_discovery::CreatureJson;
 
 /// Test: Production scenario - target through saturated intermediate
 ///
@@ -79,8 +55,8 @@ fn test_production_scenario_saturated_intermediate() {
         input: 100,
         output: 1,
         neurons: vec![
-            hidden("target", "Swish", 1.15),         // Like d28eb8a4
-            hidden("intermediate", "LOGISTIC", 0.0), // Like insider-volume-check
+            hidden_with_bias("target", "Swish", 1.15), // Like d28eb8a4
+            hidden("intermediate", "LOGISTIC"),        // Like insider-volume-check
             output("output-0", "HARD_TANH"),
         ],
         synapses: {
@@ -147,8 +123,8 @@ fn test_logistic_saturation_levels() {
             input: 1,
             output: 1,
             neurons: vec![
-                hidden("upstream", "IDENTITY", 0.0),
-                hidden("logistic", "LOGISTIC", 0.0),
+                hidden("upstream", "IDENTITY"),
+                hidden("logistic", "LOGISTIC"),
                 output("output-0", "IDENTITY"),
             ],
             synapses: vec![
@@ -208,9 +184,9 @@ fn test_chain_saturation_blocks_propagation() {
         input: 1,
         output: 1,
         neurons: vec![
-            hidden("upstream", "IDENTITY", 0.0),
-            hidden("tanh1", "TANH", 0.0),
-            hidden("tanh2", "TANH", 0.0),
+            hidden("upstream", "IDENTITY"),
+            hidden("tanh1", "TANH"),
+            hidden("tanh2", "TANH"),
             output("output-0", "IDENTITY"),
         ],
         synapses: vec![
@@ -249,8 +225,8 @@ fn test_many_inputs_cause_saturation() {
         input: 100,
         output: 1,
         neurons: vec![
-            hidden("focus", "IDENTITY", 0.0),
-            hidden("hub", "TANH", 0.0), // Hub with many inputs
+            hidden("focus", "IDENTITY"),
+            hidden("hub", "TANH"), // Hub with many inputs
             output("output-0", "IDENTITY"),
         ],
         synapses: {


### PR DESCRIPTION
## Summary

Extract shared test utilities module to eliminate duplicated helper patterns across
integration tests. Closes #377.

The `tests/common/mod.rs` module is expanded with reusable builders for neurons,
synapses, creatures, and discovery records. Four test files are refactored to
import these shared helpers instead of redefining identical functions locally.

### Changes

- **`tests/common/mod.rs`** — Added `neuron()`, `hidden()`, `hidden_with_bias()`,
  `output()`, `make_creature()`, and `record()` helpers alongside the existing
  `synapse()`, `synapse_typed()`, `test_data_dir()`, and `skip_without_gpu!` macro.
- **`tests/issue_341_dead_neuron_detection.rs`** — Removed 4 local helpers
  (`record`, `make_creature`, `neuron`, `synapse`); now imports from `common`.
- **`tests/issue_356_dormant_synapse_detection.rs`** — Removed 3 local helpers
  (`make_creature`, `neuron`, `synapse`); now imports from `common`. Retains a
  local `record()` with a different signature (3 args, value derived from activation).
- **`tests/impact_calculation_production.rs`** — Removed 3 local helpers
  (`synapse`, `hidden`, `output`); now imports from `common`.
- **`tests/saturation_detection.rs`** — Removed 3 local helpers
  (`hidden`, `output`, `synapse`); now imports from `common` including
  `hidden_with_bias()` for the non-zero-bias case.

## Evidence

Unable to generate screenshot: This is a CLI-only Rust library with no visual interface.

## Test Plan

- All 4 refactored test files pass with identical behaviour (no test logic changed)
- `./quality.sh` passes cleanly (build, fmt, clippy, check, tests, release build)
- No tests were added, removed, or modified — only the helper function source changed

---

## Automated Fix Details
This PR addresses issue #377: **Extract shared test utilities module**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #377