### PR TITLE
Add bounded range discovery module (#395)

### DIFF
--- a/docs/pr-summary-395.md
+++ b/docs/pr-summary-395.md
@@ -1,0 +1,38 @@
+## Summary
+
+Add bounded range discovery module (Issue #395) to detect neurons whose activations
+are concentrated in a narrow sub-range with sentinel values (e.g., -1 or 0) at the
+boundary. This addresses the problem where observations like "Debt-to-Equity" use -1
+as a null indicator — multiplying -1 by a weight produces a large distorting signal.
+
+The module uses gap-based bimodal distribution analysis to identify the sentinel
+cluster and the meaningful active range. When detected, it recommends bias adjustments
+to centre the active range around zero, pushing sentinel values into a neutral zone.
+
+### Key design decisions
+
+- **Gap-based detection**: Sorts activations and finds the largest gap to separate
+  sentinel values from the active range. This is robust to different sentinel values
+  (-1, 0, or any boundary value).
+- **DRY**: Uses the existing `discovery_dispatch::run_discovery_module` pattern for
+  watchdog, timing, logging, and candidate merging.
+- **Reuses existing candidate types**: Emits `SetBias` operations via
+  `CoordinatedStructuralCandidateJson` — no new candidate types needed in NEAT-AI.
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+- Added 10 integration tests in `tests/issue_395_bounded_range_detection.rs`:
+  1. Detects narrow range with sentinel values at -1
+  2. Full-range neuron is NOT flagged
+  3. Insufficient samples are rejected
+  4. Detects zero-sentinel with positive active range
+  5. Mixed neurons — only bounded-range one detected
+  6. Coordinated candidate conversion produces valid operations
+  7. Bimodal distribution with sentinel cluster detected
+  8. No records does not panic or flag
+  9. Constant activation is NOT flagged (handled by dead neuron detection)
+  10. Sentinel fraction is correctly computed

--- a/src/analysis/bounded_range.rs
+++ b/src/analysis/bounded_range.rs
@@ -1,0 +1,263 @@
+//! Bounded range neuron detection module (Issue #395).
+//!
+//! Identifies neurons whose activations are concentrated in a narrow sub-range,
+//! with a significant fraction of samples at a "sentinel" value (e.g., -1 or 0)
+//! that likely represents null/invalid data rather than a meaningful signal.
+//!
+//! For example, an observation like "Debt-to-Equity" may have meaningful values
+//! in 0.2..0.8, but uses -1 as a null indicator. Multiplying -1 by a weight
+//! produces a large negative contribution that distorts the output. This module
+//! detects that pattern and recommends bias adjustments to shift the neuron's
+//! operating point so the sentinel region has minimal effect.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron has a "bounded range" pattern if:
+//! 1. **Bimodal distribution**: activations cluster into a "meaningful" range and
+//!    a separate "sentinel" cluster at the range boundary.
+//! 2. **Sentinel fraction**: at least 10% of samples fall in the sentinel cluster.
+//! 3. **Meaningful range is narrow**: the active sub-range covers less than 70%
+//!    of the neuron's total activation span.
+//! 4. **Not constant**: the neuron must have meaningful variance (not dead/stuck).
+//!
+//! ## Recommended Actions
+//!
+//! When a bounded range is detected, we recommend:
+//! 1. **Adjust bias**: shift the neuron's operating point so sentinel values
+//!    map to a neutral (near-zero) output.
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Minimum samples required for reliable bounded range detection.
+const MIN_SAMPLES_FOR_BOUNDED_RANGE: usize = 20;
+
+/// Minimum fraction of samples that must be sentinels to trigger detection.
+const MIN_SENTINEL_FRACTION: f32 = 0.10;
+
+/// Maximum fraction of the total span that the active range may cover.
+/// If the active range covers more than this, the neuron is using its full range.
+const MAX_ACTIVE_RANGE_RATIO: f32 = 0.70;
+
+/// Minimum standard deviation to consider the neuron non-constant.
+const MIN_STD_DEV: f32 = 0.05;
+
+/// Distance threshold (in standard deviations) for identifying sentinel outliers.
+const SENTINEL_DISTANCE_THRESHOLD: f32 = 1.0;
+
+/// Result of detecting a bounded range neuron.
+#[derive(Debug, Clone)]
+pub struct BoundedRangeCandidate {
+    /// UUID of the neuron with a bounded range pattern.
+    pub neuron_uuid: String,
+    /// Current activation function of the neuron.
+    pub current_squash: String,
+    /// Lower bound of the active (meaningful) range.
+    pub active_range_low: f32,
+    /// Upper bound of the active (meaningful) range.
+    pub active_range_high: f32,
+    /// Fraction of samples that are sentinels (outside the active range).
+    pub sentinel_fraction: f32,
+    /// Estimated improvement from addressing the bounded range.
+    pub estimated_improvement: f32,
+}
+
+/// Detect neurons with bounded range patterns from their recorded activations.
+///
+/// # Arguments
+/// * `neurons` - List of `(neuron_uuid, squash, bias)` tuples for neurons to check.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `BoundedRangeCandidate` for neurons that exhibit bounded range patterns.
+pub fn detect_bounded_range_neurons(
+    neurons: &[(String, String, f32)],
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<BoundedRangeCandidate> {
+    let mut candidates = Vec::new();
+
+    let records_map: std::collections::HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    for (uuid, squash, _bias) in neurons {
+        let Some(records) = records_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES_FOR_BOUNDED_RANGE {
+            continue;
+        }
+
+        if let Some(candidate) = analyse_neuron_range(uuid, squash, records) {
+            candidates.push(candidate);
+        }
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Analyse a single neuron's activation distribution for bounded range patterns.
+fn analyse_neuron_range(
+    uuid: &str,
+    squash: &str,
+    records: &[DiscoverRecord],
+) -> Option<BoundedRangeCandidate> {
+    let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
+    let n = activations.len() as f32;
+
+    // Compute basic statistics
+    let mean: f32 = activations.iter().sum::<f32>() / n;
+    let variance: f32 = activations
+        .iter()
+        .map(|a| (a - mean) * (a - mean))
+        .sum::<f32>()
+        / n;
+    let std_dev = variance.sqrt();
+
+    // Skip constant neurons (no variance means dead/stuck, handled elsewhere)
+    if std_dev < MIN_STD_DEV {
+        return None;
+    }
+
+    // Find the overall span
+    let min_val = activations.iter().copied().fold(f32::INFINITY, f32::min);
+    let max_val = activations
+        .iter()
+        .copied()
+        .fold(f32::NEG_INFINITY, f32::max);
+    let total_span = max_val - min_val;
+
+    if total_span < MIN_STD_DEV {
+        return None;
+    }
+
+    // Identify sentinel cluster: values that are far from the mean, clustered
+    // at the extremes. We look for a gap in the distribution.
+    let sentinel_threshold = SENTINEL_DISTANCE_THRESHOLD * std_dev;
+
+    // Sort activations to find natural gaps
+    let mut sorted = activations.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Find the largest gap in the sorted activations
+    let (gap_idx, gap_size) = find_largest_gap(&sorted);
+
+    // The gap must be significant relative to the total span
+    if gap_size < sentinel_threshold || gap_size < total_span * 0.15 {
+        return None;
+    }
+
+    // Determine which side is the "sentinel" cluster (smaller group)
+    let lower_count = gap_idx + 1;
+    let upper_count = sorted.len() - lower_count;
+
+    let (sentinel_count, active_range_low, active_range_high) = if lower_count <= upper_count {
+        // Lower cluster is smaller → it's the sentinel cluster
+        let active_low = sorted[gap_idx + 1];
+        let active_high = sorted[sorted.len() - 1];
+        (lower_count, active_low, active_high)
+    } else {
+        // Upper cluster is smaller → it's the sentinel cluster
+        let active_low = sorted[0];
+        let active_high = sorted[gap_idx];
+        (upper_count, active_low, active_high)
+    };
+
+    let sentinel_fraction = sentinel_count as f32 / n;
+
+    // Check thresholds
+    if sentinel_fraction < MIN_SENTINEL_FRACTION {
+        return None;
+    }
+
+    let active_range = active_range_high - active_range_low;
+    let active_range_ratio = active_range / total_span;
+
+    if active_range_ratio > MAX_ACTIVE_RANGE_RATIO {
+        return None;
+    }
+
+    // Estimated improvement: proportional to how much of the signal is wasted
+    // on sentinel values. More sentinels and narrower active range = more to gain.
+    let estimated_improvement = sentinel_fraction * (1.0 - active_range_ratio) * 0.01;
+
+    Some(BoundedRangeCandidate {
+        neuron_uuid: uuid.to_string(),
+        current_squash: squash.to_string(),
+        active_range_low,
+        active_range_high,
+        sentinel_fraction,
+        estimated_improvement,
+    })
+}
+
+/// Find the largest gap in a sorted slice of floats.
+/// Returns `(index, gap_size)` where the gap is between `sorted[index]` and `sorted[index+1]`.
+fn find_largest_gap(sorted: &[f32]) -> (usize, f32) {
+    let mut best_idx = 0;
+    let mut best_gap = 0.0_f32;
+
+    for i in 0..sorted.len().saturating_sub(1) {
+        let gap = sorted[i + 1] - sorted[i];
+        if gap > best_gap {
+            best_gap = gap;
+            best_idx = i;
+        }
+    }
+
+    (best_idx, best_gap)
+}
+
+/// Convert bounded range candidates into coordinated structural candidates.
+///
+/// Each bounded range neuron produces a `SetBias` candidate that shifts the
+/// neuron's operating point so sentinel values map to a neutral output region.
+pub fn bounded_range_to_coordinated_candidates(
+    candidates: &[BoundedRangeCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        // Compute a bias adjustment that centres the active range around 0.
+        // The idea: shift so the midpoint of the active range maps to 0,
+        // which pushes the sentinel values further into a "don't care" zone.
+        let active_midpoint = (c.active_range_low + c.active_range_high) / 2.0;
+        let bias_delta = -active_midpoint;
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: c.neuron_uuid.clone(),
+                bias: bias_delta,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Bounded range neuron {}: {} (active range {:.3}..{:.3}, {:.0}% sentinel) \
+                 → adjust bias by {:.3} to centre active range",
+                c.neuron_uuid,
+                c.current_squash,
+                c.active_range_low,
+                c.active_range_high,
+                c.sentinel_fraction * 100.0,
+                bias_delta
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -27,9 +27,11 @@
 //! - `dormant_synapse.rs` - Dormant synapse detection for removal candidates (Issue #359)
 //! - `opposing_synapse.rs` - Opposing synapse detection for removal or weight flip candidates (Issue #360)
 //! - `output_bias_drift.rs` - Output bias drift detection for bias adjustment candidates (Issue #361)
+//! - `bounded_range.rs` - Bounded range detection for sentinel-value patterns (Issue #395)
 
 pub mod activation;
 pub mod bottleneck;
+pub mod bounded_range;
 pub mod cache;
 pub mod candidate_clustering;
 pub mod confidence;
@@ -888,6 +890,31 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 }
                 let candidates =
                     output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #395: Bounded range detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "bounded range detection",
+            "bounded_range_detection",
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_records();
+                let detected =
+                    bounded_range::detect_bounded_range_neurons(&hidden_neurons, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = bounded_range::bounded_range_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_395_bounded_range_detection.rs
+++ b/tests/issue_395_bounded_range_detection.rs
@@ -1,0 +1,304 @@
+//! Tests for Issue #395: Discover bounded ranges of observations and hidden neurons.
+//!
+//! Observations are finite numbers often normalised to -1..1. A value like -1 may
+//! represent "null/invalid" rather than a meaningful low value. This module detects
+//! neurons whose activation is concentrated in a sub-range, suggesting that values
+//! outside that range are "invalid/null" sentinels. It recommends bias/weight
+//! adjustments or activation function changes so the network can use the meaningful
+//! range without being polluted by sentinel values.
+//!
+//! ## TDD Plan
+//! 1. Detect neurons operating in a narrow bounded sub-range of their activation
+//! 2. Verify sentinel values (e.g., -1) outside the active range are identified
+//! 3. Verify neurons using their full range are NOT flagged
+//! 4. Verify insufficient samples are rejected
+//! 5. Test conversion to coordinated structural candidates
+//! 6. Test mixed neurons — only bounded-range ones detected
+//! 7. Test that estimated improvement is positive and reasonable
+
+use neat_ai_discovery::analysis::bounded_range::{
+    bounded_range_to_coordinated_candidates, detect_bounded_range_neurons, BoundedRangeCandidate,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper: create a DiscoverRecord for a neuron with given activation.
+fn record(
+    neuron_uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    value: Option<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value,
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+/// Test 1: Neuron with activations clustered in a narrow positive range, plus
+/// sentinel values at -1, should be detected as having a bounded range.
+#[test]
+fn test_detects_narrow_range_with_sentinel() {
+    // 80 samples in the "meaningful" range 0.2..0.8
+    // 20 samples at -1.0 (sentinel / null indicator)
+    let mut records: Vec<DiscoverRecord> = (0..80)
+        .map(|i| {
+            let activation = 0.2 + 0.6 * (i as f32 / 80.0);
+            record("hidden-debt", i, activation, Some(activation))
+        })
+        .collect();
+    for i in 80..100 {
+        records.push(record("hidden-debt", i, -1.0, Some(-1.0)));
+    }
+
+    let candidates = detect_bounded_range_neurons(
+        &[("hidden-debt".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-debt".to_string(), records)],
+    );
+
+    assert_eq!(candidates.len(), 1, "Should detect bounded range neuron");
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "hidden-debt");
+    assert!(
+        c.estimated_improvement > 0.0,
+        "Estimated improvement should be positive"
+    );
+}
+
+/// Test 2: Neuron with activations uniformly spread across the full range
+/// should NOT be flagged.
+#[test]
+fn test_full_range_neuron_not_flagged() {
+    // Activations uniformly distributed across -1..1
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = -1.0 + 2.0 * (i as f32 / 99.0);
+            record("uniform", i, activation, Some(activation))
+        })
+        .collect();
+
+    let candidates = detect_bounded_range_neurons(
+        &[("uniform".to_string(), "TANH".to_string(), 0.0)],
+        &[("uniform".to_string(), records)],
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Uniformly distributed neuron should not be flagged"
+    );
+}
+
+/// Test 3: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_not_flagged() {
+    let records: Vec<DiscoverRecord> = (0..5).map(|i| record("few", i, 0.5, Some(0.5))).collect();
+
+    let candidates = detect_bounded_range_neurons(
+        &[("few".to_string(), "TANH".to_string(), 0.0)],
+        &[("few".to_string(), records)],
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 4: Neuron with sentinel at 0 and meaningful range in 0.5..0.9.
+#[test]
+fn test_detects_zero_sentinel_with_positive_range() {
+    let mut records: Vec<DiscoverRecord> = (0..70)
+        .map(|i| {
+            let activation = 0.5 + 0.4 * (i as f32 / 70.0);
+            record("zero-sentinel", i, activation, Some(activation))
+        })
+        .collect();
+    // 30 samples at 0.0 (sentinel)
+    for i in 70..100 {
+        records.push(record("zero-sentinel", i, 0.0, Some(0.0)));
+    }
+
+    let candidates = detect_bounded_range_neurons(
+        &[("zero-sentinel".to_string(), "LOGISTIC".to_string(), 0.0)],
+        &[("zero-sentinel".to_string(), records)],
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect bounded range with zero sentinel"
+    );
+}
+
+/// Test 5: Mixed neurons — only the bounded-range one is detected.
+#[test]
+fn test_mixed_neurons_only_bounded_detected() {
+    // Bounded range neuron: cluster at 0.4..0.7, sentinel at -1.0
+    let mut bounded_records: Vec<DiscoverRecord> = (0..75)
+        .map(|i| {
+            let activation = 0.4 + 0.3 * (i as f32 / 75.0);
+            record("bounded", i, activation, Some(activation))
+        })
+        .collect();
+    for i in 75..100 {
+        bounded_records.push(record("bounded", i, -1.0, Some(-1.0)));
+    }
+
+    // Normal neuron: spread across full range
+    let normal_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = -0.9 + 1.8 * (i as f32 / 99.0);
+            record("normal", i, activation, Some(activation))
+        })
+        .collect();
+
+    let candidates = detect_bounded_range_neurons(
+        &[
+            ("bounded".to_string(), "TANH".to_string(), 0.0),
+            ("normal".to_string(), "TANH".to_string(), 0.0),
+        ],
+        &[
+            ("bounded".to_string(), bounded_records),
+            ("normal".to_string(), normal_records),
+        ],
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect only the bounded range neuron"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "bounded");
+}
+
+/// Test 6: Candidates produce correct coordinated structural operations.
+#[test]
+fn test_candidates_produce_coordinated_operations() {
+    let candidate = BoundedRangeCandidate {
+        neuron_uuid: "hidden-debt".to_string(),
+        current_squash: "TANH".to_string(),
+        active_range_low: 0.2,
+        active_range_high: 0.8,
+        sentinel_fraction: 0.2,
+        estimated_improvement: 0.01,
+    };
+
+    let coordinated = bounded_range_to_coordinated_candidates(&[candidate]);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the change"
+    );
+
+    // Should include a bias or weight adjustment operation
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    let has_set_bias = ops_json.contains("setBias");
+    let has_change_squash = ops_json.contains("changeSquash");
+    assert!(
+        has_set_bias || has_change_squash,
+        "Should include setBias or changeSquash operation, got: {ops_json}"
+    );
+}
+
+/// Test 7: Neuron with bimodal distribution (two clusters) is detected.
+#[test]
+fn test_detects_bimodal_distribution() {
+    // Cluster 1: activations around 0.6..0.8
+    // Cluster 2: activations at -1.0 (sentinel)
+    let mut records: Vec<DiscoverRecord> = (0..60)
+        .map(|i| {
+            let activation = 0.6 + 0.2 * (i as f32 / 60.0);
+            record("bimodal", i, activation, Some(activation))
+        })
+        .collect();
+    for i in 60..100 {
+        records.push(record("bimodal", i, -1.0, Some(-1.0)));
+    }
+
+    let candidates = detect_bounded_range_neurons(
+        &[("bimodal".to_string(), "TANH".to_string(), 0.0)],
+        &[("bimodal".to_string(), records)],
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect bimodal distribution with sentinel"
+    );
+}
+
+/// Test 8: Neuron with no records should not panic or be flagged.
+#[test]
+fn test_no_records_not_flagged() {
+    let candidates = detect_bounded_range_neurons(
+        &[("missing".to_string(), "TANH".to_string(), 0.0)],
+        &[], // no records at all
+    );
+
+    assert!(candidates.is_empty(), "No records should not be flagged");
+}
+
+/// Test 9: All activations at the same value (constant) should not be flagged
+/// as bounded range — that is a dead/constant neuron, handled elsewhere.
+#[test]
+fn test_constant_activation_not_flagged() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("constant", i, 0.5, Some(0.5)))
+        .collect();
+
+    let candidates = detect_bounded_range_neurons(
+        &[("constant".to_string(), "TANH".to_string(), 0.0)],
+        &[("constant".to_string(), records)],
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Constant activation should not be flagged as bounded range"
+    );
+}
+
+/// Test 10: Sentinel fraction is correctly computed.
+#[test]
+fn test_sentinel_fraction_computed() {
+    // 70 samples in range 0.2..0.8, 30 at -1.0
+    let mut records: Vec<DiscoverRecord> = (0..70)
+        .map(|i| {
+            let activation = 0.2 + 0.6 * (i as f32 / 70.0);
+            record("frac-test", i, activation, Some(activation))
+        })
+        .collect();
+    for i in 70..100 {
+        records.push(record("frac-test", i, -1.0, Some(-1.0)));
+    }
+
+    let candidates = detect_bounded_range_neurons(
+        &[("frac-test".to_string(), "TANH".to_string(), 0.0)],
+        &[("frac-test".to_string(), records)],
+    );
+
+    assert_eq!(candidates.len(), 1);
+    let c = &candidates[0];
+    // 30 out of 100 samples are sentinels
+    assert!(
+        c.sentinel_fraction > 0.1,
+        "Sentinel fraction should be > 0.1, got {}",
+        c.sentinel_fraction
+    );
+    assert!(
+        c.sentinel_fraction < 0.5,
+        "Sentinel fraction should be < 0.5, got {}",
+        c.sentinel_fraction
+    );
+}


### PR DESCRIPTION
## Summary

Add bounded range discovery module (Issue #395) to detect neurons whose activations
are concentrated in a narrow sub-range with sentinel values (e.g., -1 or 0) at the
boundary. This addresses the problem where observations like "Debt-to-Equity" use -1
as a null indicator — multiplying -1 by a weight produces a large distorting signal.

The module uses gap-based bimodal distribution analysis to identify the sentinel
cluster and the meaningful active range. When detected, it recommends bias adjustments
to centre the active range around zero, pushing sentinel values into a neutral zone.

### Key design decisions

- **Gap-based detection**: Sorts activations and finds the largest gap to separate
  sentinel values from the active range. This is robust to different sentinel values
  (-1, 0, or any boundary value).
- **DRY**: Uses the existing `discovery_dispatch::run_discovery_module` pattern for
  watchdog, timing, logging, and candidate merging.
- **Reuses existing candidate types**: Emits `SetBias` operations via
  `CoordinatedStructuralCandidateJson` — no new candidate types needed in NEAT-AI.

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

- Added 10 integration tests in `tests/issue_395_bounded_range_detection.rs`:
  1. Detects narrow range with sentinel values at -1
  2. Full-range neuron is NOT flagged
  3. Insufficient samples are rejected
  4. Detects zero-sentinel with positive active range
  5. Mixed neurons — only bounded-range one detected
  6. Coordinated candidate conversion produces valid operations
  7. Bimodal distribution with sentinel cluster detected
  8. No records does not panic or flag
  9. Constant activation is NOT flagged (handled by dead neuron detection)
  10. Sentinel fraction is correctly computed

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)