### PR TITLE
Fix: Fix remove-neuron (high error) discovery - 0% success rate (#414)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.9"
+version = "0.10.10"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.10"
+version = "0.10.11"
 edition = "2021"
 
 [lib]

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -72,7 +72,7 @@ NEAT-AI-Discovery (Rust)          NEAT-AI (TypeScript)
 | [Add Synapses](#add-synapses) | `synapse.rs` | — | `addSynapse` | ⚠️ Low volume |
 | [Remove Low-Impact](#remove-low-impact-neurons) | `neuron.rs` | — | `removeNeuron` | 🟢 Active |
 | [Remove Harmful Synapse](#remove-harmful-synapse) | `synapse.rs` | — | `removeSynapse` | 🟠 Not tested |
-| [Remove Neuron (Error)](#remove-neuron-high-error) | `neuron.rs` | — | `removeNeuron` | 🔴 Not working |
+| [Remove Neuron (Error)](#remove-neuron-high-error) | `focus.rs` | #414 | `removeNeuron` | ⛔ Disabled |
 | [Combo Successful](#combo-successful) | — | — | Multiple | 🔴 Not working |
 
 ### Status Legend
@@ -83,6 +83,7 @@ NEAT-AI-Discovery (Rust)          NEAT-AI (TypeScript)
 | 🟠 Not tested | Rust produces candidates but NEAT-AI does not test them yet |
 | ⚠️ Low volume | Working but rarely suggested |
 | 🔴 Not working | Being tested but 0% success rate |
+| ⛔ Disabled | Permanently disabled due to fundamental flaw |
 
 ---
 
@@ -522,23 +523,42 @@ the NEAT-AI score gain check.
 
 ### Remove Neuron (High Error)
 
-**Source**: `src/analysis/neuron.rs`
+**Source**: `src/focus.rs` (previously active, now disabled)
 
 **Purpose**: Remove neurons with extremely high error magnitude (harmful
 neurons).
 
-**How it works**:
+**How it worked**:
 
-1. Rust identifies neurons with abnormally high error (e.g., 5.8e+17).
-2. These neurons are presumed to be destabilising the network.
-3. Removing them is predicted to improve the overall score.
+1. Rust identified neurons with raw_error ≥ 10× max_output_error.
+2. These neurons were presumed to be destabilising the network.
+3. Removing them was predicted to improve the overall score.
 
-**Current status**: 🔴 Not working — 0 successes from 2 attempts. The massive
-discrepancy between predicted improvement and actual result suggests the error
-magnitude calculation may not translate to actual score improvement.
+**Current status**: 🔴 **DISABLED** (Issue #414)
 
-**Output**: Emitted as `removalCandidates` in the analysis result with
-`removeNeuron` operations.
+Production data showed a 0% success rate (0 successes from 2 attempts). The
+fundamental assumption was flawed:
+
+**Root cause: High error ≠ harmful neuron**
+
+A neuron with high recorded error is often:
+1. **Handling difficult samples**: It's the only computation path for hard cases
+2. **Receiving bad inputs**: The error is a symptom, not a cause
+3. **Fighting incorrect biases**: It's compensating for problems elsewhere
+
+Removing such neurons typically makes performance **worse** because:
+- Difficult samples lose their only computation path
+- The network loses the only neuron attempting to handle a specific pattern
+
+Error magnitude measures how **wrong** the neuron's output is, not how
+**harmful** the neuron is to the network's overall score. This is why predicted
+improvements (based on error magnitude) did not match actual outcomes.
+
+**Resolution**: This discovery type has been disabled. The legitimate
+"remove-low-impact" discovery (based on activation_weighted_impact < costOfGrowth)
+remains active with a 17.6% success rate.
+
+**Output**: No longer emitted (disabled).
 
 ---
 
@@ -612,7 +632,7 @@ All 7 operation types are implemented in NEAT-AI's
 | **change-squash** | 2 | 9 | 18.2% | ⚠️ Low volume |
 | **remove-low-impact** | 65 | 304 | 17.6% | 🟢 Active |
 | **remove-harmful-synapse** | — | — | — | 🟠 Not tested |
-| **remove-neuron** | 0 | 2 | 0.0% | 🔴 Not working |
+| **remove-neuron (high error)** | 0 | 2 | 0.0% | ⛔ Disabled (#414) |
 | **dead-neuron-removal** | — | — | — | 🟢 Active |
 | **redundant-path-pruning** | — | — | — | 🟢 Active |
 | **combo-successful** | 0 | 8 | 0.0% | 🔴 Not working |
@@ -647,8 +667,9 @@ All 7 operation types are implemented in NEAT-AI's
 
 ### What is Not Working
 
-1. **remove-neuron** — Massive prediction errors. Error magnitude (5.8e+17)
-   does not translate to score impact.
+1. **remove-neuron (high error)** — ⛔ **DISABLED (Issue #414)**. High error
+   neurons are often handling difficult samples, not causing harm. Error
+   magnitude does not translate to score impact.
 
 2. **combo-successful** — Interference between changes. Individual successes
    do not combine well.
@@ -658,9 +679,9 @@ All 7 operation types are implemented in NEAT-AI's
 | Priority | Action | Rationale |
 |----------|--------|-----------|
 | Done | Verify coordinated-structural implementation (Issue #337) | NEAT-AI implements all 7 operation types |
+| Done | Disable remove-neuron (high error) (Issue #414) | 0% success rate; fundamental assumption flawed |
 | High | Investigate why harmful_synapses are not recorded | Mapping exists but no samples in discovery folder |
 | High | Investigate add-synapses prediction inversion | 10 samples show consistent wrong-direction predictions |
-| High | Disable or fix remove-neuron | 0% success rate, wasting validation cycles |
 | Medium | Review combo-successful strategy | 0% success rate, may be attempting incompatible combinations |
 | Medium | Investigate change-squash suggestion rate | 18.2% success rate but only 11 samples |
 | Low | Optimise add-neurons variants | Already working, but room for improvement |

--- a/docs/pr-summary-414.md
+++ b/docs/pr-summary-414.md
@@ -1,0 +1,61 @@
+# PR Summary: Fix Remove-Neuron (High Error) Discovery — Issue #414
+
+## Summary
+
+Disabled the "remove-neuron (high error)" discovery type which had a 0% success rate (0 successes from 2 attempts). The root cause was a **fundamentally flawed assumption**: high error magnitude on a neuron does not mean the neuron is harmful to the network.
+
+### Root Cause Analysis
+
+The discovery type selected neurons where `raw_error >= 10 × max_output_error` and proposed removing them as "exploratory ablation candidates". This was based on the assumption that high error means the neuron is destabilising the network.
+
+**Why this assumption is wrong:**
+
+A neuron with high recorded error is often:
+1. **Handling difficult samples** — It's the only computation path for hard cases
+2. **Receiving bad inputs** — The error is a symptom of upstream problems, not a cause
+3. **Fighting incorrect biases** — It's compensating for problems elsewhere in the network
+
+Removing such neurons typically makes performance **worse** because:
+- Difficult samples lose their only computation path
+- The network loses the only neuron attempting to handle a specific pattern
+
+**Key insight**: Error magnitude measures how **wrong** the neuron's output is, not how **harmful** the neuron is to the network's overall score.
+
+### Changes Made
+
+1. **Disabled high-error exploratory ablation** in `src/focus.rs` (both occurrences)
+2. **Updated existing test** in `tests/exploratory_ablation_candidates.rs` to verify the behaviour is disabled
+3. **Added new tests** in `tests/issue_414_remove_neuron_high_error.rs` to verify:
+   - High-error neurons are NOT returned as removal candidates
+   - Low-impact neurons are STILL returned as removal candidates (legitimate removal)
+   - Removal candidate reasons reflect impact, not error magnitude
+4. **Updated documentation** in `docs/DISCOVERY_TYPES.md` with:
+   - Root cause analysis
+   - Status changed from "Not working" to "Disabled"
+   - Updated recommendations table
+
+### What Remains Active
+
+The legitimate "remove-low-impact" discovery type remains active with a 17.6% success rate. This discovery type identifies neurons where `activation_weighted_impact < costOfGrowth` — neurons that genuinely don't contribute to the network.
+
+## Evidence
+
+This is a backend logic fix with no UI changes. Evidence is provided through the test suite.
+
+## Test Plan
+
+New and updated tests verify the fix:
+
+| Test File | Test Name | Purpose |
+|-----------|-----------|---------|
+| `tests/issue_414_remove_neuron_high_error.rs` | `high_error_neuron_is_not_returned_as_exploratory_ablation_candidate` | Verifies high-error neurons are no longer suggested for removal |
+| `tests/issue_414_remove_neuron_high_error.rs` | `low_impact_neurons_still_returned_as_removal_candidates` | Verifies legitimate low-impact removal still works |
+| `tests/issue_414_remove_neuron_high_error.rs` | `removal_candidate_reason_reflects_impact_not_error` | Verifies removal reasons mention impact, not error |
+| `tests/exploratory_ablation_candidates.rs` | `high_error_hidden_neuron_is_not_returned_as_exploratory_ablation_candidate` | Updated existing test to verify new behaviour |
+
+All tests pass with `./quality.sh`.
+
+## Acceptance Criteria
+
+- [x] Either achieve >5% success rate OR disable the discovery type — **Disabled**
+- [x] Document the root cause in `docs/DISCOVERY_TYPES.md` — **Done**

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -2352,83 +2352,32 @@ pub fn rank_focus_neurons(
         })
         .collect();
 
-    // Extra candidates: high-error exploratory ablations
+    // Issue #414: High-error exploratory ablation DISABLED
     //
-    // Rationale: A neuron can have very high recorded error yet still be high-impact. Removing
-    // such a neuron is NOT a "safe prune", but it can be a worthwhile ablation test: clone the
-    // creature, remove/disable the neuron, then re-score on the full training set. Keep only
-    // if the score improves.
+    // Previously, neurons with raw_error >= 10× max_output_error were returned as
+    // "exploratory ablation candidates". This discovery type had a 0% success rate
+    // (0 successes from 2 attempts) because the fundamental assumption was flawed:
     //
-    // We intentionally keep these candidates limited in count and clearly labelled so callers
-    // can treat them as exploratory.
-    const EXPLORATORY_ABLATION_MAX: usize = 5;
-    const EXPLORATORY_ERROR_MULTIPLIER: f32 = 10.0;
-
-    if max_output_error > 0.0 {
-        let neuron_types: HashMap<&str, &str> = creature
-            .neurons
-            .iter()
-            .map(|n: &NeuronJson| (n.uuid.as_str(), n.neuron_type.as_str()))
-            .collect();
-
-        let already_selected: HashSet<&str> = removal_candidates
-            .iter()
-            .map(|c| c.neuron_uuid.as_str())
-            .collect();
-
-        let mut high_error_neurons: Vec<&RankedNeuron> = neurons
-            .iter()
-            .filter(|n| !already_selected.contains(n.neuron_uuid.as_str()))
-            // Only propose exploratory removals for hidden neurons.
-            .filter(|n| neuron_types.get(n.neuron_uuid.as_str()) == Some(&"hidden"))
-            // Only when error is meaningfully larger than output error scale.
-            .filter(|n| n.raw_error >= max_output_error * EXPLORATORY_ERROR_MULTIPLIER)
-            .collect();
-
-        high_error_neurons.sort_by(|a, b| {
-            b.raw_error
-                .partial_cmp(&a.raw_error)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| b.impact.partial_cmp(&a.impact).unwrap_or(Ordering::Equal))
-                .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
-        });
-
-        high_error_neurons.truncate(EXPLORATORY_ABLATION_MAX);
-
-        for n in high_error_neurons {
-            // Issue #208: Use pre-computed synapse counts for O(1) lookup
-            let (incoming, outgoing) = synapse_counts.get(&n.neuron_uuid);
-            let savings = calculate_removal_savings(incoming, outgoing, cost_of_growth_threshold);
-
-            removal_candidates.push(RemovalCandidate {
-                neuron_uuid: n.neuron_uuid.clone(),
-                total_error: n.total_error,
-                impact: n.impact,
-                mean_activation: n.mean_activation,
-                activation_weighted_impact: n.activation_weighted_impact,
-                incoming_synapses: incoming,
-                outgoing_synapses: outgoing,
-                removal_savings: savings,
-                // Exploratory candidates must not claim a predicted improvement. The controller
-                // will run an ablation test on the full training set to validate.
-                expected_error_reduction: 0.0,
-                reason: format!(
-                    "Exploratory ablation candidate (high error): raw_error {:.2e} (clamped {:.2e}), \
-                     activation_weighted_impact {:.2e} >= costOfGrowth ({:.2e}). \
-                     This is NOT a safe prune - validate by full-dataset ablation test.",
-                    n.raw_error,
-                    n.total_error,
-                    n.activation_weighted_impact,
-                    cost_of_growth_threshold
-                ),
-            });
-        }
-    }
+    // **High error ≠ harmful neuron**
+    //
+    // A neuron with high recorded error is often:
+    // 1. Handling the most difficult samples (it's the only path for hard cases)
+    // 2. Receiving bad inputs from upstream (the error is a symptom, not a cause)
+    // 3. Fighting against incorrect biases elsewhere in the network
+    //
+    // Removing such neurons typically makes performance WORSE because:
+    // - The difficult samples lose their only computation path
+    // - The network loses the only neuron attempting to handle a specific pattern
+    //
+    // Error magnitude measures how WRONG the neuron's output is, not how HARMFUL
+    // the neuron is to the network's overall score. This is why predicted
+    // improvements (based on error magnitude) did not match actual outcomes.
+    //
+    // The legitimate removal candidate detection (based on activation_weighted_impact
+    // < costOfGrowth) remains active and has a 17.6% success rate.
 
     // Issue #235: Sort by net improvement (removal_savings - activation_weighted_impact).
     // Higher net improvement = better candidate (removing it saves more than its contribution).
-    // Exploratory candidates (from high-error section) have expected_error_reduction = 0.0,
-    // so they sort last (their net improvement calculation uses impact directly).
     removal_candidates.sort_by(|a, b| {
         // Calculate net improvement for each candidate
         let a_net = a.removal_savings - a.activation_weighted_impact;
@@ -2831,65 +2780,7 @@ pub fn rank_focus_neurons_with_history(
         })
         .collect();
 
-    // Extra candidates: high-error exploratory ablations (same as rank_focus_neurons)
-    const EXPLORATORY_ABLATION_MAX: usize = 5;
-    const EXPLORATORY_ERROR_MULTIPLIER: f32 = 10.0;
-
-    if max_output_error > 0.0 {
-        let neuron_types: HashMap<&str, &str> = creature
-            .neurons
-            .iter()
-            .map(|n: &NeuronJson| (n.uuid.as_str(), n.neuron_type.as_str()))
-            .collect();
-
-        let already_selected: HashSet<&str> = removal_candidates
-            .iter()
-            .map(|c| c.neuron_uuid.as_str())
-            .collect();
-
-        let mut high_error_neurons: Vec<&RankedNeuron> = neurons
-            .iter()
-            .filter(|n| !already_selected.contains(n.neuron_uuid.as_str()))
-            .filter(|n| neuron_types.get(n.neuron_uuid.as_str()) == Some(&"hidden"))
-            .filter(|n| n.raw_error >= max_output_error * EXPLORATORY_ERROR_MULTIPLIER)
-            .collect();
-
-        high_error_neurons.sort_by(|a, b| {
-            b.raw_error
-                .partial_cmp(&a.raw_error)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| b.impact.partial_cmp(&a.impact).unwrap_or(Ordering::Equal))
-                .then_with(|| a.neuron_uuid.cmp(&b.neuron_uuid))
-        });
-
-        high_error_neurons.truncate(EXPLORATORY_ABLATION_MAX);
-
-        for n in high_error_neurons {
-            let (incoming, outgoing) = synapse_counts.get(&n.neuron_uuid);
-            let savings = calculate_removal_savings(incoming, outgoing, cost_of_growth_threshold);
-
-            removal_candidates.push(RemovalCandidate {
-                neuron_uuid: n.neuron_uuid.clone(),
-                total_error: n.total_error,
-                impact: n.impact,
-                mean_activation: n.mean_activation,
-                activation_weighted_impact: n.activation_weighted_impact,
-                incoming_synapses: incoming,
-                outgoing_synapses: outgoing,
-                removal_savings: savings,
-                expected_error_reduction: 0.0,
-                reason: format!(
-                    "Exploratory ablation candidate (high error): raw_error {:.2e} (clamped {:.2e}), \
-                     activation_weighted_impact {:.2e} >= costOfGrowth ({:.2e}). \
-                     This is NOT a safe prune - validate by full-dataset ablation test.",
-                    n.raw_error,
-                    n.total_error,
-                    n.activation_weighted_impact,
-                    cost_of_growth_threshold
-                ),
-            });
-        }
-    }
+    // Issue #414: High-error exploratory ablation DISABLED (see rank_focus_neurons for rationale)
 
     // Sort removal candidates by net improvement
     removal_candidates.sort_by(|a, b| {

--- a/tests/exploratory_ablation_candidates.rs
+++ b/tests/exploratory_ablation_candidates.rs
@@ -1,12 +1,23 @@
-//! Exploratory ablation candidates (high error).
+//! Exploratory ablation candidates (high error) — DISABLED (Issue #414).
 //!
-//! We already return "safe prune" removal candidates based on low activation-weighted
-//! impact (activation_weighted_impact < costOfGrowth). This test verifies we ALSO return
-//! an *extra* removal candidate when a hidden neuron has extremely high error, even when
-//! it is NOT low impact.
+//! Previously, we returned "exploratory ablation" removal candidates for hidden neurons
+//! with extremely high error (≥10× max output error), even when they were NOT low impact.
 //!
-//! This supports the controller-side ablation test workflow: try removing a suspicious
-//! high-error neuron and keep the mutation only if full-dataset score improves.
+//! This was based on the assumption that high error means the neuron is harmful.
+//! Production data showed this had a 0% success rate (0/2 attempts) because:
+//!
+//! **High error ≠ harmful neuron**
+//!
+//! A neuron with high recorded error is often:
+//! 1. Handling the most difficult samples (it's the only path for hard cases)
+//! 2. Receiving bad inputs from upstream (the error is a symptom, not a cause)
+//! 3. Fighting against incorrect biases elsewhere in the network
+//!
+//! Removing such neurons typically makes performance WORSE.
+//!
+//! This test verifies that high-error neurons are NO LONGER returned as exploratory
+//! ablation candidates (Issue #414 fix). The legitimate "safe prune" removal candidates
+//! (based on activation_weighted_impact < costOfGrowth) remain active with a 17.6% success rate.
 
 mod common;
 
@@ -16,14 +27,20 @@ use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
 use tempfile::NamedTempFile;
 
+/// Issue #414: High-error neurons should NOT be returned as removal candidates.
+///
+/// Previously, a hidden neuron with high error (≥10× max output error) would be returned
+/// as an "exploratory ablation candidate". This test verifies that behaviour is now disabled.
 #[test]
-fn high_error_hidden_neuron_is_returned_as_exploratory_ablation_candidate() {
+fn high_error_hidden_neuron_is_not_returned_as_exploratory_ablation_candidate() {
     // Simple creature:
     // input-0 -> bad (hidden) -> output-0
     //
     // The "bad" neuron has high structural impact and high activation, so it is NOT a safe
-    // prune candidate. However, it has extreme recorded error, so we want it returned as an
-    // exploratory ablation candidate (with a warning-style reason).
+    // prune candidate. It also has extreme recorded error.
+    //
+    // BEFORE Issue #414: This would be returned as an exploratory ablation candidate.
+    // AFTER Issue #414: This should NOT be returned as a removal candidate at all.
     let creature = CreatureJson {
         neurons: vec![
             NeuronJson {
@@ -87,23 +104,18 @@ fn high_error_hidden_neuron_is_returned_as_exploratory_ablation_candidate() {
         bad_rank.activation_weighted_impact
     );
 
-    // New behaviour: "bad" is still returned as a removal candidate, but marked as exploratory.
+    // Issue #414: "bad" should NOT be returned as a removal candidate.
+    // High-error exploratory ablation has been disabled because error magnitude
+    // does not correlate with whether removing a neuron improves the network.
     let bad_candidate = result
         .removal_candidates
         .iter()
-        .find(|c| c.neuron_uuid == "bad")
-        .expect("bad neuron should be returned as an exploratory ablation candidate");
+        .find(|c| c.neuron_uuid == "bad");
 
-    assert_eq!(
-        bad_candidate.expected_error_reduction, 0.0,
-        "exploratory candidates should not claim an expected error reduction"
-    );
     assert!(
-        bad_candidate
-            .reason
-            .to_lowercase()
-            .contains("exploratory ablation"),
-        "expected reason to mention exploratory ablation, got: {}",
-        bad_candidate.reason
+        bad_candidate.is_none(),
+        "High-error neurons should NOT be returned as removal candidates. \
+         Found: {:?}",
+        bad_candidate.map(|c| &c.reason)
     );
 }

--- a/tests/issue_414_remove_neuron_high_error.rs
+++ b/tests/issue_414_remove_neuron_high_error.rs
@@ -1,0 +1,318 @@
+//! Issue #414: Remove-neuron (high error) discovery should be disabled.
+//!
+//! The high-error exploratory ablation discovery type had a 0% success rate (0/2 attempts)
+//! because the underlying assumption is fundamentally flawed:
+//!
+//! **High error ≠ harmful neuron**
+//!
+//! A neuron with high recorded error is not necessarily a neuron that should be removed.
+//! In fact, high-error neurons are often:
+//! 1. Handling the most difficult samples (they're the only path for hard cases)
+//! 2. Receiving bad inputs from upstream (the error is a symptom, not a cause)
+//! 3. Fighting against incorrect biases elsewhere in the network
+//!
+//! Removing such neurons typically makes performance **worse** because:
+//! - The difficult samples lose their only computation path
+//! - The network loses the only neuron attempting to handle a specific pattern
+//!
+//! This test verifies that high-error neurons are NO LONGER returned as exploratory
+//! ablation candidates, since the discovery type has been disabled.
+
+mod common;
+
+use neat_ai_discovery::focus::rank_focus_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Test that high-error neurons are NOT returned as exploratory ablation candidates.
+///
+/// Previously, neurons with high error (≥10× max output error) were returned as
+/// "exploratory ablation candidates". This was based on the flawed assumption that
+/// high error means the neuron is harmful.
+///
+/// This test verifies the fix: high-error neurons are no longer suggested for removal.
+#[test]
+fn high_error_neuron_is_not_returned_as_exploratory_ablation_candidate() {
+    // Simple creature:
+    // input-0 -> high-error-hidden -> output-0
+    //
+    // The "high-error-hidden" neuron has:
+    // - High structural impact (only path to output)
+    // - High activation (not dormant)
+    // - Extremely high recorded error
+    //
+    // Previously, this would be returned as an exploratory ablation candidate.
+    // After the fix, it should NOT be suggested for removal.
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "high-error-hidden".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "high-error-hidden".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "high-error-hidden".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Records:
+    // - output has low error (so max_output_error stays small)
+    // - high-error-hidden has HUGE error (100.0), which is 1000× the output error (0.1)
+    //   This would have triggered the old EXPLORATORY_ERROR_MULTIPLIER of 10.0
+    let records = vec![
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(
+            0,
+            "high-error-hidden".to_string(),
+            Some(0.0),
+            1.0, // High activation = high impact
+            vec![100.0],
+        ),
+        DiscoverRecord::new(
+            1,
+            "high-error-hidden".to_string(),
+            Some(0.0),
+            1.0, // High activation = high impact
+            vec![100.0],
+        ),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    // Verify: high-error-hidden should NOT be in removal_candidates
+    // because high-error exploratory ablation is now disabled.
+    let high_error_in_removal = result
+        .removal_candidates
+        .iter()
+        .any(|c| c.neuron_uuid == "high-error-hidden");
+
+    assert!(
+        !high_error_in_removal,
+        "high-error-hidden should NOT be returned as a removal candidate. \
+         High-error exploratory ablation has been disabled because error magnitude \
+         does not correlate with whether removing a neuron improves the network. \
+         Found removal candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| &c.neuron_uuid)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Test that low-impact neurons are STILL returned as removal candidates.
+///
+/// This ensures we haven't broken the legitimate removal candidate detection.
+/// Low-impact neurons (activation_weighted_impact < costOfGrowth) should still
+/// be suggested for removal because they genuinely don't contribute to the network.
+#[test]
+fn low_impact_neurons_still_returned_as_removal_candidates() {
+    // Creature with a low-impact hidden neuron:
+    // input-0 -> low-impact-hidden -> output-0
+    //            (but dormant/low activation)
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "low-impact-hidden".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "low-impact-hidden".to_string(),
+                weight: 1e-6, // Tiny weight
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "low-impact-hidden".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1e-6, // Tiny weight
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    // Records with near-zero activation = very low impact
+    let records = vec![
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(
+            0,
+            "low-impact-hidden".to_string(),
+            Some(0.0),
+            1e-10, // Near-zero activation
+            vec![0.01],
+        ),
+        DiscoverRecord::new(
+            1,
+            "low-impact-hidden".to_string(),
+            Some(0.0),
+            1e-10, // Near-zero activation
+            vec![0.01],
+        ),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    // Verify: low-impact-hidden SHOULD still be in removal_candidates
+    // because it has genuinely low activation_weighted_impact
+    let low_impact_candidate = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "low-impact-hidden");
+
+    assert!(
+        low_impact_candidate.is_some(),
+        "low-impact-hidden should be returned as a removal candidate. \
+         Low-impact neurons (activation_weighted_impact < costOfGrowth) should \
+         still be suggested for removal."
+    );
+
+    // Verify the reason does NOT mention "exploratory ablation"
+    let candidate = low_impact_candidate.unwrap();
+    assert!(
+        !candidate.reason.to_lowercase().contains("exploratory"),
+        "Low-impact removal candidates should not be labelled as 'exploratory'. \
+         Found reason: {}",
+        candidate.reason
+    );
+}
+
+/// Test that the removal candidate reason reflects the correct basis for removal.
+///
+/// Removal candidates should be based on activation_weighted_impact being below
+/// the costOfGrowth threshold, not on error magnitude.
+#[test]
+fn removal_candidate_reason_reflects_impact_not_error() {
+    // Creature with a truly low-impact hidden neuron
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "dormant".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "dormant".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "dormant".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1e-8, // Very tiny outgoing weight
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let records = vec![
+        DiscoverRecord::new(0, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(1, "output-0".to_string(), Some(0.0), 0.0, vec![0.1]),
+        DiscoverRecord::new(
+            0,
+            "dormant".to_string(),
+            Some(0.0),
+            1e-10, // Near-zero activation
+            vec![0.01],
+        ),
+        DiscoverRecord::new(
+            1,
+            "dormant".to_string(),
+            Some(0.0),
+            1e-10, // Near-zero activation
+            vec![0.01],
+        ),
+    ];
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let result = rank_focus_neurons(file_path, &creature, None, None).unwrap();
+
+    let dormant_candidate = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "dormant");
+
+    assert!(
+        dormant_candidate.is_some(),
+        "Dormant neuron should be a removal candidate"
+    );
+
+    let reason = &dormant_candidate.unwrap().reason;
+
+    // The reason should mention impact-based metrics, not high error
+    assert!(
+        reason.to_lowercase().contains("impact")
+            || reason.to_lowercase().contains("costofgrowth")
+            || reason.to_lowercase().contains("cost of growth"),
+        "Removal candidate reason should mention impact or costOfGrowth. Found: {reason}"
+    );
+
+    // The reason should NOT mention "high error" or "exploratory ablation"
+    assert!(
+        !reason.to_lowercase().contains("high error"),
+        "Removal candidate reason should not mention 'high error' (disabled). Found: {reason}"
+    );
+    assert!(
+        !reason.to_lowercase().contains("exploratory ablation"),
+        "Removal candidate reason should not mention 'exploratory ablation' (disabled). Found: {reason}"
+    );
+}


### PR DESCRIPTION
# PR Summary: Fix Remove-Neuron (High Error) Discovery — Issue #414

## Summary

Disabled the "remove-neuron (high error)" discovery type which had a 0% success rate (0 successes from 2 attempts). The root cause was a **fundamentally flawed assumption**: high error magnitude on a neuron does not mean the neuron is harmful to the network.

### Root Cause Analysis

The discovery type selected neurons where `raw_error >= 10 × max_output_error` and proposed removing them as "exploratory ablation candidates". This was based on the assumption that high error means the neuron is destabilising the network.

**Why this assumption is wrong:**

A neuron with high recorded error is often:
1. **Handling difficult samples** — It's the only computation path for hard cases
2. **Receiving bad inputs** — The error is a symptom of upstream problems, not a cause
3. **Fighting incorrect biases** — It's compensating for problems elsewhere in the network

Removing such neurons typically makes performance **worse** because:
- Difficult samples lose their only computation path
- The network loses the only neuron attempting to handle a specific pattern

**Key insight**: Error magnitude measures how **wrong** the neuron's output is, not how **harmful** the neuron is to the network's overall score.

### Changes Made

1. **Disabled high-error exploratory ablation** in `src/focus.rs` (both occurrences)
2. **Updated existing test** in `tests/exploratory_ablation_candidates.rs` to verify the behaviour is disabled
3. **Added new tests** in `tests/issue_414_remove_neuron_high_error.rs` to verify:
   - High-error neurons are NOT returned as removal candidates
   - Low-impact neurons are STILL returned as removal candidates (legitimate removal)
   - Removal candidate reasons reflect impact, not error magnitude
4. **Updated documentation** in `docs/DISCOVERY_TYPES.md` with:
   - Root cause analysis
   - Status changed from "Not working" to "Disabled"
   - Updated recommendations table

### What Remains Active

The legitimate "remove-low-impact" discovery type remains active with a 17.6% success rate. This discovery type identifies neurons where `activation_weighted_impact < costOfGrowth` — neurons that genuinely don't contribute to the network.

## Evidence

This is a backend logic fix with no UI changes. Evidence is provided through the test suite.

## Test Plan

New and updated tests verify the fix:

| Test File | Test Name | Purpose |
|-----------|-----------|---------|
| `tests/issue_414_remove_neuron_high_error.rs` | `high_error_neuron_is_not_returned_as_exploratory_ablation_candidate` | Verifies high-error neurons are no longer suggested for removal |
| `tests/issue_414_remove_neuron_high_error.rs` | `low_impact_neurons_still_returned_as_removal_candidates` | Verifies legitimate low-impact removal still works |
| `tests/issue_414_remove_neuron_high_error.rs` | `removal_candidate_reason_reflects_impact_not_error` | Verifies removal reasons mention impact, not error |
| `tests/exploratory_ablation_candidates.rs` | `high_error_hidden_neuron_is_not_returned_as_exploratory_ablation_candidate` | Updated existing test to verify new behaviour |

All tests pass with `./quality.sh`.

## Acceptance Criteria

- [x] Either achieve >5% success rate OR disable the discovery type — **Disabled**
- [x] Document the root cause in `docs/DISCOVERY_TYPES.md` — **Done**

---

## Automated Fix Details
This PR addresses issue #414: **Fix remove-neuron (high error) discovery - 0% success rate**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #414