### PR TITLE
Fix: Target-type prioritisation — favour existing hidden neurons as targets (#468)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 
 [lib]

--- a/docs/pr-summary-468.md
+++ b/docs/pr-summary-468.md
@@ -1,0 +1,37 @@
+## Summary
+
+Target-type prioritisation for synapse candidate scoring (Issue #468). GRQ-sampler data shows existing hidden neurons as targets have a 31.4% success rate compared to 5.3-5.4% for output or discovery-hidden neurons. This change:
+
+- Adds `EXISTING_HIDDEN_TARGET_BOOST` constant (1.5x) to `constants.rs` for configurable target-type weighting
+- Adds `apply_target_type_boost()` function that boosts candidate score gains when the target is an existing hidden neuron
+- Applies the boost in the candidate scoring pipeline (after impact discounting and source-type boost)
+- Adds `order_focus_targets()` to prioritise existing hidden neurons in focus order, so they are evaluated first under deadline constraints
+
+## Evidence
+
+This is a backend/scoring change with no UI. Verified through:
+- 13 new integration tests covering all acceptance criteria
+- `./quality.sh` passes cleanly (fmt, clippy, check, 566 tests, release build)
+
+## Test Plan
+
+Added `tests/issue_468_target_type_prioritisation.rs` with 13 tests:
+
+**Constant validation:**
+- `existing_hidden_target_boost_value_is_reasonable` — verifies boost is bounded (1.0, 3.0]
+- `existing_hidden_target_boost_amplifies_score_gain` — verifies multiplier effect
+
+**Boost function (`apply_target_type_boost`):**
+- `apply_target_type_boost_boosts_existing_hidden_target` — hidden target gets boosted
+- `apply_target_type_boost_neutral_for_output_target` — output target is neutral
+- `apply_target_type_boost_neutral_for_unknown_target` — unknown target is neutral
+- `apply_target_type_boost_zero_gain_stays_zero` — zero gain stays zero
+- `apply_target_type_boost_neutral_for_input_target` — input target is neutral
+- `apply_target_type_boost_neutral_for_constant_target` — constant target is neutral
+
+**Focus ordering (`order_focus_targets`):**
+- `order_focus_targets_places_existing_hidden_before_output` — hidden targets ordered first
+- `order_focus_targets_consistent_across_seeds` — ordering holds across random seeds
+- `order_focus_targets_preserves_all_targets` — no targets lost during reordering
+- `order_focus_targets_handles_single_target` — edge case: single element
+- `order_focus_targets_handles_unknown_types_as_non_hidden` — unknown types treated as non-hidden

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -133,3 +133,18 @@ pub const INPUT_SOURCE_BOOST: f64 = 1.5;
 /// ## Valid Range
 /// Must be >= 5 to avoid noise and <= 50 to be responsive.
 pub const MIN_BOOST_SAMPLES: usize = 10;
+
+// =============================================================================
+// Target-Type Scoring (Issue #468)
+// =============================================================================
+
+/// Scoring boost multiplier for candidates targeting existing hidden neurons.
+///
+/// GRQ-sampler analysis shows existing hidden neurons as targets have a 31.4%
+/// success rate compared to 5.3–5.4% for output or discovery-hidden neurons.
+/// This boost is applied as a static multiplier to `expected_creature_score_gain`
+/// when the target neuron is an existing hidden neuron.
+///
+/// ## Valid Range
+/// Must be > 1.0 (boost) and <= 3.0 (avoid over-biasing).
+pub const EXISTING_HIDDEN_TARGET_BOOST: f64 = 1.5;

--- a/src/analysis/synapse.rs
+++ b/src/analysis/synapse.rs
@@ -39,7 +39,7 @@ use crate::analysis::activation::{
 // Import deadline handling and logging utilities from dedicated module (Issue #268)
 use crate::analysis::utils::{
     build_deadline, deadline_passed, log_analysis_start, log_analysis_timeout,
-    order_eligible_sources, parse_input_index, shuffle_slice, shuffle_within_top_k,
+    order_eligible_sources, order_focus_targets, parse_input_index, shuffle_within_top_k,
     verbose_enabled, OrderedNeuron,
 };
 
@@ -99,6 +99,9 @@ use super::constants::MIN_NEURON_SAMPLE_COUNT;
 // INPUT_SOURCE_BOOST for source-type prioritisation (Issue #467)
 use super::constants::INPUT_SOURCE_BOOST;
 
+// EXISTING_HIDDEN_TARGET_BOOST for target-type prioritisation (Issue #468)
+use super::constants::EXISTING_HIDDEN_TARGET_BOOST;
+
 // Note: MIN_NEURON_OUTPUT_STD_DEV has been moved to the activation module
 // as part of Issue #238. It is used by has_sufficient_output_variance.
 
@@ -117,6 +120,34 @@ use super::constants::INPUT_SOURCE_BOOST;
 pub fn apply_source_type_boost(gain: f32, source_uuid: &str) -> f32 {
     if parse_input_index(source_uuid).is_some() {
         gain * INPUT_SOURCE_BOOST as f32
+    } else {
+        gain
+    }
+}
+
+// =============================================================================
+// Target-Type Prioritisation (Issue #468)
+// =============================================================================
+
+/// Applies target-type boost to a candidate's expected score gain.
+///
+/// Existing hidden neurons as targets have a 31.4% success rate compared to
+/// 5.3–5.4% for output or discovery-hidden neurons (GRQ-sampler data). This
+/// function applies [`EXISTING_HIDDEN_TARGET_BOOST`] as a multiplier when the
+/// target neuron is an existing hidden neuron.
+///
+/// Output, input, constant, and unknown neurons receive no boost (multiplier = 1.0).
+pub fn apply_target_type_boost(
+    gain: f32,
+    target_uuid: &str,
+    neuron_type_map: &HashMap<String, String>,
+) -> f32 {
+    if neuron_type_map
+        .get(target_uuid)
+        .map(|t| t == "hidden")
+        .unwrap_or(false)
+    {
+        gain * EXISTING_HIDDEN_TARGET_BOOST as f32
     } else {
         gain
     }
@@ -2101,7 +2132,19 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     // that accurately predict output flips when synapse contributions cross the threshold.
     let mut focus_order: Vec<String> = unique_focus.iter().map(|s| (*s).clone()).collect();
 
-    shuffle_slice(&mut focus_order, input.random_seed, "synapse:focus_order");
+    // Issue #468: Build a neuron type map for target-type prioritisation.
+    // Existing hidden neurons as targets have a 31.4% success rate vs 5.3–5.4%
+    // for output neurons, so we evaluate hidden targets first under deadline pressure.
+    let focus_neuron_type_map: HashMap<String, String> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
+        .collect();
+
+    // Issue #468: Order focus targets so existing hidden neurons are evaluated first.
+    // Each partition is shuffled independently for exploration diversity.
+    order_focus_targets(&mut focus_order, input.random_seed, &focus_neuron_type_map);
 
     // Log analysis start with timeout duration and randomised order
     log_analysis_start(
@@ -3729,6 +3772,15 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         candidate.expected_creature_score_gain = apply_source_type_boost(
             candidate.expected_creature_score_gain,
             &candidate.from_neuron_uuid,
+        );
+
+        // Issue #468: Apply target-type prioritisation boost for existing hidden targets.
+        // Existing hidden neurons as targets have a 31.4% success rate vs 5.3–5.4%
+        // for output or discovery-hidden neurons.
+        candidate.expected_creature_score_gain = apply_target_type_boost(
+            candidate.expected_creature_score_gain,
+            &candidate.to_neuron_uuid,
+            &neuron_type_map,
         );
 
         if verbose_enabled() && is_hidden {

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -509,6 +509,46 @@ pub fn order_eligible_sources(
     eligible_sources.extend(non_inputs);
 }
 
+// =============================================================================
+// Target-Type Prioritisation (Issue #468)
+// =============================================================================
+
+/// Orders focus targets so that existing hidden neurons are evaluated before
+/// output neurons during deadline-constrained analysis.
+///
+/// GRQ-sampler data shows existing hidden neurons as targets have a 31.4%
+/// success rate compared to 5.3–5.4% for output neurons. Under deadline
+/// pressure, evaluating hidden targets first maximises the chance of finding
+/// successful candidates before time runs out.
+///
+/// Each partition (hidden, non-hidden) is shuffled independently so that
+/// repeated runs still explore different neurons within each group.
+pub fn order_focus_targets(
+    targets: &mut Vec<String>,
+    seed: Option<u64>,
+    neuron_type_map: &std::collections::HashMap<String, String>,
+) {
+    if targets.len() <= 1 {
+        return;
+    }
+
+    // Partition into existing hidden neurons and everything else
+    let (mut hidden, mut others): (Vec<_>, Vec<_>) = targets.drain(..).partition(|uuid| {
+        neuron_type_map
+            .get(uuid)
+            .map(|t| t == "hidden")
+            .unwrap_or(false)
+    });
+
+    // Shuffle each partition independently
+    shuffle_slice(&mut hidden, seed, "focus_targets:hidden");
+    shuffle_slice(&mut others, seed, "focus_targets:others");
+
+    // Hidden neurons first, then everything else
+    targets.extend(hidden);
+    targets.extend(others);
+}
+
 // ============================================================================
 // Test Override Mechanism
 // ============================================================================

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -28,8 +28,8 @@ pub use platform::{ensure_xdg_runtime_dir, suppress_mesa_warnings_if_requested};
 pub use deadline::{
     build_deadline, calculate_effective_timeout_ms, calculate_gpu_batch_timeout, deadline_passed,
     derive_seed, focus_unused_observations_from_env, log_analysis_start, log_analysis_timeout,
-    order_eligible_sources, parse_input_index, shuffle_slice, shuffle_within_top_k,
-    source_input_index_bias_from_env, OrderedNeuron, DEFAULT_DURATION_MS,
+    order_eligible_sources, order_focus_targets, parse_input_index, shuffle_slice,
+    shuffle_within_top_k, source_input_index_bias_from_env, OrderedNeuron, DEFAULT_DURATION_MS,
     GPU_QUEUE_TIMEOUT_MAX_SECS, GPU_QUEUE_TIMEOUT_MIN_SECS, MAX_DURATION_MS, MIN_DURATION_MS,
     YEAR_2000_MS,
 };

--- a/tests/issue_468_target_type_prioritisation.rs
+++ b/tests/issue_468_target_type_prioritisation.rs
@@ -1,0 +1,292 @@
+//! Tests for Issue #468: Target-type prioritisation — favour existing hidden
+//! neurons as targets.
+//!
+//! GRQ-sampler data shows existing hidden neurons as targets have a 31.4%
+//! success rate compared to 5.3–5.4% for output or discovery-hidden neurons.
+//! These tests verify that:
+//!
+//! 1. The EXISTING_HIDDEN_TARGET_BOOST constant is within a valid range
+//! 2. The apply_target_type_boost function boosts existing hidden targets
+//! 3. Under deadline constraints, existing hidden targets are evaluated first
+//! 4. Output neurons receive no target-type boost
+
+mod common;
+
+use neat_ai_discovery::analysis::constants::EXISTING_HIDDEN_TARGET_BOOST;
+use neat_ai_discovery::analysis::synapse::apply_target_type_boost;
+use std::collections::HashMap;
+
+// =============================================================================
+// EXISTING_HIDDEN_TARGET_BOOST constant validation
+// =============================================================================
+
+#[test]
+fn existing_hidden_target_boost_value_is_reasonable() {
+    // EXISTING_HIDDEN_TARGET_BOOST must be > 1.0 (boost) and <= 3.0 to avoid
+    // over-biasing. 31.4% / 5.4% ≈ 5.8× raw ratio, but we use a conservative
+    // multiplier to avoid runaway bias.
+    let boosted = 1.0_f64 * EXISTING_HIDDEN_TARGET_BOOST;
+    let unboosted = 1.0_f64;
+    assert!(
+        boosted > unboosted && boosted <= 3.0 * unboosted,
+        "EXISTING_HIDDEN_TARGET_BOOST should provide a bounded boost: got {boosted}"
+    );
+}
+
+#[test]
+fn existing_hidden_target_boost_amplifies_score_gain() {
+    let base_gain = 0.05_f64;
+    let boosted_gain = base_gain * EXISTING_HIDDEN_TARGET_BOOST;
+
+    assert!(
+        boosted_gain > base_gain,
+        "Boosted gain ({boosted_gain}) should exceed base gain ({base_gain})"
+    );
+    assert!(
+        (boosted_gain - base_gain * EXISTING_HIDDEN_TARGET_BOOST).abs() < f64::EPSILON,
+        "Boosted gain should equal base_gain × EXISTING_HIDDEN_TARGET_BOOST"
+    );
+}
+
+// =============================================================================
+// apply_target_type_boost function
+// =============================================================================
+
+#[test]
+fn apply_target_type_boost_boosts_existing_hidden_target() {
+    let gain = 0.10_f32;
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("hidden-uuid-abc".to_string(), "hidden".to_string());
+
+    let boosted = apply_target_type_boost(gain, "hidden-uuid-abc", &neuron_type_map);
+
+    assert!(
+        boosted > gain,
+        "Existing hidden target should get boosted score: {boosted} should be > {gain}"
+    );
+    let expected = gain * EXISTING_HIDDEN_TARGET_BOOST as f32;
+    assert!(
+        (boosted - expected).abs() < 1e-6,
+        "Boosted gain should equal gain × EXISTING_HIDDEN_TARGET_BOOST: expected {expected}, got {boosted}"
+    );
+}
+
+#[test]
+fn apply_target_type_boost_neutral_for_output_target() {
+    let gain = 0.10_f32;
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("output-uuid-xyz".to_string(), "output".to_string());
+
+    let result = apply_target_type_boost(gain, "output-uuid-xyz", &neuron_type_map);
+
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Output target should not be boosted: expected {gain}, got {result}"
+    );
+}
+
+#[test]
+fn apply_target_type_boost_neutral_for_unknown_target() {
+    let gain = 0.10_f32;
+    let neuron_type_map = HashMap::new(); // Empty map
+
+    let result = apply_target_type_boost(gain, "unknown-uuid", &neuron_type_map);
+
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Unknown target should not be boosted: expected {gain}, got {result}"
+    );
+}
+
+#[test]
+fn apply_target_type_boost_zero_gain_stays_zero() {
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("hidden-uuid-abc".to_string(), "hidden".to_string());
+
+    let result = apply_target_type_boost(0.0, "hidden-uuid-abc", &neuron_type_map);
+
+    assert!(
+        result.abs() < 1e-6,
+        "Zero gain should remain zero even with boost: got {result}"
+    );
+}
+
+#[test]
+fn apply_target_type_boost_neutral_for_input_target() {
+    let gain = 0.10_f32;
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("input-0".to_string(), "input".to_string());
+
+    let result = apply_target_type_boost(gain, "input-0", &neuron_type_map);
+
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Input target should not be boosted: expected {gain}, got {result}"
+    );
+}
+
+#[test]
+fn apply_target_type_boost_neutral_for_constant_target() {
+    let gain = 0.10_f32;
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("const-uuid".to_string(), "constant".to_string());
+
+    let result = apply_target_type_boost(gain, "const-uuid", &neuron_type_map);
+
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Constant target should not be boosted: expected {gain}, got {result}"
+    );
+}
+
+// =============================================================================
+// Focus order: existing hidden targets before output targets
+// =============================================================================
+
+#[test]
+fn order_focus_targets_places_existing_hidden_before_output() {
+    use neat_ai_discovery::analysis::utils::order_focus_targets;
+
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("output-uuid-1".to_string(), "output".to_string());
+    neuron_type_map.insert("hidden-uuid-a".to_string(), "hidden".to_string());
+    neuron_type_map.insert("output-uuid-2".to_string(), "output".to_string());
+    neuron_type_map.insert("hidden-uuid-b".to_string(), "hidden".to_string());
+    neuron_type_map.insert("hidden-uuid-c".to_string(), "hidden".to_string());
+
+    let mut targets = vec![
+        "output-uuid-1".to_string(),
+        "hidden-uuid-a".to_string(),
+        "output-uuid-2".to_string(),
+        "hidden-uuid-b".to_string(),
+        "hidden-uuid-c".to_string(),
+    ];
+
+    order_focus_targets(&mut targets, Some(42), &neuron_type_map);
+
+    // All hidden neurons should appear before any output neuron
+    let first_output_pos = targets
+        .iter()
+        .position(|uuid| {
+            neuron_type_map
+                .get(uuid)
+                .map(|t| t == "output")
+                .unwrap_or(false)
+        })
+        .expect("Should have at least one output neuron");
+
+    let last_hidden_pos = targets
+        .iter()
+        .rposition(|uuid| {
+            neuron_type_map
+                .get(uuid)
+                .map(|t| t == "hidden")
+                .unwrap_or(false)
+        })
+        .expect("Should have at least one hidden neuron");
+
+    assert!(
+        last_hidden_pos < first_output_pos,
+        "All hidden targets should come before output targets. \
+        Last hidden at position {last_hidden_pos}, first output at position {first_output_pos}. \
+        Order: {targets:?}"
+    );
+}
+
+#[test]
+fn order_focus_targets_consistent_across_seeds() {
+    use neat_ai_discovery::analysis::utils::order_focus_targets;
+
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("output-uuid-1".to_string(), "output".to_string());
+    neuron_type_map.insert("hidden-uuid-a".to_string(), "hidden".to_string());
+    neuron_type_map.insert("hidden-uuid-b".to_string(), "hidden".to_string());
+
+    for seed in [0u64, 1, 42, 100, 999] {
+        let mut targets = vec![
+            "output-uuid-1".to_string(),
+            "hidden-uuid-a".to_string(),
+            "hidden-uuid-b".to_string(),
+        ];
+
+        order_focus_targets(&mut targets, Some(seed), &neuron_type_map);
+
+        // Hidden neurons should always come first
+        let hidden_count = targets
+            .iter()
+            .filter(|uuid| {
+                neuron_type_map
+                    .get(*uuid)
+                    .map(|t| t == "hidden")
+                    .unwrap_or(false)
+            })
+            .count();
+
+        for (i, uuid) in targets.iter().enumerate() {
+            let is_hidden = neuron_type_map
+                .get(uuid)
+                .map(|t| t == "hidden")
+                .unwrap_or(false);
+            if i < hidden_count {
+                assert!(
+                    is_hidden,
+                    "Seed {seed}: position {i} should be a hidden neuron, got {uuid}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn order_focus_targets_preserves_all_targets() {
+    use neat_ai_discovery::analysis::utils::order_focus_targets;
+
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("output-uuid-1".to_string(), "output".to_string());
+    neuron_type_map.insert("hidden-uuid-a".to_string(), "hidden".to_string());
+
+    let mut targets = vec!["output-uuid-1".to_string(), "hidden-uuid-a".to_string()];
+
+    order_focus_targets(&mut targets, Some(42), &neuron_type_map);
+
+    assert_eq!(
+        targets.len(),
+        2,
+        "All targets should be preserved after ordering"
+    );
+
+    let has_output = targets.iter().any(|u| u == "output-uuid-1");
+    let has_hidden = targets.iter().any(|u| u == "hidden-uuid-a");
+    assert!(has_output, "Output target should be preserved");
+    assert!(has_hidden, "Hidden target should be preserved");
+}
+
+#[test]
+fn order_focus_targets_handles_single_target() {
+    use neat_ai_discovery::analysis::utils::order_focus_targets;
+
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("hidden-uuid-a".to_string(), "hidden".to_string());
+
+    let mut targets = vec!["hidden-uuid-a".to_string()];
+    order_focus_targets(&mut targets, Some(42), &neuron_type_map);
+
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0], "hidden-uuid-a");
+}
+
+#[test]
+fn order_focus_targets_handles_unknown_types_as_non_hidden() {
+    use neat_ai_discovery::analysis::utils::order_focus_targets;
+
+    let mut neuron_type_map = HashMap::new();
+    neuron_type_map.insert("hidden-uuid-a".to_string(), "hidden".to_string());
+    // "unknown-uuid" is not in the map
+
+    let mut targets = vec!["unknown-uuid".to_string(), "hidden-uuid-a".to_string()];
+
+    order_focus_targets(&mut targets, Some(42), &neuron_type_map);
+
+    // Hidden should come before unknown
+    assert_eq!(targets[0], "hidden-uuid-a", "Hidden should be first");
+}


### PR DESCRIPTION
## Summary

Target-type prioritisation for synapse candidate scoring (Issue #468). GRQ-sampler data shows existing hidden neurons as targets have a 31.4% success rate compared to 5.3-5.4% for output or discovery-hidden neurons. This change:

- Adds `EXISTING_HIDDEN_TARGET_BOOST` constant (1.5x) to `constants.rs` for configurable target-type weighting
- Adds `apply_target_type_boost()` function that boosts candidate score gains when the target is an existing hidden neuron
- Applies the boost in the candidate scoring pipeline (after impact discounting and source-type boost)
- Adds `order_focus_targets()` to prioritise existing hidden neurons in focus order, so they are evaluated first under deadline constraints

## Evidence

This is a backend/scoring change with no UI. Verified through:
- 13 new integration tests covering all acceptance criteria
- `./quality.sh` passes cleanly (fmt, clippy, check, 566 tests, release build)

## Test Plan

Added `tests/issue_468_target_type_prioritisation.rs` with 13 tests:

**Constant validation:**
- `existing_hidden_target_boost_value_is_reasonable` — verifies boost is bounded (1.0, 3.0]
- `existing_hidden_target_boost_amplifies_score_gain` — verifies multiplier effect

**Boost function (`apply_target_type_boost`):**
- `apply_target_type_boost_boosts_existing_hidden_target` — hidden target gets boosted
- `apply_target_type_boost_neutral_for_output_target` — output target is neutral
- `apply_target_type_boost_neutral_for_unknown_target` — unknown target is neutral
- `apply_target_type_boost_zero_gain_stays_zero` — zero gain stays zero
- `apply_target_type_boost_neutral_for_input_target` — input target is neutral
- `apply_target_type_boost_neutral_for_constant_target` — constant target is neutral

**Focus ordering (`order_focus_targets`):**
- `order_focus_targets_places_existing_hidden_before_output` — hidden targets ordered first
- `order_focus_targets_consistent_across_seeds` — ordering holds across random seeds
- `order_focus_targets_preserves_all_targets` — no targets lost during reordering
- `order_focus_targets_handles_single_target` — edge case: single element
- `order_focus_targets_handles_unknown_types_as_non_hidden` — unknown types treated as non-hidden

---

## Automated Fix Details
This PR addresses issue #468: **Target-type prioritisation — favour existing hidden neurons as targets**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #468