### PR TITLE
Fix: Plan (create GH issues) to discover bounded ranges (#395)

### DIFF
--- a/docs/pr-summary-395.md
+++ b/docs/pr-summary-395.md
@@ -1,0 +1,39 @@
+## Summary
+
+Add bounded range discovery module (Issue #395) to detect observation and hidden neurons where a significant cluster of activation values sits at a sentinel boundary (e.g., -1, 0, or +1), separate from the "useful" range. This addresses the problem where observations normalised to -1…1 use sentinel values like -1 to represent null/missing data, which negatively impacts the creature's score when simply multiplied by a weight.
+
+The module recommends adding a gating neuron (via `addNeuron` + `addSynapse` coordinated operations) that can learn to suppress the sentinel region while passing through useful-range values.
+
+### Key Design Decisions
+
+- **Sentinel detection at -1, 0, and +1**: These are the most common null sentinels in normalised data
+- **Minimum 20% boundary fraction**: A significant cluster must exist at the sentinel value
+- **Gap requirement**: There must be a measurable gap (≥ 0.05) between sentinel and useful range
+- **Input and hidden neurons only**: Output neurons are excluded
+- **Follows DRY pattern**: Uses the existing `discovery_dispatch::run_discovery_module` pattern from Issue #375
+- **GPU-compatible candidate**: Recommends `AddNeuron` (RELU gating) + `AddSynapse`, which are standard coordinated structural operations
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/analysis/bounded_range.rs` | New module: detection logic and candidate conversion |
+| `src/analysis/mod.rs` | Register module and add dispatch call |
+| `tests/issue_395_bounded_range_detection.rs` | 10 integration tests covering detection and edge cases |
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface. All behaviour is verified through automated tests.
+
+## Test Plan
+
+- `test_detects_observation_with_null_cluster_at_minus_one` — 40% at -1 sentinel detected
+- `test_detects_observation_with_null_cluster_at_plus_one` — 35% at +1 sentinel detected
+- `test_does_not_flag_uniform_distribution` — evenly spread values not flagged
+- `test_detects_hidden_neuron_with_boundary_cluster` — hidden neuron with TANH saturation sentinel
+- `test_insufficient_samples_not_detected` — below minimum sample threshold
+- `test_all_same_values_not_detected` — constant values not flagged
+- `test_detects_cluster_at_zero_sentinel` — 50% at 0.0 sentinel detected
+- `test_coordinated_candidate_conversion` — valid coordinated structural operations produced
+- `test_multiple_neurons_only_boundary_clustered_detected` — selective detection across multiple neurons
+- `test_output_neurons_excluded` — output neurons correctly excluded

--- a/src/analysis/bounded_range.rs
+++ b/src/analysis/bounded_range.rs
@@ -1,0 +1,287 @@
+//! Bounded range discovery module (Issue #395).
+//!
+//! Observations are finite numbers, often normalised to -1…1. Since observations lack
+//! a concept of null, sentinel values like -1 or 0 are used instead. For example, a
+//! low "Debt-to-Equity" value might meaningfully influence the output, but -1 should
+//! not (it may indicate missing data entirely).
+//!
+//! This module detects neurons (input observations and hidden neurons) where a
+//! significant cluster of activation values sits at a boundary (e.g., -1, 0, or +1),
+//! separate from the "useful" range. It then recommends adding a gating neuron so that
+//! the sentinel region does not negatively impact the creature's score.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron has a "bounded range issue" if:
+//! 1. **Boundary cluster**: A significant fraction (≥ 20%) of samples have activation
+//!    at or very near a single value (the sentinel).
+//! 2. **Gap**: There is a measurable gap between the sentinel cluster and the useful
+//!    range of values.
+//! 3. **Sufficient samples**: At least 20 samples are available.
+//! 4. **Not output neurons**: Only input and hidden neurons are considered.
+//!
+//! ## Recommended Actions
+//!
+//! When a bounded range issue is detected, the module recommends adding a gating
+//! neuron (using `addNeuron` + `addSynapse` coordinated operations) that can learn
+//! to suppress the sentinel region while passing through useful values.
+
+use std::collections::HashSet;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable bounded range detection.
+const MIN_SAMPLES_FOR_BOUNDED_RANGE: usize = 20;
+
+/// Minimum fraction of samples at a boundary value to consider it a sentinel cluster.
+const MIN_BOUNDARY_FRACTION: f32 = 0.20;
+
+/// Tolerance for grouping values into a boundary cluster.
+/// Values within this distance of the sentinel are considered part of the cluster.
+const BOUNDARY_TOLERANCE: f32 = 0.02;
+
+/// Minimum gap between the sentinel cluster and the useful range.
+/// If the gap is smaller than this, the values are too interleaved to separate.
+const MIN_GAP: f32 = 0.05;
+
+/// Candidate boundary values to check for sentinel clusters.
+/// These are the most common sentinel values in normalised data.
+const CANDIDATE_SENTINELS: [f32; 3] = [-1.0, 0.0, 1.0];
+
+/// Result of detecting a bounded range issue on a neuron.
+#[derive(Debug, Clone)]
+pub struct BoundedRangeCandidate {
+    /// UUID of the neuron with the bounded range issue.
+    pub neuron_uuid: String,
+    /// The sentinel/boundary value where the cluster sits.
+    pub boundary_value: f32,
+    /// Fraction of samples at the boundary value (0.0 to 1.0).
+    pub boundary_fraction: f32,
+    /// Minimum of the useful (non-sentinel) range.
+    pub useful_range_min: f32,
+    /// Maximum of the useful (non-sentinel) range.
+    pub useful_range_max: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Confidence in the detection (0.0 to 1.0).
+    pub detection_confidence: f32,
+    /// Estimated creature score improvement from gating the sentinel region.
+    pub estimated_improvement: f32,
+}
+
+/// Detect neurons with bounded range issues from recorded activations.
+///
+/// Analyses both input (observation) and hidden neurons to find those where a
+/// significant cluster of values sits at a sentinel boundary, separate from the
+/// useful range.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `BoundedRangeCandidate` sorted by detection confidence (highest first).
+pub fn detect_bounded_range_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<BoundedRangeCandidate> {
+    // Only consider input and hidden neurons (exclude output)
+    let eligible_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        if !eligible_uuids.contains(uuid.as_str()) {
+            continue;
+        }
+
+        if records.len() < MIN_SAMPLES_FOR_BOUNDED_RANGE {
+            continue;
+        }
+
+        if let Some(candidate) = analyse_neuron_for_boundary_cluster(uuid, records) {
+            candidates.push(candidate);
+        }
+    }
+
+    // Sort by detection confidence (highest first)
+    candidates.sort_by(|a, b| {
+        b.detection_confidence
+            .partial_cmp(&a.detection_confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Analyse a single neuron's activation records for boundary clustering.
+///
+/// Checks each candidate sentinel value (-1, 0, +1) and returns the strongest
+/// detection if any boundary cluster is found.
+fn analyse_neuron_for_boundary_cluster(
+    uuid: &str,
+    records: &[DiscoverRecord],
+) -> Option<BoundedRangeCandidate> {
+    let n = records.len() as f32;
+    let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
+
+    let mut best_candidate: Option<BoundedRangeCandidate> = None;
+
+    for &sentinel in &CANDIDATE_SENTINELS {
+        // Count samples at or near the sentinel value
+        let boundary_count = activations
+            .iter()
+            .filter(|&&a| (a - sentinel).abs() <= BOUNDARY_TOLERANCE)
+            .count();
+        let boundary_fraction = boundary_count as f32 / n;
+
+        if boundary_fraction < MIN_BOUNDARY_FRACTION {
+            continue;
+        }
+
+        // Collect the non-sentinel (useful) values
+        let useful_values: Vec<f32> = activations
+            .iter()
+            .copied()
+            .filter(|&a| (a - sentinel).abs() > BOUNDARY_TOLERANCE)
+            .collect();
+
+        if useful_values.is_empty() {
+            // All values are at the sentinel — no useful range to separate
+            continue;
+        }
+
+        let useful_min = useful_values.iter().copied().fold(f32::INFINITY, f32::min);
+        let useful_max = useful_values
+            .iter()
+            .copied()
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        // Check there is a gap between the sentinel and the useful range
+        let gap = if sentinel <= useful_min {
+            useful_min - (sentinel + BOUNDARY_TOLERANCE)
+        } else if sentinel >= useful_max {
+            (sentinel - BOUNDARY_TOLERANCE) - useful_max
+        } else {
+            // Sentinel is inside the useful range — not a clear boundary
+            0.0
+        };
+
+        if gap < MIN_GAP {
+            continue;
+        }
+
+        let confidence = compute_detection_confidence(boundary_fraction, gap, n);
+        let improvement = confidence * 0.005;
+
+        let is_better = best_candidate
+            .as_ref()
+            .is_none_or(|prev| confidence > prev.detection_confidence);
+
+        if is_better {
+            best_candidate = Some(BoundedRangeCandidate {
+                neuron_uuid: uuid.to_string(),
+                boundary_value: sentinel,
+                boundary_fraction,
+                useful_range_min: useful_min,
+                useful_range_max: useful_max,
+                sample_count: records.len(),
+                detection_confidence: confidence,
+                estimated_improvement: improvement,
+            });
+        }
+    }
+
+    best_candidate
+}
+
+/// Compute detection confidence based on boundary statistics.
+///
+/// Higher confidence when:
+/// - Boundary fraction is larger (more samples at sentinel)
+/// - Gap between sentinel and useful range is wider
+/// - More samples were analysed
+fn compute_detection_confidence(boundary_fraction: f32, gap: f32, sample_count: f32) -> f32 {
+    // Fraction factor: more values at sentinel = clearer separation
+    let fraction_factor = ((boundary_fraction - MIN_BOUNDARY_FRACTION)
+        / (1.0 - MIN_BOUNDARY_FRACTION))
+        .clamp(0.0, 1.0);
+
+    // Gap factor: wider gap = clearer separation (saturates at gap=0.5)
+    let gap_factor = (gap / 0.5).clamp(0.0, 1.0);
+
+    // Sample factor: more samples = higher confidence (plateaus at 1000)
+    let sample_factor = (sample_count / 1000.0).min(1.0);
+
+    // Combine factors
+    let raw = fraction_factor * 0.4 + gap_factor * 0.4 + sample_factor * 0.2;
+
+    // Scale to [0.5, 1.0] since we already passed threshold checks
+    0.5 + raw * 0.5
+}
+
+/// Convert bounded range candidates into coordinated structural candidates.
+///
+/// Each candidate produces a coordinated operation that adds a gating neuron
+/// between the source and its downstream targets. The gating neuron can learn
+/// to suppress sentinel values while passing through useful-range values.
+///
+/// The NEAT-AI controller will validate each candidate through ablation testing
+/// before applying it.
+pub fn bounded_range_to_coordinated_candidates(
+    candidates: &[BoundedRangeCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        // Recommend a bias that centres the gating neuron on the useful range.
+        // The bias shifts the activation so that sentinel values fall below the
+        // gating threshold while useful values pass through.
+        let useful_centre = (c.useful_range_min + c.useful_range_max) / 2.0;
+        let gate_bias = -useful_centre;
+
+        // Create a deterministic UUID for the new gating neuron
+        let gate_uuid = format!("gate-bounded-{}", c.neuron_uuid);
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::AddNeuron {
+                    neuron_uuid: gate_uuid.clone(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "RELU".to_string(),
+                    bias: gate_bias,
+                    insert_before_neuron_uuid: None,
+                },
+                CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: c.neuron_uuid.clone(),
+                    to_neuron_uuid: gate_uuid,
+                    weight: 1.0,
+                },
+            ],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Bounded range on {}: {:.0}% of samples at sentinel {:.2}, useful range [{:.2}, {:.2}] → add gating neuron to suppress sentinel region",
+                c.neuron_uuid,
+                c.boundary_fraction * 100.0,
+                c.boundary_value,
+                c.useful_range_min,
+                c.useful_range_max,
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -27,9 +27,11 @@
 //! - `dormant_synapse.rs` - Dormant synapse detection for removal candidates (Issue #359)
 //! - `opposing_synapse.rs` - Opposing synapse detection for removal or weight flip candidates (Issue #360)
 //! - `output_bias_drift.rs` - Output bias drift detection for bias adjustment candidates (Issue #361)
+//! - `bounded_range.rs` - Bounded range detection for sentinel/null value gating (Issue #395)
 
 pub mod activation;
 pub mod bottleneck;
+pub mod bounded_range;
 pub mod cache;
 pub mod candidate_clustering;
 pub mod confidence;
@@ -888,6 +890,38 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 }
                 let candidates =
                     output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #395: Bounded range detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "bounded range detection",
+            "bounded_range_detection",
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                if uuids.is_empty() {
+                    return None;
+                }
+                let records = collect_records(&uuids);
+                let detected =
+                    bounded_range::detect_bounded_range_neurons(&input.creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = bounded_range::bounded_range_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_395_bounded_range_detection.rs
+++ b/tests/issue_395_bounded_range_detection.rs
@@ -1,0 +1,368 @@
+//! Tests for Issue #395: Discover bounded ranges of observations and hidden neurons.
+//!
+//! Observations are normalised to -1…1, but -1 often represents "null" or "invalid"
+//! rather than a meaningful low value. This module detects neurons where a significant
+//! cluster of values sits at a boundary (e.g., -1) separate from the "useful" range,
+//! and recommends adding a gating neuron so that the null region does not negatively
+//! impact the creature's score.
+//!
+//! ## TDD Plan
+//! 1. Detect observation with bimodal distribution: cluster at -1 (null) and useful range
+//! 2. Verify useful range bounds are computed correctly
+//! 3. Verify neurons without boundary clustering are not flagged
+//! 4. Test hidden neurons with boundary clustering
+//! 5. Test edge cases: insufficient samples, uniform distribution, all-same values
+//! 6. Test coordinated structural candidate conversion
+
+mod common;
+
+use common::{hidden, make_creature, neuron, output, record, synapse};
+use neat_ai_discovery::analysis::bounded_range::{
+    bounded_range_to_coordinated_candidates, detect_bounded_range_neurons, BoundedRangeCandidate,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// ---------------------------------------------------------------------------
+// Test 1: Observation with cluster at -1 (null sentinel) is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_observation_with_null_cluster_at_minus_one() {
+    let creature = make_creature(
+        vec![
+            neuron("input-obs", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-obs", "output-1", 0.5)],
+    );
+
+    // 40% of samples at -1 (null sentinel), 60% in useful range [0.1, 0.8]
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..40 {
+        records.push(record("input-obs", i, -1.0, None));
+    }
+    for i in 40..100 {
+        let useful_val = 0.1 + 0.7 * ((i - 40) as f32 / 60.0);
+        records.push(record("input-obs", i, useful_val, None));
+    }
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("input-obs".to_string(), records)]);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect one bounded-range neuron"
+    );
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "input-obs");
+    assert!(
+        c.boundary_fraction >= 0.3,
+        "Boundary fraction should be >= 0.3, got {}",
+        c.boundary_fraction
+    );
+    assert!(
+        c.useful_range_min > -0.95,
+        "Useful range min should exclude the -1 cluster, got {}",
+        c.useful_range_min
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Observation with cluster at +1 (null sentinel) is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_observation_with_null_cluster_at_plus_one() {
+    let creature = make_creature(
+        vec![
+            neuron("input-obs", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-obs", "output-1", 0.5)],
+    );
+
+    // 35% at +1 (null), 65% in range [-0.5, 0.3]
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..35 {
+        records.push(record("input-obs", i, 1.0, None));
+    }
+    for i in 35..100 {
+        let useful_val = -0.5 + 0.8 * ((i - 35) as f32 / 65.0);
+        records.push(record("input-obs", i, useful_val, None));
+    }
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("input-obs".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect boundary cluster at +1");
+    let c = &candidates[0];
+    assert!(
+        c.useful_range_max < 0.95,
+        "Useful range max should exclude the +1 cluster, got {}",
+        c.useful_range_max
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Neuron with uniform distribution is NOT flagged.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_does_not_flag_uniform_distribution() {
+    let creature = make_creature(
+        vec![
+            neuron("input-uniform", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-uniform", "output-1", 0.5)],
+    );
+
+    // Evenly spread across [-1, 1]
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let val = -1.0 + 2.0 * (i as f32 / 99.0);
+            record("input-uniform", i, val, None)
+        })
+        .collect();
+
+    let candidates =
+        detect_bounded_range_neurons(&creature, &[("input-uniform".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Uniform distribution should not be flagged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Hidden neuron with boundary clustering is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_hidden_neuron_with_boundary_cluster() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("hidden-bounded", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-bounded", 0.5),
+            synapse("hidden-bounded", "output-1", 0.3),
+        ],
+    );
+
+    // Hidden neuron: 45% at -1.0 (TANH saturation as sentinel), 55% in [-0.3, 0.6]
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..45 {
+        records.push(record("hidden-bounded", i, -1.0, Some(-5.0)));
+    }
+    for i in 45..100 {
+        let useful_val = -0.3 + 0.9 * ((i - 45) as f32 / 55.0);
+        records.push(record("hidden-bounded", i, useful_val, Some(useful_val)));
+    }
+
+    let candidates =
+        detect_bounded_range_neurons(&creature, &[("hidden-bounded".to_string(), records)]);
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect hidden neuron with boundary cluster"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "hidden-bounded");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Insufficient samples → no detection.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_insufficient_samples_not_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-obs", "input", "IDENTITY"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![synapse("input-obs", "output-1", 0.5)],
+    );
+
+    // Only 5 samples (below minimum threshold)
+    let records: Vec<DiscoverRecord> = (0..5).map(|i| record("input-obs", i, -1.0, None)).collect();
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("input-obs".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not detect with insufficient samples"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: All-same values → no detection (no useful range to separate).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_all_same_values_not_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-obs", "input", "IDENTITY"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![synapse("input-obs", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("input-obs", i, 0.5, None))
+        .collect();
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("input-obs".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "All-same values should not be flagged (no boundary cluster)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Cluster at 0 (common null sentinel) is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_cluster_at_zero_sentinel() {
+    let creature = make_creature(
+        vec![
+            neuron("input-obs", "input", "IDENTITY"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![synapse("input-obs", "output-1", 0.5)],
+    );
+
+    // 50% at 0.0 (null sentinel), 50% in [0.3, 0.9]
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..50 {
+        records.push(record("input-obs", i, 0.0, None));
+    }
+    for i in 50..100 {
+        let useful_val = 0.3 + 0.6 * ((i - 50) as f32 / 50.0);
+        records.push(record("input-obs", i, useful_val, None));
+    }
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("input-obs".to_string(), records)]);
+
+    assert_eq!(candidates.len(), 1, "Should detect cluster at 0 sentinel");
+    let c = &candidates[0];
+    assert!(
+        c.boundary_fraction >= 0.4,
+        "Boundary fraction should be >= 0.4, got {}",
+        c.boundary_fraction
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Coordinated candidate conversion produces valid operations.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_coordinated_candidate_conversion() {
+    let candidates = vec![BoundedRangeCandidate {
+        neuron_uuid: "input-obs".to_string(),
+        boundary_value: -1.0,
+        boundary_fraction: 0.4,
+        useful_range_min: 0.1,
+        useful_range_max: 0.8,
+        sample_count: 100,
+        detection_confidence: 0.85,
+        estimated_improvement: 0.01,
+    }];
+
+    let coordinated = bounded_range_to_coordinated_candidates(&candidates);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        !c.operations.is_empty(),
+        "Should have at least one operation"
+    );
+    assert!(c.comment.is_some(), "Should include a descriptive comment");
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Multiple neurons — only boundary-clustered ones are detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_multiple_neurons_only_boundary_clustered_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-good", "input", "IDENTITY"),
+            neuron("input-bad", "input", "IDENTITY"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-good", "output-1", 0.5),
+            synapse("input-bad", "output-1", 0.3),
+        ],
+    );
+
+    // input-good: uniform spread — no boundary cluster
+    let good_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let val = -0.8 + 1.6 * (i as f32 / 99.0);
+            record("input-good", i, val, None)
+        })
+        .collect();
+
+    // input-bad: 40% at -1 (sentinel), 60% in [0.0, 0.5]
+    let mut bad_records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..40 {
+        bad_records.push(record("input-bad", i, -1.0, None));
+    }
+    for i in 40..100 {
+        let useful_val = 0.5 * ((i - 40) as f32 / 60.0);
+        bad_records.push(record("input-bad", i, useful_val, None));
+    }
+
+    let candidates = detect_bounded_range_neurons(
+        &creature,
+        &[
+            ("input-good".to_string(), good_records),
+            ("input-bad".to_string(), bad_records),
+        ],
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Only the boundary-clustered neuron should be detected"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "input-bad");
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Output neurons are excluded from bounded range detection.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_output_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            output("output-1", "TANH"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    // Output neuron with boundary cluster — should NOT be flagged
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+    for i in 0..40 {
+        records.push(record("output-1", i, -1.0, Some(-5.0)));
+    }
+    for i in 40..100 {
+        let val = 0.3 * ((i - 40) as f32 / 60.0);
+        records.push(record("output-1", i, val, Some(val)));
+    }
+
+    let candidates = detect_bounded_range_neurons(&creature, &[("output-1".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Output neurons should be excluded from detection"
+    );
+}


### PR DESCRIPTION
## Summary

Add bounded range discovery module (Issue #395) to detect observation and hidden neurons where a significant cluster of activation values sits at a sentinel boundary (e.g., -1, 0, or +1), separate from the "useful" range. This addresses the problem where observations normalised to -1…1 use sentinel values like -1 to represent null/missing data, which negatively impacts the creature's score when simply multiplied by a weight.

The module recommends adding a gating neuron (via `addNeuron` + `addSynapse` coordinated operations) that can learn to suppress the sentinel region while passing through useful-range values.

### Key Design Decisions

- **Sentinel detection at -1, 0, and +1**: These are the most common null sentinels in normalised data
- **Minimum 20% boundary fraction**: A significant cluster must exist at the sentinel value
- **Gap requirement**: There must be a measurable gap (≥ 0.05) between sentinel and useful range
- **Input and hidden neurons only**: Output neurons are excluded
- **Follows DRY pattern**: Uses the existing `discovery_dispatch::run_discovery_module` pattern from Issue #375
- **GPU-compatible candidate**: Recommends `AddNeuron` (RELU gating) + `AddSynapse`, which are standard coordinated structural operations

### Files Changed

| File | Change |
|------|--------|
| `src/analysis/bounded_range.rs` | New module: detection logic and candidate conversion |
| `src/analysis/mod.rs` | Register module and add dispatch call |
| `tests/issue_395_bounded_range_detection.rs` | 10 integration tests covering detection and edge cases |

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface. All behaviour is verified through automated tests.

## Test Plan

- `test_detects_observation_with_null_cluster_at_minus_one` — 40% at -1 sentinel detected
- `test_detects_observation_with_null_cluster_at_plus_one` — 35% at +1 sentinel detected
- `test_does_not_flag_uniform_distribution` — evenly spread values not flagged
- `test_detects_hidden_neuron_with_boundary_cluster` — hidden neuron with TANH saturation sentinel
- `test_insufficient_samples_not_detected` — below minimum sample threshold
- `test_all_same_values_not_detected` — constant values not flagged
- `test_detects_cluster_at_zero_sentinel` — 50% at 0.0 sentinel detected
- `test_coordinated_candidate_conversion` — valid coordinated structural operations produced
- `test_multiple_neurons_only_boundary_clustered_detected` — selective detection across multiple neurons
- `test_output_neurons_excluded` — output neurons correctly excluded

---

## Automated Fix Details
This PR addresses issue #395: **Plan (create GH issues) to discover bounded ranges**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #395