### PR TITLE
Fix: Bounded range neuron detection — identify neurons with restricted activation ranges (#399)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-399.md
+++ b/docs/pr-summary-399.md
@@ -1,0 +1,47 @@
+## Summary
+
+Adds a new `restricted_range` discovery module (Issue #399) that detects hidden neurons operating in a restricted sub-range of their activation function's output domain. For example, a TANH neuron consistently outputting values in [0.1, 0.3] is only using 10% of its [-1, 1] range, wasting representational capacity.
+
+This complements existing detection modules:
+- **Saturation detection** (Issue #342): neurons stuck at activation bounds.
+- **Dead neuron detection** (Issue #341): neurons with near-zero activation.
+- **Bounded range / sentinel detection** (Issue #395): sentinel clusters at boundary values.
+- **Restricted range** (this PR): neurons active but confined to a narrow band within the theoretical bounds.
+
+### Changes
+
+- **New module**: `src/analysis/restricted_range.rs` — detection logic and candidate generation.
+- **Integration**: Wired into `analyze_all()` via `run_discovery_module` dispatch pattern (DRY, Issue #375).
+- **Module registration**: Added to `src/analysis/mod.rs`.
+- **Tests**: 11 TDD tests in `tests/issue_399_restricted_range_detection.rs`.
+
+### Detection Logic
+
+- Computes `range_utilisation = (activation_max - activation_min) / theoretical_range` for bounded squash functions.
+- Flags neurons below a configurable utilisation threshold (default: 20%).
+- Excludes unbounded activations (IDENTITY, RELU, etc.), output neurons, dead neurons, and saturated neurons.
+
+### Candidate Types
+
+- `changeSquash` — switch to IDENTITY to remove bounding.
+- `setBias` — adjust bias to centre the operating region.
+- `setWeight` + `setBias` (coordinated) — scale incoming weights to expand range.
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+All 11 tests in `tests/issue_399_restricted_range_detection.rs`:
+- `test_detects_tanh_neuron_with_restricted_range` — TANH using 10% of range is detected
+- `test_does_not_flag_neuron_using_full_range` — TANH at 80% utilisation not flagged
+- `test_unbounded_activations_excluded` — IDENTITY and RELU skipped
+- `test_output_neurons_excluded` — output neurons skipped
+- `test_insufficient_samples_skipped` — fewer than 20 samples skipped
+- `test_dead_neurons_excluded` — near-zero activation excluded
+- `test_candidate_generation_includes_expected_operations` — produces changeSquash/setBias/setWeight
+- `test_configurable_utilisation_threshold` — custom threshold works
+- `test_multiple_neurons_only_restricted_detected` — only restricted neurons flagged
+- `test_detects_logistic_neuron_with_restricted_range` — LOGISTIC at 4% utilisation detected
+- `test_saturated_neurons_not_flagged_as_restricted` — saturation excluded

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -29,6 +29,7 @@
 //! - `output_bias_drift.rs` - Output bias drift detection for bias adjustment candidates (Issue #361)
 //! - `bounded_range.rs` - Bounded range detection for sentinel/null value gating (Issue #395)
 //! - `observation_range.rs` - Observation effective range detection from recorded samples (Issue #398)
+//! - `restricted_range.rs` - Restricted activation range detection for underutilised neurons (Issue #399)
 
 pub mod activation;
 pub mod bottleneck;
@@ -52,6 +53,7 @@ pub mod opposing_synapse;
 pub mod oscillating_neuron;
 pub mod output_bias_drift;
 pub mod redundant_path;
+pub mod restricted_range;
 pub mod samples;
 pub mod saturation;
 pub mod shared;
@@ -924,6 +926,38 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     return None;
                 }
                 let candidates = bounded_range::bounded_range_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #399: Restricted activation range detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "restricted range detection",
+            "restricted_range_detection",
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_records();
+                let config = restricted_range::RestrictedRangeConfig::default();
+                let detected = restricted_range::detect_restricted_range_neurons(
+                    &input.creature,
+                    &records,
+                    &config,
+                );
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = restricted_range::restricted_range_to_coordinated_candidates(
+                    &detected,
+                    &input.creature,
+                );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/src/analysis/restricted_range.rs
+++ b/src/analysis/restricted_range.rs
@@ -1,0 +1,325 @@
+//! Restricted activation range detection module (Issue #399).
+//!
+//! Hidden neurons may operate in a restricted sub-range of their activation
+//! function's output domain. For example, a TANH neuron consistently outputting
+//! values in [0.1, 0.3] is only using 10% of its [-1, 1] range. This wastes
+//! representational capacity and suggests the neuron's activation function,
+//! bias, or incoming weights are misconfigured.
+//!
+//! ## Relationship to Other Detection Modules
+//!
+//! - **Saturation detection** (Issue #342): neurons stuck at the *bounds* of
+//!   their activation (e.g., TANH at ±1).
+//! - **Dead neuron detection** (Issue #341): neurons with near-zero activation.
+//! - **Bounded range / sentinel detection** (Issue #395): neurons with sentinel
+//!   clusters at boundary values (e.g., -1 meaning "null").
+//! - **This module** (Issue #399): neurons *active* but confined to a narrow
+//!   band *within* the theoretical bounds.
+//!
+//! ## Detection Criteria
+//!
+//! A hidden neuron has a "restricted range" if:
+//! 1. It uses a bounded squash function (TANH, LOGISTIC, etc.).
+//! 2. `range_utilisation = (activation_max - activation_min) / theoretical_range`
+//!    is below a configurable threshold (default: 20%).
+//! 3. The neuron is not dead (observed range is not near zero).
+//! 4. The neuron is not saturated (not at the activation bounds).
+//! 5. Sufficient samples are available (≥ 20).
+//!
+//! ## Recommended Actions
+//!
+//! - `changeSquash` — switch to an activation function better suited to the
+//!   observed range (e.g., IDENTITY for a TANH neuron in a narrow band).
+//! - `setBias` — adjust bias to centre the neuron in its active region.
+//! - `setWeight` — scale incoming weights to expand the operating range.
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples required for reliable restricted range detection.
+const MIN_SAMPLES: usize = 20;
+
+/// Minimum observed range (activation_max - activation_min) to distinguish
+/// from dead neurons. Below this, the neuron is considered dead, not restricted.
+const MIN_OBSERVED_RANGE: f32 = 0.01;
+
+/// Distance from the theoretical bounds within which a neuron is considered
+/// saturated rather than restricted. If both activation_min and activation_max
+/// fall within this margin of the bounds, it is saturation.
+const SATURATION_MARGIN: f32 = 0.10;
+
+/// Configuration for restricted range detection.
+#[derive(Debug, Clone)]
+pub struct RestrictedRangeConfig {
+    /// Maximum range utilisation below which a neuron is flagged (default: 0.20 = 20%).
+    pub utilisation_threshold: f32,
+    /// Minimum samples required for detection.
+    pub min_samples: usize,
+}
+
+impl Default for RestrictedRangeConfig {
+    fn default() -> Self {
+        Self {
+            utilisation_threshold: 0.20,
+            min_samples: MIN_SAMPLES,
+        }
+    }
+}
+
+/// Result of detecting a restricted-range neuron.
+#[derive(Debug, Clone)]
+pub struct RestrictedRangeNeuron {
+    /// UUID of the neuron with the restricted range.
+    pub neuron_uuid: String,
+    /// Current squash (activation) function.
+    pub squash: String,
+    /// Current bias of the neuron.
+    pub bias: f32,
+    /// Minimum observed activation across samples.
+    pub activation_min: f32,
+    /// Maximum observed activation across samples.
+    pub activation_max: f32,
+    /// Theoretical range of the squash function (e.g., 2.0 for TANH).
+    pub theoretical_range: f32,
+    /// Ratio of observed range to theoretical range (0.0 to 1.0).
+    pub range_utilisation: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+}
+
+/// Returns the theoretical output range `(min, max)` for bounded squash functions.
+///
+/// Returns `None` for unbounded activations (IDENTITY, RELU, etc.) since they
+/// have no fixed output bounds and restricted range detection does not apply.
+fn theoretical_bounds(squash: &str) -> Option<(f32, f32)> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        "TANH" | "HARD_TANH" | "CLIPPED" | "BIPOLAR_SIGMOID" | "SOFTSIGN" | "ISRU" => {
+            Some((-1.0, 1.0))
+        }
+        "LOGISTIC" => Some((0.0, 1.0)),
+        "BIPOLAR" | "STEP" => Some((-1.0, 1.0)),
+        "ARCTAN" => {
+            // arctan output range is approximately (-π/2, π/2) ≈ (-1.5708, 1.5708)
+            Some((-std::f32::consts::FRAC_PI_2, std::f32::consts::FRAC_PI_2))
+        }
+        "RELU6" => Some((0.0, 6.0)),
+        _ => None, // Unbounded: IDENTITY, RELU, LEAKYRELU, ELU, SELU, GELU, MISH, etc.
+    }
+}
+
+/// Detect hidden neurons with restricted activation ranges.
+///
+/// Analyses hidden neurons to find those where the observed activation range
+/// is a small fraction of the theoretical range of their squash function.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+/// * `config` - Detection configuration (thresholds).
+///
+/// # Returns
+/// A list of `RestrictedRangeNeuron` sorted by range utilisation (lowest first).
+pub fn detect_restricted_range_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    config: &RestrictedRangeConfig,
+) -> Vec<RestrictedRangeNeuron> {
+    // Build map from UUID to neuron info (only hidden neurons)
+    let hidden_neurons: Vec<(&str, &str, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.as_str(), n.squash.as_str(), n.bias))
+        .collect();
+
+    let neuron_map: std::collections::HashMap<&str, (&str, f32)> = hidden_neurons
+        .iter()
+        .map(|&(uuid, squash, bias)| (uuid, (squash, bias)))
+        .collect();
+
+    let mut results = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        // Only consider hidden neurons
+        let Some(&(squash, bias)) = neuron_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        // Skip if insufficient samples
+        if records.len() < config.min_samples {
+            continue;
+        }
+
+        // Skip unbounded activations
+        let Some((theoretical_min, theoretical_max)) = theoretical_bounds(squash) else {
+            continue;
+        };
+        let theoretical_range = theoretical_max - theoretical_min;
+
+        // Compute observed activation range
+        let mut act_min = f32::INFINITY;
+        let mut act_max = f32::NEG_INFINITY;
+        for r in records {
+            act_min = act_min.min(r.activation);
+            act_max = act_max.max(r.activation);
+        }
+
+        let observed_range = act_max - act_min;
+
+        // Exclude dead neurons (near-zero range)
+        if observed_range < MIN_OBSERVED_RANGE {
+            continue;
+        }
+
+        // Exclude saturated neurons (at bounds)
+        // A neuron is "at bounds" if its activation range touches the theoretical
+        // boundary within SATURATION_MARGIN
+        let near_lower = act_min < (theoretical_min + SATURATION_MARGIN);
+        let near_upper = act_max > (theoretical_max - SATURATION_MARGIN);
+        if near_lower || near_upper {
+            continue;
+        }
+
+        // Compute range utilisation
+        let range_utilisation = observed_range / theoretical_range;
+
+        if range_utilisation >= config.utilisation_threshold {
+            continue;
+        }
+
+        results.push(RestrictedRangeNeuron {
+            neuron_uuid: uuid.clone(),
+            squash: squash.to_string(),
+            bias,
+            activation_min: act_min,
+            activation_max: act_max,
+            theoretical_range,
+            range_utilisation,
+            sample_count: records.len(),
+        });
+    }
+
+    // Sort by range utilisation (lowest first — worst offenders first)
+    results.sort_by(|a, b| {
+        a.range_utilisation
+            .partial_cmp(&b.range_utilisation)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+/// Convert restricted range neurons into coordinated structural candidates.
+///
+/// Each restricted-range neuron may produce multiple candidates:
+/// 1. **changeSquash** — switch to IDENTITY to remove the bounding constraint.
+/// 2. **setBias** — adjust bias to centre the operating range.
+/// 3. **setWeight** — scale incoming weights to expand the range.
+///
+/// Bias and weight adjustments are combined into a `coordinatedStructural`
+/// candidate for atomic application.
+pub fn restricted_range_to_coordinated_candidates(
+    detected: &[RestrictedRangeNeuron],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::new();
+
+    for n in detected {
+        let base_improvement = (1.0 - n.range_utilisation) * 0.005;
+
+        // Candidate 1: Change squash to IDENTITY (removes bounding)
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: n.neuron_uuid.clone(),
+                squash: "IDENTITY".to_string(),
+            }],
+            expected_creature_score_gain: base_improvement,
+            comment: Some(format!(
+                "Restricted range on {}: {} using {:.0}% of range [{:.3}, {:.3}] → change to IDENTITY",
+                n.neuron_uuid,
+                n.squash,
+                n.range_utilisation * 100.0,
+                n.activation_min,
+                n.activation_max,
+            )),
+        });
+
+        // Candidate 2: Adjust bias to centre the operating region
+        // The ideal centre of the activation function is the midpoint of the theoretical range.
+        // Move bias so the neuron's mean activation shifts toward that centre.
+        let observed_centre = (n.activation_min + n.activation_max) / 2.0;
+        let (theoretical_min, theoretical_max) =
+            theoretical_bounds(&n.squash).unwrap_or((-1.0, 1.0));
+        let theoretical_centre = (theoretical_min + theoretical_max) / 2.0;
+        let bias_delta = theoretical_centre - observed_centre;
+        let new_bias = n.bias + bias_delta;
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: n.neuron_uuid.clone(),
+                bias: new_bias,
+            }],
+            expected_creature_score_gain: base_improvement * 0.7,
+            comment: Some(format!(
+                "Restricted range on {}: {} using {:.0}% → adjust bias from {:.3} to {:.3} to centre activation",
+                n.neuron_uuid,
+                n.squash,
+                n.range_utilisation * 100.0,
+                n.bias,
+                new_bias,
+            )),
+        });
+
+        // Candidate 3: Scale incoming weights to expand the operating range
+        // Find all synapses targeting this neuron and compute a scale factor
+        let incoming_synapses: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.to_uuid == n.neuron_uuid)
+            .collect();
+
+        if !incoming_synapses.is_empty() {
+            // Scale factor: we want the observed range to expand to fill more of the
+            // theoretical range. Target ~80% utilisation.
+            let target_utilisation = 0.80;
+            let scale_factor = target_utilisation / n.range_utilisation.max(0.01);
+
+            let mut weight_ops: Vec<CoordinatedStructuralOpJson> = Vec::new();
+            for s in &incoming_synapses {
+                weight_ops.push(CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: s.from_uuid.clone(),
+                    to_neuron_uuid: s.to_uuid.clone(),
+                    weight: s.weight * scale_factor,
+                });
+            }
+
+            // Also adjust bias proportionally
+            weight_ops.push(CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: n.neuron_uuid.clone(),
+                bias: n.bias * scale_factor,
+            });
+
+            results.push(CoordinatedStructuralCandidateJson {
+                operations: weight_ops,
+                expected_creature_score_gain: base_improvement * 0.5,
+                comment: Some(format!(
+                    "Restricted range on {}: {} using {:.0}% → scale weights by {:.2}× to expand range",
+                    n.neuron_uuid,
+                    n.squash,
+                    n.range_utilisation * 100.0,
+                    scale_factor,
+                )),
+            });
+        }
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/tests/issue_399_restricted_range_detection.rs
+++ b/tests/issue_399_restricted_range_detection.rs
@@ -1,0 +1,467 @@
+//! Tests for Issue #399: Bounded range neuron detection — identify neurons with
+//! restricted activation ranges.
+//!
+//! Hidden neurons may operate in a restricted sub-range of their activation
+//! function's output domain. For example, a TANH neuron consistently outputting
+//! values in [0.1, 0.3] is only using 10% of its [-1, 1] range. This module
+//! detects such neurons and proposes corrective candidates.
+//!
+//! ## TDD Plan
+//! 1. Detect TANH neuron using only 10% of its range
+//! 2. Verify neurons using full range are NOT flagged
+//! 3. Verify unbounded activations (IDENTITY, RELU) are excluded
+//! 4. Verify output neurons are excluded
+//! 5. Verify insufficient samples are skipped
+//! 6. Verify dead neurons (near-zero activation) are excluded
+//! 7. Test candidate generation: changeSquash, setBias, setWeight
+//! 8. Test configurable utilisation threshold
+//! 9. Test multiple neurons — only restricted ones detected
+
+mod common;
+
+use common::{hidden, hidden_with_bias, make_creature, neuron, output, synapse};
+use neat_ai_discovery::analysis::restricted_range::{
+    detect_restricted_range_neurons, restricted_range_to_coordinated_candidates,
+    RestrictedRangeConfig,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::CoordinatedStructuralOpJson;
+
+/// Helper to create records for a neuron with activations in a specific range.
+fn make_records_in_range(
+    uuid: &str,
+    count: usize,
+    min_val: f32,
+    max_val: f32,
+) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| {
+            let t = i as f32 / (count - 1).max(1) as f32;
+            let activation = min_val + t * (max_val - min_val);
+            common::record(uuid, i as u32, activation, Some(activation))
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: TANH neuron using only 10% of its [-1, 1] range is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_tanh_neuron_with_restricted_range() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // TANH range is [-1, 1] (theoretical range = 2.0)
+    // Activations in [0.1, 0.3] → observed range = 0.2, utilisation = 0.2/2.0 = 10%
+    let records = make_records_in_range("h1", 100, 0.1, 0.3);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Should detect one restricted-range neuron"
+    );
+    let n = &detected[0];
+    assert_eq!(n.neuron_uuid, "h1");
+    assert!(
+        n.range_utilisation < 0.20,
+        "Range utilisation should be < 20%, got {:.2}%",
+        n.range_utilisation * 100.0
+    );
+    assert_eq!(n.squash, "TANH");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: TANH neuron using 80% of its range is NOT flagged.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_does_not_flag_neuron_using_full_range() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // Activations in [-0.8, 0.8] → observed range = 1.6, utilisation = 1.6/2.0 = 80%
+    let records = make_records_in_range("h1", 100, -0.8, 0.8);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Neuron using 80% of range should not be flagged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Unbounded activations (IDENTITY, RELU) are excluded.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_unbounded_activations_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h-identity", "IDENTITY"),
+            hidden("h-relu", "RELU"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h-identity", 0.5),
+            synapse("input-1", "h-relu", 0.5),
+            synapse("h-identity", "output-1", 0.3),
+            synapse("h-relu", "output-1", 0.3),
+        ],
+    );
+
+    // Even with narrow ranges, unbounded activations should not be flagged
+    let identity_records = make_records_in_range("h-identity", 100, 0.1, 0.2);
+    let relu_records = make_records_in_range("h-relu", 100, 0.1, 0.2);
+
+    let config = RestrictedRangeConfig::default();
+    let detected = detect_restricted_range_neurons(
+        &creature,
+        &[
+            ("h-identity".to_string(), identity_records),
+            ("h-relu".to_string(), relu_records),
+        ],
+        &config,
+    );
+
+    assert!(
+        detected.is_empty(),
+        "Unbounded activations should not be flagged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Output neurons are excluded.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_output_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            output("output-1", "TANH"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    // Output neuron with restricted range — should NOT be flagged
+    let records = make_records_in_range("output-1", 100, 0.1, 0.2);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("output-1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Output neurons should be excluded from detection"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Insufficient samples are skipped.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_insufficient_samples_skipped() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // Only 5 samples — below minimum threshold
+    let records = make_records_in_range("h1", 5, 0.1, 0.2);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Should not detect with insufficient samples"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Dead neurons (near-zero activation) are excluded.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_dead_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // Near-zero activations — this is a dead neuron, not a restricted range issue
+    let records = make_records_in_range("h1", 100, -0.001, 0.001);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Dead neurons should be excluded (near-zero activation)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Candidate generation includes changeSquash, setBias, setWeight.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_candidate_generation_includes_expected_operations() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 2.0),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.1),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // TANH neuron stuck in narrow band [0.3, 0.5] due to bias — clearly within bounds
+    let records = make_records_in_range("h1", 100, 0.3, 0.5);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        !detected.is_empty(),
+        "Should detect restricted-range neuron"
+    );
+
+    let coordinated = restricted_range_to_coordinated_candidates(&detected, &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    // Collect all operation types across all candidates
+    let mut has_change_squash = false;
+    let mut has_set_bias = false;
+    let mut has_set_weight = false;
+
+    for candidate in &coordinated {
+        assert!(
+            candidate.expected_creature_score_gain > 0.0,
+            "Expected improvement should be positive"
+        );
+        assert!(
+            candidate.comment.is_some(),
+            "Should include a descriptive comment"
+        );
+
+        for op in &candidate.operations {
+            match op {
+                CoordinatedStructuralOpJson::ChangeSquash { .. } => has_change_squash = true,
+                CoordinatedStructuralOpJson::SetBias { .. } => has_set_bias = true,
+                CoordinatedStructuralOpJson::SetWeight { .. } => has_set_weight = true,
+                _ => {}
+            }
+        }
+    }
+
+    assert!(
+        has_change_squash || has_set_bias || has_set_weight,
+        "Should produce at least one of changeSquash, setBias, or setWeight"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Configurable utilisation threshold.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_configurable_utilisation_threshold() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // TANH with range [-0.4, 0.4] → utilisation = 0.8/2.0 = 40%
+    let records = make_records_in_range("h1", 100, -0.4, 0.4);
+
+    // Default threshold (20%) — should NOT flag at 40% utilisation
+    let config_default = RestrictedRangeConfig::default();
+    let detected = detect_restricted_range_neurons(
+        &creature,
+        &[("h1".to_string(), records.clone())],
+        &config_default,
+    );
+    assert!(
+        detected.is_empty(),
+        "40% utilisation should not be flagged with default 20% threshold"
+    );
+
+    // Higher threshold (50%) — should flag at 40% utilisation
+    let config_strict = RestrictedRangeConfig {
+        utilisation_threshold: 0.50,
+        ..RestrictedRangeConfig::default()
+    };
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config_strict);
+    assert_eq!(
+        detected.len(),
+        1,
+        "40% utilisation should be flagged with 50% threshold"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Multiple neurons — only restricted ones detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_multiple_neurons_only_restricted_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h-good", "TANH"),
+            hidden("h-bad", "LOGISTIC"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h-good", 0.5),
+            synapse("input-1", "h-bad", 0.5),
+            synapse("h-good", "output-1", 0.3),
+            synapse("h-bad", "output-1", 0.3),
+        ],
+    );
+
+    // h-good: TANH using 70% of range → not flagged
+    let good_records = make_records_in_range("h-good", 100, -0.7, 0.7);
+
+    // h-bad: LOGISTIC using 10% of [0, 1] range → flagged
+    let bad_records = make_records_in_range("h-bad", 100, 0.45, 0.55);
+
+    let config = RestrictedRangeConfig::default();
+    let detected = detect_restricted_range_neurons(
+        &creature,
+        &[
+            ("h-good".to_string(), good_records),
+            ("h-bad".to_string(), bad_records),
+        ],
+        &config,
+    );
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Only the restricted-range neuron should be detected"
+    );
+    assert_eq!(detected[0].neuron_uuid, "h-bad");
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: LOGISTIC neuron with restricted range is detected.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_detects_logistic_neuron_with_restricted_range() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "LOGISTIC"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // LOGISTIC range is [0, 1] (theoretical range = 1.0)
+    // Activations in [0.48, 0.52] → utilisation = 0.04/1.0 = 4%
+    let records = make_records_in_range("h1", 100, 0.48, 0.52);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Should detect restricted LOGISTIC neuron"
+    );
+    let n = &detected[0];
+    assert!(
+        n.range_utilisation < 0.10,
+        "Range utilisation should be < 10%, got {:.2}%",
+        n.range_utilisation * 100.0
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Saturated neurons are NOT flagged (saturation is a different issue).
+// ---------------------------------------------------------------------------
+#[test]
+fn test_saturated_neurons_not_flagged_as_restricted() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.5),
+            synapse("h1", "output-1", 0.3),
+        ],
+    );
+
+    // TANH neuron stuck near +1 (saturated) — should NOT be flagged here
+    // Range [0.95, 1.0] → small range, but it's at the boundary (saturation, not restricted range)
+    let records = make_records_in_range("h1", 100, 0.95, 1.0);
+
+    let config = RestrictedRangeConfig::default();
+    let detected =
+        detect_restricted_range_neurons(&creature, &[("h1".to_string(), records)], &config);
+
+    // This is saturation, not a restricted range issue — should be excluded
+    assert!(
+        detected.is_empty(),
+        "Saturated neurons (at activation bounds) should not be flagged as restricted range"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a new `restricted_range` discovery module (Issue #399) that detects hidden neurons operating in a restricted sub-range of their activation function's output domain. For example, a TANH neuron consistently outputting values in [0.1, 0.3] is only using 10% of its [-1, 1] range, wasting representational capacity.

This complements existing detection modules:
- **Saturation detection** (Issue #342): neurons stuck at activation bounds.
- **Dead neuron detection** (Issue #341): neurons with near-zero activation.
- **Bounded range / sentinel detection** (Issue #395): sentinel clusters at boundary values.
- **Restricted range** (this PR): neurons active but confined to a narrow band within the theoretical bounds.

### Changes

- **New module**: `src/analysis/restricted_range.rs` — detection logic and candidate generation.
- **Integration**: Wired into `analyze_all()` via `run_discovery_module` dispatch pattern (DRY, Issue #375).
- **Module registration**: Added to `src/analysis/mod.rs`.
- **Tests**: 11 TDD tests in `tests/issue_399_restricted_range_detection.rs`.

### Detection Logic

- Computes `range_utilisation = (activation_max - activation_min) / theoretical_range` for bounded squash functions.
- Flags neurons below a configurable utilisation threshold (default: 20%).
- Excludes unbounded activations (IDENTITY, RELU, etc.), output neurons, dead neurons, and saturated neurons.

### Candidate Types

- `changeSquash` — switch to IDENTITY to remove bounding.
- `setBias` — adjust bias to centre the operating region.
- `setWeight` + `setBias` (coordinated) — scale incoming weights to expand range.

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

All 11 tests in `tests/issue_399_restricted_range_detection.rs`:
- `test_detects_tanh_neuron_with_restricted_range` — TANH using 10% of range is detected
- `test_does_not_flag_neuron_using_full_range` — TANH at 80% utilisation not flagged
- `test_unbounded_activations_excluded` — IDENTITY and RELU skipped
- `test_output_neurons_excluded` — output neurons skipped
- `test_insufficient_samples_skipped` — fewer than 20 samples skipped
- `test_dead_neurons_excluded` — near-zero activation excluded
- `test_candidate_generation_includes_expected_operations` — produces changeSquash/setBias/setWeight
- `test_configurable_utilisation_threshold` — custom threshold works
- `test_multiple_neurons_only_restricted_detected` — only restricted neurons flagged
- `test_detects_logistic_neuron_with_restricted_range` — LOGISTIC at 4% utilisation detected
- `test_saturated_neurons_not_flagged_as_restricted` — saturation excluded

---

## Automated Fix Details
This PR addresses issue #399: **Bounded range neuron detection — identify neurons with restricted activation ranges**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #399