### PR TITLE
Fix: Hidden neuron operating-point analysis — detect neurons working outside their effective zone (#401)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-401.md
+++ b/docs/pr-summary-401.md
@@ -1,0 +1,35 @@
+## Summary
+
+Added hidden neuron operating-point analysis module (Issue #401) that detects neurons working outside their squash function's effective zone. Unlike the restricted range module (#399) which analyses post-activation output range, this module analyses the **pre-activation (`value`) distribution** against each squash function's active zone to measure dynamic range utilisation.
+
+For example, a LOGISTIC neuron with a very negative bias always outputs ~0, wasting the sigmoid's S-curve. A TANH neuron with tiny incoming weights only uses the linear region near zero.
+
+### Changes
+
+- **`src/analysis/operating_point.rs`** (new): Detection module with:
+  - `detect_operating_point_issues()` — analyses pre-activation distribution vs squash active zone
+  - `operating_point_to_coordinated_candidates()` — generates `setBias`, `changeSquash`, and `setWeight` candidates
+  - `OperatingPointIssue` struct with dynamic range utilisation metric
+  - Reuses `target_simulation_fn()` from `src/activations.rs` for squash function evaluation
+  - Reuses `get_bias_range()` concepts from `src/analysis/activation.rs` for active zone bounds
+- **`src/analysis/mod.rs`**: Registered module and added `run_discovery_module` dispatch
+- **`tests/issue_401_operating_point_analysis.rs`** (new): 11 integration tests
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+11 tests covering detection and candidate generation:
+1. `test_detects_logistic_neuron_with_negative_operating_point` — LOGISTIC with very negative bias detected
+2. `test_detects_tanh_neuron_using_only_linear_region` — TANH confined to linear region detected
+3. `test_well_placed_tanh_not_flagged` — well-placed neuron not flagged
+4. `test_output_neurons_excluded` — output neurons excluded
+5. `test_input_neurons_excluded` — input neurons excluded
+6. `test_insufficient_samples_skipped` — fewer than 20 samples skipped
+7. `test_records_without_value_skipped` — records without pre-activation value skipped
+8. `test_unbounded_activations_excluded` — IDENTITY/RELU excluded
+9. `test_multiple_neurons_only_poorly_placed_detected` — only poorly-placed neurons flagged
+10. `test_candidate_generation_includes_expected_operations` — setBias, changeSquash, setWeight generated
+11. `test_configurable_utilisation_threshold` — custom threshold works

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -50,6 +50,7 @@ pub mod gpu;
 pub mod multi_hop;
 pub mod neuron;
 pub mod observation_range;
+pub mod operating_point;
 pub mod opposing_synapse;
 pub mod oscillating_neuron;
 pub mod output_bias_drift;
@@ -992,6 +993,38 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     return None;
                 }
                 let candidates = restricted_range::restricted_range_to_coordinated_candidates(
+                    &detected,
+                    &input.creature,
+                );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #401: Hidden neuron operating-point analysis
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "operating point analysis",
+            "operating_point_analysis",
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_records();
+                let config = operating_point::OperatingPointConfig::default();
+                let detected = operating_point::detect_operating_point_issues(
+                    &input.creature,
+                    &records,
+                    &config,
+                );
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = operating_point::operating_point_to_coordinated_candidates(
                     &detected,
                     &input.creature,
                 );

--- a/src/analysis/operating_point.rs
+++ b/src/analysis/operating_point.rs
@@ -1,0 +1,336 @@
+//! Hidden neuron operating-point analysis module (Issue #401).
+//!
+//! Hidden neurons may have a bias or incoming weight configuration that places
+//! their operating point outside the "active zone" of their squash function.
+//! For example:
+//! - A LOGISTIC neuron with a very negative bias always outputs ~0 (wasting
+//!   the sigmoid's S-curve).
+//! - A TANH neuron where the pre-activation (`value`) is always in [-0.1, 0.1]
+//!   — only using the linear region.
+//!
+//! ## Relationship to Other Detection Modules
+//!
+//! - **Restricted range** (Issue #399): analyses *activation* (post-squash)
+//!   output range as a fraction of the theoretical bounds.
+//! - **Saturation** (Issue #342): neurons stuck at the *bounds* of their
+//!   activation function.
+//! - **This module** (Issue #401): analyses the *pre-activation* (`value`)
+//!   distribution against the squash function's active zone to measure how
+//!   much of the dynamic range is actually being utilised.
+//!
+//! ## Detection Criteria
+//!
+//! A hidden neuron has an operating-point issue if:
+//! 1. It uses a bounded squash function with a known active zone.
+//! 2. `dynamic_range_utilisation` — the fraction of the squash function's
+//!    dynamic range actually exercised by the observed pre-activation
+//!    distribution — is below a configurable threshold (default: 20%).
+//! 3. Sufficient samples with pre-activation values are available (≥ 20).
+//!
+//! ## Recommended Actions
+//!
+//! - `setBias` — shift the operating point into the active zone.
+//! - `changeSquash` — switch to a function whose active zone matches the
+//!   current operating point.
+//! - `setWeight` — scale incoming weights to expand the pre-activation range.
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum samples with pre-activation values required for detection.
+const MIN_SAMPLES: usize = 20;
+
+/// Configuration for operating-point analysis.
+#[derive(Debug, Clone)]
+pub struct OperatingPointConfig {
+    /// Maximum dynamic range utilisation below which a neuron is flagged
+    /// (default: 0.20 = 20%).
+    pub utilisation_threshold: f32,
+    /// Minimum samples with valid pre-activation values.
+    pub min_samples: usize,
+}
+
+impl Default for OperatingPointConfig {
+    fn default() -> Self {
+        Self {
+            utilisation_threshold: 0.20,
+            min_samples: MIN_SAMPLES,
+        }
+    }
+}
+
+/// Result of detecting an operating-point issue on a hidden neuron.
+#[derive(Debug, Clone)]
+pub struct OperatingPointIssue {
+    /// UUID of the neuron with the operating-point issue.
+    pub neuron_uuid: String,
+    /// Current squash (activation) function name.
+    pub squash: String,
+    /// Current bias of the neuron.
+    pub bias: f32,
+    /// Minimum observed pre-activation value.
+    pub value_min: f32,
+    /// Maximum observed pre-activation value.
+    pub value_max: f32,
+    /// Active zone lower bound for the squash function.
+    pub active_zone_min: f32,
+    /// Active zone upper bound for the squash function.
+    pub active_zone_max: f32,
+    /// Fraction of the squash function's dynamic range being utilised (0.0–1.0).
+    pub dynamic_range_utilisation: f32,
+    /// Number of samples with valid pre-activation values.
+    pub sample_count: usize,
+}
+
+/// Returns the "active zone" `(min, max)` for a squash function — the
+/// pre-activation range over which the function transitions most of its
+/// output dynamic range.
+///
+/// Uses `get_bias_range()` from `src/analysis/activation.rs` as a baseline
+/// and narrows to the region where the function is most sensitive.
+///
+/// Returns `None` for unbounded or discrete activations where the concept
+/// of an active zone does not apply.
+fn active_zone(squash: &str) -> Option<(f32, f32)> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        // TANH: tanh(x) transitions from ~-0.96 to ~0.96 over x ∈ [-2, 2]
+        "TANH" | "HARD_TANH" | "CLIPPED" => Some((-2.0, 2.0)),
+        // LOGISTIC: sigmoid transitions from ~0.02 to ~0.98 over x ∈ [-4, 4]
+        "LOGISTIC" => Some((-4.0, 4.0)),
+        // SOFTSIGN: x/(1+|x|) transitions over a wider range
+        "SOFTSIGN" => Some((-4.0, 4.0)),
+        // ARCTAN: transitions over roughly [-3, 3]
+        "ARCTAN" => Some((-3.0, 3.0)),
+        // RELU6: active in [0, 6]
+        "RELU6" => Some((0.0, 6.0)),
+        // Discrete or unbounded activations — no meaningful active zone
+        _ => None,
+    }
+}
+
+/// Compute what fraction of a squash function's dynamic range is utilised
+/// by the given pre-activation range.
+///
+/// Uses `target_simulation_fn()` to evaluate the squash function at the
+/// observed min/max pre-activation values and at the active zone bounds,
+/// then computes the ratio of observed output range to theoretical output
+/// range.
+fn compute_dynamic_range_utilisation(
+    squash: &str,
+    value_min: f32,
+    value_max: f32,
+    zone_min: f32,
+    zone_max: f32,
+) -> f32 {
+    let activation_fn = match crate::activations::target_simulation_fn(squash) {
+        Some(f) => f,
+        None => return 0.0,
+    };
+
+    // Output range at the active zone bounds (theoretical dynamic range)
+    let zone_out_min = activation_fn(zone_min);
+    let zone_out_max = activation_fn(zone_max);
+    let theoretical_range = (zone_out_max - zone_out_min).abs();
+
+    if theoretical_range < 1e-9 {
+        return 0.0;
+    }
+
+    // Output range at the observed pre-activation bounds
+    let obs_out_min = activation_fn(value_min);
+    let obs_out_max = activation_fn(value_max);
+    let observed_range = (obs_out_max - obs_out_min).abs();
+
+    (observed_range / theoretical_range).clamp(0.0, 1.0)
+}
+
+/// Detect hidden neurons with operating-point issues.
+///
+/// Analyses pre-activation (`value`) distribution per hidden neuron and
+/// compares it against the squash function's active zone.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples.
+/// * `config` - Detection configuration.
+///
+/// # Returns
+/// A list of `OperatingPointIssue` sorted by utilisation (lowest first).
+pub fn detect_operating_point_issues(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    config: &OperatingPointConfig,
+) -> Vec<OperatingPointIssue> {
+    // Build map: UUID → (squash, bias) for hidden neurons only
+    let neuron_map: std::collections::HashMap<&str, (&str, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.as_str(), (n.squash.as_str(), n.bias)))
+        .collect();
+
+    let mut results = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        let Some(&(squash, bias)) = neuron_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        // Get the active zone for this squash function
+        let Some((zone_min, zone_max)) = active_zone(squash) else {
+            continue;
+        };
+
+        // Collect pre-activation values (only records that have `value`)
+        let values: Vec<f32> = records
+            .iter()
+            .filter_map(|r| r.value)
+            .filter(|v| v.is_finite())
+            .collect();
+
+        if values.len() < config.min_samples {
+            continue;
+        }
+
+        let value_min = values.iter().copied().fold(f32::INFINITY, f32::min);
+        let value_max = values.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+        let utilisation =
+            compute_dynamic_range_utilisation(squash, value_min, value_max, zone_min, zone_max);
+
+        if utilisation >= config.utilisation_threshold {
+            continue;
+        }
+
+        results.push(OperatingPointIssue {
+            neuron_uuid: uuid.clone(),
+            squash: squash.to_string(),
+            bias,
+            value_min,
+            value_max,
+            active_zone_min: zone_min,
+            active_zone_max: zone_max,
+            dynamic_range_utilisation: utilisation,
+            sample_count: values.len(),
+        });
+    }
+
+    // Sort by utilisation (lowest first — worst offenders first)
+    results.sort_by(|a, b| {
+        a.dynamic_range_utilisation
+            .partial_cmp(&b.dynamic_range_utilisation)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}
+
+/// Convert operating-point issues into coordinated structural candidates.
+///
+/// Each issue may produce up to three candidates:
+/// 1. **setBias** — shift the operating point into the active zone.
+/// 2. **changeSquash** — switch to a function whose active zone matches.
+/// 3. **setWeight** — scale incoming weights to expand the pre-activation range.
+pub fn operating_point_to_coordinated_candidates(
+    detected: &[OperatingPointIssue],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::new();
+
+    for issue in detected {
+        let base_improvement = (1.0 - issue.dynamic_range_utilisation) * 0.005;
+
+        // Candidate 1: setBias — shift the operating point to the centre of the active zone
+        let observed_centre = (issue.value_min + issue.value_max) / 2.0;
+        let active_zone_centre = (issue.active_zone_min + issue.active_zone_max) / 2.0;
+        let bias_delta = active_zone_centre - observed_centre;
+        let new_bias = issue.bias + bias_delta;
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: issue.neuron_uuid.clone(),
+                bias: new_bias,
+            }],
+            expected_creature_score_gain: base_improvement,
+            comment: Some(format!(
+                "Operating point on {}: {} using {:.0}% of dynamic range, pre-activation [{:.2}, {:.2}] vs active zone [{:.1}, {:.1}] → setBias from {:.3} to {:.3}",
+                issue.neuron_uuid,
+                issue.squash,
+                issue.dynamic_range_utilisation * 100.0,
+                issue.value_min,
+                issue.value_max,
+                issue.active_zone_min,
+                issue.active_zone_max,
+                issue.bias,
+                new_bias,
+            )),
+        });
+
+        // Candidate 2: changeSquash — switch to IDENTITY (no bounding)
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: issue.neuron_uuid.clone(),
+                squash: "IDENTITY".to_string(),
+            }],
+            expected_creature_score_gain: base_improvement * 0.7,
+            comment: Some(format!(
+                "Operating point on {}: {} using {:.0}% of dynamic range → changeSquash to IDENTITY",
+                issue.neuron_uuid,
+                issue.squash,
+                issue.dynamic_range_utilisation * 100.0,
+            )),
+        });
+
+        // Candidate 3: setWeight — scale incoming weights to expand range into active zone
+        let incoming_synapses: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.to_uuid == issue.neuron_uuid)
+            .collect();
+
+        if !incoming_synapses.is_empty() {
+            let observed_range = (issue.value_max - issue.value_min).abs().max(0.001);
+            let active_zone_range = issue.active_zone_max - issue.active_zone_min;
+            // Target 80% of active zone coverage
+            let target_range = active_zone_range * 0.80;
+            let scale_factor = target_range / observed_range;
+
+            let mut weight_ops: Vec<CoordinatedStructuralOpJson> = Vec::new();
+            for s in &incoming_synapses {
+                weight_ops.push(CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: s.from_uuid.clone(),
+                    to_neuron_uuid: s.to_uuid.clone(),
+                    weight: s.weight * scale_factor,
+                });
+            }
+
+            // Also adjust bias proportionally
+            weight_ops.push(CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: issue.neuron_uuid.clone(),
+                bias: issue.bias * scale_factor,
+            });
+
+            results.push(CoordinatedStructuralCandidateJson {
+                operations: weight_ops,
+                expected_creature_score_gain: base_improvement * 0.5,
+                comment: Some(format!(
+                    "Operating point on {}: {} using {:.0}% → setWeight scale {:.2}× to expand pre-activation range",
+                    issue.neuron_uuid,
+                    issue.squash,
+                    issue.dynamic_range_utilisation * 100.0,
+                    scale_factor,
+                )),
+            });
+        }
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/tests/issue_401_operating_point_analysis.rs
+++ b/tests/issue_401_operating_point_analysis.rs
@@ -1,0 +1,465 @@
+//! Tests for hidden neuron operating-point analysis (Issue #401).
+//!
+//! Detects neurons working outside their effective zone — e.g., a LOGISTIC
+//! neuron with a very negative bias that always outputs ~0, or a TANH neuron
+//! only using the linear region around zero.
+
+mod common;
+
+use common::{hidden, hidden_with_bias, make_creature, neuron, output, synapse};
+use neat_ai_discovery::analysis::operating_point::{
+    detect_operating_point_issues, operating_point_to_coordinated_candidates, OperatingPointConfig,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper to build a record with a specific pre-activation value.
+fn record_with_value(uuid: &str, obs_index: u32, activation: f32, value: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+// ============================================================================
+// Detection tests
+// ============================================================================
+
+/// A LOGISTIC neuron with very negative pre-activation values (always outputting ~0)
+/// should be flagged — the S-curve is wasted.
+#[test]
+fn test_detects_logistic_neuron_with_negative_operating_point() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "LOGISTIC", -10.0),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.5), synapse("h1", "out", 1.0)],
+    );
+
+    // Pre-activation always very negative → activation always near 0
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -8.0 + (i as f32) * 0.02; // range [-8.0, -6.0]
+        let activation = 1.0 / (1.0 + (-value).exp()); // logistic → near 0
+        records.push(record_with_value("h1", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Should detect the poorly-placed LOGISTIC neuron"
+    );
+    assert_eq!(detected[0].neuron_uuid, "h1");
+    assert!(
+        detected[0].dynamic_range_utilisation < 0.20,
+        "Utilisation should be very low: got {:.3}",
+        detected[0].dynamic_range_utilisation
+    );
+}
+
+/// A TANH neuron where pre-activation is always near zero (only using linear region)
+/// should be flagged.
+#[test]
+fn test_detects_tanh_neuron_using_only_linear_region() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.01), synapse("h1", "out", 1.0)],
+    );
+
+    // Pre-activation in [-0.1, 0.1] → TANH outputs in ~[-0.1, 0.1] (linear region)
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -0.1 + (i as f32) * 0.002;
+        let activation = value.tanh();
+        records.push(record_with_value("h1", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Should detect TANH neuron in linear region only"
+    );
+    assert!(detected[0].dynamic_range_utilisation < 0.15);
+}
+
+/// A TANH neuron well-placed in its active zone should NOT be flagged.
+#[test]
+fn test_well_placed_tanh_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 1.0), synapse("h1", "out", 1.0)],
+    );
+
+    // Pre-activation spread across [-2, 2] → TANH outputs span most of [-0.96, 0.96]
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -2.0 + (i as f32) * 0.04;
+        let activation = value.tanh();
+        records.push(record_with_value("h1", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Well-placed neuron should not be flagged"
+    );
+}
+
+/// Output neurons should be excluded from operating-point analysis.
+#[test]
+fn test_output_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("out", "output", "LOGISTIC"),
+        ],
+        vec![synapse("input-1", "out", 0.01)],
+    );
+
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -0.05 + (i as f32) * 0.001;
+        let activation = 1.0 / (1.0 + (-value).exp());
+        records.push(record_with_value("out", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("out".to_string(), records)], &config);
+
+    assert!(detected.is_empty(), "Output neurons should be excluded");
+}
+
+/// Input neurons should be excluded from operating-point analysis.
+#[test]
+fn test_input_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "LOGISTIC"),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "out", 1.0)],
+    );
+
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -0.05 + (i as f32) * 0.001;
+        let activation = 1.0 / (1.0 + (-value).exp());
+        records.push(record_with_value("input-1", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("input-1".to_string(), records)], &config);
+
+    assert!(detected.is_empty(), "Input neurons should be excluded");
+}
+
+/// Neurons with fewer than min_samples should not be flagged.
+#[test]
+fn test_insufficient_samples_skipped() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "LOGISTIC", -10.0),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.5), synapse("h1", "out", 1.0)],
+    );
+
+    // Only 5 samples (below the default threshold of 20)
+    let mut records = Vec::new();
+    for i in 0..5 {
+        let value = -8.0 + (i as f32) * 0.5;
+        let activation = 1.0 / (1.0 + (-value).exp());
+        records.push(record_with_value("h1", i, activation, value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Records without pre-activation values (value=None) should be skipped.
+#[test]
+fn test_records_without_value_skipped() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "LOGISTIC", -10.0),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.5), synapse("h1", "out", 1.0)],
+    );
+
+    // Records without pre-activation value
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "h1".to_string(),
+            value: None,
+            activation: 0.01,
+            errors: vec![0.01],
+        })
+        .collect();
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Records without value should not trigger detection"
+    );
+}
+
+/// Unbounded activations (IDENTITY, RELU) have no fixed active zone,
+/// so they should not be flagged by this module.
+#[test]
+fn test_unbounded_activations_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "IDENTITY"),
+            hidden("h2", "RELU"),
+            output("out", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "h1", 0.01),
+            synapse("input-1", "h2", 0.01),
+            synapse("h1", "out", 1.0),
+            synapse("h2", "out", 1.0),
+        ],
+    );
+
+    let mut records = Vec::new();
+    for i in 0..100 {
+        let value = -0.05 + (i as f32) * 0.001;
+        records.push(record_with_value("h1", i, value, value)); // IDENTITY: activation==value
+        records.push(record_with_value("h2", i, value.max(0.0), value));
+    }
+
+    let config = OperatingPointConfig::default();
+    let h1_records: Vec<_> = records
+        .iter()
+        .filter(|r| r.neuron_uuid == "h1")
+        .cloned()
+        .collect();
+    let h2_records: Vec<_> = records
+        .iter()
+        .filter(|r| r.neuron_uuid == "h2")
+        .cloned()
+        .collect();
+    let detected = detect_operating_point_issues(
+        &creature,
+        &[
+            ("h1".to_string(), h1_records),
+            ("h2".to_string(), h2_records),
+        ],
+        &config,
+    );
+
+    assert!(
+        detected.is_empty(),
+        "Unbounded activations should be excluded"
+    );
+}
+
+/// Multiple neurons — only the poorly-placed one should be detected.
+#[test]
+fn test_multiple_neurons_only_poorly_placed_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("good", "TANH", 0.0),
+            hidden_with_bias("bad", "LOGISTIC", -10.0),
+            output("out", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "good", 1.0),
+            synapse("input-1", "bad", 0.5),
+            synapse("good", "out", 1.0),
+            synapse("bad", "out", 1.0),
+        ],
+    );
+
+    // "good" neuron: well-placed
+    let good_records: Vec<_> = (0..100)
+        .map(|i| {
+            let value = -2.0 + (i as f32) * 0.04;
+            record_with_value("good", i, value.tanh(), value)
+        })
+        .collect();
+
+    // "bad" neuron: stuck near 0
+    let bad_records: Vec<_> = (0..100)
+        .map(|i| {
+            let value = -8.0 + (i as f32) * 0.02;
+            let activation = 1.0 / (1.0 + (-value).exp());
+            record_with_value("bad", i, activation, value)
+        })
+        .collect();
+
+    let config = OperatingPointConfig::default();
+    let detected = detect_operating_point_issues(
+        &creature,
+        &[
+            ("good".to_string(), good_records),
+            ("bad".to_string(), bad_records),
+        ],
+        &config,
+    );
+
+    assert_eq!(
+        detected.len(),
+        1,
+        "Only the poorly-placed neuron should be detected"
+    );
+    assert_eq!(detected[0].neuron_uuid, "bad");
+}
+
+// ============================================================================
+// Candidate generation tests
+// ============================================================================
+
+/// Candidate generation should produce setBias, changeSquash, and setWeight candidates.
+#[test]
+fn test_candidate_generation_includes_expected_operations() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "LOGISTIC", -10.0),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.5), synapse("h1", "out", 1.0)],
+    );
+
+    let records: Vec<_> = (0..100)
+        .map(|i| {
+            let value = -8.0 + (i as f32) * 0.02;
+            let activation = 1.0 / (1.0 + (-value).exp());
+            record_with_value("h1", i, activation, value)
+        })
+        .collect();
+
+    let config = OperatingPointConfig::default();
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &config);
+
+    assert!(!detected.is_empty());
+
+    let candidates = operating_point_to_coordinated_candidates(&detected, &creature);
+    assert!(!candidates.is_empty(), "Should produce candidates");
+
+    // Check we have the three candidate types
+    let comments: Vec<String> = candidates
+        .iter()
+        .filter_map(|c| c.comment.as_ref().cloned())
+        .collect();
+
+    let has_set_bias = comments
+        .iter()
+        .any(|c| c.contains("setBias") || c.contains("bias"));
+    let has_change_squash = comments
+        .iter()
+        .any(|c| c.contains("changeSquash") || c.contains("squash"));
+    let has_set_weight = comments
+        .iter()
+        .any(|c| c.contains("setWeight") || c.contains("weight"));
+
+    assert!(
+        has_set_bias,
+        "Should have a setBias candidate. Comments: {comments:?}"
+    );
+    assert!(
+        has_change_squash,
+        "Should have a changeSquash candidate. Comments: {comments:?}"
+    );
+    assert!(
+        has_set_weight,
+        "Should have a setWeight candidate. Comments: {comments:?}"
+    );
+
+    // All candidates should have positive expected improvement
+    for c in &candidates {
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "Expected positive improvement, got {}",
+            c.expected_creature_score_gain
+        );
+    }
+}
+
+/// Configurable utilisation threshold should work.
+#[test]
+fn test_configurable_utilisation_threshold() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            hidden("h1", "TANH"),
+            output("out", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "h1", 0.5), synapse("h1", "out", 1.0)],
+    );
+
+    // Pre-activation range [-1, 1] → TANH outputs ~[-0.76, 0.76] = ~76% utilisation
+    let records: Vec<_> = (0..100)
+        .map(|i| {
+            let value = -1.0 + (i as f32) * 0.02;
+            record_with_value("h1", i, value.tanh(), value)
+        })
+        .collect();
+
+    // Default threshold (20%) — should NOT flag this neuron
+    let default_config = OperatingPointConfig::default();
+    let detected = detect_operating_point_issues(
+        &creature,
+        &[("h1".to_string(), records.clone())],
+        &default_config,
+    );
+    assert!(
+        detected.is_empty(),
+        "76% utilisation should not be flagged at default threshold"
+    );
+
+    // High threshold (80%) — SHOULD flag this neuron
+    let strict_config = OperatingPointConfig {
+        utilisation_threshold: 0.80,
+        ..Default::default()
+    };
+    let detected =
+        detect_operating_point_issues(&creature, &[("h1".to_string(), records)], &strict_config);
+    assert_eq!(
+        detected.len(),
+        1,
+        "76% utilisation should be flagged at 80% threshold"
+    );
+}


### PR DESCRIPTION
## Summary

Added hidden neuron operating-point analysis module (Issue #401) that detects neurons working outside their squash function's effective zone. Unlike the restricted range module (#399) which analyses post-activation output range, this module analyses the **pre-activation (`value`) distribution** against each squash function's active zone to measure dynamic range utilisation.

For example, a LOGISTIC neuron with a very negative bias always outputs ~0, wasting the sigmoid's S-curve. A TANH neuron with tiny incoming weights only uses the linear region near zero.

### Changes

- **`src/analysis/operating_point.rs`** (new): Detection module with:
  - `detect_operating_point_issues()` — analyses pre-activation distribution vs squash active zone
  - `operating_point_to_coordinated_candidates()` — generates `setBias`, `changeSquash`, and `setWeight` candidates
  - `OperatingPointIssue` struct with dynamic range utilisation metric
  - Reuses `target_simulation_fn()` from `src/activations.rs` for squash function evaluation
  - Reuses `get_bias_range()` concepts from `src/analysis/activation.rs` for active zone bounds
- **`src/analysis/mod.rs`**: Registered module and added `run_discovery_module` dispatch
- **`tests/issue_401_operating_point_analysis.rs`** (new): 11 integration tests

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

11 tests covering detection and candidate generation:
1. `test_detects_logistic_neuron_with_negative_operating_point` — LOGISTIC with very negative bias detected
2. `test_detects_tanh_neuron_using_only_linear_region` — TANH confined to linear region detected
3. `test_well_placed_tanh_not_flagged` — well-placed neuron not flagged
4. `test_output_neurons_excluded` — output neurons excluded
5. `test_input_neurons_excluded` — input neurons excluded
6. `test_insufficient_samples_skipped` — fewer than 20 samples skipped
7. `test_records_without_value_skipped` — records without pre-activation value skipped
8. `test_unbounded_activations_excluded` — IDENTITY/RELU excluded
9. `test_multiple_neurons_only_poorly_placed_detected` — only poorly-placed neurons flagged
10. `test_candidate_generation_includes_expected_operations` — setBias, changeSquash, setWeight generated
11. `test_configurable_utilisation_threshold` — custom threshold works

---

## Automated Fix Details
This PR addresses issue #401: **Hidden neuron operating-point analysis — detect neurons working outside their effective zone**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #401