### PR TITLE
Fix: Increase change-squash suggestion rate (#417)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.31"
+version = "0.10.32"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.30"
+version = "0.10.31"
 edition = "2021"
 
 [lib]

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -106,10 +106,14 @@ in their region of the network.
 
 **Detection criteria**:
 
-1. **Activation near bounds**: For TANH, mean activation > 0.95 or < −0.95
-   across samples.
+1. **Activation near bounds**: For TANH, mean activation > 0.85 or < −0.85
+   across samples (Issue #417: lowered from 0.95 to catch near-saturated
+   neurons earlier). For LOGISTIC, mean activation > 0.90 or < 0.10
+   (lowered from 0.95/0.05). For HARD_TANH, mean activation > 0.95
+   (lowered from 0.99).
 2. **Low relative variance**: Input varies but output does not (activation
-   function is squashing all variation).
+   function is squashing all variation). Maximum std dev: 0.08 (Issue #417:
+   raised from 0.05 to accommodate near-saturated neurons).
 3. **Uses a bounded activation**: Only bounded activations (TANH, LOGISTIC,
    HARD_TANH, etc.) can saturate. Unbounded activations (RELU, IDENTITY) are
    excluded, except RELU dead-zone detection (all activations at zero).
@@ -289,10 +293,12 @@ their output.
 
 **Detection criteria**:
 
-1. **Sign changes**: The activation crosses zero frequently (more than a
-   minimum fraction of samples show sign changes).
+1. **Sign changes**: The activation crosses zero frequently (more than 15%
+   of consecutive sample pairs show sign changes; Issue #417: lowered from
+   30% to catch mildly oscillating neurons).
 2. **Balanced signs**: Both positive and negative activations appear in
-   substantial proportions (neither dominates overwhelmingly).
+   at least 10% of samples (Issue #417: lowered from 20% to catch more
+   oscillating neurons).
 3. **Meaningful magnitude**: The mean absolute activation is above a minimum
    threshold (distinguishing from dead neurons).
 4. **Hidden neurons only**: Input and output neurons are excluded.
@@ -840,7 +846,7 @@ All 7 operation types are implemented in NEAT-AI's
 | **add-neurons** | 556 | 8,944 | 5.9% | 🟢 Active |
 | **add-synapses** | 1 | 9 | 10.0% | 🟡 Fixed (#413) |
 | **coordinated-structural** | — | — | — | 🟢 Active |
-| **change-squash** | 2 | 9 | 18.2% | ⚠️ Low volume |
+| **change-squash** | 2 | 9 | 18.2% | 🟡 Fixed (#417) |
 | **remove-low-impact** | 65 | 304 | 17.6% | 🟢 Active |
 | **remove-harmful-synapse** | — | — | — | 🟢 Active (#416) |
 | **remove-neuron (high error)** | 0 | 2 | 0.0% | ⛔ Disabled (#414) |
@@ -864,13 +870,12 @@ All 7 operation types are implemented in NEAT-AI's
    reduce complexity. Impact-weighted predictions are reasonably accurate.
 
 3. **change-squash** (18.2% success rate when suggested) — High success rate
-   but very rarely suggested. Investigation needed: why are more squash changes
-   not being proposed?
+   but previously very rarely suggested. Issue #417 addressed this by lowering
+   detection thresholds and integrating proactive activation recommendations.
 
 ### What Needs Investigation
 
-1. **change-squash** — Low suggestion rate. Only 11 total samples across all
-   experiments.
+1. *(None currently — previous items addressed by Issues #413–#417.)*
 
 ### What is Not Working
 
@@ -907,6 +912,23 @@ All 7 operation types are implemented in NEAT-AI's
    **Fix**: Added a threshold check to only include candidates where removing
    the synapse would actually improve the score (positive expected gain).
 
+4. **change-squash** — 🟡 **FIXED (Issue #417)**. The change-squash discovery
+   type had an 18.2% success rate (highest among active types) but very low
+   volume — only 11 total samples across all experiments.
+
+   **Root cause**: Detection thresholds were too conservative. Saturation
+   threshold (TANH) was 0.95, oscillation sign-change threshold was 0.30,
+   and the proactive activation recommendation engine was not integrated.
+
+   **Fix**: Three changes to increase candidate volume:
+   - Lowered saturation thresholds (TANH: 0.95→0.85, LOGISTIC: 0.95/0.05→0.90/0.10,
+     HARD_TANH: 0.99→0.95) to catch neurons approaching saturation
+   - Lowered oscillation thresholds (sign change fraction: 0.30→0.15,
+     minority sign fraction: 0.20→0.10) to catch milder oscillation
+   - Integrated proactive activation recommendation engine (Issue #431) into
+     the analysis pipeline to recommend activation changes based on input
+     distribution analysis before problems occur
+
 ### Recommended Actions
 
 | Priority | Action | Rationale |
@@ -916,7 +938,7 @@ All 7 operation types are implemented in NEAT-AI's
 | Done | Add interference detection (Issue #415) | Filter incompatible pairs before combo-successful |
 | Done | Fix harmful synapse threshold filtering (Issue #416) | Candidates with non-positive expected gain were included |
 | Done | Fix add-synapses prediction inversion (Issue #413) | Saturation-aware weight search for bounded targets |
-| Medium | Investigate change-squash suggestion rate | 18.2% success rate but only 11 samples |
+| Done | Increase change-squash suggestion rate (Issue #417) | Lowered thresholds, integrated proactive recommendations |
 | Low | Optimise add-neurons variants | Already working, but room for improvement |
 
 ---

--- a/docs/pr-summary-417.md
+++ b/docs/pr-summary-417.md
@@ -1,0 +1,68 @@
+## Summary
+
+Increases the change-squash suggestion rate (Issue #417). The change-squash discovery type
+had an 18.2% success rate (highest among active types) but very low volume — only 11 total
+samples across all experiments. The low volume was caused by overly conservative detection
+thresholds and the proactive activation recommendation engine not being integrated.
+
+### Changes
+
+**1. Lowered saturation detection thresholds** (`src/analysis/saturation.rs`):
+- TANH threshold: 0.95 → 0.85 (catches neurons approaching saturation earlier)
+- LOGISTIC upper/lower: 0.95/0.05 → 0.90/0.10
+- HARD_TANH threshold: 0.99 → 0.95
+- Max activation std dev: 0.05 → 0.08 (accommodates near-saturated neurons)
+
+**2. Lowered oscillation detection thresholds** (`src/analysis/oscillating_neuron.rs`):
+- Sign change fraction: 0.30 → 0.15 (catches mildly oscillating neurons)
+- Minority sign fraction: 0.20 → 0.10
+
+**3. Integrated proactive activation recommendation** (`src/analysis/mod.rs`):
+- The activation recommendation engine (Issue #431) was already implemented but not
+  wired into the `analyze_all()` pipeline. Now integrated using the standard
+  `discovery_dispatch::run_discovery_module()` pattern, generating `changeSquash`
+  candidates based on input distribution analysis before saturation/oscillation occurs.
+
+### Rationale for threshold values
+
+- **TANH at 0.85**: At tanh(1.26) ≈ 0.85, the derivative is ~0.28 (down from 1.0 at
+  x=0). This means gradient flow is already reduced by 72%. Catching these neurons
+  early allows activation changes before gradient information is fully lost.
+- **Oscillation sign change at 0.15**: Even 15% sign changes in consecutive samples
+  indicates the neuron is meaningfully fighting between two functions. The previous
+  30% threshold missed neurons with periodic (not random) oscillation patterns.
+- **Minority sign at 0.10**: A neuron with 10% negative activations still has significant
+  sign conflict that an activation change (e.g., ABSOLUTE) can resolve.
+
+## Evidence
+
+Unable to generate screenshot: This is a CLI-only library with no visual interface.
+
+The expected increase in candidate volume is structural:
+- Near-saturation: TANH neurons at 0.85–0.95 are now detected (previously only >0.95)
+- Near-oscillation: Neurons with 15–30% sign change fraction are now detected
+- Proactive recommendations: All hidden neurons are now analysed for suboptimal activation
+  function choices based on input distribution
+
+## Test Plan
+
+- Added `tests/issue_417_increase_change_squash_rate.rs` with 15 tests:
+  - `test_detects_tanh_near_saturation_at_090` — TANH at 0.90 detected
+  - `test_detects_tanh_near_saturation_at_negative_088` — TANH at -0.88 detected
+  - `test_detects_logistic_near_saturation_at_092` — LOGISTIC at 0.92 detected
+  - `test_detects_logistic_near_saturation_at_lower_bound` — LOGISTIC at 0.08 detected
+  - `test_does_not_detect_tanh_at_070` — TANH at 0.70 not flagged
+  - `test_near_saturation_has_lower_improvement_than_full` — Severity grading correct
+  - `test_detects_mild_oscillation_at_020_sign_change_fraction` — Mild oscillation detected
+  - `test_detects_oscillation_with_lower_minority_fraction` — Lower minority sign detected
+  - `test_does_not_detect_stable_neuron_with_lowered_thresholds` — Stable neurons excluded
+  - `test_saturation_recommends_expanded_activations` — changeSquash operations produced
+  - `test_oscillation_recommends_appropriate_activation_for_logistic` — Correct activation recommended
+  - `test_proactive_recommendation_for_suboptimal_activation` — Proactive recommendation works
+  - `test_proactive_recommendations_to_coordinated_candidates` — Conversion to candidates works
+  - `test_lowered_thresholds_increase_candidate_volume` — Multiple neurons detected
+  - `test_detects_softsign_near_saturation` — SOFTSIGN at 0.88 detected
+- All 13 existing saturation tests pass (Issue #342)
+- All 19 existing oscillation tests pass (Issue #358)
+- All 17 existing activation recommendation tests pass (Issue #431)
+- `quality.sh` passes cleanly

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1283,6 +1283,43 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 })
             },
         );
+
+        // Issue #417: Proactive activation function recommendation
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "activation recommendation",
+            "activation_recommendation",
+            max_candidates,
+            diversify,
+            || {
+                if hidden_neurons.is_empty() {
+                    return None;
+                }
+                let records = collect_hidden_records();
+                let mut recommendations = Vec::new();
+                for (uuid, squash, _bias) in &hidden_neurons {
+                    if let Some(neuron_records) = records.iter().find(|(u, _)| u == uuid) {
+                        if let Some(rec) = activation_recommendation::recommend_activation_function(
+                            &neuron_records.1,
+                            squash,
+                        ) {
+                            recommendations.push(rec);
+                        }
+                    }
+                }
+                if recommendations.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    activation_recommendation::recommendations_to_coordinated_candidates(
+                        &recommendations,
+                    );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: recommendations.len(),
+                    candidates,
+                })
+            },
+        );
     }
 
     // Issue #224: Candidate clustering to reduce redundant ablation tests.

--- a/src/analysis/oscillating_neuron.rs
+++ b/src/analysis/oscillating_neuron.rs
@@ -35,11 +35,18 @@ const MIN_SAMPLES_FOR_OSCILLATION: usize = 20;
 
 /// Minimum fraction of consecutive sample pairs that must show a sign change
 /// to consider the neuron oscillating.
-const MIN_SIGN_CHANGE_FRACTION: f32 = 0.3;
+///
+/// Issue #417: Lowered from 0.3 to 0.15 to catch mildly oscillating neurons.
+/// Even moderate oscillation (15%+ sign changes) indicates the neuron is
+/// fighting between two functions and may benefit from an activation change.
+const MIN_SIGN_CHANGE_FRACTION: f32 = 0.15;
 
 /// Minimum fraction of samples on the minority sign side.
 /// If 90%+ are one sign, it is not truly oscillating — it is biased.
-const MIN_MINORITY_SIGN_FRACTION: f32 = 0.2;
+///
+/// Issue #417: Lowered from 0.2 to 0.1 to catch more oscillating neurons.
+/// Even 10% minority sign presence indicates meaningful sign conflict.
+const MIN_MINORITY_SIGN_FRACTION: f32 = 0.1;
 
 /// Minimum mean absolute activation to distinguish from dead neurons.
 const MIN_MEAN_ABS_ACTIVATION: f32 = 0.01;

--- a/src/analysis/saturation.rs
+++ b/src/analysis/saturation.rs
@@ -32,19 +32,31 @@ use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 const MIN_SAMPLES_FOR_SATURATION: usize = 20;
 
 /// Activation threshold for bounded functions to consider the neuron saturated.
-/// For TANH: |mean_activation| > 0.95 is saturated.
-const TANH_SATURATION_THRESHOLD: f32 = 0.95;
+///
+/// Issue #417: Lowered from 0.95 to 0.85 to catch "near-saturated" neurons earlier.
+/// The change-squash discovery type has an 18.2% success rate but very low volume.
+/// Neurons approaching saturation (0.85–0.95) still have reduced gradient flow and
+/// benefit from activation function changes before they become fully saturated.
+const TANH_SATURATION_THRESHOLD: f32 = 0.85;
 
 /// LOGISTIC saturation thresholds: output near 0 or 1.
-const LOGISTIC_UPPER_THRESHOLD: f32 = 0.95;
-const LOGISTIC_LOWER_THRESHOLD: f32 = 0.05;
+///
+/// Issue #417: Lowered upper from 0.95 to 0.90, raised lower from 0.05 to 0.10
+/// to catch neurons approaching logistic saturation earlier.
+const LOGISTIC_UPPER_THRESHOLD: f32 = 0.90;
+const LOGISTIC_LOWER_THRESHOLD: f32 = 0.10;
 
 /// HARD_TANH / CLIPPED saturation threshold (clamped at exactly ±1.0).
-const HARD_TANH_SATURATION_THRESHOLD: f32 = 0.99;
+///
+/// Issue #417: Lowered from 0.99 to 0.95 to detect near-saturation.
+const HARD_TANH_SATURATION_THRESHOLD: f32 = 0.95;
 
 /// Maximum activation standard deviation to confirm saturation.
 /// If output varies significantly, the neuron is not truly saturated.
-const MAX_ACTIVATION_STD_DEV: f32 = 0.05;
+///
+/// Issue #417: Raised from 0.05 to 0.08 to accommodate near-saturated neurons
+/// which may have slightly more output variance than fully saturated neurons.
+const MAX_ACTIVATION_STD_DEV: f32 = 0.08;
 
 /// RELU dead-zone: mean activation is 0.0 (or very close).
 const RELU_DEAD_THRESHOLD: f32 = 1e-6;

--- a/tests/issue_417_increase_change_squash_rate.rs
+++ b/tests/issue_417_increase_change_squash_rate.rs
@@ -1,0 +1,510 @@
+//! Tests for Issue #417: Increase change-squash suggestion rate.
+//!
+//! The change-squash discovery type has an 18.2% success rate (highest among active types)
+//! but very low volume — only 11 total samples across all experiments. This issue aims to
+//! increase the suggestion rate by:
+//!
+//! 1. Lowering saturation detection thresholds to catch "near-saturated" neurons
+//! 2. Lowering oscillation detection thresholds to catch more oscillating neurons
+//! 3. Expanding activation function recommendations (not just IDENTITY/ABSOLUTE)
+//! 4. Integrating the proactive activation recommendation engine into the pipeline
+//!
+//! ## TDD Plan
+//! - Test near-saturation detection at lower thresholds (0.85 instead of 0.95)
+//! - Test oscillation detection at lower thresholds (0.15 instead of 0.3)
+//! - Test expanded activation function recommendations
+//! - Test proactive activation recommendation integration
+
+use neat_ai_discovery::analysis::activation_recommendation::{
+    recommend_activation_function, recommendations_to_coordinated_candidates,
+};
+use neat_ai_discovery::analysis::oscillating_neuron::detect_oscillating_neurons;
+use neat_ai_discovery::analysis::saturation::{
+    detect_saturated_neurons, saturated_neurons_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper: create a DiscoverRecord for a neuron with given activation.
+fn record(
+    neuron_uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    value: Option<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value,
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+// =============================================================================
+// Near-Saturation Detection Tests (lowered thresholds)
+// =============================================================================
+
+/// Test: TANH neuron at 0.90 (near saturation) should now be detected.
+///
+/// Previously, the threshold was 0.95, which meant neurons at 0.90 were missed.
+/// With the lowered threshold of 0.85, these "approaching saturation" neurons
+/// should now be caught and recommended for activation function changes.
+#[test]
+fn test_detects_tanh_near_saturation_at_090() {
+    // TANH neuron at 0.90 — approaching saturation but not fully saturated
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            record(
+                "hidden-near-sat",
+                i,
+                0.90 + 0.005 * (i as f32 / 100.0),
+                Some(2.0 + i as f32 * 0.01),
+            )
+        })
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[("hidden-near-sat".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-near-sat".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-saturated TANH neuron at mean activation ~0.90"
+    );
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "hidden-near-sat");
+    assert!(
+        c.mean_activation > 0.85,
+        "Mean activation should be > 0.85, got {}",
+        c.mean_activation
+    );
+}
+
+/// Test: TANH neuron at negative near-saturation (-0.88) should be detected.
+#[test]
+fn test_detects_tanh_near_saturation_at_negative_088() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            record(
+                "hidden-neg-near-sat",
+                i,
+                -0.88 - 0.005 * (i as f32 / 100.0),
+                Some(-1.5 - i as f32 * 0.01),
+            )
+        })
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[("hidden-neg-near-sat".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-neg-near-sat".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-saturated TANH neuron at mean activation ~-0.88"
+    );
+}
+
+/// Test: LOGISTIC neuron at 0.92 (near saturation) should be detected.
+#[test]
+fn test_detects_logistic_near_saturation_at_092() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            record(
+                "hidden-log-near-sat",
+                i,
+                0.92 + 0.003 * (i as f32 / 100.0),
+                Some(3.0 + i as f32 * 0.01),
+            )
+        })
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[(
+            "hidden-log-near-sat".to_string(),
+            "LOGISTIC".to_string(),
+            0.0,
+        )],
+        &[("hidden-log-near-sat".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-saturated LOGISTIC neuron at mean activation ~0.92"
+    );
+}
+
+/// Test: LOGISTIC neuron at 0.08 (near lower saturation) should be detected.
+#[test]
+fn test_detects_logistic_near_saturation_at_lower_bound() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            record(
+                "hidden-log-lower-sat",
+                i,
+                0.08 - 0.003 * (i as f32 / 100.0),
+                Some(-2.5 - i as f32 * 0.01),
+            )
+        })
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[(
+            "hidden-log-lower-sat".to_string(),
+            "LOGISTIC".to_string(),
+            0.0,
+        )],
+        &[("hidden-log-lower-sat".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-saturated LOGISTIC neuron at mean activation ~0.08"
+    );
+}
+
+/// Test: Neuron at 0.70 should NOT be detected (still well within active range).
+#[test]
+fn test_does_not_detect_tanh_at_070() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            record(
+                "hidden-active",
+                i,
+                0.70 + 0.005 * (i as f32 / 100.0),
+                Some(1.0 + i as f32 * 0.01),
+            )
+        })
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[("hidden-active".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-active".to_string(), records)],
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Should not detect TANH neuron at 0.70 as saturated"
+    );
+}
+
+/// Test: Near-saturation candidates should have lower estimated improvement
+/// than fully-saturated candidates, reflecting the lower severity.
+#[test]
+fn test_near_saturation_has_lower_improvement_than_full() {
+    // Fully saturated at 0.999
+    let full_sat_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("full-sat", i, 0.999, Some(10.0)))
+        .collect();
+
+    // Near-saturated at 0.90
+    let near_sat_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("near-sat", i, 0.90, Some(2.0)))
+        .collect();
+
+    let full_candidates = detect_saturated_neurons(
+        &[("full-sat".to_string(), "TANH".to_string(), 0.0)],
+        &[("full-sat".to_string(), full_sat_records)],
+    );
+    let near_candidates = detect_saturated_neurons(
+        &[("near-sat".to_string(), "TANH".to_string(), 0.0)],
+        &[("near-sat".to_string(), near_sat_records)],
+    );
+
+    assert!(
+        !full_candidates.is_empty(),
+        "Full saturation should be detected"
+    );
+    assert!(
+        !near_candidates.is_empty(),
+        "Near saturation should be detected"
+    );
+
+    assert!(
+        full_candidates[0].estimated_improvement > near_candidates[0].estimated_improvement,
+        "Full saturation ({}) should have higher estimated improvement than near-saturation ({})",
+        full_candidates[0].estimated_improvement,
+        near_candidates[0].estimated_improvement
+    );
+}
+
+// =============================================================================
+// Lower Oscillation Threshold Tests
+// =============================================================================
+
+/// Test: Neuron with 20% sign change fraction (previously below 30% threshold)
+/// should now be detected as oscillating.
+#[test]
+fn test_detects_mild_oscillation_at_020_sign_change_fraction() {
+    // Create a pattern with ~20% sign changes: mostly positive with occasional negatives
+    let mut records = Vec::new();
+    for i in 0..100u32 {
+        // Every 5th sample is negative, creating ~20% sign change fraction
+        let activation = if i % 5 == 0 { -0.5 } else { 0.5 };
+        records.push(record("hidden-mild-osc", i, activation, Some(activation)));
+    }
+
+    let candidates = detect_oscillating_neurons(
+        &[("hidden-mild-osc".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-mild-osc".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect mildly oscillating neuron with ~20% sign change fraction"
+    );
+}
+
+/// Test: Neuron with 15% minority sign fraction (previously below 20% threshold)
+/// should now be detected.
+#[test]
+fn test_detects_oscillation_with_lower_minority_fraction() {
+    // Pattern: 85% positive, 15% negative but with frequent sign changes
+    let mut records = Vec::new();
+    for i in 0..100u32 {
+        // Create alternating pattern in the first 30 records, rest positive
+        let activation = if i < 30 && i % 2 == 0 { -0.5 } else { 0.5 };
+        records.push(record(
+            "hidden-low-minority",
+            i,
+            activation,
+            Some(activation),
+        ));
+    }
+
+    let candidates = detect_oscillating_neurons(
+        &[("hidden-low-minority".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-low-minority".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect oscillation with lower minority sign fraction"
+    );
+}
+
+/// Test: Completely stable neuron (all positive) should NOT be detected even
+/// with lowered thresholds.
+#[test]
+fn test_does_not_detect_stable_neuron_with_lowered_thresholds() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-stable", i, 0.5, Some(0.5)))
+        .collect();
+
+    let candidates = detect_oscillating_neurons(
+        &[("hidden-stable".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-stable".to_string(), records)],
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Stable neuron should not be detected as oscillating"
+    );
+}
+
+// =============================================================================
+// Expanded Activation Function Recommendation Tests
+// =============================================================================
+
+/// Test: Saturated TANH neuron should recommend more than just IDENTITY.
+/// The recommendation should consider RELU, LEAKYRELU, or other alternatives
+/// based on the activation pattern.
+#[test]
+fn test_saturation_recommends_expanded_activations() {
+    // Positively saturated TANH neuron
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-exp-act", i, 0.98, Some(5.0)))
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[("hidden-exp-act".to_string(), "TANH".to_string(), 0.0)],
+        &[("hidden-exp-act".to_string(), records)],
+    );
+
+    assert!(!candidates.is_empty(), "Should detect saturated neuron");
+
+    // Convert to coordinated candidates and check that we get candidates
+    let coordinated = saturated_neurons_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated structural candidates"
+    );
+
+    // At least one candidate should include a changeSquash operation
+    let has_change_squash = coordinated.iter().any(|c| {
+        c.operations.iter().any(|op| {
+            matches!(
+                op,
+                neat_ai_discovery::CoordinatedStructuralOpJson::ChangeSquash { .. }
+            )
+        })
+    });
+    assert!(has_change_squash, "Should include changeSquash operations");
+}
+
+/// Test: Oscillating neuron with LOGISTIC should recommend ABSOLUTE not just RELU.
+#[test]
+fn test_oscillation_recommends_appropriate_activation_for_logistic() {
+    let mut records = Vec::new();
+    for i in 0..100u32 {
+        let activation = if i % 2 == 0 { 0.3 } else { -0.3 };
+        records.push(record("hidden-osc-log", i, activation, Some(activation)));
+    }
+
+    let candidates = detect_oscillating_neurons(
+        &[("hidden-osc-log".to_string(), "LOGISTIC".to_string(), 0.0)],
+        &[("hidden-osc-log".to_string(), records)],
+    );
+
+    assert!(!candidates.is_empty(), "Should detect oscillating neuron");
+    // LOGISTIC is not in the symmetric group, so should recommend RELU
+    assert_eq!(
+        candidates[0].recommended_squash, "RELU",
+        "LOGISTIC oscillation should recommend RELU"
+    );
+}
+
+// =============================================================================
+// Proactive Activation Recommendation Tests
+// =============================================================================
+
+/// Test: Proactive activation recommendation should produce changeSquash candidates
+/// for neurons where the current activation is suboptimal for the input distribution.
+#[test]
+fn test_proactive_recommendation_for_suboptimal_activation() {
+    // Create a sparse input pattern — many zeros with occasional non-zero values
+    // This pattern should recommend RELU over TANH
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = if i % 4 == 0 { 1.0 } else { 0.0 };
+            record("hidden-sparse-input", i, activation, Some(activation))
+        })
+        .collect();
+
+    let recommendation = recommend_activation_function(&records, "TANH");
+
+    assert!(
+        recommendation.is_some(),
+        "Should produce a recommendation for TANH on sparse inputs"
+    );
+
+    let rec = recommendation.unwrap();
+    assert_eq!(rec.current_squash, "TANH");
+    assert!(
+        rec.expected_improvement > 0.0,
+        "Expected improvement should be positive"
+    );
+}
+
+/// Test: Proactive recommendation converts to coordinated structural candidates.
+#[test]
+fn test_proactive_recommendations_to_coordinated_candidates() {
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = if i % 4 == 0 { 1.0 } else { 0.0 };
+            record("hidden-sparse-convert", i, activation, Some(activation))
+        })
+        .collect();
+
+    let recommendation = recommend_activation_function(&records, "TANH");
+    if let Some(rec) = recommendation {
+        let candidates = recommendations_to_coordinated_candidates(&[rec]);
+        assert!(
+            !candidates.is_empty(),
+            "Should convert recommendations to coordinated candidates"
+        );
+
+        // Check that the candidate has a changeSquash operation
+        let has_change_squash = candidates[0].operations.iter().any(|op| {
+            matches!(
+                op,
+                neat_ai_discovery::CoordinatedStructuralOpJson::ChangeSquash { .. }
+            )
+        });
+        assert!(has_change_squash, "Should include changeSquash operation");
+    }
+}
+
+/// Test: Near-saturation detection produces more candidates than full-saturation-only
+/// detection. This validates that the lowered thresholds increase volume.
+#[test]
+fn test_lowered_thresholds_increase_candidate_volume() {
+    // Create several neurons at different saturation levels
+    let neurons = vec![
+        ("full-sat-1".to_string(), "TANH".to_string(), 0.0f32),
+        ("near-sat-1".to_string(), "TANH".to_string(), 0.0f32),
+        ("near-sat-2".to_string(), "TANH".to_string(), 0.0f32),
+        ("active-1".to_string(), "TANH".to_string(), 0.0f32),
+    ];
+
+    let neuron_records = vec![
+        // Fully saturated at 0.99
+        (
+            "full-sat-1".to_string(),
+            (0..100u32)
+                .map(|i| record("full-sat-1", i, 0.99, Some(5.0)))
+                .collect(),
+        ),
+        // Near-saturated at 0.90
+        (
+            "near-sat-1".to_string(),
+            (0..100u32)
+                .map(|i| record("near-sat-1", i, 0.90, Some(2.5)))
+                .collect(),
+        ),
+        // Near-saturated at 0.87
+        (
+            "near-sat-2".to_string(),
+            (0..100u32)
+                .map(|i| record("near-sat-2", i, 0.87, Some(2.0)))
+                .collect(),
+        ),
+        // Active at 0.50
+        (
+            "active-1".to_string(),
+            (0..100u32)
+                .map(|i| record("active-1", i, 0.50, Some(0.5)))
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_saturated_neurons(&neurons, &neuron_records);
+
+    // With lowered thresholds (0.85), we should detect 3 neurons:
+    // full-sat-1 (0.99), near-sat-1 (0.90), near-sat-2 (0.87)
+    // But NOT active-1 (0.50)
+    assert!(
+        candidates.len() >= 3,
+        "Should detect at least 3 saturated/near-saturated neurons with lowered thresholds, got {}",
+        candidates.len()
+    );
+
+    // Verify active neuron is not included
+    assert!(
+        !candidates.iter().any(|c| c.neuron_uuid == "active-1"),
+        "Active neuron at 0.50 should not be detected"
+    );
+}
+
+/// Test: SOFTSIGN near-saturation detection at 0.85
+#[test]
+fn test_detects_softsign_near_saturation() {
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-softsign-sat", i, 0.88, Some(7.0)))
+        .collect();
+
+    let candidates = detect_saturated_neurons(
+        &[(
+            "hidden-softsign-sat".to_string(),
+            "SOFTSIGN".to_string(),
+            0.0,
+        )],
+        &[("hidden-softsign-sat".to_string(), records)],
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-saturated SOFTSIGN neuron at 0.88"
+    );
+}


### PR DESCRIPTION
## Summary

Increases the change-squash suggestion rate (Issue #417). The change-squash discovery type
had an 18.2% success rate (highest among active types) but very low volume — only 11 total
samples across all experiments. The low volume was caused by overly conservative detection
thresholds and the proactive activation recommendation engine not being integrated.

### Changes

**1. Lowered saturation detection thresholds** (`src/analysis/saturation.rs`):
- TANH threshold: 0.95 → 0.85 (catches neurons approaching saturation earlier)
- LOGISTIC upper/lower: 0.95/0.05 → 0.90/0.10
- HARD_TANH threshold: 0.99 → 0.95
- Max activation std dev: 0.05 → 0.08 (accommodates near-saturated neurons)

**2. Lowered oscillation detection thresholds** (`src/analysis/oscillating_neuron.rs`):
- Sign change fraction: 0.30 → 0.15 (catches mildly oscillating neurons)
- Minority sign fraction: 0.20 → 0.10

**3. Integrated proactive activation recommendation** (`src/analysis/mod.rs`):
- The activation recommendation engine (Issue #431) was already implemented but not
  wired into the `analyze_all()` pipeline. Now integrated using the standard
  `discovery_dispatch::run_discovery_module()` pattern, generating `changeSquash`
  candidates based on input distribution analysis before saturation/oscillation occurs.

### Rationale for threshold values

- **TANH at 0.85**: At tanh(1.26) ≈ 0.85, the derivative is ~0.28 (down from 1.0 at
  x=0). This means gradient flow is already reduced by 72%. Catching these neurons
  early allows activation changes before gradient information is fully lost.
- **Oscillation sign change at 0.15**: Even 15% sign changes in consecutive samples
  indicates the neuron is meaningfully fighting between two functions. The previous
  30% threshold missed neurons with periodic (not random) oscillation patterns.
- **Minority sign at 0.10**: A neuron with 10% negative activations still has significant
  sign conflict that an activation change (e.g., ABSOLUTE) can resolve.

## Evidence

Unable to generate screenshot: This is a CLI-only library with no visual interface.

The expected increase in candidate volume is structural:
- Near-saturation: TANH neurons at 0.85–0.95 are now detected (previously only >0.95)
- Near-oscillation: Neurons with 15–30% sign change fraction are now detected
- Proactive recommendations: All hidden neurons are now analysed for suboptimal activation
  function choices based on input distribution

## Test Plan

- Added `tests/issue_417_increase_change_squash_rate.rs` with 15 tests:
  - `test_detects_tanh_near_saturation_at_090` — TANH at 0.90 detected
  - `test_detects_tanh_near_saturation_at_negative_088` — TANH at -0.88 detected
  - `test_detects_logistic_near_saturation_at_092` — LOGISTIC at 0.92 detected
  - `test_detects_logistic_near_saturation_at_lower_bound` — LOGISTIC at 0.08 detected
  - `test_does_not_detect_tanh_at_070` — TANH at 0.70 not flagged
  - `test_near_saturation_has_lower_improvement_than_full` — Severity grading correct
  - `test_detects_mild_oscillation_at_020_sign_change_fraction` — Mild oscillation detected
  - `test_detects_oscillation_with_lower_minority_fraction` — Lower minority sign detected
  - `test_does_not_detect_stable_neuron_with_lowered_thresholds` — Stable neurons excluded
  - `test_saturation_recommends_expanded_activations` — changeSquash operations produced
  - `test_oscillation_recommends_appropriate_activation_for_logistic` — Correct activation recommended
  - `test_proactive_recommendation_for_suboptimal_activation` — Proactive recommendation works
  - `test_proactive_recommendations_to_coordinated_candidates` — Conversion to candidates works
  - `test_lowered_thresholds_increase_candidate_volume` — Multiple neurons detected
  - `test_detects_softsign_near_saturation` — SOFTSIGN at 0.88 detected
- All 13 existing saturation tests pass (Issue #342)
- All 19 existing oscillation tests pass (Issue #358)
- All 17 existing activation recommendation tests pass (Issue #431)
- `quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #417: **Increase change-squash suggestion rate**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #417