### PR TITLE
Add bounded range discovery plan and detection module (#395)

### DIFF
--- a/docs/pr-summary-395.md
+++ b/docs/pr-summary-395.md
@@ -1,0 +1,47 @@
+## Summary
+
+Plan and initial implementation for discovering bounded ranges of observations and hidden neurons (Issue #395).
+
+### Planning Phase
+
+Created 5 sub-issues breaking down the bounded range discovery feature:
+
+1. **#398 — Detect observation effective ranges** — Foundation module to identify effective ranges and sentinel values per observation
+2. **#399 — Bounded range neuron detection** — Detect hidden neurons with restricted activation ranges (implemented in this PR)
+3. **#400 — Sentinel value gating** — Propose gated connections using scalar (GPU-compatible) squash functions to ignore sentinel values
+4. **#401 — Hidden neuron operating-point analysis** — Detect neurons whose pre-activation distribution is poorly placed for their squash function
+5. **#402 — Range-aware weight optimisation** — Enhance weight computation to exclude sentinel samples
+
+### Implementation Phase
+
+Implemented the bounded range neuron detection module (`#399`) as the first concrete deliverable:
+
+- New `src/analysis/bounded_range.rs` module that detects hidden neurons operating in a restricted sub-range of their activation function's output domain
+- Integrated into the analysis pipeline via the DRY `run_discovery_module` dispatch pattern (Issue #375)
+- Proposes `ChangeSquash` and `SetBias` coordinated structural candidates
+- Only analyses hidden neurons with bounded activation functions (TANH, LOGISTIC, HARD_TANH, etc.)
+- Excludes dead neurons, input/output/constant neurons, and neurons with insufficient samples
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+Added 15 integration tests in `tests/issue_395_bounded_range_detection.rs`:
+
+- `test_empty_records_returns_empty` — no records produces no candidates
+- `test_single_neuron_narrow_range_detected` — TANH neuron using 10% of range is detected
+- `test_neuron_using_full_range_not_detected` — 90% utilisation is not flagged
+- `test_unbounded_squash_not_flagged` — IDENTITY (unbounded) neurons excluded
+- `test_dead_neuron_excluded` — near-zero activation excluded (dead neuron territory)
+- `test_input_neurons_excluded` — input neurons not analysed
+- `test_output_neurons_excluded` — output neurons not analysed
+- `test_constant_neurons_excluded` — constant neurons not analysed
+- `test_insufficient_samples_skipped` — fewer than 20 samples skipped
+- `test_utilisation_ratio_computed_correctly` — verifies range/theoretical calculation
+- `test_candidates_sorted_by_improvement` — candidates ordered best-first
+- `test_coordinated_candidates_contain_change_squash` — output has ChangeSquash/SetBias ops
+- `test_multiple_neurons_analysed` — two narrow-range neurons produce two candidates
+- `test_logistic_narrow_range_detected` — LOGISTIC neuron at 10% utilisation detected
+- `test_hard_tanh_narrow_range_detected` — HARD_TANH neuron at 5% utilisation detected

--- a/src/analysis/bounded_range.rs
+++ b/src/analysis/bounded_range.rs
@@ -1,0 +1,279 @@
+//! Bounded range neuron detection module (Issue #395).
+//!
+//! Identifies hidden neurons that operate in a restricted sub-range of their
+//! activation function's output domain. For example, a TANH neuron consistently
+//! outputting values in [0.1, 0.3] is only using 10% of its [-1, 1] range.
+//! This wastes representational capacity and suggests the neuron's activation
+//! function, bias, or incoming weights are misconfigured.
+//!
+//! ## Detection Criteria
+//!
+//! A hidden neuron has a "bounded range" issue if:
+//! 1. **Bounded activation function**: The squash function has a known theoretical
+//!    range (e.g., TANH → [-1, 1], LOGISTIC → [0, 1]).
+//! 2. **Low utilisation**: The observed activation range is a small fraction of the
+//!    theoretical range (below `MAX_UTILISATION_THRESHOLD`).
+//! 3. **Not dead**: The neuron has meaningful activation (not near-zero).
+//! 4. **Sufficient samples**: At least `MIN_SAMPLES` records to be statistically
+//!    reliable.
+//!
+//! ## Recommended Actions
+//!
+//! When a bounded range neuron is detected, we recommend:
+//! 1. **Change activation** (`ChangeSquash`) — switch to a function better suited
+//!    to the observed operating range.
+//! 2. **Adjust bias** (`SetBias`) — shift the operating point to use more of the
+//!    activation function's range.
+
+use std::collections::HashMap;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable bounded range detection.
+const MIN_SAMPLES: usize = 20;
+
+/// Maximum utilisation ratio to flag a neuron as restricted.
+/// A neuron using less than 30% of its activation range is flagged.
+const MAX_UTILISATION_THRESHOLD: f32 = 0.30;
+
+/// Minimum activation range (max - min) to exclude dead/near-constant neurons.
+/// Neurons with a range below this are likely dead or constant and handled
+/// by other detection modules.
+const MIN_ACTIVATION_RANGE: f32 = 0.01;
+
+/// Get the theoretical output range for a bounded activation function.
+///
+/// Returns `Some((min, max))` for bounded squash functions, `None` for unbounded.
+fn theoretical_range(squash: &str) -> Option<(f32, f32)> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        "TANH" | "HARD_TANH" | "CLIPPED" | "BIPOLAR" | "BIPOLAR_SIGMOID" => Some((-1.0, 1.0)),
+        "LOGISTIC" => Some((0.0, 1.0)),
+        "STEP" => Some((0.0, 1.0)),
+        "SOFTSIGN" | "ISRU" => Some((-1.0, 1.0)),
+        "ARCTAN" => {
+            // arctan output is in (-π/2, π/2), practically ≈ (-1.57, 1.57)
+            let half_pi = std::f32::consts::FRAC_PI_2;
+            Some((-half_pi, half_pi))
+        }
+        "RELU6" => Some((0.0, 6.0)),
+        _ => None, // IDENTITY, RELU, ELU, GELU, MISH, etc. are unbounded
+    }
+}
+
+/// Result of detecting a bounded range neuron.
+#[derive(Debug, Clone)]
+pub struct BoundedRangeCandidate {
+    /// UUID of the neuron with restricted range.
+    pub neuron_uuid: String,
+    /// Current activation function of the neuron.
+    pub current_squash: String,
+    /// Observed activation minimum.
+    pub observed_min: f32,
+    /// Observed activation maximum.
+    pub observed_max: f32,
+    /// Theoretical activation range of the squash function.
+    pub theoretical_min: f32,
+    /// Theoretical activation range of the squash function.
+    pub theoretical_max: f32,
+    /// Fraction of theoretical range actually used (0.0 to 1.0).
+    pub utilisation_ratio: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Estimated creature score improvement from fixing this neuron.
+    pub estimated_improvement: f32,
+}
+
+/// Detect hidden neurons with restricted activation ranges.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `BoundedRangeCandidate` for neurons with restricted ranges,
+/// sorted by estimated improvement (best first).
+pub fn detect_bounded_range_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<BoundedRangeCandidate> {
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for neuron in &creature.neurons {
+        // Only analyse hidden neurons
+        if neuron.neuron_type != "hidden" {
+            continue;
+        }
+
+        // Must be a bounded activation function
+        let Some((theo_min, theo_max)) = theoretical_range(&neuron.squash) else {
+            continue;
+        };
+        let theoretical_span = theo_max - theo_min;
+        if theoretical_span <= 0.0 {
+            continue;
+        }
+
+        // Must have recorded data
+        let Some(records) = records_map.get(neuron.uuid.as_str()) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Compute observed activation range
+        let mut obs_min = f32::INFINITY;
+        let mut obs_max = f32::NEG_INFINITY;
+        let mut valid_count = 0usize;
+
+        for record in records.iter() {
+            if record.activation.is_finite() {
+                if record.activation < obs_min {
+                    obs_min = record.activation;
+                }
+                if record.activation > obs_max {
+                    obs_max = record.activation;
+                }
+                valid_count += 1;
+            }
+        }
+
+        if valid_count < MIN_SAMPLES {
+            continue;
+        }
+
+        let observed_range = obs_max - obs_min;
+
+        // Exclude dead/near-constant neurons (handled by dead_neuron detection)
+        if observed_range < MIN_ACTIVATION_RANGE {
+            continue;
+        }
+
+        let utilisation_ratio = observed_range / theoretical_span;
+
+        if utilisation_ratio >= MAX_UTILISATION_THRESHOLD {
+            continue;
+        }
+
+        // Estimated improvement: higher for lower utilisation (more wasted capacity)
+        // Scale so that 0% utilisation → 0.005, 30% → ~0.0
+        let estimated_improvement = 0.005 * (1.0 - utilisation_ratio / MAX_UTILISATION_THRESHOLD);
+
+        candidates.push(BoundedRangeCandidate {
+            neuron_uuid: neuron.uuid.clone(),
+            current_squash: neuron.squash.clone(),
+            observed_min: obs_min,
+            observed_max: obs_max,
+            theoretical_min: theo_min,
+            theoretical_max: theo_max,
+            utilisation_ratio,
+            sample_count: valid_count,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Convert bounded range candidates into coordinated structural candidates.
+///
+/// Each bounded range neuron produces a `ChangeSquash` coordinated candidate
+/// to switch to an activation function that better utilises the observed range.
+/// NEAT-AI validates the change through ablation testing.
+pub fn bounded_range_to_coordinated_candidates(
+    candidates: &[BoundedRangeCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        // Suggest a squash function that better matches the observed range.
+        // If the neuron uses a small positive range, RELU might be appropriate.
+        // If it uses a small range near zero, IDENTITY could work.
+        let suggested_squash = suggest_squash_for_range(c);
+
+        let mut operations = Vec::new();
+
+        // Primary recommendation: change squash function
+        if suggested_squash != c.current_squash {
+            operations.push(CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: c.neuron_uuid.clone(),
+                squash: suggested_squash.clone(),
+            });
+        }
+
+        // Secondary recommendation: adjust bias to centre in active region
+        let observed_midpoint = (c.observed_min + c.observed_max) / 2.0;
+        let theoretical_midpoint = (c.theoretical_min + c.theoretical_max) / 2.0;
+        let bias_offset = theoretical_midpoint - observed_midpoint;
+        if bias_offset.abs() > 0.01 {
+            operations.push(CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: c.neuron_uuid.clone(),
+                bias: bias_offset,
+            });
+        }
+
+        if operations.is_empty() {
+            continue;
+        }
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Bounded range {}: {} uses [{:.3}, {:.3}] of [{:.1}, {:.1}] ({:.0}% utilisation, {} samples)",
+                c.neuron_uuid,
+                c.current_squash,
+                c.observed_min,
+                c.observed_max,
+                c.theoretical_min,
+                c.theoretical_max,
+                c.utilisation_ratio * 100.0,
+                c.sample_count,
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+/// Suggest a better squash function based on the observed activation range.
+fn suggest_squash_for_range(candidate: &BoundedRangeCandidate) -> String {
+    let mid = (candidate.observed_min + candidate.observed_max) / 2.0;
+    let range = candidate.observed_max - candidate.observed_min;
+
+    // If the neuron operates in a small positive range, RELU may be appropriate
+    if candidate.observed_min >= -0.01 && range > 0.0 {
+        return "RELU".to_string();
+    }
+
+    // If the neuron operates near zero in a symmetric range, IDENTITY avoids squashing
+    if mid.abs() < 0.1 && range < 0.5 {
+        return "IDENTITY".to_string();
+    }
+
+    // Default: suggest IDENTITY to avoid wasting dynamic range
+    "IDENTITY".to_string()
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -19,6 +19,7 @@
 //! - `bottleneck.rs` - Bottleneck neuron detection for information flow widening (Issue #343)
 //! - `dead_neuron.rs` - Dead neuron detection for removal candidates (Issue #341)
 //! - `correlated_error.rs` - Correlated error pattern detection for shared-cause identification (Issue #344)
+//! - `bounded_range.rs` - Bounded range neuron detection for restricted activation ranges (Issue #395)
 //! - `discovery_dispatch.rs` - Generic discovery module dispatch pattern (Issue #375)
 //! - `candidate_clustering.rs` - Candidate clustering to reduce redundant ablation tests (Issue #224)
 //! - `multi_hop.rs` - Multi-hop candidate analysis for deeper network improvements (Issue #230)
@@ -30,6 +31,7 @@
 
 pub mod activation;
 pub mod bottleneck;
+pub mod bounded_range;
 pub mod cache;
 pub mod candidate_clustering;
 pub mod confidence;
@@ -888,6 +890,35 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 }
                 let candidates =
                     output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #395: Bounded range neuron detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "bounded range detection",
+            "bounded_range_detection",
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "hidden")
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                let records = collect_records(&uuids);
+                let detected =
+                    bounded_range::detect_bounded_range_neurons(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = bounded_range::bounded_range_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_395_bounded_range_detection.rs
+++ b/tests/issue_395_bounded_range_detection.rs
@@ -1,0 +1,464 @@
+//! Tests for bounded range detection (Issue #395).
+//!
+//! ## TDD Plan
+//!
+//! 1. `test_empty_records_returns_empty` — no records → no candidates
+//! 2. `test_single_neuron_narrow_range_detected` — TANH neuron using [0.1, 0.3] of [-1, 1] → detected
+//! 3. `test_neuron_using_full_range_not_detected` — TANH neuron using [-0.9, 0.9] → not detected
+//! 4. `test_unbounded_squash_not_flagged` — IDENTITY neuron with narrow range → not flagged
+//! 5. `test_dead_neuron_excluded` — near-zero activation neuron → excluded (dead neuron territory)
+//! 6. `test_input_neurons_excluded` — input neurons are not analysed for bounded range
+//! 7. `test_output_neurons_excluded` — output neurons are not analysed for bounded range
+//! 8. `test_constant_neurons_excluded` — constant neurons are not analysed
+//! 9. `test_insufficient_samples_skipped` — too few samples → skip
+//! 10. `test_sentinel_cluster_detected` — many samples at exact -1.0 → sentinel detected
+//! 11. `test_no_sentinel_when_values_spread` — uniformly spread values → no sentinel
+//! 12. `test_utilisation_ratio_computed_correctly` — verify range/theoretical calculation
+//! 13. `test_candidates_sorted_by_improvement` — candidates ordered best-first
+//! 14. `test_coordinated_candidates_contain_change_squash` — output has correct operations
+//! 15. `test_multiple_neurons_analysed` — two narrow-range neurons → two candidates
+//! 16. `test_logistic_narrow_range_detected` — LOGISTIC neuron using [0.45, 0.55] → detected
+//! 17. `test_hard_tanh_narrow_range_detected` — HARD_TANH neuron using [0.0, 0.1] → detected
+
+mod common;
+
+use neat_ai_discovery::analysis::bounded_range::{
+    bounded_range_to_coordinated_candidates, detect_bounded_range_neurons,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CoordinatedStructuralOpJson, CreatureJson};
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+fn make_records(neuron_uuid: &str, activations: &[f32]) -> Vec<DiscoverRecord> {
+    activations
+        .iter()
+        .enumerate()
+        .map(|(i, &a)| {
+            DiscoverRecord::new(i as u32, neuron_uuid.to_string(), Some(a), a, vec![0.01])
+        })
+        .collect()
+}
+
+fn make_neuron_records(entries: &[(&str, &[f32])]) -> Vec<(String, Vec<DiscoverRecord>)> {
+    entries
+        .iter()
+        .map(|(uuid, activations)| (uuid.to_string(), make_records(uuid, activations)))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_empty_records_returns_empty() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.is_empty(), "No records → no candidates");
+}
+
+#[test]
+fn test_single_neuron_narrow_range_detected() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // TANH has range [-1, 1] = 2.0 total
+    // Neuron uses [0.1, 0.3] = 0.2 range → 10% utilisation
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 + 0.2 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert_eq!(
+        result.len(),
+        1,
+        "One narrow-range neuron should be detected"
+    );
+    assert_eq!(result[0].neuron_uuid, "h1");
+    assert!(
+        result[0].utilisation_ratio < 0.2,
+        "Utilisation should be ~10%, got {:.2}",
+        result[0].utilisation_ratio
+    );
+}
+
+#[test]
+fn test_neuron_using_full_range_not_detected() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // Neuron uses [-0.9, 0.9] = 1.8 range → 90% utilisation
+    let activations: Vec<f32> = (0..50).map(|i| -0.9 + 1.8 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(
+        result.is_empty(),
+        "Full-range neuron should not be detected"
+    );
+}
+
+#[test]
+fn test_unbounded_squash_not_flagged() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "IDENTITY"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // IDENTITY is unbounded — no theoretical range to compare against
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 + 0.01 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(
+        result.is_empty(),
+        "Unbounded activation (IDENTITY) should not be flagged"
+    );
+}
+
+#[test]
+fn test_dead_neuron_excluded() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // Near-zero activation — this is dead neuron territory
+    let activations: Vec<f32> = (0..50).map(|_| 0.000001).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(
+        result.is_empty(),
+        "Dead neuron (near-zero activation) should be excluded"
+    );
+}
+
+#[test]
+fn test_input_neurons_excluded() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // Even if input has narrow range, it should not be flagged
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 + 0.01 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("input-0", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.is_empty(), "Input neurons should be excluded");
+}
+
+#[test]
+fn test_output_neurons_excluded() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // Output neurons should not be flagged for bounded range
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 + 0.01 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("output-0", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.is_empty(), "Output neurons should be excluded");
+}
+
+#[test]
+fn test_constant_neurons_excluded() {
+    let creature = CreatureJson {
+        neurons: vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::neuron("const-0", "constant", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        synapses: vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("const-0", "h1", 0.5),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    let activations: Vec<f32> = (0..50).map(|_| 1.0).collect();
+    let records = make_neuron_records(&[("const-0", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.is_empty(), "Constant neurons should be excluded");
+}
+
+#[test]
+fn test_insufficient_samples_skipped() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // Only 5 samples — not enough
+    let activations: Vec<f32> = vec![0.1, 0.15, 0.2, 0.25, 0.3];
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.is_empty(), "Too few samples should be skipped");
+}
+
+#[test]
+fn test_utilisation_ratio_computed_correctly() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // TANH theoretical range = 2.0 (from -1 to 1)
+    // Observed range = 0.5 - 0.0 = 0.5
+    // Utilisation = 0.5 / 2.0 = 0.25
+    let activations: Vec<f32> = (0..50).map(|i| 0.5 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(!result.is_empty(), "25% utilisation should be detected");
+    let ratio = result[0].utilisation_ratio;
+    assert!(
+        (ratio - 0.25).abs() < 0.02,
+        "Utilisation ratio should be ~0.25, got {ratio:.3}"
+    );
+}
+
+#[test]
+fn test_candidates_sorted_by_improvement() {
+    let creature = CreatureJson {
+        neurons: vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::hidden("h2", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        synapses: vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("input-0", "h2", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+            common::synapse("h2", "output-0", 1.0),
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    // h1: uses 10% of range (very restricted)
+    let h1_acts: Vec<f32> = (0..50).map(|i| 0.1 + 0.2 * (i as f32 / 49.0)).collect();
+    // h2: uses 25% of range (less restricted)
+    let h2_acts: Vec<f32> = (0..50).map(|i| 0.5 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &h1_acts), ("h2", &h2_acts)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(result.len() >= 2, "Both neurons should be detected");
+    assert!(
+        result[0].estimated_improvement >= result[1].estimated_improvement,
+        "Candidates should be sorted best-first"
+    );
+}
+
+#[test]
+fn test_coordinated_candidates_contain_change_squash() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 + 0.2 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let candidates = detect_bounded_range_neurons(&creature, &records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = bounded_range_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    // Verify at least one candidate has a ChangeSquash or SetBias operation
+    let has_relevant_op = coordinated.iter().any(|c| {
+        c.operations.iter().any(|op| {
+            matches!(
+                op,
+                CoordinatedStructuralOpJson::ChangeSquash { .. }
+                    | CoordinatedStructuralOpJson::SetBias { .. }
+            )
+        })
+    });
+    assert!(
+        has_relevant_op,
+        "Coordinated candidates should include ChangeSquash or SetBias operations"
+    );
+}
+
+#[test]
+fn test_multiple_neurons_analysed() {
+    let creature = CreatureJson {
+        neurons: vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "TANH"),
+            common::hidden("h2", "LOGISTIC"),
+            common::output("output-0", "TANH"),
+        ],
+        synapses: vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("input-0", "h2", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+            common::synapse("h2", "output-0", 1.0),
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    // h1 (TANH): narrow range [0.1, 0.3]
+    let h1_acts: Vec<f32> = (0..50).map(|i| 0.1 + 0.2 * (i as f32 / 49.0)).collect();
+    // h2 (LOGISTIC): narrow range [0.45, 0.55] (out of [0, 1])
+    let h2_acts: Vec<f32> = (0..50).map(|i| 0.45 + 0.1 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &h1_acts), ("h2", &h2_acts)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert!(
+        result.len() >= 2,
+        "Both narrow-range neurons should be detected, got {}",
+        result.len()
+    );
+}
+
+#[test]
+fn test_logistic_narrow_range_detected() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "LOGISTIC"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // LOGISTIC has range [0, 1] = 1.0 total
+    // Neuron uses [0.45, 0.55] = 0.1 range → 10% utilisation
+    let activations: Vec<f32> = (0..50).map(|i| 0.45 + 0.1 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].neuron_uuid, "h1");
+    assert!(
+        result[0].utilisation_ratio < 0.2,
+        "LOGISTIC utilisation should be ~10%"
+    );
+}
+
+#[test]
+fn test_hard_tanh_narrow_range_detected() {
+    let creature = common::make_creature(
+        vec![
+            common::neuron("input-0", "input", "IDENTITY"),
+            common::hidden("h1", "HARD_TANH"),
+            common::output("output-0", "TANH"),
+        ],
+        vec![
+            common::synapse("input-0", "h1", 1.0),
+            common::synapse("h1", "output-0", 1.0),
+        ],
+    );
+
+    // HARD_TANH has range [-1, 1] = 2.0 total
+    // Neuron uses [0.0, 0.1] = 0.1 range → 5% utilisation
+    let activations: Vec<f32> = (0..50).map(|i| 0.1 * (i as f32 / 49.0)).collect();
+    let records = make_neuron_records(&[("h1", &activations)]);
+
+    let result = detect_bounded_range_neurons(&creature, &records);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].neuron_uuid, "h1");
+    assert!(
+        result[0].utilisation_ratio < 0.1,
+        "HARD_TANH utilisation should be ~5%"
+    );
+}


### PR DESCRIPTION
## Summary
- Created 5 sub-issues (#398–#402) planning the full bounded range discovery feature
- Implemented bounded range neuron detection module (`src/analysis/bounded_range.rs`)
- Detects hidden neurons operating in a restricted sub-range of their bounded activation function (e.g., TANH neuron using only [0.1, 0.3] of [-1, 1])
- Proposes `ChangeSquash` and `SetBias` coordinated structural candidates
- Integrated via DRY `run_discovery_module` dispatch pattern (Issue #375)
- 15 TDD integration tests covering detection, exclusions, and candidate generation

### Sub-Issues Created

| Issue | Title | Dependency |
|-------|-------|------------|
| #398 | Detect observation effective ranges | Foundation |
| #399 | Bounded range neuron detection | Independent (implemented here) |
| #400 | Sentinel value gating | Depends on #398 |
| #401 | Hidden neuron operating-point analysis | Depends on #399 |
| #402 | Range-aware weight optimisation | Depends on #398 |

Closes #395

## Test plan
- Added 15 tests in `tests/issue_395_bounded_range_detection.rs`
- All tests verify detection outcomes, not implementation details
- Covers: empty input, narrow/full range, unbounded squash exclusion, dead/input/output/constant neuron exclusion, insufficient samples, utilisation ratio calculation, sorting, coordinated candidate generation, multiple activation functions (TANH, LOGISTIC, HARD_TANH)
- `./quality.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)