### PR TITLE
Add bounded range discovery for sentinel/null value detection (#395)

### DIFF
--- a/docs/pr-summary-395.md
+++ b/docs/pr-summary-395.md
@@ -1,0 +1,50 @@
+## Summary
+
+Implements bounded range discovery (Issue #395) to detect observations and hidden neurons
+where activation values split into a meaningful bounded range and a sentinel/null cluster.
+
+For example, an observation like "Debt-to-Equity" might use -1 as a sentinel for "no data",
+while values in 0..1 carry actual meaning. Without gating, a linear weight treats the sentinel
+as a real value, which degrades the creature's score. This module detects such bimodal
+distributions and recommends inserting an IF-gated hidden neuron that passes the meaningful
+signal when in the valid range and outputs zero at the sentinel value.
+
+### Key design decisions
+
+- **Histogram-based bimodal detection**: Uses a 20-bin histogram to find the dominant cluster
+  (sentinel), then validates separation from the meaningful range.
+- **IF squash function**: Recommends coordinated structural candidates using the existing `IF`
+  squash function (`if condition > 0 then positive_input else negative_input`), which is
+  already supported by NEAT-AI. No new candidate types required.
+- **DRY**: Uses the generic `discovery_dispatch::run_discovery_module()` pattern (Issue #375)
+  for dispatch, consistent with all other discovery modules.
+- **Input and hidden neurons**: Both observation inputs and hidden neurons are eligible for
+  bounded range detection.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/analysis/bounded_range.rs` | New module: detection and candidate conversion |
+| `src/analysis/mod.rs` | Register module and add dispatch call in `analyze_all()` |
+| `tests/issue_395_bounded_range_detection.rs` | 13 integration tests covering all detection scenarios |
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only Rust library with no visual interface.
+
+## Test Plan
+
+- `test_detects_sentinel_at_lower_bound` — Sentinel at -1, meaningful range 0..1
+- `test_uniform_spread_not_flagged` — Uniform distribution is not flagged
+- `test_insufficient_samples_not_flagged` — Too few samples rejected
+- `test_output_neurons_not_flagged` — Output neurons excluded
+- `test_detects_sentinel_at_upper_bound` — Sentinel at +1, meaningful range -1..0
+- `test_detects_sentinel_at_zero` — Sentinel at 0, meaningful range 0.3..1.0
+- `test_candidates_produce_if_gated_operations` — Coordinated candidate has IF squash
+- `test_mixed_neurons_only_bounded_range_detected` — Only bimodal neurons flagged
+- `test_hidden_neuron_with_bounded_range_detected` — Hidden neurons also eligible
+- `test_estimated_improvement_positive` — All improvements are positive
+- `test_sample_count_recorded` — Sample count matches records
+- `test_confidence_increases_with_more_samples` — Confidence scales with sample size
+- `test_neuron_with_downstream_found` — Downstream neurons correctly identified

--- a/src/analysis/bounded_range.rs
+++ b/src/analysis/bounded_range.rs
@@ -1,0 +1,460 @@
+//! Bounded range discovery module (Issue #395).
+//!
+//! Identifies neurons (observations and hidden) where activation values split into
+//! a meaningful bounded range and a sentinel/null cluster. For example, an observation
+//! like "Debt-to-Equity" might use -1 as a sentinel for "no data", while values in
+//! 0..1 carry actual meaning. Simply multiplying by a weight treats the sentinel as
+//! a real value, which degrades the creature's score.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron has a bounded range with sentinel if:
+//! 1. **Bimodal clustering**: A significant fraction of activations cluster tightly
+//!    around a single value (the sentinel), while the remainder spread across a
+//!    different sub-range (the meaningful range).
+//! 2. **Separation gap**: There is a clear gap between the sentinel cluster and the
+//!    meaningful range.
+//! 3. **Only input and hidden neurons**: Output neurons are excluded.
+//!
+//! ## Recommended Actions
+//!
+//! When a bounded range is detected, we recommend inserting an IF-gated hidden neuron
+//! that passes the meaningful signal when above/below the sentinel threshold, and
+//! outputs zero otherwise. This uses the existing "IF" squash function which implements
+//! `if condition > 0 then positive_input else negative_input`.
+//!
+//! See `docs/DISCOVERY_TYPES.md` § "Bounded Range Detection" for full documentation.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable bounded range detection.
+const MIN_SAMPLES_FOR_DETECTION: usize = 30;
+
+/// Minimum fraction of samples that must cluster at the sentinel to trigger detection.
+/// Below this, the "sentinel" is too rare to justify structural changes.
+const MIN_SENTINEL_FRACTION: f32 = 0.10;
+
+/// Maximum fraction of samples at the sentinel. If nearly all samples are at the
+/// sentinel, there is no meaningful range to exploit.
+const MAX_SENTINEL_FRACTION: f32 = 0.80;
+
+/// Maximum standard deviation within the sentinel cluster (relative to overall range).
+/// The sentinel cluster should be tightly concentrated.
+const MAX_SENTINEL_CLUSTER_RELATIVE_STD: f32 = 0.05;
+
+/// Minimum gap between sentinel cluster and meaningful range, as a fraction of the
+/// overall activation range. Ensures the two groups are well-separated.
+const MIN_SEPARATION_GAP_FRACTION: f32 = 0.10;
+
+/// Number of histogram bins used for detecting bimodal clustering.
+const HISTOGRAM_BINS: usize = 20;
+
+/// Result of detecting a bounded range neuron.
+#[derive(Debug, Clone)]
+pub struct BoundedRangeCandidate {
+    /// UUID of the neuron with a bounded range.
+    pub neuron_uuid: String,
+    /// The detected sentinel value (centre of the sentinel cluster).
+    pub sentinel_value: f32,
+    /// Fraction of samples at the sentinel.
+    pub sentinel_fraction: f32,
+    /// Lower bound of the meaningful activation range.
+    pub meaningful_range_lo: f32,
+    /// Upper bound of the meaningful activation range.
+    pub meaningful_range_hi: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Confidence that the bounded range detection is correct (0.0 to 1.0).
+    pub detection_confidence: f32,
+    /// Estimated creature score improvement from gating this input.
+    pub estimated_improvement: f32,
+    /// UUIDs of neurons directly downstream from this neuron.
+    pub downstream_uuids: Vec<String>,
+}
+
+/// Detect neurons with bounded activation ranges and sentinel values.
+///
+/// Examines activation distributions to find bimodal patterns where one mode
+/// is a tight sentinel cluster and the other is a spread of meaningful values.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `BoundedRangeCandidate` sorted by detection confidence (highest first).
+pub fn detect_bounded_ranges(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<BoundedRangeCandidate> {
+    // Identify eligible neurons (input and hidden only)
+    let eligible_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Build fan-out map for finding downstream neurons
+    let mut fan_out_map: HashMap<&str, Vec<&str>> = HashMap::new();
+    for s in &creature.synapses {
+        fan_out_map
+            .entry(s.from_uuid.as_str())
+            .or_default()
+            .push(s.to_uuid.as_str());
+    }
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for uuid in &eligible_uuids {
+        let Some(records) = records_map.get(uuid) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES_FOR_DETECTION {
+            continue;
+        }
+
+        if let Some(candidate) = analyse_activation_distribution(uuid, records, &fan_out_map) {
+            candidates.push(candidate);
+        }
+    }
+
+    // Sort by detection confidence (highest first)
+    candidates.sort_by(|a, b| {
+        b.detection_confidence
+            .partial_cmp(&a.detection_confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Analyse the activation distribution of a single neuron to detect bimodal
+/// sentinel + meaningful-range patterns.
+fn analyse_activation_distribution(
+    uuid: &str,
+    records: &[DiscoverRecord],
+    fan_out_map: &HashMap<&str, Vec<&str>>,
+) -> Option<BoundedRangeCandidate> {
+    let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
+    let n = activations.len() as f32;
+
+    // Compute overall range
+    let min_val = activations.iter().cloned().fold(f32::INFINITY, f32::min);
+    let max_val = activations
+        .iter()
+        .cloned()
+        .fold(f32::NEG_INFINITY, f32::max);
+    let range = max_val - min_val;
+
+    // Need a meaningful range to analyse
+    if range < 1e-6 {
+        return None;
+    }
+
+    // Build histogram to find clusters
+    let bin_width = range / HISTOGRAM_BINS as f32;
+    let mut histogram = [0u32; HISTOGRAM_BINS];
+
+    for &val in &activations {
+        let bin = ((val - min_val) / bin_width).floor() as usize;
+        let bin = bin.min(HISTOGRAM_BINS - 1);
+        histogram[bin] += 1;
+    }
+
+    // Find the peak bin (potential sentinel cluster)
+    let (peak_bin, &peak_count) = histogram
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, &count)| count)
+        .unwrap();
+
+    let peak_fraction = peak_count as f32 / n;
+
+    // The peak must represent a sentinel-like cluster
+    if peak_fraction < MIN_SENTINEL_FRACTION {
+        return None;
+    }
+
+    if peak_fraction > MAX_SENTINEL_FRACTION {
+        return None;
+    }
+
+    // Compute the sentinel cluster centre and spread
+    let peak_lo = min_val + peak_bin as f32 * bin_width;
+    let peak_hi = peak_lo + bin_width;
+
+    // Collect activations in the peak bin
+    let sentinel_activations: Vec<f32> = activations
+        .iter()
+        .filter(|&&v| v >= peak_lo && v <= peak_hi)
+        .cloned()
+        .collect();
+
+    let sentinel_mean =
+        sentinel_activations.iter().sum::<f32>() / sentinel_activations.len() as f32;
+    let sentinel_var = sentinel_activations
+        .iter()
+        .map(|&v| {
+            let d = v - sentinel_mean;
+            d * d
+        })
+        .sum::<f32>()
+        / sentinel_activations.len() as f32;
+    let sentinel_std = sentinel_var.sqrt();
+
+    // Sentinel cluster must be tight relative to overall range
+    if sentinel_std / range > MAX_SENTINEL_CLUSTER_RELATIVE_STD {
+        return None;
+    }
+
+    // Collect non-sentinel activations (meaningful range)
+    // Use a tolerance of 2 std devs around sentinel mean, or bin width, whichever is larger
+    let sentinel_tolerance = (sentinel_std * 2.0).max(bin_width);
+    let meaningful_activations: Vec<f32> = activations
+        .iter()
+        .filter(|&&v| (v - sentinel_mean).abs() > sentinel_tolerance)
+        .cloned()
+        .collect();
+
+    if meaningful_activations.is_empty() {
+        return None;
+    }
+
+    let sentinel_fraction = 1.0 - (meaningful_activations.len() as f32 / n);
+
+    // Re-check sentinel fraction with the refined count
+    if !(MIN_SENTINEL_FRACTION..=MAX_SENTINEL_FRACTION).contains(&sentinel_fraction) {
+        return None;
+    }
+
+    // Compute meaningful range bounds
+    let meaningful_lo = meaningful_activations
+        .iter()
+        .cloned()
+        .fold(f32::INFINITY, f32::min);
+    let meaningful_hi = meaningful_activations
+        .iter()
+        .cloned()
+        .fold(f32::NEG_INFINITY, f32::max);
+
+    // Check separation gap between sentinel and meaningful range
+    let gap = if sentinel_mean < meaningful_lo {
+        meaningful_lo - (sentinel_mean + sentinel_tolerance)
+    } else if sentinel_mean > meaningful_hi {
+        (sentinel_mean - sentinel_tolerance) - meaningful_hi
+    } else {
+        // Sentinel is in the middle of the meaningful range — not a clear bimodal pattern
+        0.0
+    };
+
+    if gap / range < MIN_SEPARATION_GAP_FRACTION {
+        return None;
+    }
+
+    // Find downstream neurons
+    let downstream_uuids: Vec<String> = fan_out_map
+        .get(uuid)
+        .map(|targets| targets.iter().map(|&t| t.to_string()).collect())
+        .unwrap_or_default();
+
+    // Compute detection confidence
+    let confidence = compute_detection_confidence(sentinel_fraction, gap / range, n);
+
+    // Estimated improvement: gating sentinel values prevents them from corrupting the signal.
+    // The more samples are sentinel, the more damage is being done.
+    let estimated_improvement = confidence * sentinel_fraction * 0.01;
+
+    Some(BoundedRangeCandidate {
+        neuron_uuid: uuid.to_string(),
+        sentinel_value: sentinel_mean,
+        sentinel_fraction,
+        meaningful_range_lo: meaningful_lo,
+        meaningful_range_hi: meaningful_hi,
+        sample_count: records.len(),
+        detection_confidence: confidence,
+        estimated_improvement,
+        downstream_uuids,
+    })
+}
+
+/// Compute detection confidence from distribution characteristics.
+///
+/// Higher confidence when:
+/// - Sentinel fraction is clearly in the valid range (not borderline)
+/// - Gap between sentinel and meaningful range is large
+/// - More samples were analysed
+fn compute_detection_confidence(
+    sentinel_fraction: f32,
+    gap_fraction: f32,
+    sample_count: f32,
+) -> f32 {
+    // Sentinel fraction factor: peaks at ~0.3, lower near boundaries
+    let mid_sentinel = 0.5 * (MIN_SENTINEL_FRACTION + MAX_SENTINEL_FRACTION);
+    let sentinel_range = 0.5 * (MAX_SENTINEL_FRACTION - MIN_SENTINEL_FRACTION);
+    let sentinel_factor =
+        1.0 - ((sentinel_fraction - mid_sentinel).abs() / sentinel_range).min(1.0);
+
+    // Gap factor: larger gap = higher confidence
+    let gap_factor = (gap_fraction / MIN_SEPARATION_GAP_FRACTION).min(2.0) / 2.0;
+
+    // Sample size factor: more samples = higher confidence, plateaus at 1000
+    let sample_factor = (sample_count / 1000.0).min(1.0);
+
+    // Combine factors
+    let raw = sentinel_factor * 0.3 + gap_factor * 0.4 + sample_factor * 0.3;
+
+    // Scale to [0.3, 1.0] since we already passed threshold checks
+    0.3 + raw * 0.7
+}
+
+/// Convert bounded range candidates into coordinated structural candidates.
+///
+/// For each bounded range detection, produces a coordinated candidate that inserts
+/// an IF-gated hidden neuron. The IF squash function implements:
+///   `if condition > 0 then positive_input else negative_input`
+///
+/// This allows the network to use the meaningful signal when the observation is in
+/// the valid range and output zero (or a learned default) when at the sentinel value.
+///
+/// The IF neuron requires three incoming synapses:
+/// - `condition`: the source neuron, with bias set so `condition > 0` when in meaningful range
+/// - `positive`: the source neuron (passes through when condition is met)
+/// - `negative`: effectively zero (sentinel case)
+pub fn bounded_ranges_to_coordinated_candidates(
+    candidates: &[BoundedRangeCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    // Find existing synapses from each candidate neuron
+    let mut downstream_synapses: HashMap<&str, Vec<&crate::SynapseJson>> = HashMap::new();
+    for s in &creature.synapses {
+        downstream_synapses
+            .entry(s.from_uuid.as_str())
+            .or_default()
+            .push(s);
+    }
+
+    for c in candidates {
+        // For each downstream synapse from the bounded-range neuron, create an
+        // IF-gated replacement path.
+        let synapses = downstream_synapses
+            .get(c.neuron_uuid.as_str())
+            .cloned()
+            .unwrap_or_default();
+
+        if synapses.is_empty() {
+            continue;
+        }
+
+        // Pick the first downstream target for the IF-gated path.
+        // Each downstream synapse could get its own IF gate, but we start with one
+        // to minimise structural complexity.
+        let target_synapse = synapses[0];
+
+        // Generate a deterministic UUID for the new IF neuron
+        let if_neuron_uuid = format!("if-gate-{}-{}", c.neuron_uuid, target_synapse.to_uuid);
+
+        // Compute the threshold bias: the IF condition fires when
+        // (activation * weight + bias) > 0. We want it to fire when the activation
+        // is in the meaningful range, not at the sentinel.
+        //
+        // If sentinel < meaningful range: condition = activation + bias > 0
+        //   → bias = -(midpoint between sentinel and meaningful_lo)
+        //   → so activation > midpoint triggers the positive branch
+        //
+        // If sentinel > meaningful range: condition = -activation + bias > 0
+        //   → bias = midpoint between meaningful_hi and sentinel
+        let (condition_weight, condition_bias) = if c.sentinel_value < c.meaningful_range_lo {
+            let threshold = (c.sentinel_value + c.meaningful_range_lo) / 2.0;
+            (1.0, -threshold)
+        } else {
+            let threshold = (c.meaningful_range_hi + c.sentinel_value) / 2.0;
+            (-1.0, threshold)
+        };
+
+        let mut operations = vec![
+            // Add the IF-gated hidden neuron
+            CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: if_neuron_uuid.clone(),
+                neuron_type: "hidden".to_string(),
+                squash: "IF".to_string(),
+                bias: condition_bias,
+                insert_before_neuron_uuid: Some(target_synapse.to_uuid.clone()),
+            },
+            // Condition synapse: determines if we are in the meaningful range
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: c.neuron_uuid.clone(),
+                to_neuron_uuid: if_neuron_uuid.clone(),
+                weight: condition_weight,
+            },
+            // Positive synapse: passes through the original signal when in range
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: c.neuron_uuid.clone(),
+                to_neuron_uuid: if_neuron_uuid.clone(),
+                weight: target_synapse.weight,
+            },
+            // Connect the IF neuron to the downstream target
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: if_neuron_uuid,
+                to_neuron_uuid: target_synapse.to_uuid.clone(),
+                weight: 1.0,
+            },
+            // Remove the original direct synapse (replaced by the IF-gated path)
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: c.neuron_uuid.clone(),
+                to_neuron_uuid: target_synapse.to_uuid.clone(),
+            },
+        ];
+
+        // Annotate IF synapse types for clarity
+        if let CoordinatedStructuralOpJson::AddSynapse { .. } = &operations[1] {
+            // The first AddSynapse is the condition
+        }
+        if let CoordinatedStructuralOpJson::AddSynapse { .. } = &operations[2] {
+            // The second AddSynapse is the positive branch
+        }
+
+        // Sort operations: removes first, then adds (standard ordering)
+        operations.sort_by_key(|op| match op {
+            CoordinatedStructuralOpJson::RemoveSynapse { .. } => 0,
+            CoordinatedStructuralOpJson::AddNeuron { .. } => 1,
+            CoordinatedStructuralOpJson::AddSynapse { .. } => 2,
+            _ => 3,
+        });
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Bounded range {}: sentinel {:.3} ({:.0}% of samples), meaningful range [{:.3}, {:.3}] → IF-gated path to {}",
+                c.neuron_uuid,
+                c.sentinel_value,
+                c.sentinel_fraction * 100.0,
+                c.meaningful_range_lo,
+                c.meaningful_range_hi,
+                target_synapse.to_uuid
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -27,9 +27,11 @@
 //! - `dormant_synapse.rs` - Dormant synapse detection for removal candidates (Issue #359)
 //! - `opposing_synapse.rs` - Opposing synapse detection for removal or weight flip candidates (Issue #360)
 //! - `output_bias_drift.rs` - Output bias drift detection for bias adjustment candidates (Issue #361)
+//! - `bounded_range.rs` - Bounded range detection for sentinel/null value gating (Issue #395)
 
 pub mod activation;
 pub mod bottleneck;
+pub mod bounded_range;
 pub mod cache;
 pub mod candidate_clustering;
 pub mod confidence;
@@ -888,6 +890,40 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 }
                 let candidates =
                     output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #395: Bounded range detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "bounded range detection",
+            "bounded_range_detection",
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                if uuids.is_empty() {
+                    return None;
+                }
+                let records = collect_records(&uuids);
+                let detected = bounded_range::detect_bounded_ranges(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = bounded_range::bounded_ranges_to_coordinated_candidates(
+                    &detected,
+                    &input.creature,
+                );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_395_bounded_range_detection.rs
+++ b/tests/issue_395_bounded_range_detection.rs
@@ -1,0 +1,425 @@
+//! Tests for Issue #395: Discover bounded ranges of observations and hidden neurons.
+//!
+//! Observations are finite numbers often normalised to -1..1, but they do not have
+//! a concept of null. A sentinel value (e.g., -1 or 0) is used instead. This module
+//! detects neurons where a bounded sub-range of activation values is meaningful while
+//! values at extremes act as sentinel/null markers.
+//!
+//! When a bounded range is detected, the module recommends a coordinated structural
+//! candidate that inserts an IF-gated path so the network can treat the meaningful
+//! range separately from sentinel values.
+//!
+//! ## TDD Plan
+//! 1. Detect observation with bimodal distribution: meaningful range + sentinel cluster
+//! 2. Verify active neurons with uniform spread are NOT flagged
+//! 3. Verify neurons with insufficient samples are NOT flagged
+//! 4. Verify output neurons are NOT flagged
+//! 5. Test sentinel at lower bound (-1 sentinel, meaningful values in 0..1)
+//! 6. Test sentinel at upper bound (1 sentinel, meaningful values in -1..0)
+//! 7. Test sentinel at zero (0 sentinel, meaningful values away from zero)
+//! 8. Test coordinated candidate conversion produces IF-gated structure
+//! 9. Test mixed neurons — only bounded-range ones are detected
+//! 10. Test that estimated improvement is positive
+
+mod common;
+
+use common::{make_creature, neuron, record, synapse};
+use neat_ai_discovery::analysis::bounded_range::{
+    bounded_ranges_to_coordinated_candidates, detect_bounded_ranges, BoundedRangeCandidate,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper: create records with a sentinel cluster at `sentinel_value` and meaningful
+/// values spread uniformly in `[range_lo, range_hi]`.
+fn make_bimodal_records(
+    uuid: &str,
+    sentinel_value: f32,
+    sentinel_fraction: f32,
+    range_lo: f32,
+    range_hi: f32,
+    total: u32,
+) -> Vec<DiscoverRecord> {
+    let sentinel_count = (total as f32 * sentinel_fraction) as u32;
+    let mut records = Vec::with_capacity(total as usize);
+
+    for i in 0..sentinel_count {
+        records.push(record(uuid, i, sentinel_value, Some(sentinel_value)));
+    }
+
+    let meaningful_count = total - sentinel_count;
+    for i in 0..meaningful_count {
+        let t = i as f32 / meaningful_count.max(1) as f32;
+        let activation = range_lo + t * (range_hi - range_lo);
+        records.push(record(
+            uuid,
+            sentinel_count + i,
+            activation,
+            Some(activation),
+        ));
+    }
+
+    records
+}
+
+/// Test 1: Observation with sentinel cluster at -1 and meaningful values in 0..1 is detected.
+#[test]
+fn test_detects_sentinel_at_lower_bound() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-debt", "output-1", 0.5)],
+    );
+
+    // 30% of samples are sentinel (-1), 70% are meaningful (0..1)
+    let records = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect bounded range neuron");
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "obs-debt");
+    assert!(
+        c.sentinel_value < 0.0,
+        "Sentinel should be at the lower bound"
+    );
+    assert!(
+        c.meaningful_range_lo > c.sentinel_value,
+        "Meaningful range should be above sentinel"
+    );
+}
+
+/// Test 2: Neuron with uniform spread across full range is NOT flagged.
+#[test]
+fn test_uniform_spread_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-normal", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-normal", "output-1", 0.5)],
+    );
+
+    // Uniform activation across -1..1 — no sentinel cluster
+    let records: Vec<DiscoverRecord> = (0..200)
+        .map(|i| {
+            let activation = -1.0 + 2.0 * (i as f32 / 199.0);
+            record("obs-normal", i, activation, Some(activation))
+        })
+        .collect();
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-normal".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Uniform spread should not be flagged as bounded range"
+    );
+}
+
+/// Test 3: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-few", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-few", "output-1", 0.5)],
+    );
+
+    let records = make_bimodal_records("obs-few", -1.0, 0.30, 0.0, 1.0, 10);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-few".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 4: Output neurons are NOT flagged.
+#[test]
+fn test_output_neurons_not_flagged() {
+    let creature = make_creature(vec![neuron("output-1", "output", "IDENTITY")], vec![]);
+
+    let records = make_bimodal_records("output-1", -1.0, 0.30, 0.0, 1.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("output-1".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Output neurons should not be flagged"
+    );
+}
+
+/// Test 5: Sentinel at upper bound (1 sentinel, meaningful values in -1..0).
+#[test]
+fn test_detects_sentinel_at_upper_bound() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-upper", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-upper", "output-1", 0.5)],
+    );
+
+    // 25% sentinel at +1, meaningful values in -1..0
+    let records = make_bimodal_records("obs-upper", 1.0, 0.25, -1.0, 0.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-upper".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect upper-bound sentinel");
+    let c = &candidates[0];
+    assert!(
+        c.sentinel_value > 0.0,
+        "Sentinel should be at the upper bound"
+    );
+}
+
+/// Test 6: Sentinel at zero (0 sentinel, meaningful values away from zero).
+#[test]
+fn test_detects_sentinel_at_zero() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-zero", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-zero", "output-1", 0.5)],
+    );
+
+    // 30% sentinel at 0, meaningful values in 0.3..1.0
+    let records = make_bimodal_records("obs-zero", 0.0, 0.30, 0.3, 1.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-zero".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect zero sentinel");
+    let c = &candidates[0];
+    assert!(
+        (c.sentinel_value).abs() < 0.05,
+        "Sentinel should be near zero"
+    );
+}
+
+/// Test 7: Coordinated candidate produces IF-gated structural operations.
+#[test]
+fn test_candidates_produce_if_gated_operations() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-debt", "output-1", 0.5)],
+    );
+
+    let candidate = BoundedRangeCandidate {
+        neuron_uuid: "obs-debt".to_string(),
+        sentinel_value: -1.0,
+        sentinel_fraction: 0.30,
+        meaningful_range_lo: 0.0,
+        meaningful_range_hi: 1.0,
+        sample_count: 200,
+        detection_confidence: 0.85,
+        estimated_improvement: 0.005,
+        downstream_uuids: vec!["output-1".to_string()],
+    };
+
+    let coordinated = bounded_ranges_to_coordinated_candidates(&[candidate], &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the recommendation"
+    );
+
+    // Check that operations include an AddNeuron with IF squash
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("addNeuron"),
+        "Should include addNeuron operation, got: {ops_json}"
+    );
+    assert!(
+        ops_json.contains("IF"),
+        "Should use IF squash function, got: {ops_json}"
+    );
+}
+
+/// Test 8: Mixed neurons — only bounded-range ones are detected.
+#[test]
+fn test_mixed_neurons_only_bounded_range_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-bounded", "input", "IDENTITY"),
+            neuron("obs-normal", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("obs-bounded", "hidden-1", 0.5),
+            synapse("obs-normal", "hidden-1", 0.3),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // obs-bounded: bimodal with sentinel
+    let bounded_records = make_bimodal_records("obs-bounded", -1.0, 0.30, 0.0, 1.0, 200);
+
+    // obs-normal: uniform, no sentinel
+    let normal_records: Vec<DiscoverRecord> = (0..200)
+        .map(|i| {
+            let activation = -1.0 + 2.0 * (i as f32 / 199.0);
+            record("obs-normal", i, activation, Some(activation))
+        })
+        .collect();
+
+    let candidates = detect_bounded_ranges(
+        &creature,
+        &[
+            ("obs-bounded".to_string(), bounded_records),
+            ("obs-normal".to_string(), normal_records),
+        ],
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Only bounded-range neuron should be detected"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "obs-bounded");
+}
+
+/// Test 9: Hidden neuron with bounded range is also detected.
+#[test]
+fn test_hidden_neuron_with_bounded_range_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-1", "input", "IDENTITY"),
+            neuron("hidden-bounded", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("obs-1", "hidden-bounded", 0.5),
+            synapse("hidden-bounded", "output-1", 0.8),
+        ],
+    );
+
+    // Hidden neuron: 30% at -1 (tanh saturation acting as sentinel), 70% in 0..0.8
+    let records = make_bimodal_records("hidden-bounded", -1.0, 0.30, 0.0, 0.8, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("hidden-bounded".to_string(), records)]);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Hidden neuron with bounded range should be detected"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "hidden-bounded");
+}
+
+/// Test 10: Estimated improvement is positive for all candidates.
+#[test]
+fn test_estimated_improvement_positive() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-debt", "output-1", 0.5)],
+    );
+
+    let records = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records)]);
+
+    assert!(!candidates.is_empty());
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement > 0.0,
+            "Estimated improvement should be positive"
+        );
+    }
+}
+
+/// Test 11: Sample count is correctly recorded.
+#[test]
+fn test_sample_count_recorded() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-debt", "output-1", 0.5)],
+    );
+
+    let records = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 300);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates[0].sample_count, 300,
+        "Sample count should match record count"
+    );
+}
+
+/// Test 12: Detection confidence increases with more samples.
+#[test]
+fn test_confidence_increases_with_more_samples() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("obs-debt", "output-1", 0.5)],
+    );
+
+    let records_small = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 50);
+    let records_large = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 500);
+
+    let candidates_small =
+        detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records_small)]);
+    let candidates_large =
+        detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records_large)]);
+
+    assert!(!candidates_small.is_empty(), "Small sample should detect");
+    assert!(!candidates_large.is_empty(), "Large sample should detect");
+    assert!(
+        candidates_large[0].detection_confidence >= candidates_small[0].detection_confidence,
+        "More samples should yield equal or higher confidence"
+    );
+}
+
+/// Test 13: Neurons with no downstream synapses are still detected
+/// (input neurons connected to nothing may still be flagged for future use).
+#[test]
+fn test_neuron_with_downstream_found() {
+    let creature = make_creature(
+        vec![
+            neuron("obs-debt", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("obs-debt", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    let records = make_bimodal_records("obs-debt", -1.0, 0.30, 0.0, 1.0, 200);
+
+    let candidates = detect_bounded_ranges(&creature, &[("obs-debt".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1);
+    assert!(
+        !candidates[0].downstream_uuids.is_empty(),
+        "Should identify downstream neurons"
+    );
+}


### PR DESCRIPTION
## Summary
- Detect observations and hidden neurons where activations split into a meaningful bounded range and a sentinel/null cluster (e.g., -1 meaning "no data")
- Recommend IF-gated coordinated structural candidates to prevent sentinel values from corrupting the signal
- Uses the generic `discovery_dispatch::run_discovery_module()` pattern (DRY, Issue #375)

## Evidence
Unable to generate screenshot: This is a CLI-only Rust library with no visual interface.

## Test Plan
- `test_detects_sentinel_at_lower_bound` — Sentinel at -1, meaningful range 0..1
- `test_uniform_spread_not_flagged` — Uniform distribution is not flagged
- `test_insufficient_samples_not_flagged` — Too few samples rejected
- `test_output_neurons_not_flagged` — Output neurons excluded
- `test_detects_sentinel_at_upper_bound` — Sentinel at +1, meaningful range -1..0
- `test_detects_sentinel_at_zero` — Sentinel at 0, meaningful range 0.3..1.0
- `test_candidates_produce_if_gated_operations` — Coordinated candidate has IF squash
- `test_mixed_neurons_only_bounded_range_detected` — Only bimodal neurons flagged
- `test_hidden_neuron_with_bounded_range_detected` — Hidden neurons also eligible
- `test_estimated_improvement_positive` — All improvements are positive
- `test_sample_count_recorded` — Sample count matches records
- `test_confidence_increases_with_more_samples` — Confidence scales with sample size
- `test_neuron_with_downstream_found` — Downstream neurons correctly identified

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)