### PR TITLE
Fix: Could replacing ReLU ( or similar) with ReLU6 reduce noise? (#441)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.14"
+version = "0.10.15"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.13"
+version = "0.10.14"
 edition = "2021"
 
 [lib]

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -18,6 +18,7 @@ output format, and production success/failure rates.
   - [Opposing Synapse Detection](#opposing-synapse-detection)
   - [Output Bias Drift Detection](#output-bias-drift-detection)
   - [Oscillating Neuron Detection](#oscillating-neuron-detection)
+  - [Unbounded Capping Detection](#unbounded-capping-detection)
   - [Correlated Error Pattern Detection](#correlated-error-pattern-detection)
   - [Multi-Hop Candidate Analysis](#multi-hop-candidate-analysis)
   - [Redundant Path Pruning](#redundant-path-pruning)
@@ -65,6 +66,7 @@ NEAT-AI-Discovery (Rust)          NEAT-AI (TypeScript)
 | [Opposing Synapse](#opposing-synapse-detection) | `opposing_synapse.rs` | #360 | `removeSynapse`, `setWeight` | 🟢 Active |
 | [Output Bias Drift](#output-bias-drift-detection) | `output_bias_drift.rs` | #361 | `setBias` | 🟢 Active |
 | [Oscillating Neuron](#oscillating-neuron-detection) | `oscillating_neuron.rs` | #358 | `changeSquash`, `setBias` | 🟢 Active |
+| [Unbounded Capping](#unbounded-capping-detection) | `unbounded_capping.rs` | #441 | `changeSquash` | 🟢 Active |
 | [Correlated Error](#correlated-error-pattern-detection) | `correlated_error.rs` | #344 | `addNeuron`, `addSynapse` | 🟢 Active |
 | [Multi-Hop](#multi-hop-candidate-analysis) | `multi_hop.rs` | #230 | `addNeuron`, `addSynapse` | 🟢 Active |
 | [Redundant Path](#redundant-path-pruning) | `redundant_path.rs` | #164 | `removeSynapse`, `setWeight` | 🟢 Active |
@@ -300,6 +302,39 @@ their output.
 
 **Output**: Emitted as `coordinatedStructuralCandidates` with `changeSquash`
 and/or `setBias` operations.
+
+---
+
+### Unbounded Capping Detection
+
+**Source**: `src/analysis/unbounded_capping.rs` (Issue #441)
+
+**Purpose**: Identifies neurons with unbounded activation functions (RELU,
+IDENTITY, LEAKYRELU, etc.) that are producing high activations ("spiking")
+and recommends capping them with a bounded version (e.g., RELU → RELU6).
+High activations from unbounded functions can introduce noise into the
+network.
+
+**Detection criteria**:
+
+1. **Uses an unbounded activation**: RELU, IDENTITY, LEAKYRELU, SOFTPLUS,
+   ELU, SELU, SWISH, MISH, GELU, EXPONENTIAL, SQUARE, CUBE.
+2. **High activations**: Maximum activation exceeds the capping threshold
+   (e.g., > 6.0 for RELU → RELU6).
+3. **Consistent spiking**: At least 30% of samples exceed the threshold
+   (not just occasional spikes).
+4. **Hidden neurons only**: Output neurons are excluded.
+
+**Recommended actions**:
+
+1. **Change RELU → RELU6**: Cap activations at 6.0 to reduce noise.
+2. **Change LEAKYRELU → RELU6**: Cap positive activations (loses negative
+   leak, but caps the positive side).
+3. **Change IDENTITY → HARD_TANH or RELU6**: For high positive activations,
+   use RELU6; for mixed activations, use HARD_TANH.
+
+**Output**: Emitted as `coordinatedStructuralCandidates` with `changeSquash`
+operations.
 
 ---
 

--- a/docs/pr-summary-441.md
+++ b/docs/pr-summary-441.md
@@ -1,0 +1,64 @@
+## Summary
+
+Implements **Unbounded Capping Detection** (Issue #441), a new discovery type that identifies neurons with unbounded activation functions (RELU, IDENTITY, LEAKYRELU, etc.) producing high activations ("spiking") and recommends capping them with bounded versions like RELU6.
+
+### The Problem
+
+Unbounded activation functions like RELU can produce arbitrarily high values. When a neuron consistently outputs very high activations, it may introduce noise into the network. Capping these activations with RELU6 (which clips outputs to [0, 6]) can reduce this noise and improve the creature's score.
+
+### Solution
+
+The new discovery module:
+
+1. **Detects spiking neurons**: Identifies hidden neurons using unbounded activations where:
+   - Maximum activation exceeds the capping threshold (> 6.0 for RELU family)
+   - At least 30% of samples exceed the threshold (consistent spiking, not occasional)
+
+2. **Recommends bounded replacements**:
+   - RELU → RELU6
+   - LEAKYRELU → RELU6
+   - IDENTITY → RELU6 (high positive) or HARD_TANH (mixed)
+   - Other unbounded functions → appropriate bounded versions
+
+3. **Emits coordinated structural candidates** with `changeSquash` operations
+
+### Files Changed
+
+| File | Description |
+|------|-------------|
+| `src/analysis/unbounded_capping.rs` | New detection module with `detect_unbounded_capping_candidates()` and `unbounded_capping_to_coordinated_candidates()` |
+| `src/analysis/mod.rs` | Register new module and add dispatch in `analyze_all()` |
+| `tests/issue_441_unbounded_capping.rs` | 8 comprehensive unit tests |
+| `docs/DISCOVERY_TYPES.md` | Documentation for the new discovery type |
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only library with no visual interface. The feature is validated through unit tests.
+
+## Test Plan
+
+Added 8 unit tests covering:
+
+- `test_relu_spiking_detected` — RELU neurons with consistently high activations are detected
+- `test_identity_spiking_detected` — IDENTITY neurons with high activations are detected
+- `test_output_neurons_excluded` — Output neurons are not considered (hidden only)
+- `test_bounded_activations_excluded` — Already-bounded activations (RELU6, TANH, LOGISTIC) are excluded
+- `test_conversion_to_coordinated_candidates` — Detection results convert to proper coordinated candidates
+- `test_insufficient_samples_skipped` — Neurons with < 20 samples are skipped
+- `test_leakyrelu_spiking_detected` — LEAKYRELU spiking detection works
+- `test_occasional_spikes_not_detected` — Occasional high activations (< 30% of samples) don't trigger detection
+
+All tests pass:
+```
+running 8 tests
+test test_insufficient_samples_skipped ... ok
+test test_identity_spiking_detected ... ok
+test test_leakyrelu_spiking_detected ... ok
+test test_conversion_to_coordinated_candidates ... ok
+test test_bounded_activations_excluded ... ok
+test test_output_neurons_excluded ... ok
+test test_occasional_spikes_not_detected ... ok
+test test_relu_spiking_detected ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored
+```

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -31,6 +31,7 @@
 //! - `observation_range.rs` - Observation effective range detection from recorded samples (Issue #398)
 //! - `sentinel_gating.rs` - Sentinel value gating for null/sentinel observation suppression (Issue #400)
 //! - `restricted_range.rs` - Restricted activation range detection for underutilised neurons (Issue #399)
+//! - `unbounded_capping.rs` - Unbounded activation capping detection for noise reduction (Issue #441)
 
 pub mod activation;
 pub mod bottleneck;
@@ -63,6 +64,7 @@ pub mod shared;
 pub mod streaming;
 pub mod synapse;
 pub mod system;
+pub mod unbounded_capping;
 pub mod utils;
 pub mod weights;
 
@@ -1029,6 +1031,34 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     &detected,
                     &input.creature,
                 );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #441: Unbounded activation capping detection
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "unbounded capping detection",
+            "unbounded_capping_detection",
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_records();
+                let detected = unbounded_capping::detect_unbounded_capping_candidates(
+                    &hidden_neurons,
+                    &records,
+                );
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    unbounded_capping::unbounded_capping_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/src/analysis/unbounded_capping.rs
+++ b/src/analysis/unbounded_capping.rs
@@ -1,0 +1,260 @@
+//! Unbounded activation capping detection module (Issue #441).
+//!
+//! Identifies neurons with unbounded activation functions (RELU, IDENTITY, LEAKYRELU, etc.)
+//! that are producing high activations ("spiking") and would benefit from being capped
+//! with a bounded version (e.g., RELU → RELU6).
+//!
+//! See `docs/DISCOVERY_TYPES.md` § "Unbounded Capping Detection" for full documentation.
+//!
+//! ## The Problem
+//!
+//! Unbounded activations like RELU can produce arbitrarily high values. When a neuron
+//! consistently outputs very high activations, it may be introducing noise into the
+//! network. Capping these activations with RELU6 (or similar bounded activation) can
+//! reduce this noise and improve the creature's score.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron is a candidate for capping if:
+//! 1. **Uses an unbounded activation**: RELU, IDENTITY, LEAKYRELU, SOFTPLUS, ELU, SELU, etc.
+//! 2. **Has high activations**: Max activation exceeds the capping threshold (e.g., > 6.0).
+//! 3. **Consistent spiking**: Significant fraction of samples exceed the threshold.
+//! 4. **Hidden neurons only**: Output neurons are excluded.
+//!
+//! ## Recommended Actions
+//!
+//! When unbounded capping is detected, we recommend:
+//! 1. **Change RELU → RELU6**: Cap activations at 6.0.
+//! 2. **Change LEAKYRELU → RELU6**: Cap activations (loses negative leak, but caps positive).
+//! 3. **Change IDENTITY → HARD_TANH**: Cap activations at ±1.0.
+//! 4. **Optionally adjust weights**: Scale down incoming weights to reduce activation magnitude.
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Minimum samples required for reliable detection.
+const MIN_SAMPLES_FOR_DETECTION: usize = 20;
+
+/// Default capping threshold for RELU → RELU6 transition.
+/// Activations above this value would be clipped by RELU6.
+const RELU6_CAP_THRESHOLD: f32 = 6.0;
+
+/// Minimum fraction of samples that must exceed the cap threshold to trigger detection.
+/// We require at least 30% of samples to be above threshold to avoid false positives
+/// from occasional spikes.
+const MIN_FRACTION_ABOVE_CAP: f32 = 0.3;
+
+/// Result of detecting an unbounded capping candidate.
+#[derive(Debug, Clone)]
+pub struct UnboundedCappingCandidate {
+    /// UUID of the neuron.
+    pub neuron_uuid: String,
+    /// Current activation function of the neuron.
+    pub current_squash: String,
+    /// Maximum activation observed across all samples.
+    pub max_activation: f32,
+    /// Mean activation across all samples.
+    pub mean_activation: f32,
+    /// Fraction of samples that exceed the capping threshold.
+    pub fraction_above_cap: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Recommended new activation function (e.g., "RELU6").
+    pub recommended_squash: Option<String>,
+    /// Estimated creature score improvement from capping.
+    pub estimated_improvement: f32,
+}
+
+/// Returns whether a squash function is unbounded (can produce arbitrarily high values).
+fn is_unbounded_squash(squash: &str) -> bool {
+    let upper = squash.to_ascii_uppercase();
+    matches!(
+        upper.as_str(),
+        "RELU"
+            | "IDENTITY"
+            | "LEAKYRELU"
+            | "SOFTPLUS"
+            | "ELU"
+            | "SELU"
+            | "SWISH"
+            | "MISH"
+            | "GELU"
+            | "EXPONENTIAL"
+            | "SQUARE"
+            | "CUBE"
+    )
+}
+
+/// Returns the appropriate capping threshold for a given activation function.
+fn get_capping_threshold(squash: &str) -> f32 {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        // ReLU family: use RELU6 threshold
+        "RELU" | "LEAKYRELU" | "ELU" | "SELU" | "GELU" | "SWISH" | "MISH" | "SOFTPLUS" => {
+            RELU6_CAP_THRESHOLD
+        }
+        // Identity: use HARD_TANH threshold
+        "IDENTITY" => 1.0,
+        // Others: use a generous default
+        _ => RELU6_CAP_THRESHOLD,
+    }
+}
+
+/// Returns the recommended bounded activation function for a given unbounded activation.
+fn recommend_bounded_squash(squash: &str, mean_activation: f32) -> Option<String> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        // ReLU family → RELU6
+        "RELU" | "LEAKYRELU" | "ELU" | "SELU" | "GELU" | "SWISH" | "MISH" | "SOFTPLUS" => {
+            Some("RELU6".to_string())
+        }
+        // Identity with high positive activations → RELU6
+        // Identity with mixed activations → HARD_TANH
+        "IDENTITY" => {
+            if mean_activation > 0.0 {
+                Some("RELU6".to_string())
+            } else {
+                Some("HARD_TANH".to_string())
+            }
+        }
+        // Exponential is a special case - very aggressive growth
+        "EXPONENTIAL" => Some("SOFTPLUS".to_string()),
+        // Square/Cube → RELU6 to cap growth
+        "SQUARE" | "CUBE" => Some("RELU6".to_string()),
+        _ => None,
+    }
+}
+
+/// Detect neurons with unbounded activations that would benefit from capping.
+///
+/// # Arguments
+/// * `neurons` - List of `(neuron_uuid, squash, bias)` tuples for hidden neurons to check.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with the recorded activations.
+///
+/// # Returns
+/// A list of `UnboundedCappingCandidate` for neurons that would benefit from capping,
+/// sorted by estimated improvement (best first).
+pub fn detect_unbounded_capping_candidates(
+    neurons: &[(String, String, f32)],
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<UnboundedCappingCandidate> {
+    let mut candidates = Vec::new();
+
+    // Build a map from uuid to records for quick lookup
+    let records_map: std::collections::HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    for (uuid, squash, _bias) in neurons {
+        // Skip bounded activations
+        if !is_unbounded_squash(squash) {
+            continue;
+        }
+
+        let Some(records) = records_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES_FOR_DETECTION {
+            continue;
+        }
+
+        let n = records.len() as f32;
+        let cap_threshold = get_capping_threshold(squash);
+
+        // Compute activation statistics
+        let sum_activation: f32 = records.iter().map(|r| r.activation).sum();
+        let mean_activation = sum_activation / n;
+
+        let max_activation = records
+            .iter()
+            .map(|r| r.activation)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        // Count samples exceeding the cap threshold
+        let count_above_cap = records
+            .iter()
+            .filter(|r| r.activation > cap_threshold)
+            .count();
+        let fraction_above_cap = count_above_cap as f32 / n;
+
+        // Skip if not enough samples exceed the threshold
+        if fraction_above_cap < MIN_FRACTION_ABOVE_CAP {
+            continue;
+        }
+
+        // Skip if max activation doesn't exceed threshold
+        if max_activation <= cap_threshold {
+            continue;
+        }
+
+        let recommended_squash = recommend_bounded_squash(squash, mean_activation);
+
+        // Estimate improvement based on how much is being "lost" to high activations.
+        // Higher fraction above cap and higher excess = higher potential improvement.
+        let excess_ratio = (max_activation - cap_threshold) / cap_threshold;
+        let estimated_improvement = fraction_above_cap * excess_ratio.min(1.0) * 0.01;
+
+        candidates.push(UnboundedCappingCandidate {
+            neuron_uuid: uuid.clone(),
+            current_squash: squash.clone(),
+            max_activation,
+            mean_activation,
+            fraction_above_cap,
+            sample_count: records.len(),
+            recommended_squash,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Convert unbounded capping candidates into coordinated structural candidates.
+///
+/// Each candidate produces a `ChangeSquash` operation to switch to the bounded activation.
+pub fn unbounded_capping_to_coordinated_candidates(
+    candidates: &[UnboundedCappingCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        let Some(ref new_squash) = c.recommended_squash else {
+            continue;
+        };
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: c.neuron_uuid.clone(),
+                squash: new_squash.clone(),
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Unbounded capping: {} {} (max activation {:.2}, {:.0}% above cap {:.1}) → change to {} to reduce noise",
+                c.neuron_uuid,
+                c.current_squash,
+                c.max_activation,
+                c.fraction_above_cap * 100.0,
+                get_capping_threshold(&c.current_squash),
+                new_squash
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
+}

--- a/tests/issue_441_unbounded_capping.rs
+++ b/tests/issue_441_unbounded_capping.rs
@@ -1,0 +1,453 @@
+//! Tests for unbounded activation capping detection (Issue #441).
+//!
+//! Detects neurons with unbounded activation functions (RELU, IDENTITY, LEAKYRELU, etc.)
+//! that are producing high activations ("spiking") and would benefit from being capped
+//! with a bounded version (e.g., RELU6).
+//!
+//! ## The Problem
+//!
+//! Unbounded activations like RELU can produce arbitrarily high values. When a neuron
+//! consistently outputs very high activations, it may be introducing noise into the
+//! network. Capping these activations with RELU6 (or similar bounded activation) can
+//! reduce this noise and improve the creature's score.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron is a candidate for capping if:
+//! 1. Uses an unbounded activation (RELU, IDENTITY, LEAKYRELU, SOFTPLUS, ELU, SELU, etc.)
+//! 2. Has high max activation (e.g., > 6.0 for RELU → RELU6)
+//! 3. Significant fraction of samples exceed the capping threshold
+//! 4. Hidden neurons only (output neurons excluded)
+//!
+//! ## Recommended Actions
+//!
+//! 1. Change activation from RELU to RELU6 to cap high activations
+//! 2. For other unbounded activations, may recommend HARD_TANH or adjust weights
+
+mod common;
+
+use common::{hidden, make_creature, output, record, synapse};
+use neat_ai_discovery::analysis::unbounded_capping::{
+    detect_unbounded_capping_candidates, unbounded_capping_to_coordinated_candidates,
+};
+
+/// Test: RELU neuron with high activations should be detected
+#[test]
+fn test_relu_spiking_detected() {
+    let neurons = vec![
+        hidden("hidden-1", "RELU"),
+        hidden("hidden-2", "RELU"),
+        output("output-0", "IDENTITY"),
+    ];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // hidden-1: High activations (spiking) - should be detected
+    // hidden-2: Normal activations - should NOT be detected
+    let neuron_records = vec![
+        (
+            "hidden-1".to_string(),
+            vec![
+                record("hidden-1", 0, 10.0, Some(10.0)),  // Very high
+                record("hidden-1", 1, 15.0, Some(15.0)),  // Very high
+                record("hidden-1", 2, 8.0, Some(8.0)),    // High
+                record("hidden-1", 3, 12.0, Some(12.0)),  // Very high
+                record("hidden-1", 4, 7.0, Some(7.0)),    // High
+                record("hidden-1", 5, 20.0, Some(20.0)),  // Very high
+                record("hidden-1", 6, 9.0, Some(9.0)),    // High
+                record("hidden-1", 7, 11.0, Some(11.0)),  // Very high
+                record("hidden-1", 8, 6.5, Some(6.5)),    // Just above threshold
+                record("hidden-1", 9, 14.0, Some(14.0)),  // Very high
+                record("hidden-1", 10, 8.0, Some(8.0)),   // High
+                record("hidden-1", 11, 7.5, Some(7.5)),   // High
+                record("hidden-1", 12, 13.0, Some(13.0)), // Very high
+                record("hidden-1", 13, 9.5, Some(9.5)),   // High
+                record("hidden-1", 14, 16.0, Some(16.0)), // Very high
+                record("hidden-1", 15, 10.5, Some(10.5)), // Very high
+                record("hidden-1", 16, 8.0, Some(8.0)),   // High
+                record("hidden-1", 17, 11.0, Some(11.0)), // Very high
+                record("hidden-1", 18, 7.0, Some(7.0)),   // High
+                record("hidden-1", 19, 12.0, Some(12.0)), // Very high
+            ],
+        ),
+        (
+            "hidden-2".to_string(),
+            vec![
+                record("hidden-2", 0, 0.5, Some(0.5)),
+                record("hidden-2", 1, 1.0, Some(1.0)),
+                record("hidden-2", 2, 0.8, Some(0.8)),
+                record("hidden-2", 3, 1.2, Some(1.2)),
+                record("hidden-2", 4, 0.3, Some(0.3)),
+                record("hidden-2", 5, 2.0, Some(2.0)),
+                record("hidden-2", 6, 1.5, Some(1.5)),
+                record("hidden-2", 7, 0.7, Some(0.7)),
+                record("hidden-2", 8, 1.1, Some(1.1)),
+                record("hidden-2", 9, 0.9, Some(0.9)),
+                record("hidden-2", 10, 1.3, Some(1.3)),
+                record("hidden-2", 11, 0.6, Some(0.6)),
+                record("hidden-2", 12, 1.8, Some(1.8)),
+                record("hidden-2", 13, 0.4, Some(0.4)),
+                record("hidden-2", 14, 2.5, Some(2.5)),
+                record("hidden-2", 15, 1.0, Some(1.0)),
+                record("hidden-2", 16, 0.8, Some(0.8)),
+                record("hidden-2", 17, 1.4, Some(1.4)),
+                record("hidden-2", 18, 0.5, Some(0.5)),
+                record("hidden-2", 19, 1.6, Some(1.6)),
+            ],
+        ),
+    ];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    // Should detect hidden-1 (spiking) but not hidden-2 (normal)
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect exactly one spiking neuron"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "hidden-1");
+    assert_eq!(candidates[0].current_squash, "RELU");
+    assert_eq!(
+        candidates[0].recommended_squash,
+        Some("RELU6".to_string()),
+        "Should recommend RELU6 for spiking RELU neuron"
+    );
+    assert!(
+        candidates[0].max_activation > 6.0,
+        "Max activation should exceed RELU6 cap"
+    );
+    assert!(
+        candidates[0].fraction_above_cap > 0.5,
+        "Majority of samples should exceed cap"
+    );
+}
+
+/// Test: IDENTITY neuron with high activations should be detected
+#[test]
+fn test_identity_spiking_detected() {
+    let neurons = vec![
+        hidden("hidden-1", "IDENTITY"),
+        output("output-0", "IDENTITY"),
+    ];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // High positive activations for IDENTITY neuron
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        vec![
+            record("hidden-1", 0, 5.0, Some(5.0)),
+            record("hidden-1", 1, 8.0, Some(8.0)),
+            record("hidden-1", 2, 12.0, Some(12.0)),
+            record("hidden-1", 3, 7.0, Some(7.0)),
+            record("hidden-1", 4, 15.0, Some(15.0)),
+            record("hidden-1", 5, 6.0, Some(6.0)),
+            record("hidden-1", 6, 9.0, Some(9.0)),
+            record("hidden-1", 7, 11.0, Some(11.0)),
+            record("hidden-1", 8, 4.0, Some(4.0)),
+            record("hidden-1", 9, 10.0, Some(10.0)),
+            record("hidden-1", 10, 8.0, Some(8.0)),
+            record("hidden-1", 11, 7.0, Some(7.0)),
+            record("hidden-1", 12, 13.0, Some(13.0)),
+            record("hidden-1", 13, 6.0, Some(6.0)),
+            record("hidden-1", 14, 9.0, Some(9.0)),
+            record("hidden-1", 15, 5.0, Some(5.0)),
+            record("hidden-1", 16, 8.0, Some(8.0)),
+            record("hidden-1", 17, 11.0, Some(11.0)),
+            record("hidden-1", 18, 7.0, Some(7.0)),
+            record("hidden-1", 19, 10.0, Some(10.0)),
+        ],
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert_eq!(candidates.len(), 1, "Should detect IDENTITY spiking neuron");
+    assert_eq!(candidates[0].neuron_uuid, "hidden-1");
+    // For IDENTITY, recommend HARD_TANH if within [-1, 1] threshold is exceeded
+    // Or RELU6 if all positive and high
+    assert!(
+        candidates[0].recommended_squash.is_some(),
+        "Should recommend a bounded activation"
+    );
+}
+
+/// Test: Output neurons should NOT be detected (even if spiking)
+#[test]
+fn test_output_neurons_excluded() {
+    let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "RELU")];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    // Only include hidden neurons
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // Hidden neuron has low activations, output neuron would spike but is excluded
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        vec![
+            record("hidden-1", 0, 0.5, Some(0.5)),
+            record("hidden-1", 1, 1.0, Some(1.0)),
+            record("hidden-1", 2, 0.8, Some(0.8)),
+            record("hidden-1", 3, 1.2, Some(1.2)),
+            record("hidden-1", 4, 0.3, Some(0.3)),
+            record("hidden-1", 5, 2.0, Some(2.0)),
+            record("hidden-1", 6, 1.5, Some(1.5)),
+            record("hidden-1", 7, 0.7, Some(0.7)),
+            record("hidden-1", 8, 1.1, Some(1.1)),
+            record("hidden-1", 9, 0.9, Some(0.9)),
+            record("hidden-1", 10, 1.3, Some(1.3)),
+            record("hidden-1", 11, 0.6, Some(0.6)),
+            record("hidden-1", 12, 1.8, Some(1.8)),
+            record("hidden-1", 13, 0.4, Some(0.4)),
+            record("hidden-1", 14, 2.5, Some(2.5)),
+            record("hidden-1", 15, 1.0, Some(1.0)),
+            record("hidden-1", 16, 0.8, Some(0.8)),
+            record("hidden-1", 17, 1.4, Some(1.4)),
+            record("hidden-1", 18, 0.5, Some(0.5)),
+            record("hidden-1", 19, 1.6, Some(1.6)),
+        ],
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    // hidden-1 has low activations, should not be detected
+    assert!(
+        candidates.is_empty(),
+        "Should not detect low-activation neurons"
+    );
+}
+
+/// Test: Bounded activations (RELU6, TANH, LOGISTIC) should NOT be detected
+#[test]
+fn test_bounded_activations_excluded() {
+    let neurons = vec![
+        hidden("hidden-1", "RELU6"),
+        hidden("hidden-2", "TANH"),
+        hidden("hidden-3", "LOGISTIC"),
+        output("output-0", "IDENTITY"),
+    ];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // Even with high activations (within their bounds), bounded activations are excluded
+    let neuron_records = vec![
+        (
+            "hidden-1".to_string(),
+            (0..20)
+                .map(|i| record("hidden-1", i, 6.0, Some(10.0))) // RELU6 capped at 6
+                .collect(),
+        ),
+        (
+            "hidden-2".to_string(),
+            (0..20)
+                .map(|i| record("hidden-2", i, 0.99, Some(5.0))) // TANH saturated
+                .collect(),
+        ),
+        (
+            "hidden-3".to_string(),
+            (0..20)
+                .map(|i| record("hidden-3", i, 0.99, Some(5.0))) // LOGISTIC saturated
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Bounded activations should not be detected for capping"
+    );
+}
+
+/// Test: Conversion to coordinated structural candidates
+#[test]
+fn test_conversion_to_coordinated_candidates() {
+    let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "IDENTITY")];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        (0..20)
+            .map(|i| record("hidden-1", i, 10.0 + (i as f32), Some(10.0 + (i as f32))))
+            .collect(),
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert!(!candidates.is_empty(), "Should detect spiking neuron");
+
+    let coordinated = unbounded_capping_to_coordinated_candidates(&candidates);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+    assert!(
+        coordinated[0].expected_creature_score_gain > 0.0,
+        "Should have positive expected improvement"
+    );
+
+    // Check the operation is a ChangeSquash
+    assert_eq!(coordinated[0].operations.len(), 1);
+    match &coordinated[0].operations[0] {
+        neat_ai_discovery::CoordinatedStructuralOpJson::ChangeSquash {
+            neuron_uuid,
+            squash,
+        } => {
+            assert_eq!(neuron_uuid, "hidden-1");
+            assert_eq!(squash, "RELU6");
+        }
+        _ => panic!("Expected ChangeSquash operation"),
+    }
+}
+
+/// Test: Insufficient samples should not trigger detection
+#[test]
+fn test_insufficient_samples_skipped() {
+    let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "IDENTITY")];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // Only 5 samples - below minimum threshold
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        vec![
+            record("hidden-1", 0, 10.0, Some(10.0)),
+            record("hidden-1", 1, 15.0, Some(15.0)),
+            record("hidden-1", 2, 12.0, Some(12.0)),
+            record("hidden-1", 3, 20.0, Some(20.0)),
+            record("hidden-1", 4, 8.0, Some(8.0)),
+        ],
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not detect with insufficient samples"
+    );
+}
+
+/// Test: LEAKYRELU spiking should also be detected
+#[test]
+fn test_leakyrelu_spiking_detected() {
+    let neurons = vec![
+        hidden("hidden-1", "LEAKYRELU"),
+        output("output-0", "IDENTITY"),
+    ];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        (0..20)
+            .map(|i| record("hidden-1", i, 10.0 + (i as f32), Some(10.0 + (i as f32))))
+            .collect(),
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert_eq!(candidates.len(), 1, "Should detect LEAKYRELU spiking");
+    assert_eq!(candidates[0].current_squash, "LEAKYRELU");
+    assert!(
+        candidates[0].recommended_squash.is_some(),
+        "Should recommend bounded activation"
+    );
+}
+
+/// Test: Neurons with mostly low activations but occasional spikes should not be detected
+#[test]
+fn test_occasional_spikes_not_detected() {
+    let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "IDENTITY")];
+
+    let creature = make_creature(neurons.clone(), vec![synapse("hidden-1", "output-0", 1.0)]);
+
+    let hidden_neurons: Vec<(String, String, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+        .collect();
+
+    // Most activations are low, only 2 out of 20 are high
+    let neuron_records = vec![(
+        "hidden-1".to_string(),
+        vec![
+            record("hidden-1", 0, 0.5, Some(0.5)),
+            record("hidden-1", 1, 1.0, Some(1.0)),
+            record("hidden-1", 2, 15.0, Some(15.0)), // Spike
+            record("hidden-1", 3, 0.8, Some(0.8)),
+            record("hidden-1", 4, 1.2, Some(1.2)),
+            record("hidden-1", 5, 0.3, Some(0.3)),
+            record("hidden-1", 6, 2.0, Some(2.0)),
+            record("hidden-1", 7, 1.5, Some(1.5)),
+            record("hidden-1", 8, 0.7, Some(0.7)),
+            record("hidden-1", 9, 20.0, Some(20.0)), // Spike
+            record("hidden-1", 10, 1.1, Some(1.1)),
+            record("hidden-1", 11, 0.9, Some(0.9)),
+            record("hidden-1", 12, 1.3, Some(1.3)),
+            record("hidden-1", 13, 0.6, Some(0.6)),
+            record("hidden-1", 14, 1.8, Some(1.8)),
+            record("hidden-1", 15, 0.4, Some(0.4)),
+            record("hidden-1", 16, 2.5, Some(2.5)),
+            record("hidden-1", 17, 1.0, Some(1.0)),
+            record("hidden-1", 18, 0.8, Some(0.8)),
+            record("hidden-1", 19, 1.4, Some(1.4)),
+        ],
+    )];
+
+    let candidates = detect_unbounded_capping_candidates(&hidden_neurons, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not detect when spikes are occasional (< threshold fraction)"
+    );
+}


### PR DESCRIPTION
## Summary

Implements **Unbounded Capping Detection** (Issue #441), a new discovery type that identifies neurons with unbounded activation functions (RELU, IDENTITY, LEAKYRELU, etc.) producing high activations ("spiking") and recommends capping them with bounded versions like RELU6.

### The Problem

Unbounded activation functions like RELU can produce arbitrarily high values. When a neuron consistently outputs very high activations, it may introduce noise into the network. Capping these activations with RELU6 (which clips outputs to [0, 6]) can reduce this noise and improve the creature's score.

### Solution

The new discovery module:

1. **Detects spiking neurons**: Identifies hidden neurons using unbounded activations where:
   - Maximum activation exceeds the capping threshold (> 6.0 for RELU family)
   - At least 30% of samples exceed the threshold (consistent spiking, not occasional)

2. **Recommends bounded replacements**:
   - RELU → RELU6
   - LEAKYRELU → RELU6
   - IDENTITY → RELU6 (high positive) or HARD_TANH (mixed)
   - Other unbounded functions → appropriate bounded versions

3. **Emits coordinated structural candidates** with `changeSquash` operations

### Files Changed

| File | Description |
|------|-------------|
| `src/analysis/unbounded_capping.rs` | New detection module with `detect_unbounded_capping_candidates()` and `unbounded_capping_to_coordinated_candidates()` |
| `src/analysis/mod.rs` | Register new module and add dispatch in `analyze_all()` |
| `tests/issue_441_unbounded_capping.rs` | 8 comprehensive unit tests |
| `docs/DISCOVERY_TYPES.md` | Documentation for the new discovery type |

## Evidence

Unable to generate screenshot: This is a CLI-only library with no visual interface. The feature is validated through unit tests.

## Test Plan

Added 8 unit tests covering:

- `test_relu_spiking_detected` — RELU neurons with consistently high activations are detected
- `test_identity_spiking_detected` — IDENTITY neurons with high activations are detected
- `test_output_neurons_excluded` — Output neurons are not considered (hidden only)
- `test_bounded_activations_excluded` — Already-bounded activations (RELU6, TANH, LOGISTIC) are excluded
- `test_conversion_to_coordinated_candidates` — Detection results convert to proper coordinated candidates
- `test_insufficient_samples_skipped` — Neurons with < 20 samples are skipped
- `test_leakyrelu_spiking_detected` — LEAKYRELU spiking detection works
- `test_occasional_spikes_not_detected` — Occasional high activations (< 30% of samples) don't trigger detection

All tests pass:
```
running 8 tests
test test_insufficient_samples_skipped ... ok
test test_identity_spiking_detected ... ok
test test_leakyrelu_spiking_detected ... ok
test test_conversion_to_coordinated_candidates ... ok
test test_bounded_activations_excluded ... ok
test test_output_neurons_excluded ... ok
test test_occasional_spikes_not_detected ... ok
test test_relu_spiking_detected ... ok

test result: ok. 8 passed; 0 failed; 0 ignored
```

---

## Automated Fix Details
This PR addresses issue #441: **Could replacing ReLU ( or similar) with ReLU6 reduce noise?**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #441