### PR TITLE
Fix: Sample-weighted discovery - prioritise high-error samples (#423)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.10.34"
+version = "0.10.35"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-423.md
+++ b/docs/pr-summary-423.md
@@ -1,0 +1,40 @@
+## Summary
+
+Implements sample-weighted discovery (Issue #423) to prioritise high-error samples during analysis. Previously, all samples were treated equally. Now, samples are weighted by absolute error magnitude, and neurons with disproportionately high weighted error are identified as candidates for improvement.
+
+### What changed
+
+- **New module `src/analysis/sample_weighted.rs`**: Implements error-weighted sample analysis with three core functions:
+  - `compute_sample_weights()` — normalised importance weights proportional to absolute error
+  - `stratify_samples()` — separates samples into easy (low-error) and hard (high-error) strata based on median error
+  - `detect_high_error_neurons()` — identifies neurons with weighted mean error exceeding a configurable threshold
+  - `high_error_neurons_to_coordinated_candidates()` — converts detections to `setBias` coordinated candidates
+
+- **Pipeline integration in `src/analysis/mod.rs`**: Registered as a standard discovery dispatch module, running on all neuron records
+
+- **Configurable via `SampleWeightedConfig`**: `min_weighted_error` (default: 0.25) and `min_samples` (default: 10) thresholds
+
+### Design decisions
+
+- Uses absolute error magnitude for weighting (simpler and more robust than squared error)
+- Stratification uses median split rather than percentile-based, avoiding arbitrary threshold choices
+- Generates `setBias` candidates since high-error neurons often benefit from operating point shifts
+- Estimated improvement scales with both weighted error and hard-to-easy ratio, capped at 0.1
+
+## Evidence
+
+Unable to generate screenshot: This is a Rust library with no visual interface.
+
+## Test Plan
+
+Added 17 integration tests in `tests/issue_423_sample_weighted_discovery.rs`:
+
+1. **Sample weighting**: Weights proportional to error, uniform errors produce equal weights, empty records handled
+2. **Detection**: High-error neurons detected, low-error neurons not flagged, insufficient samples return empty
+3. **Stratification**: Easy/hard separation verified, uniform errors produce balanced ratio, empty records handled
+4. **Candidate conversion**: Positive improvement, comments present, operations non-empty, sorted by improvement
+5. **Weighted improvement**: Higher error produces higher estimated improvement
+6. **Edge cases**: Single sample, NaN/infinity errors, zero errors, bimodal error patterns
+7. **Configuration**: Custom thresholds affect detection sensitivity
+
+All 17 tests pass. Full `quality.sh` passes (fmt, clippy, check, test, release build).

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -38,6 +38,7 @@
 //! - `activation_recommendation.rs` - Proactive activation function recommendation engine (Issue #431)
 //! - `weight_coherence.rs` - Weight coherence validation for brittleness detection (Issue #437)
 //! - `topology.rs` - Topology-aware network structure analysis (Issue #422)
+//! - `sample_weighted.rs` - Sample-weighted discovery prioritising high-error samples (Issue #423)
 
 pub mod activation;
 pub mod activation_recommendation;
@@ -67,6 +68,7 @@ pub mod oscillating_neuron;
 pub mod output_bias_drift;
 pub mod redundant_path;
 pub mod restricted_range;
+pub mod sample_weighted;
 pub mod samples;
 pub mod saturation;
 pub mod sentinel_gating;
@@ -1347,6 +1349,38 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 }
                 let candidates =
                     topology::topology_issues_to_coordinated_candidates(&detected, &input.creature);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            },
+        );
+
+        // Issue #423: Sample-weighted discovery — prioritise high-error samples
+        discovery_dispatch::run_discovery_module(
+            syn,
+            "sample-weighted discovery",
+            "sample_weighted_discovery",
+            max_candidates,
+            diversify,
+            || {
+                let uuids: Vec<String> = input
+                    .creature
+                    .neurons
+                    .iter()
+                    .map(|n| n.uuid.clone())
+                    .collect();
+                let records = collect_records(&uuids);
+                if records.is_empty() {
+                    return None;
+                }
+                let config = sample_weighted::SampleWeightedConfig::default();
+                let detected = sample_weighted::detect_high_error_neurons(&records, &config);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    sample_weighted::high_error_neurons_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/src/analysis/sample_weighted.rs
+++ b/src/analysis/sample_weighted.rs
@@ -1,0 +1,356 @@
+//! Sample-weighted discovery module (Issue #423).
+//!
+//! Prioritises high-error samples during discovery analysis. Current discovery
+//! treats all samples equally, but samples with high error are more important
+//! for improvement and should receive proportional analysis attention.
+//!
+//! ## Approach
+//!
+//! 1. **Compute sample importance**: Weight each sample by absolute error magnitude
+//! 2. **Detect high-error neurons**: Identify neurons with disproportionate high-error samples
+//! 3. **Stratified analysis**: Separately characterise easy vs hard samples
+//! 4. **Candidate generation**: Produce coordinated candidates targeting high-error patterns
+//!
+//! ## Configuration
+//!
+//! Detection thresholds can be configured via `SampleWeightedConfig`:
+//! - `min_weighted_error`: Minimum weighted error to flag a neuron (default: 0.25)
+//! - `min_samples`: Minimum samples required for statistical reliability (default: 10)
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Default minimum weighted error to consider a neuron as high-error.
+const DEFAULT_MIN_WEIGHTED_ERROR: f32 = 0.25;
+
+/// Default minimum samples required for detection.
+const DEFAULT_MIN_SAMPLES: usize = 10;
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/// Configuration for sample-weighted discovery.
+#[derive(Debug, Clone)]
+pub struct SampleWeightedConfig {
+    /// Minimum weighted error to flag a neuron as high-error.
+    pub min_weighted_error: f32,
+    /// Minimum samples required for detection.
+    pub min_samples: usize,
+}
+
+impl Default for SampleWeightedConfig {
+    fn default() -> Self {
+        Self {
+            min_weighted_error: DEFAULT_MIN_WEIGHTED_ERROR,
+            min_samples: DEFAULT_MIN_SAMPLES,
+        }
+    }
+}
+
+// =============================================================================
+// Detection Types
+// =============================================================================
+
+/// A neuron identified as contributing disproportionately to high-error samples.
+#[derive(Debug, Clone)]
+pub struct HighErrorNeuronCandidate {
+    /// UUID of the neuron with high weighted error.
+    pub neuron_uuid: String,
+    /// Weighted mean error across all samples.
+    pub weighted_mean_error: f32,
+    /// Proportion of samples in the high-error stratum (0.0 to 1.0).
+    pub high_error_proportion: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Hard-to-easy error ratio from stratified analysis.
+    pub hard_to_easy_ratio: f32,
+    /// Estimated creature score improvement from addressing this neuron.
+    pub estimated_improvement: f32,
+}
+
+/// Result of stratifying samples into easy and hard groups.
+#[derive(Debug, Clone)]
+pub struct StratifiedAnalysis {
+    /// Indices of easy (low-error) samples.
+    pub easy_samples: Vec<usize>,
+    /// Indices of hard (high-error) samples.
+    pub hard_samples: Vec<usize>,
+    /// Mean error of easy samples.
+    pub easy_mean_error: f32,
+    /// Mean error of hard samples.
+    pub hard_mean_error: f32,
+    /// Ratio of hard mean error to easy mean error.
+    pub hard_to_easy_ratio: f32,
+}
+
+// =============================================================================
+// Core Functions
+// =============================================================================
+
+/// Compute importance weights for each sample based on absolute error magnitude.
+///
+/// Returns a vector of normalised weights (summing to 1.0) where higher-error
+/// samples receive proportionally higher weights.
+///
+/// Non-finite error values are filtered out and receive zero weight.
+pub fn compute_sample_weights(records: &[DiscoverRecord]) -> Vec<f32> {
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    // Extract absolute error for each record, filtering non-finite values
+    let abs_errors: Vec<f32> = records
+        .iter()
+        .map(|r| {
+            let avg_err = if r.errors.is_empty() {
+                0.0
+            } else {
+                r.errors.iter().sum::<f32>() / r.errors.len() as f32
+            };
+            if avg_err.is_finite() {
+                avg_err.abs()
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    let total: f32 = abs_errors.iter().sum();
+
+    if total <= f32::EPSILON {
+        // All errors are zero or negligible — return uniform weights
+        let uniform = 1.0 / abs_errors.len() as f32;
+        return vec![uniform; abs_errors.len()];
+    }
+
+    // Normalise to sum to 1.0
+    abs_errors.iter().map(|&e| e / total).collect()
+}
+
+/// Stratify samples into easy (low-error) and hard (high-error) groups.
+///
+/// Uses the median absolute error as the split point. Returns indices into
+/// the original records vector for each group.
+pub fn stratify_samples(records: &[DiscoverRecord]) -> StratifiedAnalysis {
+    if records.is_empty() {
+        return StratifiedAnalysis {
+            easy_samples: Vec::new(),
+            hard_samples: Vec::new(),
+            easy_mean_error: 0.0,
+            hard_mean_error: 0.0,
+            hard_to_easy_ratio: 1.0,
+        };
+    }
+
+    // Compute absolute error for each record
+    let abs_errors: Vec<f32> = records
+        .iter()
+        .map(|r| {
+            if r.errors.is_empty() {
+                0.0
+            } else {
+                let avg = r.errors.iter().sum::<f32>() / r.errors.len() as f32;
+                if avg.is_finite() {
+                    avg.abs()
+                } else {
+                    0.0
+                }
+            }
+        })
+        .collect();
+
+    // Compute median
+    let mut sorted_errors: Vec<f32> = abs_errors.clone();
+    sorted_errors.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median = sorted_errors[sorted_errors.len() / 2];
+
+    // Split into easy (≤ median) and hard (> median)
+    let mut easy_samples = Vec::new();
+    let mut hard_samples = Vec::new();
+    let mut easy_sum = 0.0f32;
+    let mut hard_sum = 0.0f32;
+
+    for (i, &err) in abs_errors.iter().enumerate() {
+        if err <= median {
+            easy_samples.push(i);
+            easy_sum += err;
+        } else {
+            hard_samples.push(i);
+            hard_sum += err;
+        }
+    }
+
+    // Handle edge case where all values equal median (all go to easy)
+    if hard_samples.is_empty() && !easy_samples.is_empty() {
+        // Split in half: move second half to hard
+        let mid = easy_samples.len() / 2;
+        hard_samples = easy_samples.split_off(mid);
+        // Recalculate sums
+        easy_sum = easy_samples.iter().map(|&i| abs_errors[i]).sum();
+        hard_sum = hard_samples.iter().map(|&i| abs_errors[i]).sum();
+    }
+
+    let easy_mean = if easy_samples.is_empty() {
+        0.0
+    } else {
+        easy_sum / easy_samples.len() as f32
+    };
+
+    let hard_mean = if hard_samples.is_empty() {
+        0.0
+    } else {
+        hard_sum / hard_samples.len() as f32
+    };
+
+    let ratio = if easy_mean > f32::EPSILON {
+        hard_mean / easy_mean
+    } else if hard_mean > f32::EPSILON {
+        hard_mean / f32::EPSILON
+    } else {
+        1.0
+    };
+
+    StratifiedAnalysis {
+        easy_samples,
+        hard_samples,
+        easy_mean_error: easy_mean,
+        hard_mean_error: hard_mean,
+        hard_to_easy_ratio: ratio,
+    }
+}
+
+/// Detect neurons with disproportionately high weighted error.
+///
+/// For each neuron, computes a weighted mean error (weighted by sample importance)
+/// and flags neurons that exceed the configured threshold.
+///
+/// # Arguments
+/// * `records` - Vector of (neuron_uuid, records) tuples
+/// * `config` - Configuration for detection thresholds
+///
+/// # Returns
+/// Vector of candidates, sorted by estimated improvement (best first).
+pub fn detect_high_error_neurons(
+    records: &[(String, Vec<DiscoverRecord>)],
+    config: &SampleWeightedConfig,
+) -> Vec<HighErrorNeuronCandidate> {
+    let mut candidates = Vec::new();
+
+    for (neuron_uuid, neuron_records) in records {
+        if neuron_records.len() < config.min_samples {
+            continue;
+        }
+
+        // Compute sample weights
+        let weights = compute_sample_weights(neuron_records);
+        if weights.is_empty() {
+            continue;
+        }
+
+        // Compute absolute errors
+        let abs_errors: Vec<f32> = neuron_records
+            .iter()
+            .map(|r| {
+                if r.errors.is_empty() {
+                    0.0
+                } else {
+                    let avg = r.errors.iter().sum::<f32>() / r.errors.len() as f32;
+                    if avg.is_finite() {
+                        avg.abs()
+                    } else {
+                        0.0
+                    }
+                }
+            })
+            .collect();
+
+        // Compute weighted mean error
+        let weighted_mean: f32 = weights
+            .iter()
+            .zip(abs_errors.iter())
+            .map(|(&w, &e)| w * e)
+            .sum();
+
+        if weighted_mean < config.min_weighted_error {
+            continue;
+        }
+
+        // Stratify to get hard-to-easy ratio and high-error proportion
+        let stratified = stratify_samples(neuron_records);
+        let high_error_proportion =
+            stratified.hard_samples.len() as f32 / neuron_records.len() as f32;
+
+        // Estimate improvement: weighted mean error scaled by the hard-to-easy
+        // ratio, capped at a reasonable maximum
+        let estimated_improvement =
+            (weighted_mean * stratified.hard_to_easy_ratio.min(10.0) * 0.01).min(0.1);
+
+        candidates.push(HighErrorNeuronCandidate {
+            neuron_uuid: neuron_uuid.clone(),
+            weighted_mean_error: weighted_mean,
+            high_error_proportion,
+            sample_count: neuron_records.len(),
+            hard_to_easy_ratio: stratified.hard_to_easy_ratio,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+// =============================================================================
+// Candidate Conversion
+// =============================================================================
+
+/// Convert high-error neuron candidates to coordinated structural candidates.
+///
+/// Generates `setBias` operations to adjust the bias of high-error neurons,
+/// which can help shift the neuron's operating point to reduce error on
+/// difficult samples.
+pub fn high_error_neurons_to_coordinated_candidates(
+    candidates: &[HighErrorNeuronCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut result: Vec<CoordinatedStructuralCandidateJson> = candidates
+        .iter()
+        .map(|c| {
+            // Recommend a bias adjustment proportional to the weighted error
+            let bias_adjustment = -c.weighted_mean_error * 0.1;
+
+            CoordinatedStructuralCandidateJson {
+                operations: vec![CoordinatedStructuralOpJson::SetBias {
+                    neuron_uuid: c.neuron_uuid.clone(),
+                    bias: bias_adjustment,
+                }],
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(format!(
+                    "Sample-weighted discovery: weighted error {:.3}, {:.0}% high-error samples, hard/easy ratio {:.1}x ({} samples)",
+                    c.weighted_mean_error,
+                    c.high_error_proportion * 100.0,
+                    c.hard_to_easy_ratio,
+                    c.sample_count,
+                )),
+            }
+        })
+        .collect();
+
+    // Sort by improvement (best first)
+    result.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .partial_cmp(&a.expected_creature_score_gain)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    result
+}

--- a/tests/issue_423_sample_weighted_discovery.rs
+++ b/tests/issue_423_sample_weighted_discovery.rs
@@ -1,0 +1,508 @@
+//! Tests for Issue #423: Sample-weighted discovery — prioritise high-error samples.
+//!
+//! Current discovery treats all samples equally. Samples with high error are more
+//! important for improvement but don't receive proportional analysis attention.
+//! This module weights samples by error magnitude and focuses analysis on neurons
+//! active during high-error samples.
+//!
+//! ## TDD Plan
+//! 1. Test sample importance weighting by absolute error magnitude
+//! 2. Test detection of high-error-dominant neurons (neurons that disproportionately
+//!    contribute to high-error samples)
+//! 3. Test stratified analysis — easy vs hard sample separation
+//! 4. Test that balanced-error neurons are NOT flagged
+//! 5. Test candidate generation produces valid coordinated candidates
+//! 6. Test edge cases: empty records, single sample, all-equal errors
+//! 7. Test outlier sample detection (consistently failing samples)
+//! 8. Test weighted improvement estimation
+
+mod common;
+
+use neat_ai_discovery::analysis::sample_weighted::{
+    compute_sample_weights, detect_high_error_neurons,
+    high_error_neurons_to_coordinated_candidates, stratify_samples, SampleWeightedConfig,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helper: create records with specified error magnitudes
+// =============================================================================
+
+fn make_records(neuron_uuid: &str, errors: &[f32]) -> Vec<DiscoverRecord> {
+    errors
+        .iter()
+        .enumerate()
+        .map(|(i, &err)| DiscoverRecord {
+            obs_index: i as u32,
+            neuron_uuid: neuron_uuid.to_string(),
+            value: Some(0.5),
+            activation: 0.5,
+            errors: vec![err],
+        })
+        .collect()
+}
+
+// =============================================================================
+// Test 1: Sample importance weighting by absolute error magnitude
+// =============================================================================
+
+/// Samples with higher absolute error should receive higher weights.
+#[test]
+fn test_sample_weights_proportional_to_error() {
+    let errors = vec![0.1, 0.2, 0.5, 1.0, 2.0];
+    let records = make_records("neuron-a", &errors);
+
+    let weights = compute_sample_weights(&records);
+
+    assert_eq!(weights.len(), 5);
+
+    // Higher error → higher weight
+    for i in 1..weights.len() {
+        assert!(
+            weights[i] >= weights[i - 1],
+            "Weight at index {i} ({}) should be >= weight at index {} ({})",
+            weights[i],
+            i - 1,
+            weights[i - 1]
+        );
+    }
+
+    // Weights should sum to approximately 1.0 (normalised)
+    let sum: f32 = weights.iter().sum();
+    assert!(
+        (sum - 1.0).abs() < 0.01,
+        "Weights should sum to ~1.0, got {sum}"
+    );
+
+    // The highest-error sample should get a noticeably larger weight
+    assert!(
+        weights[4] > weights[0] * 1.5,
+        "Highest error weight ({}) should be significantly larger than lowest ({})",
+        weights[4],
+        weights[0]
+    );
+}
+
+/// All-equal errors should produce uniform weights.
+#[test]
+fn test_uniform_errors_produce_equal_weights() {
+    let errors = vec![0.5; 50];
+    let records = make_records("neuron-a", &errors);
+
+    let weights = compute_sample_weights(&records);
+
+    assert_eq!(weights.len(), 50);
+
+    let expected_weight = 1.0 / 50.0;
+    for (i, &w) in weights.iter().enumerate() {
+        assert!(
+            (w - expected_weight).abs() < 0.001,
+            "Weight at index {i} should be ~{expected_weight}, got {w}"
+        );
+    }
+}
+
+/// Empty records should produce empty weights.
+#[test]
+fn test_empty_records_produce_empty_weights() {
+    let weights = compute_sample_weights(&[]);
+    assert!(weights.is_empty());
+}
+
+// =============================================================================
+// Test 2: Detection of high-error-dominant neurons
+// =============================================================================
+
+/// A neuron that has disproportionately high errors on high-error samples
+/// should be detected as a candidate.
+#[test]
+fn test_detects_high_error_neuron() {
+    // Neuron with mostly high errors — a problem neuron
+    let high_error_records = make_records(
+        "problem-neuron",
+        &[
+            0.8, 0.9, 1.0, 0.7, 0.85, 0.95, 0.6, 0.75, 0.88, 0.92, 0.82, 0.91, 0.87, 0.93, 0.78,
+            0.86, 0.94, 0.89, 0.81, 0.96,
+        ],
+    );
+
+    // Neuron with low errors — a healthy neuron
+    let low_error_records = make_records(
+        "healthy-neuron",
+        &[
+            0.01, 0.02, 0.03, 0.01, 0.02, 0.01, 0.03, 0.02, 0.01, 0.02, 0.01, 0.02, 0.03, 0.01,
+            0.02, 0.01, 0.03, 0.02, 0.01, 0.02,
+        ],
+    );
+
+    let records = vec![
+        ("problem-neuron".to_string(), high_error_records),
+        ("healthy-neuron".to_string(), low_error_records),
+    ];
+
+    let config = SampleWeightedConfig::default();
+    let candidates = detect_high_error_neurons(&records, &config);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect at least one high-error neuron"
+    );
+
+    // The problem neuron should be detected
+    assert!(
+        candidates.iter().any(|c| c.neuron_uuid == "problem-neuron"),
+        "Should detect 'problem-neuron' as high-error"
+    );
+
+    // The healthy neuron should NOT be detected
+    assert!(
+        !candidates.iter().any(|c| c.neuron_uuid == "healthy-neuron"),
+        "Should NOT detect 'healthy-neuron' as high-error"
+    );
+}
+
+/// Neurons with uniformly low errors should NOT be flagged.
+#[test]
+fn test_low_error_neurons_not_flagged() {
+    let records = vec![
+        (
+            "neuron-a".to_string(),
+            make_records("neuron-a", &[0.01; 30]),
+        ),
+        (
+            "neuron-b".to_string(),
+            make_records("neuron-b", &[0.02; 30]),
+        ),
+    ];
+
+    let config = SampleWeightedConfig::default();
+    let candidates = detect_high_error_neurons(&records, &config);
+
+    assert!(
+        candidates.is_empty(),
+        "No high-error neurons expected when all errors are low, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+/// Detection needs a minimum number of samples.
+#[test]
+fn test_insufficient_samples_returns_empty() {
+    let records = vec![(
+        "neuron-a".to_string(),
+        make_records("neuron-a", &[0.9, 0.8]),
+    )];
+
+    let config = SampleWeightedConfig::default();
+    let candidates = detect_high_error_neurons(&records, &config);
+
+    assert!(
+        candidates.is_empty(),
+        "Should return empty for insufficient samples"
+    );
+}
+
+// =============================================================================
+// Test 3: Stratified analysis — easy vs hard samples
+// =============================================================================
+
+/// Stratified analysis should separate samples into easy (low error) and hard
+/// (high error) groups based on the median error threshold.
+#[test]
+fn test_stratify_samples_separates_easy_and_hard() {
+    // Mix of easy and hard samples
+    let records = make_records(
+        "neuron-a",
+        &[
+            0.01, 0.02, 0.03, 0.04, 0.05, // Easy samples
+            0.5, 0.6, 0.7, 0.8, 0.9,
+        ], // Hard samples
+    );
+
+    let stratified = stratify_samples(&records);
+
+    assert!(
+        !stratified.easy_samples.is_empty(),
+        "Should have easy samples"
+    );
+    assert!(
+        !stratified.hard_samples.is_empty(),
+        "Should have hard samples"
+    );
+
+    // Mean error of hard samples should be higher than easy samples
+    assert!(
+        stratified.hard_mean_error > stratified.easy_mean_error,
+        "Hard mean error ({}) should exceed easy mean error ({})",
+        stratified.hard_mean_error,
+        stratified.easy_mean_error
+    );
+
+    // Hard-to-easy ratio should be meaningful
+    assert!(
+        stratified.hard_to_easy_ratio > 1.0,
+        "Hard-to-easy ratio ({}) should be > 1.0",
+        stratified.hard_to_easy_ratio
+    );
+}
+
+/// Stratifying uniform errors should produce similar easy and hard groups.
+#[test]
+fn test_stratify_uniform_errors_balanced() {
+    let records = make_records("neuron-a", &[0.5; 20]);
+
+    let stratified = stratify_samples(&records);
+
+    // With uniform errors, hard-to-easy ratio should be close to 1.0
+    assert!(
+        stratified.hard_to_easy_ratio < 1.5,
+        "Uniform errors should have ratio near 1.0, got {}",
+        stratified.hard_to_easy_ratio
+    );
+}
+
+/// Stratifying empty records should return an empty/default stratification.
+#[test]
+fn test_stratify_empty_records() {
+    let stratified = stratify_samples(&[]);
+
+    assert!(stratified.easy_samples.is_empty());
+    assert!(stratified.hard_samples.is_empty());
+}
+
+// =============================================================================
+// Test 4: Candidate conversion produces valid coordinated candidates
+// =============================================================================
+
+/// Detected high-error neurons should convert to valid coordinated candidates
+/// with positive expected improvement and appropriate comments.
+#[test]
+fn test_candidates_have_positive_improvement() {
+    let high_error_records = make_records(
+        "problem-neuron",
+        &[
+            0.8, 0.9, 1.0, 0.7, 0.85, 0.95, 0.6, 0.75, 0.88, 0.92, 0.82, 0.91, 0.87, 0.93, 0.78,
+            0.86, 0.94, 0.89, 0.81, 0.96,
+        ],
+    );
+
+    let records = vec![("problem-neuron".to_string(), high_error_records)];
+
+    let config = SampleWeightedConfig::default();
+    let detected = detect_high_error_neurons(&records, &config);
+
+    assert!(!detected.is_empty(), "Should detect candidates");
+
+    let coordinated = high_error_neurons_to_coordinated_candidates(&detected);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    for candidate in &coordinated {
+        assert!(
+            candidate.expected_creature_score_gain > 0.0,
+            "Expected improvement should be positive, got {}",
+            candidate.expected_creature_score_gain
+        );
+        assert!(
+            candidate.comment.is_some(),
+            "Candidate should have a comment"
+        );
+        assert!(
+            !candidate.operations.is_empty(),
+            "Candidate should have at least one operation"
+        );
+    }
+}
+
+/// Candidates should be sorted by expected improvement (best first).
+#[test]
+fn test_candidates_sorted_by_improvement() {
+    // Create multiple neurons with varying error levels
+    let records = vec![
+        (
+            "slight-problem".to_string(),
+            make_records("slight-problem", &[0.3; 30]),
+        ),
+        (
+            "big-problem".to_string(),
+            make_records("big-problem", &[0.9; 30]),
+        ),
+        (
+            "medium-problem".to_string(),
+            make_records("medium-problem", &[0.6; 30]),
+        ),
+    ];
+
+    let config = SampleWeightedConfig::default();
+    let detected = detect_high_error_neurons(&records, &config);
+
+    if detected.len() >= 2 {
+        let coordinated = high_error_neurons_to_coordinated_candidates(&detected);
+
+        for i in 1..coordinated.len() {
+            assert!(
+                coordinated[i - 1].expected_creature_score_gain
+                    >= coordinated[i].expected_creature_score_gain,
+                "Candidates should be sorted by improvement (descending)"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Test 5: Weighted improvement estimation
+// =============================================================================
+
+/// A neuron with high weighted error should have a higher estimated improvement
+/// than one with moderate weighted error.
+#[test]
+fn test_weighted_improvement_scales_with_error() {
+    let records = vec![
+        (
+            "high-error-neuron".to_string(),
+            make_records("high-error-neuron", &[0.9; 30]),
+        ),
+        (
+            "moderate-error-neuron".to_string(),
+            make_records("moderate-error-neuron", &[0.4; 30]),
+        ),
+    ];
+
+    let config = SampleWeightedConfig::default();
+    let detected = detect_high_error_neurons(&records, &config);
+
+    let high = detected
+        .iter()
+        .find(|c| c.neuron_uuid == "high-error-neuron");
+    let moderate = detected
+        .iter()
+        .find(|c| c.neuron_uuid == "moderate-error-neuron");
+
+    if let (Some(h), Some(m)) = (high, moderate) {
+        assert!(
+            h.estimated_improvement > m.estimated_improvement,
+            "High-error neuron improvement ({}) should exceed moderate ({})",
+            h.estimated_improvement,
+            m.estimated_improvement
+        );
+    }
+}
+
+// =============================================================================
+// Test 6: Edge cases
+// =============================================================================
+
+/// A single sample should not produce candidates (insufficient for statistics).
+#[test]
+fn test_single_sample_no_candidates() {
+    let records = vec![("neuron-a".to_string(), make_records("neuron-a", &[1.0]))];
+
+    let config = SampleWeightedConfig::default();
+    let candidates = detect_high_error_neurons(&records, &config);
+
+    assert!(
+        candidates.is_empty(),
+        "Single sample should not produce candidates"
+    );
+}
+
+/// NaN and infinite errors should be safely handled.
+#[test]
+fn test_non_finite_errors_handled() {
+    let mut records_data: Vec<f32> = vec![0.1; 20];
+    records_data.push(f32::NAN);
+    records_data.push(f32::INFINITY);
+
+    let records = make_records("neuron-a", &records_data);
+    let weights = compute_sample_weights(&records);
+
+    // Should not panic and should filter out non-finite values
+    assert!(!weights.is_empty());
+
+    // All weights should be finite
+    for (i, &w) in weights.iter().enumerate() {
+        assert!(
+            w.is_finite(),
+            "Weight at index {i} should be finite, got {w}"
+        );
+    }
+}
+
+/// Zero errors should produce minimal weights.
+#[test]
+fn test_zero_errors_produce_minimal_weights() {
+    let errors = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let records = make_records("neuron-a", &errors);
+
+    let weights = compute_sample_weights(&records);
+
+    // All weights should be equal (uniform) since all errors are zero
+    let expected = 1.0 / weights.len() as f32;
+    for &w in &weights {
+        assert!(
+            (w - expected).abs() < 0.01,
+            "All-zero errors should produce uniform weights"
+        );
+    }
+}
+
+// =============================================================================
+// Test 7: Detection with mixed-error patterns
+// =============================================================================
+
+/// A neuron with bimodal errors (some very low, some very high) should be detected
+/// as a high-error candidate based on the high-error subpopulation.
+#[test]
+fn test_bimodal_error_neuron_detected() {
+    let mut errors: Vec<f32> = vec![0.01; 15]; // Easy samples
+    errors.extend(vec![0.9; 15]); // Hard samples
+
+    let records = vec![(
+        "bimodal-neuron".to_string(),
+        make_records("bimodal-neuron", &errors),
+    )];
+
+    let config = SampleWeightedConfig::default();
+    let candidates = detect_high_error_neurons(&records, &config);
+
+    // The bimodal neuron should still be detected because the high-error
+    // subpopulation has significant weighted error
+    assert!(
+        !candidates.is_empty(),
+        "Bimodal error neuron should be detected"
+    );
+}
+
+// =============================================================================
+// Test 8: Config customisation
+// =============================================================================
+
+/// Custom config thresholds should affect detection.
+#[test]
+fn test_custom_config_threshold() {
+    let records = vec![("neuron-a".to_string(), make_records("neuron-a", &[0.3; 30]))];
+
+    // Very low threshold should detect more
+    let lenient_config = SampleWeightedConfig {
+        min_weighted_error: 0.1,
+        ..SampleWeightedConfig::default()
+    };
+    let lenient_candidates = detect_high_error_neurons(&records, &lenient_config);
+
+    // Very high threshold should detect fewer
+    let strict_config = SampleWeightedConfig {
+        min_weighted_error: 0.95,
+        ..SampleWeightedConfig::default()
+    };
+    let strict_candidates = detect_high_error_neurons(&records, &strict_config);
+
+    assert!(
+        lenient_candidates.len() >= strict_candidates.len(),
+        "Lenient config should detect >= strict config candidates ({} vs {})",
+        lenient_candidates.len(),
+        strict_candidates.len()
+    );
+}


### PR DESCRIPTION
## Summary

Implements sample-weighted discovery (Issue #423) to prioritise high-error samples during analysis. Previously, all samples were treated equally. Now, samples are weighted by absolute error magnitude, and neurons with disproportionately high weighted error are identified as candidates for improvement.

### What changed

- **New module `src/analysis/sample_weighted.rs`**: Implements error-weighted sample analysis with three core functions:
  - `compute_sample_weights()` — normalised importance weights proportional to absolute error
  - `stratify_samples()` — separates samples into easy (low-error) and hard (high-error) strata based on median error
  - `detect_high_error_neurons()` — identifies neurons with weighted mean error exceeding a configurable threshold
  - `high_error_neurons_to_coordinated_candidates()` — converts detections to `setBias` coordinated candidates

- **Pipeline integration in `src/analysis/mod.rs`**: Registered as a standard discovery dispatch module, running on all neuron records

- **Configurable via `SampleWeightedConfig`**: `min_weighted_error` (default: 0.25) and `min_samples` (default: 10) thresholds

### Design decisions

- Uses absolute error magnitude for weighting (simpler and more robust than squared error)
- Stratification uses median split rather than percentile-based, avoiding arbitrary threshold choices
- Generates `setBias` candidates since high-error neurons often benefit from operating point shifts
- Estimated improvement scales with both weighted error and hard-to-easy ratio, capped at 0.1

## Evidence

Unable to generate screenshot: This is a Rust library with no visual interface.

## Test Plan

Added 17 integration tests in `tests/issue_423_sample_weighted_discovery.rs`:

1. **Sample weighting**: Weights proportional to error, uniform errors produce equal weights, empty records handled
2. **Detection**: High-error neurons detected, low-error neurons not flagged, insufficient samples return empty
3. **Stratification**: Easy/hard separation verified, uniform errors produce balanced ratio, empty records handled
4. **Candidate conversion**: Positive improvement, comments present, operations non-empty, sorted by improvement
5. **Weighted improvement**: Higher error produces higher estimated improvement
6. **Edge cases**: Single sample, NaN/infinity errors, zero errors, bimodal error patterns
7. **Configuration**: Custom thresholds affect detection sensitivity

All 17 tests pass. Full `quality.sh` passes (fmt, clippy, check, test, release build).

---

## Automated Fix Details
This PR addresses issue #423: **Sample-weighted discovery - prioritise high-error samples**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #423