### PR TITLE
Fix: Split synapse.rs into focused submodules (4,383 lines → ~1,000 each) (#482)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,15 @@ src/
 │   ├── mod.rs                # Module organisation
 │   ├── constants.rs          # Central discovery thresholds (Issue #424)
 │   ├── shared.rs             # Common types, results, diagnostics
-│   ├── synapse.rs            # Synapse analysis
+│   ├── synapse/              # Synapse analysis (Issue #482)
+│   │   ├── mod.rs            # Public API, entry points, orchestration
+│   │   ├── target_analysis.rs # Per-target analysis loop
+│   │   ├── scoring.rs        # Improvement calculation, boosting
+│   │   ├── gpu_evaluation.rs # GPU batch orchestration
+│   │   ├── candidate_generation.rs # Sample building, locality grouping
+│   │   ├── filtering.rs      # Candidate filtering, deduplication
+│   │   ├── structural_patterns.rs # Coordinated structural discovery
+│   │   └── post_processing.rs # Impact discounting, sorting, metadata
 │   ├── neuron.rs             # Neuron analysis
 │   ├── activation.rs         # Activation function analysis
 │   ├── samples.rs            # Sample data structures

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-482.md
+++ b/docs/pr-summary-482.md
@@ -1,38 +1,50 @@
 ## Summary
 
-Split the monolithic `src/analysis/synapse.rs` (4,375 lines) into focused submodules under `src/analysis/synapse/` (Issue #482). This is a pure structural refactoring — no logic changes, no public API changes.
+Further split the synapse analysis submodules to bring all files under the ~1,500-line target (Issue #482). The previous PR (#495) split the monolithic `synapse.rs` into submodules but left `mod.rs` at 2,485 lines. This PR extracts three new focused modules, reducing `mod.rs` from 2,485 to 860 lines — a 65% reduction.
 
 ### New Module Structure
 
 | File | Lines | Responsibility |
 |------|------:|----------------|
-| `synapse/mod.rs` | 2,485 | Core pipeline (`analyze_synapses_with_cache_impl`), public API, re-exports, tests |
+| `synapse/mod.rs` | 860 | Orchestration, public API, re-exports, tests |
+| `synapse/target_analysis.rs` | 1,020 | Per-target analysis loop (helpful, harmful, coordinated) |
 | `synapse/gpu_evaluation.rs` | 975 | ReLU/activation candidate evaluation, batched GPU processing |
-| `synapse/scoring.rs` | 532 | Improvement calculation, saturation-aware simulation, source/target boosting |
-| `synapse/filtering.rs` | 243 | Candidate truncation, deduplication, deterministic UUID generation |
-| `synapse/candidate_generation.rs` | 220 | Sample locality grouping (Issue #221), ordered neuron building |
-| **Total** | **4,455** | |
+| `synapse/scoring.rs` | 532 | Improvement calculation, saturation-aware simulation, boosting |
+| `synapse/structural_patterns.rs` | 411 | Noisy vs trusted input folding, collapse hidden neurons |
+| `synapse/post_processing.rs` | 315 | Impact discounting, sorting, diversification, metadata |
+| `synapse/filtering.rs` | 243 | Candidate truncation, deduplication |
+| `synapse/candidate_generation.rs` | 220 | Sample locality grouping, ordered neuron building |
+| **Total** | **4,576** | All files under 1,500-line target |
+
+### Extractions in this PR
+
+1. **`target_analysis.rs`** — Extracted the 1,200-line per-target parallel loop body into `analyse_single_target()`. Uses a `TargetAnalysisContext` struct to share pre-computed data across targets, and returns `TargetAnalysisResults` for the orchestrator to merge.
+
+2. **`structural_patterns.rs`** — Extracted coordinated structural discovery:
+   - Noisy vs trusted input folding (Issue #165)
+   - Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
+
+3. **`post_processing.rs`** — Extracted all post-analysis processing:
+   - Impact-based discounting for helpful, harmful, and coordinated candidates
+   - Source-type and target-type boosting (Issues #467, #468)
+   - Sorting, diversification, truncation
+   - Metadata assembly via `MetadataParams` struct
 
 ### Design Constraints
 
-- NEAT-AI does not need to change — all public API functions (`analyze_synapses`, `analyze_synapses_with_cache_and_gpu_queue`) remain at the same path
+- No changes to the public API — NEAT-AI does not need to change
 - All `pub(crate)` items used by `analysis/mod.rs` and `neuron.rs` are re-exported from `synapse/mod.rs`
 - All existing candidate types are reused unchanged
-- All 463+ existing tests continue to pass without modification
-
-### Key Decisions
-
-- **`mod.rs` retains the core pipeline**: The 1,946-line `analyze_synapses_with_cache_impl` function stays in `mod.rs` because it is deeply intertwined with parallel iteration, closures, and local struct definitions that make further extraction impractical without major refactoring
-- **`#[path]` directive updated**: The `implementation_tests` path attribute changed from `"implementation_tests/mod.rs"` to `"../implementation_tests/mod.rs"` to reflect the new directory depth
-- **`#[cfg(test)]` imports isolated**: Test-only functions (`get_target_simulation_fn`, `build_samples`, etc.) use conditional `#[cfg(test)]` imports and re-exports to avoid unused-import warnings in non-test builds
+- All existing tests continue to pass without modification
+- Updated AGENTS.md source layout to reflect new module structure
 
 ## Evidence
 
 This is a backend/CLI change with no visual UI. Evidence is provided via:
-- All 463+ existing unit and integration tests continue to pass
+- All existing unit and integration tests continue to pass
 - `quality.sh` passes cleanly (fmt, clippy, check, test, release build)
 - Zero compilation warnings
-- No logic changes — byte-for-byte equivalent behaviour
+- No logic changes — behaviour is preserved
 
 ## Test Plan
 

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -24,11 +24,17 @@
 //! - `candidate_generation` — Sample building, locality grouping, ordered neurons
 //! - `gpu_evaluation` — ReLU/activation evaluation, batched GPU processing
 //! - `filtering` — Candidate filtering, deduplication, truncation
+//! - `target_analysis` — Per-target analysis loop (helpful, harmful, coordinated)
+//! - `structural_patterns` — Coordinated structural discovery (noisy vs trusted, collapse hidden)
+//! - `post_processing` — Impact discounting, sorting, diversification, metadata
 
 mod candidate_generation;
 mod filtering;
 mod gpu_evaluation;
+mod post_processing;
 mod scoring;
+mod structural_patterns;
+mod target_analysis;
 
 // Re-export items used by code outside this module (analysis/mod.rs, neuron.rs, implementation_tests).
 pub use scoring::{apply_source_type_boost, apply_target_type_boost};
@@ -47,7 +53,10 @@ pub(crate) use gpu_evaluation::{
     evaluate_all_activation_specs_batched, evaluate_relu_candidates_split,
 };
 
-pub(crate) use scoring::{compute_synapse_improvement_and_count, upsert_candidate};
+pub(crate) use scoring::upsert_candidate;
+
+#[cfg(test)]
+pub(crate) use scoring::compute_synapse_improvement_and_count;
 
 // Test-only re-exports used by implementation_tests
 #[cfg(test)]
@@ -65,69 +74,27 @@ pub(crate) use scoring::{
 // =============================================================================
 
 use crate::intern::NeuronIndex;
-use crate::types::DiscoverRecord;
 use crate::{AnalyzeSynapsesInput, CandidateSynapseJson, SynapseJson};
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
-// Import shared types from the new module structure
-use crate::analysis::shared::{AnalyzeSynapsesResult, TimingScope};
+use crate::analysis::shared::AnalyzeSynapsesResult;
 
-// Import activation functions from the dedicated activation module (Issue #266, #238)
-use crate::analysis::activation::{get_target_simulation_fn, is_saturating_target};
+use crate::analysis::diagnostics::{TargetDiagnostics, require_unique_focus};
 
-// Import deadline handling and logging utilities from dedicated module (Issue #268)
 use crate::analysis::utils::{
-    OrderedNeuron, build_deadline, deadline_passed, log_analysis_start, log_analysis_timeout,
-    order_eligible_sources, order_focus_targets, parse_input_index, shuffle_within_top_k,
+    build_deadline, deadline_passed, log_analysis_start, log_analysis_timeout, order_focus_targets,
     verbose_enabled,
 };
 
-// Import sample data structures from dedicated module (Issue #269)
-use crate::analysis::samples::{
-    EPSILON, HelpfulSample, NeuronStats, compute_source_std_dev, get_constant_source_threshold,
-};
+use crate::analysis::samples::{compute_source_std_dev, get_constant_source_threshold};
 
-// Import confidence interval calculations (Issue #194)
-use crate::analysis::confidence::compute_confidence_metrics;
-
-// Import weight calculation functions from dedicated module (Issue #270)
-use crate::analysis::weights::{
-    MAX_OUTGOING_WEIGHT, calculate_optimal_outgoing_weight, clamp_weight_update_delta,
-    coordinated_structural_activation_delta,
-};
-
-// Import diagnostics and rejection tracking from dedicated module (Issue #271)
-use crate::analysis::diagnostics::{
-    TargetDiagnostics, TargetMap, ThresholdContext, compute_impact_scores_for_discounting,
-    require_unique_focus,
-};
-
-// Import epistatic pair detection module (Issue #202), synergistic discovery (Issue #189),
-// and interference filtering (Issue #415)
-use crate::analysis::epistatic::{
-    SourceContribution, build_source_contribution, detect_epistatic_pairs,
-    detect_synergistic_candidates, epistatic_pairs_to_coordinated_candidates,
-    filter_interfering_epistatic_pairs, filter_interfering_synergistic_candidates,
-    synergistic_to_coordinated_candidates,
-};
-
-// Import redundant path pruning module (Issue #164)
-use crate::analysis::redundant_path::{
-    ExistingPathContribution, detect_redundant_paths, redundant_paths_to_coordinated_candidates,
-};
-
-// Import GPU infrastructure from dedicated modules (Issue #272, #273, #274)
 use crate::analysis::gpu::{GpuAnalyzer, GpuWorkQueue};
 
-// Import RecordCache from cache module (Issue #185)
 use super::cache::RecordCache;
 
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-
-// MIN_NEURON_SAMPLE_COUNT moved to constants.rs (Issue #424)
-use super::constants::MIN_NEURON_SAMPLE_COUNT;
 
 // =============================================================================
 // Core Implementation
@@ -149,14 +116,11 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         .map(|neuron| (neuron.uuid.clone(), neuron.index))
         .collect();
 
-    // Issue #210: Use NeuronIndex to intern UUID strings, reducing memory allocations.
-    // Instead of cloning UUID strings for each synapse (72+ bytes per entry for String pairs),
-    // we use u32 indices (8 bytes per entry) for ~89% memory reduction.
     let mut neuron_index = NeuronIndex::with_capacity(
         input.creature.neurons.len() + input.creature.input + input.creature.synapses.len() / 10,
     );
 
-    // Pre-intern all neuron UUIDs (inputs + neurons from creature)
+    // Pre-intern all neuron UUIDs
     for i in 0..input.creature.input {
         neuron_index.intern(&format!("input-{i}"));
     }
@@ -164,7 +128,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         neuron_index.intern(&neuron.uuid);
     }
 
-    // Build existing_synapses using interned indices instead of String clones
+    // Build existing_synapses using interned indices
     let existing_synapses: HashSet<(u32, u32)> = input
         .creature
         .synapses
@@ -177,7 +141,6 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         })
         .collect();
 
-    // Build existing_synapse_weights using interned indices
     let existing_synapse_weights: HashMap<(u32, u32), f32> = input
         .creature
         .synapses
@@ -193,7 +156,6 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         })
         .collect();
 
-    // Build synapses_by_target using interned index as key
     let synapses_by_target: HashMap<u32, Vec<SynapseJson>> = input
         .creature
         .synapses
@@ -204,7 +166,6 @@ pub(crate) fn analyze_synapses_with_cache_impl(
             acc
         });
 
-    // Build a lookup map for neuron squash functions to identify discrete targets
     let neuron_squash_map: HashMap<String, String> = input
         .creature
         .neurons
@@ -214,38 +175,25 @@ pub(crate) fn analyze_synapses_with_cache_impl(
 
     let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_synapses")?;
 
-    // Issue #216: TargetDiagnostics uses DashMap internally for lock-free concurrent access.
-    // No Mutex wrapper needed - the struct handles concurrency internally.
     let diagnostics = Arc::new(TargetDiagnostics::new(&unique_focus));
 
-    // GPU timing collector (Issue #195)
-    // Only collects timing data when NEAT_AI_DISCOVERY_GPU_TIMING=1 is set
     let timing_collector = Arc::new(super::shared::TimingCollector::new(
         super::utils::gpu_timing_enabled(),
     ));
 
     let deadline = build_deadline(input.analysis_deadline_ms);
-    // Randomise the focus neuron order so that repeated runs with timeouts will
-    // eventually cover all neurons. Convert to owned strings, shuffle, then use.
-    // STEP/BIPOLAR neurons are now included - both get proper simulation functions
-    // that accurately predict output flips when synapse contributions cross the threshold.
+
     let mut focus_order: Vec<String> = unique_focus.iter().map(|s| (*s).clone()).collect();
 
-    // Issue #468: Build a neuron type map for target-type prioritisation.
-    // Existing hidden neurons as targets have a 31.4% success rate vs 5.3–5.4%
-    // for output neurons, so we evaluate hidden targets first under deadline pressure.
+    // Issue #468: Order focus targets by neuron type (hidden first)
     let focus_neuron_type_map: HashMap<String, String> = input
         .creature
         .neurons
         .iter()
         .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
         .collect();
-
-    // Issue #468: Order focus targets so existing hidden neurons are evaluated first.
-    // Each partition is shuffled independently for exploration diversity.
     order_focus_targets(&mut focus_order, input.random_seed, &focus_neuron_type_map);
 
-    // Log analysis start with timeout duration and randomised order
     log_analysis_start(
         "synapse",
         input.analysis_deadline_ms,
@@ -253,27 +201,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         &focus_order,
     );
 
-    // Track completed focus neurons for timeout logging
     let total_focus_count = focus_order.len();
     let completed_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
-    // v0.1.134: Return ALL positive improvements.
-    // NEAT-AI applies the cost-of-growth gate during evaluation.
-    let threshold = 0.0;
-
-    // Collect all helpful evaluation work first for batching
-    struct HelpfulWork {
-        source_uuid: String,
-        target_uuid: String,
-        samples: Vec<HelpfulSample>,
-        /// Existing synapse weight (when the synapse already exists).
-        ///
-        /// When set, we propose a delta-based weight update rather than adding a new synapse.
-        existing_weight: Option<f32>,
-    }
-
-    // GPU is always required - TypeScript layer calls check_gpu_available() and skips
-    // discovery entirely on machines without GPU. Reaching here without GPU is a bug.
+    // GPU is always required
     assert!(
         GpuAnalyzer::gpu_is_available(),
         "Discovery logic called without GPU - check_gpu_available should have prevented this"
@@ -288,58 +219,50 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     let helpful_fallback = Arc::new(Mutex::new(Option::<CandidateSynapseJson>::None));
     let analysis_timed_out = Arc::new(Mutex::new(false));
 
-    // Metadata tracking for observability (v0.2.17+)
-    // These track whether target_value was available and whether saturation-aware simulation was used
+    // Metadata tracking for observability
     let metadata_target_value_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let metadata_saturation_aware_used = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let metadata_seen_any_input_with_records = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let metadata_input_min_with_records = Arc::new(std::sync::atomic::AtomicUsize::new(usize::MAX));
     let metadata_input_max_with_records = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
-    // Issue #192: Collect error values for error distribution analysis
-    // We collect errors from all target neurons to compute aggregate distribution statistics
     let error_values_for_distribution = Arc::new(Mutex::new(Vec::<f32>::new()));
 
-    let focus_order_arc = Arc::new(focus_order);
-    let ordered_neurons_arc = Arc::new(ordered_neurons);
-    let existing_synapses_arc = Arc::new(existing_synapses);
-    let existing_synapse_weights_arc = Arc::new(existing_synapse_weights);
-    let synapses_by_target_arc = Arc::new(synapses_by_target);
-    let order_map_arc = Arc::new(order_map);
-    let neuron_squash_map_arc = Arc::new(neuron_squash_map);
-    // Issue #210: Share neuron index for interned UUID lookups across parallel threads
-    let neuron_index_arc = Arc::new(neuron_index);
+    // Build comprehensive neuron type map
+    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+    for input_index in 0..input.creature.input {
+        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
+    }
+    for neuron in &input.creature.neurons {
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
+    }
 
-    // Issue #182: Build a set of "used" input neurons (those with at least one outgoing synapse)
-    // for the focus_unused_observations feature. Unused inputs will be prioritised in source ordering.
+    let input_neuron_uuids: HashSet<String> = (0..input.creature.input)
+        .map(|i| format!("input-{i}"))
+        .collect();
+
+    // Issue #182: Build used inputs set
     let used_inputs: HashSet<String> = input
         .creature
         .synapses
         .iter()
-        .filter(|s| parse_input_index(&s.from_uuid).is_some())
+        .filter(|s| crate::analysis::utils::parse_input_index(&s.from_uuid).is_some())
         .map(|s| s.from_uuid.clone())
         .collect();
-    let used_inputs_arc = Arc::new(used_inputs);
 
-    // Map of neuron UUID -> bias, used when folding constant-source synapses into `setBias`.
-    // Inputs are not present here (they have no bias).
+    // Neuron bias map for constant-source folding
     let neuron_bias_map: HashMap<String, f32> = input
         .creature
         .neurons
         .iter()
         .map(|n| (n.uuid.clone(), n.bias))
         .collect();
-    let neuron_bias_map_arc = Arc::new(neuron_bias_map);
 
-    // Issue #199: Compute source variance profile for dynamic constant-source threshold.
-    // We sample source neurons to compute an average standard deviation, which is used
-    // to scale the threshold for folding constant sources into setBias operations.
-    // This captures more coordinated candidates in creatures where "constant" is relative.
+    // Compute dynamic constant-source threshold
     let source_std_dev_avg: Option<f32> = {
-        // Sample input neurons to compute average std dev
         let mut std_dev_sum = 0.0f64;
         let mut std_dev_count = 0u32;
-        let max_samples = input.creature.input.min(50); // Sample up to 50 input neurons
+        let max_samples = input.creature.input.min(50);
 
         for input_idx in 0..max_samples {
             let input_uuid = format!("input-{input_idx}");
@@ -367,40 +290,30 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         }
     };
 
-    // Issue #178, #199: threshold for folding constant-ish sources into bias adjustments.
-    // Now uses dynamic threshold based on source variance profile (Issue #199).
     let constant_source_effect_threshold = get_constant_source_threshold(source_std_dev_avg);
 
-    // Build a comprehensive map of ALL neuron UUIDs to their types
-    // This includes: input neurons, and all neurons from creature.neurons (hidden, output, constant)
-    // If a UUID is not in this map, it's an invalid UUID (bug)
-    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
-
-    // Add input neurons (they're not in creature.neurons, only represented by creature.input count)
-    for input_index in 0..input.creature.input {
-        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
-    }
-
-    // Add all neurons from creature.neurons (hidden, output, constant)
-    for neuron in &input.creature.neurons {
-        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
-    }
-
-    let neuron_type_map_arc = Arc::new(neuron_type_map);
-
-    // Keep input neuron UUIDs set for quick checks (backwards compatibility)
-    let input_neuron_uuids: HashSet<String> = (0..input.creature.input)
-        .map(|i| format!("input-{i}"))
-        .collect();
-    let input_neuron_uuids_arc = Arc::new(input_neuron_uuids);
-
-    // Use the provided GPU work queue.
-    // This eliminates the overhead of creating multiple GPU devices (one per thread).
-    // All GPU operations are processed by a single dedicated thread, improving utilisation.
-    // CRITICAL: The GpuAnalyzer is created INSIDE the GPU thread to avoid wgpu deadlocks.
+    // Build shared context for per-target analysis
+    let ctx = Arc::new(target_analysis::TargetAnalysisContext {
+        ordered_neurons: Arc::new(ordered_neurons),
+        order_map: Arc::new(order_map),
+        neuron_index: Arc::new(neuron_index),
+        existing_synapses: Arc::new(existing_synapses),
+        existing_synapse_weights: Arc::new(existing_synapse_weights),
+        synapses_by_target: Arc::new(synapses_by_target),
+        neuron_squash_map: Arc::new(neuron_squash_map),
+        neuron_type_map: Arc::new(neuron_type_map),
+        input_neuron_uuids: Arc::new(input_neuron_uuids),
+        used_inputs: Arc::new(used_inputs),
+        neuron_bias_map: Arc::new(neuron_bias_map),
+        constant_source_effect_threshold,
+        diagnostics: diagnostics.clone(),
+        timing_collector: timing_collector.clone(),
+        deadline,
+        threshold: 0.0,
+    });
 
     // Process each focus neuron in parallel
-    focus_order_arc
+    focus_order
         .par_iter()
         .try_for_each(|target_uuid| -> Result<()> {
             if *analysis_timed_out.lock().expect("Mutex poisoned") || deadline_passed(&deadline) {
@@ -408,1213 +321,58 @@ pub(crate) fn analyze_synapses_with_cache_impl(
                 return Ok(());
             }
 
-            crate::watchdog::beat(format!(
-                "synapse analysis → processing target {target_uuid}"
-            ));
+            let target_results = target_analysis::analyse_single_target(
+                target_uuid,
+                input,
+                cache.as_ref(),
+                &gpu_queue,
+                &ctx,
+            )?;
 
-            // Use the shared GPU work queue instead of creating a new GpuAnalyzer per thread.
-            // This eliminates device creation overhead and improves GPU utilisation.
-            let gpu = &*gpu_queue;
-
-            let target_records_arc = cache.get(target_uuid.as_str())?;
-            if target_records_arc.is_empty() {
-                diagnostics.set_target_record_count(target_uuid, 0);
-                return Ok(());
-            }
-            let target_records = target_records_arc.as_ref();
-            diagnostics.set_target_record_count(target_uuid, target_records.len());
-
-            // Issue #192: Collect error values for distribution analysis
-            // Extract errors from target records and add to shared collection
-            {
-                let errors: Vec<f32> = target_records
-                    .iter()
-                    .flat_map(|r| r.errors.iter().filter(|e| e.is_finite()).copied())
-                    .collect();
-                if !errors.is_empty() {
-                    let mut error_vec = error_values_for_distribution
-                        .lock()
-                        .expect("Mutex poisoned: error_values_for_distribution");
-                    error_vec.extend(errors);
-                }
-            }
-
-            let target_index = match order_map_arc.get(target_uuid.as_str()) {
-                Some(index) => *index,
-                None => {
-                    // Target neuron not found in order map - this indicates a data integrity issue
-                    // This should never happen for valid hidden/output neurons
-                    if verbose_enabled() {
-                        eprintln!(
-                            "[NEAT-AI-Discovery][verbose] Target {target_uuid} not found in creature neuron order map (neuron may not exist in creature definition). Skipping."
-                        );
-                    }
-                    return Ok(());
-                }
-            };
-
-            // Early validation: skip input and constant neurons (they have no upstream sources)
-            // Validate target UUID exists in comprehensive neuron type map
-            let target_neuron_type = neuron_type_map_arc.get(target_uuid.as_str())
-                .ok_or_else(|| anyhow!(
-                    "Invalid target neuron UUID '{}': not found in neuron type map. \
-                    This indicates a serious data integrity bug. All valid neurons must be in the type map \
-                    (input neurons: input-0..input-{}, or neurons from creature.neurons array).",
-                    target_uuid,
-                    input_neuron_uuids_arc.len().saturating_sub(1)
-                ))?;
-
-            let input_count = input_neuron_uuids_arc.len();
-            let is_input_neuron = target_neuron_type == "input";
-            let is_constant_neuron = target_neuron_type == "constant";
-
-            // Skip actual input/constant neurons (expected - they have no upstream sources)
-            // Only skip by UUID check, not by index, to avoid incorrectly skipping hidden neurons
-            // that might have been assigned incorrect indices due to ordering bugs
-            if is_input_neuron || is_constant_neuron {
-                return Ok(());
-            }
-
-            // Filter eligible sources: must have index < target_index and not be a constant
-            // All neurons should be in the comprehensive neuron_type_map
-            let mut eligible_sources: Vec<&OrderedNeuron> = ordered_neurons_arc
-                .iter()
-                .filter(|neuron| {
-                    neuron.index < target_index
-                        && {
-                            // Look up neuron type - if missing, it's a serious bug
-                            match neuron_type_map_arc.get(&neuron.uuid) {
-                                Some(neuron_type) => {
-                                    // Valid neuron - exclude constants, include everything else (input, hidden, output)
-                                    neuron_type != "constant"
-                                }
-                                None => {
-                                    // Invalid UUID - serious data integrity bug
-                                    eprintln!(
-                                        "[NEAT-AI-Discovery] ERROR: Invalid neuron UUID '{}' found in ordered_neurons. \
-                                        Not found in comprehensive neuron type map. This indicates a serious data integrity bug.",
-                                        neuron.uuid
-                                    );
-                                    false // Exclude invalid neurons
-                                }
-                            }
-                        }
-                })
-                .collect();
-
-            // Track total eligible sources before filtering
-            let total_eligible = eligible_sources.len() as u32;
-
-            // For hidden/output neurons with index >= input_count, there should always be at least the input neurons as eligible sources
-            // If total_eligible == 0, this indicates a serious bug
-            if total_eligible == 0 {
-                // This should be impossible - we've already filtered out input/constant neurons
-                // Log detailed diagnostics to help debug
-                let neurons_before_index = ordered_neurons_arc
-                    .iter()
-                    .filter(|n| n.index < target_index)
-                    .count();
-                let constants_before_index = ordered_neurons_arc
-                    .iter()
-                    .filter(|n| {
-                        n.index < target_index
-                            && neuron_type_map_arc
-                                .get(&n.uuid)
-                                .map(|t| t == "constant")
-                                .unwrap_or(false)
-                    })
-                    .count();
-                let input_neurons_before_index = ordered_neurons_arc
-                    .iter()
-                    .filter(|n| n.index < target_index && input_neuron_uuids_arc.contains(&n.uuid))
-                    .count();
-
-                eprintln!(
-                    "[NEAT-AI-Discovery] BUG: Target {target_uuid} (type: {target_neuron_type}, index: {target_index}) has no eligible upstream neurons. \
-                    creature.input: {input_count}, neurons before target: {neurons_before_index}, constants before target: {constants_before_index}, \
-                    input neurons before target: {input_neurons_before_index}. This should not happen for hidden/output neurons with index >= creature.input."
-                );
-
-                // Still skip to avoid crashing, but log the bug
-                return Ok(());
-            }
-            // Count how many eligible sources are input neurons
-            let input_neuron_count = eligible_sources
-                .iter()
-                .filter(|neuron| input_neuron_uuids_arc.contains(&neuron.uuid))
-                .count() as u32;
-            diagnostics.set_total_eligible_sources(target_uuid, total_eligible);
-            diagnostics.set_input_neuron_count(target_uuid, input_neuron_count);
-
-            let context = format!("synapse:eligible_sources:{target_uuid}");
-            order_eligible_sources(
-                &mut eligible_sources,
-                input.random_seed,
-                &context,
-                input.creature.input,
-                Some(&*used_inputs_arc),
-            );
-
-            // Improved GPU utilisation: Build samples on CPU in parallel, then batch GPU evaluation
-            // This avoids the GPU sync overhead of calling build_samples_gpu for each source.
-            // The heavy computation is in evaluate_helpful_batch which is properly batched.
-            struct SourceWorkResult {
-                work: Option<HelpfulWork>,
-                had_samples: bool,
-                source_uuid: String,
-                record_count: usize,
-            }
-
-            // Pre-filter sources and collect their records (cache is thread-safe)
-            // Track already-connected, load-failure, and empty-record counts separately
-            let mut already_connected_count = 0u32;
-            let mut load_failure_count = 0u32;
-            let mut empty_record_sources: Vec<String> = Vec::new();
-            struct ExistingSourceToProcess<'a> {
-                source: &'a OrderedNeuron,
-                records: Arc<Vec<DiscoverRecord>>,
-                old_weight: f32,
-            }
-
-            // Note: This vector is for *add-synapse* candidates only.
-            // Existing edges are intentionally excluded to preserve the original
-            // `NoEligibleSources` diagnostics semantics (tests rely on this).
-            let mut sources_to_process: Vec<(&OrderedNeuron, Arc<Vec<DiscoverRecord>>)> =
-                Vec::with_capacity(eligible_sources.len());
-
-            // Existing edges are evaluated separately as weight-update candidates.
-            let mut existing_sources_to_process: Vec<ExistingSourceToProcess> =
-                Vec::with_capacity(eligible_sources.len());
-
-            for source in &eligible_sources {
-                if deadline_passed(&deadline) {
-                    *analysis_timed_out.lock().expect("Mutex poisoned") = true;
-                    break;
-                }
-                let source_uuid = source.uuid.as_str();
-
-                // Issue #210: Use interned indices for efficient lookup (avoids String allocations)
-                let source_idx = neuron_index_arc.get_index(source_uuid);
-                let target_idx = neuron_index_arc.get_index(target_uuid.as_str());
-                let is_connected = match (source_idx, target_idx) {
-                    (Some(s), Some(t)) => existing_synapses_arc.contains(&(s, t)),
-                    _ => false, // UUID not interned means it's not in the creature
-                };
-                if is_connected {
-                    already_connected_count += 1;
-                };
-                let existing_weight = if is_connected {
-                    match (source_idx, target_idx) {
-                        (Some(s), Some(t)) => existing_synapse_weights_arc.get(&(s, t)).copied(),
-                        _ => None,
-                    }
-                } else {
-                    None
-                };
-
-                match cache.get(source_uuid) {
-                    Ok(records) => {
-                        if !records.is_empty() {
-                            if let Some(input_index) = parse_input_index(source_uuid) {
-                                metadata_seen_any_input_with_records.store(
-                                    true,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                );
-                                // Update min/max atomically (best-effort).
-                                let _ = metadata_input_min_with_records.fetch_min(
-                                    input_index,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                );
-                                let _ = metadata_input_max_with_records.fetch_max(
-                                    input_index,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                );
-                            }
-                            if let Some(old_weight) = existing_weight {
-                                existing_sources_to_process.push(ExistingSourceToProcess {
-                                    source,
-                                    records,
-                                    old_weight,
-                                });
-                            } else if !is_connected {
-                                sources_to_process.push((source, records));
-                            }
-                        } else {
-                            // Empty records - track for diagnostics
-                            empty_record_sources.push(source_uuid.to_string());
-                            let is_input_neuron = input_neuron_uuids_arc.contains(source_uuid);
-                            // Log non-input neurons with empty records (input neurons are logged as summary below)
-                            if verbose_enabled() && !is_input_neuron {
-                                eprintln!(
-                                    "[NEAT-AI-Discovery][verbose] Source {source_uuid} (target {target_uuid}) has no records in parquet file."
-                                );
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        load_failure_count += 1;
-                        if verbose_enabled() {
-                            eprintln!(
-                                "[NEAT-AI-Discovery][verbose] Failed to load records for source {source_uuid} (target {target_uuid}): {err}"
-                            );
-                        }
-                    }
-                };
-            }
-
-            // Count how many empty record sources are input neurons (helps diagnose parquet data issues)
-            let empty_input_neuron_count = empty_record_sources
-                .iter()
-                .filter(|uuid| input_neuron_uuids_arc.contains(uuid.as_str()))
-                .count();
-            let empty_non_input_count = empty_record_sources.len() - empty_input_neuron_count;
-
-            // Log summary if many input neurons have empty records (indicates data issue)
-            if verbose_enabled() && empty_input_neuron_count > 0 {
-                eprintln!(
-                    "[NEAT-AI-Discovery][verbose] Target {target_uuid}: {} of {} input neurons have no records in parquet file (plus {} non-input sources). This may indicate incomplete parquet data.",
-                    empty_input_neuron_count,
-                    input_neuron_uuids_arc.len(),
-                    empty_non_input_count
-                );
-            }
-
-            // Update diagnostics for already-connected, load failures, and empty records
-            // Issue #216: Direct method calls - no lock needed with DashMap-based diagnostics
-            if already_connected_count > 0
-                || load_failure_count > 0
-                || !empty_record_sources.is_empty()
-            {
-                for _ in 0..already_connected_count {
-                    diagnostics.record_already_connected(target_uuid);
-                }
-                for _ in 0..load_failure_count {
-                    diagnostics.record_load_failure(target_uuid);
-                }
-                // Record diagnostics for sources with empty records (matches old sequential behaviour)
-                for source_uuid in &empty_record_sources {
-                    diagnostics.record_candidate_attempt(target_uuid, false);
-                    diagnostics.record_no_samples(target_uuid, source_uuid, 0);
-                }
-            }
-
-            // Build samples on CPU (fast hashmap matching, no GPU sync overhead)
-            // OPTIMIZATION: Pre-build target map ONCE, reuse for all sources.
-            // This avoids rebuilding the HashMap for each of ~1000+ source neurons.
-            let target_map = TargetMap::from_records(target_records);
-            let target_map_ref = &target_map;
-
-            // ================================================================
-            // Coordinated Structural Discovery (Issue #165): noisy vs trusted
-            // ================================================================
-            //
-            // This targets the "simple case" described in the docs:
-            // - Two input signals with the same mean and the same starting synapse weight.
-            // - One signal is much noisier (higher activation variance).
-            //
-            // The intended coordinated fix is:
-            // - remove the noisy synapse completely
-            // - remove the trusted synapse
-            // - add the trusted synapse back with a higher weight (typically doubled)
-            //
-            // This is designed for large-scale feature inputs (eg market data), where variance
-            // differences can reflect noise rather than signal.
-            let coordinated_candidate = (|| -> Option<crate::CoordinatedStructuralCandidateJson> {
-                fn activation_mean_and_variance(records: &[DiscoverRecord]) -> Option<(f32, f32)> {
-                    let mut n = 0.0f32;
-                    let mut sum = 0.0f32;
-                    let mut sum_sq = 0.0f32;
-                    for r in records {
-                        if r.activation.is_finite() {
-                            n += 1.0;
-                            sum += r.activation;
-                            sum_sq += r.activation * r.activation;
-                        }
-                    }
-                    if n <= 0.0 {
-                        return None;
-                    }
-                    let mean = sum / n;
-                    let var = (sum_sq / n) - (mean * mean);
-                    Some((mean, var.max(0.0)))
-                }
-
-                fn activation_map(records: &[DiscoverRecord]) -> HashMap<u32, f32> {
-                    let mut map = HashMap::with_capacity(records.len());
-                    for r in records {
-                        if r.activation.is_finite() {
-                            map.insert(r.obs_index, r.activation);
-                        }
-                    }
-                    map
-                }
-
-                // Issue #210: Use interned index for synapses_by_target lookup
-                let target_idx_for_synapses = neuron_index_arc.get_index(target_uuid.as_str())?;
-                let existing = synapses_by_target_arc.get(&target_idx_for_synapses)?;
-
-                #[derive(Clone)]
-                struct IncomingInput {
-                    from_uuid: String,
-                    weight: f32,
-                    mean: f32,
-                    var: f32,
-                }
-
-                let mut incoming_inputs: Vec<IncomingInput> = Vec::new();
-                for syn in existing.iter() {
-                    if !syn.from_uuid.starts_with("input-") {
-                        continue;
-                    }
-                    let Ok(from_records_arc) = cache.get(&syn.from_uuid) else {
-                        continue;
-                    };
-                    if from_records_arc.is_empty() {
-                        continue;
-                    }
-                    let Some((mean, var)) = activation_mean_and_variance(from_records_arc.as_ref())
-                    else {
-                        continue;
-                    };
-                    incoming_inputs.push(IncomingInput {
-                        from_uuid: syn.from_uuid.clone(),
-                        weight: syn.weight,
-                        mean,
-                        var,
-                    });
-                }
-
-                if incoming_inputs.len() < 2 || target_map_ref.map.is_empty() {
-                    None
-                } else {
-                    // Strict matching for the simple-case test: same weights and same means.
-                    const WEIGHT_EPS: f32 = 1e-6;
-                    const MEAN_EPS: f32 = 1e-3;
-                    const MIN_VAR_RATIO: f32 = 10.0;
-
-                    let target_squash = neuron_squash_map_arc
-                        .get(target_uuid.as_str())
-                        .map(|s| s.as_str());
-
-                    let mut best: Option<(IncomingInput, IncomingInput, f32)> = None; // (noisy, trusted, gain)
-
-                    for i in 0..incoming_inputs.len() {
-                        for j in (i + 1)..incoming_inputs.len() {
-                            let a = incoming_inputs[i].clone();
-                            let b = incoming_inputs[j].clone();
-
-                            if (a.weight - b.weight).abs() > WEIGHT_EPS {
-                                continue;
-                            }
-                            if (a.mean - b.mean).abs() > MEAN_EPS {
-                                continue;
-                            }
-
-                            let (noisy, trusted) = if a.var >= b.var { (a, b) } else { (b, a) };
-                            let ratio = noisy.var / trusted.var.max(EPSILON);
-                            if ratio < MIN_VAR_RATIO {
-                                continue;
-                            }
-
-                            let Ok(noisy_records_arc) = cache.get(&noisy.from_uuid) else {
-                                continue;
-                            };
-                            let Ok(trusted_records_arc) = cache.get(&trusted.from_uuid) else {
-                                continue;
-                            };
-
-                            let noisy_map = activation_map(noisy_records_arc.as_ref());
-                            let trusted_map = activation_map(trusted_records_arc.as_ref());
-
-                            let mut delta_samples: Vec<HelpfulSample> =
-                                Vec::with_capacity(target_map_ref.map.len());
-                            for (obs_index, target) in target_map_ref.map.iter() {
-                                let Some(noisy_act) = noisy_map.get(obs_index) else {
-                                    continue;
-                                };
-                                let Some(trusted_act) = trusted_map.get(obs_index) else {
-                                    continue;
-                                };
-                                let Some(activation) = coordinated_structural_activation_delta(
-                                    *trusted_act,
-                                    *noisy_act,
-                                    noisy.weight,
-                                    trusted.weight,
-                                ) else {
-                                    continue;
-                                };
-                                if !activation.is_finite() || !target.avg_error.is_finite() {
-                                    continue;
-                                }
-                                delta_samples.push(HelpfulSample {
-                                    activation,
-                                    avg_error: target.avg_error,
-                                    target_value: target.value,
-                                    target_activation: Some(target.activation),
-                                });
-                            }
-
-                            if delta_samples.is_empty() {
-                                continue;
-                            }
-
-                            let baseline_sq: f32 = delta_samples
-                                .iter()
-                                .map(|s| s.avg_error * s.avg_error)
-                                .sum();
-
-                            // Move the noisy weight onto the trusted input:
-                            // Δoutput = w_noisy * (trusted - noisy)
-                            let moved_weight = noisy.weight;
-                            let (improvement, _, _, _) = compute_synapse_improvement_and_count(
-                                delta_samples.as_slice(),
-                                moved_weight,
-                                baseline_sq,
-                                target_squash,
-                            );
-
-                            if improvement <= 0.0 {
-                                continue;
-                            }
-
-                            match &best {
-                                Some((_, _, best_gain)) if *best_gain >= improvement => {}
-                                _ => best = Some((noisy, trusted, improvement)),
-                            }
-                        }
-                    }
-
-                    best.map(|(noisy, trusted, gain)| {
-                        let new_weight = trusted.weight + noisy.weight;
-                        crate::CoordinatedStructuralCandidateJson {
-                            operations: vec![
-                                crate::CoordinatedStructuralOpJson::RemoveSynapse {
-                                    from_neuron_uuid: noisy.from_uuid,
-                                    to_neuron_uuid: target_uuid.to_string(),
-                                },
-                                crate::CoordinatedStructuralOpJson::RemoveSynapse {
-                                    from_neuron_uuid: trusted.from_uuid.clone(),
-                                    to_neuron_uuid: target_uuid.to_string(),
-                                },
-                                crate::CoordinatedStructuralOpJson::AddSynapse {
-                                    from_neuron_uuid: trusted.from_uuid,
-                                    to_neuron_uuid: target_uuid.to_string(),
-                                    weight: new_weight,
-                                },
-                            ],
-                            expected_creature_score_gain: gain,
-                            comment: Some(
-                                "Coordinated: prune noisy input (high variance), strengthen trusted input"
-                                    .to_string(),
-                            ),
-                        }
-                    })
-                }
-            })();
-
-            if let Some(candidate) = coordinated_candidate {
-                let mut results = coordinated_structural_results
+            // Merge results into shared collections
+            if !target_results.helpful.is_empty() {
+                helpful_results
                     .lock()
-                    .expect("Mutex poisoned: coordinated_structural_results");
-                results.push(candidate);
+                    .expect("Mutex poisoned")
+                    .extend(target_results.helpful);
+            }
+            if !target_results.harmful.is_empty() {
+                harmful_results
+                    .lock()
+                    .expect("Mutex poisoned")
+                    .extend(target_results.harmful);
+            }
+            if !target_results.coordinated.is_empty() {
+                coordinated_structural_results
+                    .lock()
+                    .expect("Mutex poisoned")
+                    .extend(target_results.coordinated);
+            }
+            if !target_results.error_values.is_empty() {
+                error_values_for_distribution
+                    .lock()
+                    .expect("Mutex poisoned")
+                    .extend(target_results.error_values);
+            }
+            if target_results.target_value_seen {
+                metadata_target_value_seen.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            if target_results.saturation_aware_used {
+                metadata_saturation_aware_used.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+            if target_results.input_metadata.seen_any {
+                metadata_seen_any_input_with_records
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                let _ = metadata_input_min_with_records.fetch_min(
+                    target_results.input_metadata.min_index,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                let _ = metadata_input_max_with_records.fetch_max(
+                    target_results.input_metadata.max_index,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
             }
 
-            // Even if target_map is empty, we continue to record diagnostics
-            // about what sources were evaluated (important for debugging).
-            //
-            // Issue #221: Sample Locality Optimisation
-            // Group sources by obs_index overlap to reduce redundant sample building.
-            // Sources with ≥80% obs_index overlap share sample building in a single pass.
-            let source_results: Vec<SourceWorkResult> = {
-                let _timing = TimingScope::sample_building(&timing_collector);
-
-                // Group sources by sample locality
-                let locality_groups = group_sources_by_locality(&sources_to_process);
-
-                // Log locality grouping stats if verbose
-                if verbose_enabled() && sources_to_process.len() >= MIN_GROUP_SIZE_FOR_LOCALITY {
-                    let group_sizes: Vec<usize> = locality_groups.iter().map(|g| g.sources.len()).collect();
-                    let max_group = group_sizes.iter().max().copied().unwrap_or(0);
-                    let avg_group = if !group_sizes.is_empty() {
-                        group_sizes.iter().sum::<usize>() as f32 / group_sizes.len() as f32
-                    } else {
-                        0.0
-                    };
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Target {}: {} sources grouped into {} locality groups (max={}, avg={:.1})",
-                        target_uuid,
-                        sources_to_process.len(),
-                        locality_groups.len(),
-                        max_group,
-                        avg_group
-                    );
-                }
-
-                // Build samples for each group (groups with multiple sources use batched building)
-                locality_groups
-                    .par_iter()
-                    .flat_map(|group| {
-                        let group_results = build_samples_for_locality_group(group, target_map_ref);
-                        group_results
-                            .into_iter()
-                            .map(|(source_uuid, samples, record_count)| {
-                                let had_samples = !samples.is_empty();
-                                let work = if had_samples {
-                                    Some(HelpfulWork {
-                                        source_uuid: source_uuid.clone(),
-                                        target_uuid: target_uuid.to_string(),
-                                        samples,
-                                        existing_weight: None,
-                                    })
-                                } else {
-                                    None
-                                };
-                                SourceWorkResult {
-                                    work,
-                                    had_samples,
-                                    source_uuid,
-                                    record_count,
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .collect()
-            };
-
-            // Extract work batch and batch diagnostics updates
-            let mut helpful_work_batch: Vec<HelpfulWork> = Vec::new();
-            let mut diagnostics_updates: Vec<(String, String, bool, usize)> = Vec::new();
-
-            for result in source_results {
-                if let Some(work) = result.work {
-                    helpful_work_batch.push(work);
-                }
-                diagnostics_updates.push((
-                    target_uuid.to_string(),
-                    result.source_uuid,
-                    result.had_samples,
-                    result.record_count,
-                ));
-            }
-
-            // Apply all diagnostics updates directly (no lock needed with DashMap - Issue #216)
-            for (target, source, had_samples, record_count) in diagnostics_updates {
-                diagnostics.record_candidate_attempt(&target, had_samples);
-                if !had_samples {
-                    diagnostics.record_no_samples(&target, &source, record_count);
-                }
-            }
-
-            // Append existing edges for weight-update evaluation.
-            //
-            // Important: we do NOT record these as "candidate attempts" in TargetDiagnostics because
-            // `no_candidate_reasons` is reporting add-synapse eligibility (existing edges are not
-            // eligible for add-synapse). This preserves the historical semantics and unit tests.
-            //
-            // Issue #164: Also collect ExistingPathContribution for redundant path detection.
-            let mut existing_path_contributions: Vec<ExistingPathContribution> = Vec::new();
-            if !existing_sources_to_process.is_empty() {
-                let existing_work: Vec<HelpfulWork> = existing_sources_to_process
-                    .par_iter()
-                    .filter_map(|item| {
-                        let source_uuid = item.source.uuid.as_str();
-                        let from_records = item.records.as_ref();
-                        let samples = target_map_ref.build_samples_from(from_records);
-                        if samples.is_empty() {
-                            return None;
-                        }
-                        Some(HelpfulWork {
-                            source_uuid: source_uuid.to_string(),
-                            target_uuid: target_uuid.to_string(),
-                            samples,
-                            existing_weight: Some(item.old_weight),
-                        })
-                    })
-                    .collect();
-
-                // Issue #164: Collect existing path contributions for redundant path detection
-                for work in &existing_work {
-                    existing_path_contributions.push(ExistingPathContribution {
-                        source_uuid: work.source_uuid.clone(),
-                        existing_weight: work.existing_weight.unwrap_or(0.0),
-                        samples: work.samples.clone(),
-                    });
-                }
-
-                helpful_work_batch.extend(existing_work);
-            }
-
-            // Process helpful work in batches for better GPU utilization
-            // Vertical timeout: Complete all GPU batch processing for the current focus neuron
-            if !helpful_work_batch.is_empty() {
-                // Clone samples for the GPU queue (queue takes ownership)
-                let helpful_samples: Vec<Vec<HelpfulSample>> = helpful_work_batch
-                    .iter()
-                    .map(|w| w.samples.clone())
-                    .collect();
-
-                // Track metadata: check if any samples have target_value data
-                // This is used to determine if saturation-aware simulation was possible.
-                for samples in &helpful_samples {
-                    if samples.iter().any(|s| s.target_value.is_some()) {
-                        metadata_target_value_seen.store(true, std::sync::atomic::Ordering::Relaxed);
-                        break;
-                    }
-                }
-
-                let helpful_stats_batch = {
-                    let _timing = TimingScope::shader(&timing_collector, "helpful");
-                    gpu.evaluate_helpful_batch(helpful_samples, &deadline)?
-                };
-
-                // Process results - collect all updates first, then apply in batches (reduces mutex contention)
-                let mut candidates_to_add = Vec::new();
-                let mut coordinated_to_add = Vec::new();
-                let mut diagnostics_zero_improvements = Vec::new();
-                let mut diagnostics_below_threshold = Vec::new();
-                let mut diagnostics_selected = Vec::new();
-
-                // Issue #202: Track source contributions for epistatic pair detection
-                let mut source_contributions: Vec<SourceContribution> = Vec::new();
-
-                {
-                    let _timing = TimingScope::result_processing(&timing_collector);
-                    for (work, stats) in helpful_work_batch.iter().zip(helpful_stats_batch.iter()) {
-                    let positive_is_better = stats.positive_count >= stats.negative_count;
-                    let gpu_improved_count = if positive_is_better {
-                        stats.positive_count
-                    } else {
-                        stats.negative_count
-                    };
-                    if gpu_improved_count == 0 {
-                        diagnostics_zero_improvements.push((
-                            work.target_uuid.clone(),
-                            work.source_uuid.clone(),
-                            work.samples.len(),
-                            stats.positive_count,
-                            stats.negative_count,
-                        ));
-                        continue;
-                    }
-
-                    let total_count = work.samples.len() as u32;
-                    if total_count == 0 {
-                        continue;
-                    }
-
-                    // Use shared weight calculation (synapse = direct connection, so incoming_weight = 1.0)
-                    // The shared function ensures consistent weight calculation across synapse and neuron analysis
-                    let weight = match calculate_optimal_outgoing_weight(
-                        stats.error_activation_sum,
-                        stats.activation_sq_sum,
-                        1.0, // Synapses are direct connections, no intermediate neuron
-                    ) {
-                        Some(w) => w,
-                        None => continue, // Skip if weight is invalid
-                    };
-
-                    // Get target's squash function for saturation-aware improvement calculation.
-                    // For saturating activations (HARD_TANH, TANH, LOGISTIC, etc.), the linear model
-                    // overpredicts improvement near saturation. Using the actual activation function
-                    // gives accurate predictions that match real-world results.
-                    let target_squash = neuron_squash_map_arc
-                        .get(&work.target_uuid)
-                        .map(|s| s.as_str());
-
-                    // Track metadata: check if saturation-aware simulation is used for this candidate.
-                    // get_target_simulation_fn returns Some when:
-                    // 1. The target squash is a supported saturating activation, AND
-                    // 2. All samples have target_value/target_activation data
-                    if get_target_simulation_fn(&work.samples, target_squash).is_some() {
-                        metadata_saturation_aware_used.store(true, std::sync::atomic::Ordering::Relaxed);
-                    }
-
-                    // Compute expected improvement using the linear error model.
-                    // This works for ALL squash types because we're measuring actual errors
-                    // from recordings, not predicting theoretical errors. The correlation
-                    // between source activation and target error determines improvement.
-                    // Issue #128: This is neuron-level improvement - impact discounting converts to creature-level.
-                    let baseline_error_sq = stats.error_sq_sum;
-
-                    // IMPORTANT (3-Jan-2026):
-                    // For weight updates, we must compute expected improvement using the *effective*
-                    // (clamped) delta weight, not the proposed delta weight. Otherwise, expected gains
-                    // are overstated and candidates are mis-prioritised.
-                    let (applied_weight, neuron_error_improvement, improved_count, worsened_count) =
-                        if let Some(old_weight) = work.existing_weight {
-                            let Some((_new_weight, delta_weight)) =
-                                clamp_weight_update_delta(old_weight, weight)
-                            else {
-                                continue;
-                            };
-                            let (improvement, improved, worsened, _) =
-                                compute_synapse_improvement_and_count(
-                                    &work.samples,
-                                    delta_weight,
-                                    baseline_error_sq,
-                                    target_squash,
-                                );
-                            (delta_weight, improvement, improved, worsened)
-                        } else if is_saturating_target(&work.samples, target_squash) {
-                            // Issue #413: For saturating target activations (HARD_TANH, TANH,
-                            // LOGISTIC, etc.), the linear-model weight can overshoot into
-                            // saturation, causing inverted predictions. Search over scaled
-                            // weights to find the best candidate, matching the approach used
-                            // by add-neuron candidates (synapse.rs evaluate_activation_candidate).
-                            let weight_candidates: [f32; 9] = [
-                                weight * 0.1,
-                                weight * 0.25,
-                                weight * 0.5,
-                                weight * 0.75,
-                                weight,
-                                weight * 1.5,
-                                weight * 2.0,
-                                -weight * 0.5,
-                                -weight,
-                            ];
-
-                            let mut best_weight = weight;
-                            let mut best_improvement = f32::NEG_INFINITY;
-                            let mut best_improved = 0u32;
-                            let mut best_worsened = 0u32;
-
-                            for &w in &weight_candidates {
-                                let clamped =
-                                    w.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
-                                if clamped.abs() <= EPSILON {
-                                    continue;
-                                }
-                                let (imp, improved, worsened, _) =
-                                    compute_synapse_improvement_and_count(
-                                        &work.samples,
-                                        clamped,
-                                        baseline_error_sq,
-                                        target_squash,
-                                    );
-                                if imp > best_improvement {
-                                    best_improvement = imp;
-                                    best_weight = clamped;
-                                    best_improved = improved;
-                                    best_worsened = worsened;
-                                }
-                            }
-                            (best_weight, best_improvement, best_improved, best_worsened)
-                        } else {
-                            let (improvement, improved, worsened, _) =
-                                compute_synapse_improvement_and_count(
-                                    &work.samples,
-                                    weight,
-                                    baseline_error_sq,
-                                    target_squash,
-                                );
-                            (weight, improvement, improved, worsened)
-                        };
-
-                    // Issue #202: Track source contribution for epistatic pair detection
-                    // Collect ALL sources (including non-positive improvements) because
-                    // epistatic pairs may have low individual improvements but high combined
-                    if work.existing_weight.is_none() {
-                        source_contributions.push(build_source_contribution(
-                            &work.source_uuid,
-                            work.samples.clone(),
-                            stats.clone(),
-                            applied_weight,
-                            neuron_error_improvement,
-                        ));
-                    }
-
-                    // Accept all positive improvements as candidates (not just those above threshold)
-                    // Only reject if improvement is non-positive (<= 0.0)
-                    if neuron_error_improvement <= 0.0 {
-                        // Skip non-positive improvements
-                        continue;
-                    }
-
-                    // If positive but below threshold, still accept as candidate but log for diagnostics
-                    if neuron_error_improvement <= threshold {
-                        diagnostics_below_threshold.push((
-                            work.target_uuid.clone(),
-                            work.source_uuid.clone(),
-                            ThresholdContext {
-                                sample_count: work.samples.len(),
-                                expected_improvement: neuron_error_improvement,
-                                threshold,
-                                improved_count,
-                                worsened_count,
-                                weight: applied_weight,
-                            },
-                        ));
-                    }
-
-                    let target_stats = cache
-                        .get(&work.target_uuid)
-                        .ok()
-                        .and_then(|records| NeuronStats::from_records(records.as_ref()))
-                        .map(|s| s.to_json());
-                    if let Some(old_weight) = work.existing_weight {
-                        // Issue #180 (9-Jan-2026): Weight update using setWeight operation.
-                        // Previously used remove+add pattern; now use a single setWeight op
-                        // for simplicity and directness.
-                        let Some((new_weight, delta_weight)) =
-                            clamp_weight_update_delta(old_weight, weight)
-                        else {
-                            continue;
-                        };
-                        // NOTE: We keep the computed improvement based on the effective (clamped)
-                        // delta (`delta_weight`) but apply the absolute `new_weight` in the op.
-                        coordinated_to_add.push(crate::CoordinatedStructuralCandidateJson {
-                            operations: vec![crate::CoordinatedStructuralOpJson::SetWeight {
-                                from_neuron_uuid: work.source_uuid.clone(),
-                                to_neuron_uuid: work.target_uuid.clone(),
-                                weight: new_weight,
-                            }],
-                            expected_creature_score_gain: neuron_error_improvement,
-                            comment: Some(format!(
-                                "Adjust synapse weight: old={old_weight:.6}, new={new_weight:.6}, delta={delta_weight:.6}"
-                            )),
-                        });
-                    } else {
-                        diagnostics_selected.push(work.target_uuid.clone());
-                        // Issue #178 (7-Jan-2026): If the source activation is constant/near-constant,
-                        // an add-synapse behaves like a bias shift on the target. Prefer `setBias`
-                        // to avoid paying complexity cost for what is effectively a constant offset.
-                        if let Some(threshold) = constant_source_effect_threshold {
-                            let mut act_min = f32::INFINITY;
-                            let mut act_max = f32::NEG_INFINITY;
-                            let mut act_sum = 0.0f64;
-                            let mut act_count: u32 = 0;
-                            for s in &work.samples {
-                                if s.activation.is_finite() {
-                                    act_min = act_min.min(s.activation);
-                                    act_max = act_max.max(s.activation);
-                                    act_sum += s.activation as f64;
-                                    act_count += 1;
-                                }
-                            }
-
-                            if act_count > 0 {
-                                let mean_activation = (act_sum / act_count as f64) as f32;
-                                let activation_range = (act_max - act_min).abs();
-                                let effect_range = applied_weight.abs() * activation_range;
-
-                                if mean_activation.is_finite()
-                                    && activation_range.is_finite()
-                                    && effect_range.is_finite()
-                                    && effect_range <= threshold
-                                {
-                                    let old_bias = neuron_bias_map_arc
-                                        .get(&work.target_uuid)
-                                        .copied()
-                                        .unwrap_or(0.0);
-                                    let new_bias = old_bias + (applied_weight * mean_activation);
-                                    if new_bias.is_finite() {
-                                        coordinated_to_add.push(crate::CoordinatedStructuralCandidateJson {
-                                            operations: vec![crate::CoordinatedStructuralOpJson::SetBias {
-                                                neuron_uuid: work.target_uuid.clone(),
-                                                bias: new_bias,
-                                            }],
-                                            expected_creature_score_gain: neuron_error_improvement,
-                                            comment: Some(format!(
-                                                "Fold constant source into setBias: old_bias={old_bias:.6}, new_bias={new_bias:.6}, weight={applied_weight:.6}, mean_act={mean_activation:.6}, act_range={activation_range:.6e}, effect_range={effect_range:.6e}"
-                                            )),
-                                        });
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-
-                        // Issue #128: Use creature-level metrics (impact discounting applied later)
-                        // Issue #194: Compute confidence metrics for this prediction
-                        let confidence_metrics = compute_confidence_metrics(
-                            &work.samples,
-                            neuron_error_improvement,
-                            None, // R² not available for synapse candidates
-                        );
-                        candidates_to_add.push(CandidateSynapseJson {
-                            from_neuron_uuid: work.source_uuid.clone(),
-                            to_neuron_uuid: work.target_uuid.clone(),
-                            from_neuron_index: None,
-                            to_neuron_index: None,
-                            weight: applied_weight,
-                            target_neuron_impact: 1.0,
-                            expected_creature_error_reduction: neuron_error_improvement,
-                            expected_creature_score_gain: neuron_error_improvement,
-                            improved_count,
-                            total_count,
-                            target_neuron_stats: target_stats,
-                            outlier_reduction_info: None, // Set during outlier analysis pass if enabled (Issue #192)
-                            prediction_confidence: confidence_metrics.prediction_confidence,
-                            expected_score_gain_confidence_interval: confidence_metrics.expected_score_gain_confidence_interval,
-                        });
-                    }
-                    } // End timing scope for result processing
-                }
-
-                // Apply all diagnostics updates directly (no lock needed with DashMap - Issue #216)
-                for (target, source, sample_count, pos, neg) in diagnostics_zero_improvements {
-                    diagnostics.record_zero_improvement(&target, &source, sample_count, pos, neg);
-                }
-                for (target, source, context) in diagnostics_below_threshold {
-                    diagnostics.record_below_threshold(&target, &source, context);
-                }
-                for target in diagnostics_selected {
-                    diagnostics.mark_candidate_selected(&target);
-                }
-                if !candidates_to_add.is_empty() {
-                    let mut results = helpful_results
-                        .lock()
-                        .expect("Mutex poisoned: helpful_results");
-                    results.extend(candidates_to_add);
-                }
-                if !coordinated_to_add.is_empty() {
-                    let mut results = coordinated_structural_results
-                        .lock()
-                        .expect("Mutex poisoned: coordinated_structural_results");
-                    results.extend(coordinated_to_add);
-                }
-
-                // Issue #202: Detect epistatic neuron pairs for this target
-                // Epistatic pairs are sources where neither improves individually, but
-                // both together could improve the target due to complementary patterns.
-                if verbose_enabled() {
-                    eprintln!(
-                        "[NEAT-AI-Discovery][verbose] Target {target_uuid}: collected {} source contributions for epistatic detection",
-                        source_contributions.len()
-                    );
-                }
-                if source_contributions.len() >= 2 {
-                    // Get target neuron impact for discounting
-                    let target_is_output = neuron_type_map_arc
-                        .get(target_uuid.as_str())
-                        .map(|t| t == "output")
-                        .unwrap_or(false);
-                    let target_impact = if target_is_output {
-                        1.0
-                    } else {
-                        // Use a default impact for hidden neurons (will be recalculated later)
-                        0.5
-                    };
-
-                    let epistatic_pairs = detect_epistatic_pairs(
-                        target_uuid.as_str(),
-                        &source_contributions,
-                        target_impact,
-                    );
-
-                    if !epistatic_pairs.is_empty() {
-                        // Issue #415: Filter out interfering pairs before converting to candidates
-                        let filtered_pairs =
-                            filter_interfering_epistatic_pairs(epistatic_pairs, &source_contributions);
-
-                        if !filtered_pairs.is_empty() {
-                            let epistatic_candidates =
-                                epistatic_pairs_to_coordinated_candidates(&filtered_pairs);
-                            if !epistatic_candidates.is_empty() {
-                                let mut results = coordinated_structural_results
-                                    .lock()
-                                    .expect("Mutex poisoned: coordinated_structural_results");
-                                results.extend(epistatic_candidates);
-
-                                if verbose_enabled() {
-                                    eprintln!(
-                                        "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} epistatic pair(s)",
-                                        filtered_pairs.len()
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    // Issue #189: Detect synergistic candidates via residual analysis
-                    // This detects XOR-like patterns where:
-                    // - Neither source alone provides strong improvement
-                    // - Together they reduce error better than either alone
-                    let synergistic_candidates = detect_synergistic_candidates(
-                        target_uuid.as_str(),
-                        &source_contributions,
-                        target_impact,
-                    );
-
-                    if !synergistic_candidates.is_empty() {
-                        // Issue #415: Filter out interfering candidates before converting
-                        let filtered_synergistic = filter_interfering_synergistic_candidates(
-                            synergistic_candidates,
-                            &source_contributions,
-                        );
-
-                        if !filtered_synergistic.is_empty() {
-                            let synergistic_coordinated =
-                                synergistic_to_coordinated_candidates(&filtered_synergistic);
-                            if !synergistic_coordinated.is_empty() {
-                                let mut results = coordinated_structural_results
-                                    .lock()
-                                    .expect("Mutex poisoned: coordinated_structural_results");
-                                results.extend(synergistic_coordinated);
-
-                                if verbose_enabled() {
-                                    eprintln!(
-                                        "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} synergistic candidate(s)",
-                                        filtered_synergistic.len()
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Issue #164: Detect redundant paths feeding the same target.
-                // Two existing synapses with highly correlated activations are redundant –
-                // prune the weaker path and renormalise the survivor's weight.
-                if existing_path_contributions.len() >= 2 {
-                    let target_is_output = neuron_type_map_arc
-                        .get(target_uuid.as_str())
-                        .map(|t| t == "output")
-                        .unwrap_or(false);
-                    let target_impact = if target_is_output {
-                        1.0
-                    } else {
-                        0.5
-                    };
-
-                    let redundant_paths = detect_redundant_paths(
-                        target_uuid.as_str(),
-                        &existing_path_contributions,
-                        target_impact,
-                    );
-
-                    if !redundant_paths.is_empty() {
-                        let redundant_coordinated =
-                            redundant_paths_to_coordinated_candidates(&redundant_paths);
-                        if !redundant_coordinated.is_empty() {
-                            let mut results = coordinated_structural_results
-                                .lock()
-                                .expect("Mutex poisoned: coordinated_structural_results");
-                            results.extend(redundant_coordinated);
-
-                            if verbose_enabled() {
-                                eprintln!(
-                                    "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} redundant path(s) for pruning",
-                                    redundant_paths.len()
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Process harmful synapses for this target - BATCHED GPU evaluation for better utilisation
-            // Vertical timeout: Complete all harmful synapse processing for the current focus neuron
-            if !*analysis_timed_out.lock().expect("Mutex poisoned") {
-                // Issue #210: Use interned index for synapses_by_target lookup
-                let target_idx_for_harmful = neuron_index_arc.get_index(target_uuid.as_str());
-                if let Some(existing) = target_idx_for_harmful.and_then(|idx| synapses_by_target_arc.get(&idx)) {
-                    // Phase 1: Build all samples on CPU (fast, parallel-friendly)
-                    // Reuse the target_map we already built for helpful synapse processing
-                    struct HarmfulWork {
-                        synapse: SynapseJson,
-                        samples: Vec<HelpfulSample>,
-                    }
-                    let mut harmful_work: Vec<HarmfulWork> = Vec::with_capacity(existing.len());
-
-                    for synapse in existing {
-                        let from_records_arc = match cache.get(&synapse.from_uuid) {
-                            Ok(records) => records,
-                            Err(_) => continue,
-                        };
-                        if from_records_arc.is_empty() {
-                            continue;
-                        }
-                        let from_records = from_records_arc.as_ref();
-                        // Use pre-built target map - avoids rebuilding HashMap for each synapse
-                        let samples = target_map_ref.build_samples_from(from_records);
-                        if samples.is_empty() {
-                            continue;
-                        }
-
-                        harmful_work.push(HarmfulWork {
-                            synapse: synapse.clone(),
-                            samples,
-                        });
-                    }
-
-                    // Phase 2: Batch GPU evaluation (single submission for all synapses)
-                    if !harmful_work.is_empty() {
-                        // Clone samples for the GPU queue (queue takes ownership)
-                        let batch_input: Vec<(Vec<HelpfulSample>, f32)> = harmful_work
-                            .iter()
-                            .map(|w| (w.samples.clone(), w.synapse.weight))
-                            .collect();
-
-                        let batch_stats = {
-                            let _timing = TimingScope::shader(&timing_collector, "harmful");
-                            gpu.evaluate_harmful_batch(batch_input, &deadline)?
-                        };
-
-                        // Phase 3: Process results
-                        let mut harmful_candidates = Vec::with_capacity(batch_stats.len());
-                        let target_stats = cache
-                            .get(target_uuid.as_str())
-                            .ok()
-                            .and_then(|records| NeuronStats::from_records(records.as_ref()))
-                            .map(|s| s.to_json());
-
-                        for (work, stats) in harmful_work.iter().zip(batch_stats.iter()) {
-                            let total_count = work.samples.len() as u32;
-                            if total_count == 0 {
-                                continue;
-                            }
-
-                            // Issue #128: This is neuron-level - impact discounting converts to creature-level
-                            let neuron_error_improvement = (stats.harmful_count as f32
-                                - stats.helpful_count as f32)
-                                / total_count as f32;
-
-                            // Issue #416: Only include candidates where removing the synapse
-                            // would improve the score (positive expected_creature_score_gain).
-                            // Candidates with non-positive gain are synapses that are actually
-                            // helpful - they should NOT be in harmful_synapses.
-                            if neuron_error_improvement <= 0.0 {
-                                continue;
-                            }
-
-                            // Issue #128: Use creature-level metrics (impact discounting applied later)
-                            // Issue #194: Compute confidence metrics for this prediction
-                            let confidence_metrics = compute_confidence_metrics(
-                                &work.samples,
-                                neuron_error_improvement,
-                                None, // R² not available for synapse candidates
-                            );
-                            harmful_candidates.push(CandidateSynapseJson {
-                                from_neuron_uuid: work.synapse.from_uuid.clone(),
-                                to_neuron_uuid: work.synapse.to_uuid.clone(),
-                                from_neuron_index: None,
-                                to_neuron_index: None,
-                                weight: work.synapse.weight,
-                                target_neuron_impact: 1.0,
-                                expected_creature_error_reduction: neuron_error_improvement,
-                                expected_creature_score_gain: neuron_error_improvement,
-                                improved_count: stats.harmful_count,
-                                total_count,
-                                target_neuron_stats: target_stats.clone(),
-                                outlier_reduction_info: None, // Set during outlier analysis pass if enabled (Issue #192)
-                                prediction_confidence: confidence_metrics.prediction_confidence,
-                                expected_score_gain_confidence_interval: confidence_metrics.expected_score_gain_confidence_interval,
-                            });
-                        }
-
-                        // Batch push all harmful candidates (single lock)
-                        if !harmful_candidates.is_empty() {
-                            let mut results = harmful_results
-                                .lock()
-                                .expect("Mutex poisoned: harmful_results");
-                            results.extend(harmful_candidates);
-                        }
-                    }
-                }
-            }
-
-            // Track completion of this focus neuron for timeout reporting.
             let completed =
                 completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
             crate::watchdog::beat(format!(
@@ -1632,7 +390,6 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         .clone();
     let mut helpful_fallback = helpful_fallback.lock().expect("Mutex poisoned").take();
 
-    // Log timeout with completion stats (always visible, not just verbose)
     if analysis_timed_out {
         let completed = completed_count.load(std::sync::atomic::Ordering::Relaxed);
         log_analysis_timeout("synapse", completed, total_focus_count);
@@ -1641,445 +398,61 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     if helpful_results.is_empty()
         && let Some(candidate) = helpful_fallback.take()
     {
-        // Issue #216: Direct method call - no lock needed with DashMap-based diagnostics
         diagnostics.mark_candidate_selected(&candidate.to_neuron_uuid);
         helpful_results.push(candidate);
     }
 
-    // Coordinated structural discovery (7-Jan-2026): collapse a simple hidden neuron into a single synapse.
-    //
-    // This is the "reverse" of synapse→neuron insertion: when a hidden neuron forms a simple 1-in/1-out
-    // chain (a → h → b), we can propose removing that neuron and replacing the chain with a direct
-    // synapse (a → b). This must be applied atomically, so it is emitted as a coordinated-structural
-    // candidate group.
-    //
-    // Initial scope: only hidden neurons with exactly one incoming and one outgoing synapse.
-    // This keeps the candidate safe and deterministic; broader graph rewrites can be added later.
-    {
-        // Build incoming/outgoing synapse lists per neuron.
-        let mut incoming: HashMap<String, Vec<SynapseJson>> = HashMap::new();
-        let mut outgoing: HashMap<String, Vec<SynapseJson>> = HashMap::new();
-        for s in &input.creature.synapses {
-            incoming
-                .entry(s.to_uuid.clone())
-                .or_default()
-                .push(s.clone());
-            outgoing
-                .entry(s.from_uuid.clone())
-                .or_default()
-                .push(s.clone());
-        }
+    // Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
+    let collapse_candidates =
+        structural_patterns::detect_collapsible_hidden_neurons(input, cache.as_ref());
+    coordinated_structural_results.extend(collapse_candidates);
 
-        // Quick neuron-type lookup (only creature.neurons; inputs are not here).
-        let neuron_type_map_local: HashMap<String, String> = input
-            .creature
-            .neurons
-            .iter()
-            .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
-            .collect();
-
-        // Precompute existing direct synapses so we don't propose duplicates.
-        let mut existing_edges: HashSet<(String, String)> = HashSet::new();
-        for s in &input.creature.synapses {
-            existing_edges.insert((s.from_uuid.clone(), s.to_uuid.clone()));
-        }
-
-        for neuron in &input.creature.neurons {
-            if neuron.neuron_type != "hidden" {
-                continue;
-            }
-            let h = neuron.uuid.as_str();
-            let Some(ins) = incoming.get(h) else { continue };
-            let Some(outs) = outgoing.get(h) else {
-                continue;
-            };
-            if ins.len() != 1 || outs.len() != 1 {
-                continue;
-            }
-
-            let a_syn = &ins[0];
-            let b_syn = &outs[0];
-            let a = a_syn.from_uuid.as_str();
-            let b = b_syn.to_uuid.as_str();
-
-            // Skip degenerate / non-actionable cases.
-            if a == b || a == h || b == h {
-                continue;
-            }
-            if existing_edges.contains(&(a.to_string(), b.to_string())) {
-                // A direct synapse already exists; collapsing would need additional ops (future work).
-                continue;
-            }
-
-            // Ensure the target exists (either input-* or a neuron) so the op is not stale.
-            let target_is_known = b.starts_with("input-") || neuron_type_map_local.contains_key(b);
-            if !target_is_known {
-                continue;
-            }
-
-            // Build samples: correlate a's activation to b's adjusted error after removing h→b.
-            let Ok(a_records) = cache.get(a) else {
-                continue;
-            };
-            let Ok(h_records) = cache.get(h) else {
-                continue;
-            };
-            let Ok(b_records) = cache.get(b) else {
-                continue;
-            };
-            if a_records.is_empty() || h_records.is_empty() || b_records.is_empty() {
-                continue;
-            }
-
-            let target_map_b = TargetMap::from_records(b_records.as_ref());
-            if target_map_b.map.is_empty() {
-                continue;
-            }
-            let build_act_map = |records: &[DiscoverRecord]| -> HashMap<u32, f32> {
-                let mut map: HashMap<u32, f32> = HashMap::with_capacity(records.len());
-                for r in records {
-                    if r.activation.is_finite() {
-                        map.insert(r.obs_index, r.activation);
-                    }
-                }
-                map
-            };
-            let a_map = build_act_map(a_records.as_ref());
-            let h_map = build_act_map(h_records.as_ref());
-
-            let mut samples: Vec<HelpfulSample> = Vec::with_capacity(target_map_b.map.len());
-            for (obs_index, target) in target_map_b.map.iter() {
-                let Some(a_act) = a_map.get(obs_index) else {
-                    continue;
-                };
-                let Some(h_act) = h_map.get(obs_index) else {
-                    continue;
-                };
-                if !a_act.is_finite() || !h_act.is_finite() || !target.avg_error.is_finite() {
-                    continue;
-                }
-                let adjusted_error = target.avg_error + b_syn.weight * (*h_act);
-                if !adjusted_error.is_finite() {
-                    continue;
-                }
-                samples.push(HelpfulSample {
-                    activation: *a_act,
-                    avg_error: adjusted_error,
-                    target_value: None,
-                    target_activation: None,
-                });
-            }
-
-            if samples.len() < MIN_NEURON_SAMPLE_COUNT {
-                continue;
-            }
-
-            let mut sum_act_sq = 0.0f32;
-            let mut sum_err_act = 0.0f32;
-            let mut baseline_sq = 0.0f32;
-            for s in &samples {
-                sum_act_sq += s.activation * s.activation;
-                sum_err_act += s.activation * s.avg_error;
-                baseline_sq += s.avg_error * s.avg_error;
-            }
-            if baseline_sq <= EPSILON {
-                continue;
-            }
-
-            let Some(weight) = calculate_optimal_outgoing_weight(sum_err_act, sum_act_sq, 1.0)
-            else {
-                continue;
-            };
-
-            let (improvement, improved, worsened, total) =
-                compute_synapse_improvement_and_count(&samples, weight, baseline_sq, None);
-            let _ = (improved, worsened, total);
-            if improvement <= 0.0 {
-                continue;
-            }
-
-            coordinated_structural_results.push(crate::CoordinatedStructuralCandidateJson {
-                operations: vec![
-                    crate::CoordinatedStructuralOpJson::RemoveSynapse {
-                        from_neuron_uuid: a.to_string(),
-                        to_neuron_uuid: h.to_string(),
-                    },
-                    crate::CoordinatedStructuralOpJson::RemoveSynapse {
-                        from_neuron_uuid: h.to_string(),
-                        to_neuron_uuid: b.to_string(),
-                    },
-                    crate::CoordinatedStructuralOpJson::RemoveNeuron {
-                        neuron_uuid: h.to_string(),
-                    },
-                    crate::CoordinatedStructuralOpJson::AddSynapse {
-                        from_neuron_uuid: a.to_string(),
-                        to_neuron_uuid: b.to_string(),
-                        weight,
-                    },
-                ],
-                expected_creature_score_gain: improvement,
-                comment: Some(
-                    "Coordinated collapse: remove 1-in/1-out hidden neuron and add bypass synapse"
-                        .to_string(),
-                ),
-            });
-        }
-    }
-
-    // Issue #128: Apply impact-based discounting and set creature-level metrics.
-    // Output neurons have impact = 1.0 (no discount).
-    // Hidden neurons have impact in [0, 1] based on their weighted paths to outputs.
-    let impact_scores = compute_impact_scores_for_discounting(&input.creature, cache.as_ref());
-    let neuron_type_map: HashMap<String, String> = input
-        .creature
-        .neurons
-        .iter()
-        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
-        .collect();
-
-    // Apply impact discounting to helpful synapse candidates
-    for candidate in &mut helpful_results {
-        // Populate indices for debugging/analysis (consistent with CandidateNeuronJson).
-        candidate.from_neuron_index = order_map_arc.get(&candidate.from_neuron_uuid).copied();
-        candidate.to_neuron_index = order_map_arc.get(&candidate.to_neuron_uuid).copied();
-
-        let is_hidden = neuron_type_map
-            .get(&candidate.to_neuron_uuid)
-            .map(|t| t != "output")
-            .unwrap_or(true); // Default to hidden if type unknown
-
-        let impact = if is_hidden {
-            if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
-                impact.clamp(0.0, 1.0)
-            } else {
-                // No impact score means disconnected from outputs - heavy discount
-                0.1
-            }
-        } else {
-            // Output neuron - full impact
-            1.0
-        };
-
-        // Update creature-level metrics
-        candidate.target_neuron_impact = impact;
-        let original = candidate.expected_creature_error_reduction;
-        candidate.expected_creature_error_reduction *= impact;
-        candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
-
-        // Issue #467: Apply source-type prioritisation boost for input-neuron sources.
-        // Input neurons have a 36.2% success rate vs 2.8–3.3% for hidden neurons.
-        candidate.expected_creature_score_gain = apply_source_type_boost(
-            candidate.expected_creature_score_gain,
-            &candidate.from_neuron_uuid,
-        );
-
-        // Issue #468: Apply target-type prioritisation boost for existing hidden targets.
-        // Existing hidden neurons as targets have a 31.4% success rate vs 5.3–5.4%
-        // for output or discovery-hidden neurons.
-        candidate.expected_creature_score_gain = apply_target_type_boost(
-            candidate.expected_creature_score_gain,
-            &candidate.to_neuron_uuid,
-            &neuron_type_map,
-        );
-
-        if verbose_enabled() && is_hidden {
-            eprintln!(
-                "[NEAT-AI-Discovery][verbose] Synapse candidate → {} impact {:.3}: \
-                {:.4}% → {:.4}%",
-                &candidate.to_neuron_uuid[..12.min(candidate.to_neuron_uuid.len())],
-                impact,
-                original * 100.0,
-                candidate.expected_creature_score_gain * 100.0
-            );
-        }
-    }
-
-    // Apply impact discounting to harmful synapse candidates (same logic)
-    for candidate in &mut harmful_results {
-        // Populate indices for debugging/analysis (consistent with CandidateNeuronJson).
-        candidate.from_neuron_index = order_map_arc.get(&candidate.from_neuron_uuid).copied();
-        candidate.to_neuron_index = order_map_arc.get(&candidate.to_neuron_uuid).copied();
-
-        let is_hidden = neuron_type_map
-            .get(&candidate.to_neuron_uuid)
-            .map(|t| t != "output")
-            .unwrap_or(true);
-
-        let impact = if is_hidden {
-            if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
-                impact.clamp(0.0, 1.0)
-            } else {
-                0.1
-            }
-        } else {
-            1.0
-        };
-
-        candidate.target_neuron_impact = impact;
-        candidate.expected_creature_error_reduction *= impact;
-        candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
-    }
-
-    // Apply impact discounting to coordinated candidates (based on target neuron UUID).
-    for candidate in &mut coordinated_structural_results {
-        // Heuristic: use the last op that targets a concrete neuron, so multi-op groups
-        // (remove+add synapses, add/remove neuron, etc.) get discounted by the final target.
-        // This aligns with coordinated groups that ultimately adjust the inputs of a target neuron.
-        let target_uuid = candidate
-            .operations
-            .iter()
-            .rev()
-            .map(|op| match op {
-                crate::CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. } => {
-                    to_neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::RemoveSynapse { to_neuron_uuid, .. } => {
-                    to_neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::SetWeight { to_neuron_uuid, .. } => {
-                    to_neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. } => {
-                    neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. } => {
-                    neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. } => {
-                    neuron_uuid.as_str()
-                }
-                crate::CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } => {
-                    neuron_uuid.as_str()
-                }
-            })
-            .next()
-            .unwrap_or("");
-
-        let is_hidden = neuron_type_map
-            .get(target_uuid)
-            .map(|t| t != "output")
-            .unwrap_or(true);
-        let impact = if is_hidden {
-            impact_scores
-                .get(target_uuid)
-                .copied()
-                .unwrap_or(0.1)
-                .clamp(0.0, 1.0)
-        } else {
-            1.0
-        };
-
-        candidate.expected_creature_score_gain *= impact;
-    }
-
-    // Note: helpful_fallback does NOT need separate discounting here.
-    // If helpful_results was empty, the fallback was already moved into it via .take()
-    // and gets discounted in the loop above. If helpful_results was NOT
-    // empty, the fallback is intentionally not returned (we have better candidates).
-
-    helpful_results.sort_by(|a, b| {
-        // Issue #128: Sort by expected creature score gain (highest first)
-        b.expected_creature_score_gain
-            .total_cmp(&a.expected_creature_score_gain)
-    });
-    harmful_results.sort_by(|a, b| {
-        b.expected_creature_score_gain
-            .total_cmp(&a.expected_creature_score_gain)
-    });
-    coordinated_structural_results.sort_by(|a, b| {
-        b.expected_creature_score_gain
-            .total_cmp(&a.expected_creature_score_gain)
-    });
-
-    // Deadline coverage (Jan 2026): diversify within the top-K so repeated runs explore different
-    // high-quality candidates over time (helps with failure caches and avoids category starvation).
-    if input.analysis_deadline_ms.is_some() {
-        use super::constants::DIVERSIFY_TOP_K;
-        shuffle_within_top_k(
-            helpful_results.as_mut_slice(),
-            input.random_seed,
-            "synapse:helpful_candidates:top_k",
-            DIVERSIFY_TOP_K,
-        );
-        shuffle_within_top_k(
-            harmful_results.as_mut_slice(),
-            input.random_seed,
-            "synapse:harmful_candidates:top_k",
-            DIVERSIFY_TOP_K,
-        );
-        shuffle_within_top_k(
-            coordinated_structural_results.as_mut_slice(),
-            input.random_seed,
-            "synapse:coordinated_structural_candidates:top_k",
-            DIVERSIFY_TOP_K,
-        );
-    }
-
-    // Track candidates_found before truncation for metadata
-    let candidates_found =
-        helpful_results.len() + harmful_results.len() + coordinated_structural_results.len();
-
-    if let Some(limit) = input.max_candidates {
-        let (h1, h2, c) = truncate_combined_synapse_candidate_sets(
-            std::mem::take(&mut helpful_results),
-            std::mem::take(&mut harmful_results),
-            std::mem::take(&mut coordinated_structural_results),
-            limit,
-            input.analysis_deadline_ms.is_some(),
-        );
-        helpful_results = h1;
-        harmful_results = h2;
-        coordinated_structural_results = c;
-    }
-
-    // Track candidates_returned after truncation
-    let candidates_returned =
-        helpful_results.len() + harmful_results.len() + coordinated_structural_results.len();
+    // Post-processing: impact discounting, sorting, diversification, truncation
+    let pp_metrics = post_processing::apply_post_processing(
+        &mut helpful_results,
+        &mut harmful_results,
+        &mut coordinated_structural_results,
+        input,
+        cache.as_ref(),
+        &ctx.order_map,
+    );
 
     let no_candidate_reasons = diagnostics.no_candidate_summaries();
     diagnostics.emit_logs();
 
-    // Build metadata for observability (v0.2.17+)
-    // Note: target_value_available and saturation_aware_simulation_used are tracked
-    // during the inner analysis loop via atomic flags.
+    // Build metadata
     let saw_any_input =
         metadata_seen_any_input_with_records.load(std::sync::atomic::Ordering::Relaxed);
     let input_min = metadata_input_min_with_records.load(std::sync::atomic::Ordering::Relaxed);
     let input_max = metadata_input_max_with_records.load(std::sync::atomic::Ordering::Relaxed);
 
-    // Issue #192: Compute error distribution from collected error values
-    let error_distribution = {
-        let error_vec = error_values_for_distribution
-            .lock()
-            .expect("Mutex poisoned: error_values_for_distribution");
-        super::error_distribution::ErrorDistribution::from_errors(&error_vec)
-    };
+    let error_vec = error_values_for_distribution
+        .lock()
+        .expect("Mutex poisoned")
+        .clone();
 
-    let metadata = super::shared::SynapseAnalysisMetadata {
-        target_value_available: metadata_target_value_seen
+    let metadata = post_processing::build_metadata(&post_processing::MetadataParams {
+        target_value_seen: metadata_target_value_seen.load(std::sync::atomic::Ordering::Relaxed),
+        saturation_aware_used: metadata_saturation_aware_used
             .load(std::sync::atomic::Ordering::Relaxed),
-        saturation_aware_simulation_used: metadata_saturation_aware_used
-            .load(std::sync::atomic::Ordering::Relaxed),
-        candidates_found,
-        candidates_returned,
-        timed_out: analysis_timed_out,
+        candidates_found: pp_metrics.candidates_found,
+        candidates_returned: pp_metrics.candidates_returned,
+        analysis_timed_out,
         completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
         total_focus_neurons: total_focus_count,
-        input_index_min_seen_with_records: if saw_any_input { Some(input_min) } else { None },
-        input_index_max_seen_with_records: if saw_any_input { Some(input_max) } else { None },
-        timing: timing_collector.finalize(),
-        gpu_info: GpuAnalyzer::get_adapter_info(),
-        error_distribution,
-    };
+        saw_any_input,
+        input_min,
+        input_max,
+        error_values: &error_vec,
+        timing_collector: &timing_collector,
+    });
 
     Ok(AnalyzeSynapsesResult {
         helpful_synapses: helpful_results,
         harmful_synapses: harmful_results,
-        // Weight updates are represented as remove+add coordinated candidates for KISS.
-        // This keeps NEAT-AI's apply/ablate pipeline limited to existing structural ops.
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: coordinated_structural_results,
-        candidate_clusters: Vec::new(), // populated by analyze_all post-processing (Issue #224)
+        candidate_clusters: Vec::new(),
         gpu_used,
         no_candidate_reasons,
         metadata,
@@ -2133,6 +506,8 @@ mod tests {
     use super::candidate_generation::compute_obs_index_overlap;
     use super::scoring::weight_sign;
     use super::*;
+    use crate::analysis::samples::{EPSILON, HelpfulSample};
+    use crate::analysis::weights::MAX_OUTGOING_WEIGHT;
     use std::collections::HashSet;
 
     #[test]

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -1,0 +1,315 @@
+//! Post-processing for synapse analysis results
+//!
+//! This module handles impact-based discounting, sorting, diversification,
+//! truncation, and metadata assembly for synapse analysis candidates.
+//! Extracted from mod.rs as part of Issue #482.
+
+use crate::CandidateSynapseJson;
+use crate::analysis::diagnostics::compute_impact_scores_for_discounting;
+use crate::analysis::utils::{shuffle_within_top_k, verbose_enabled};
+use std::collections::HashMap;
+
+use super::filtering::truncate_combined_synapse_candidate_sets;
+use super::scoring::{apply_source_type_boost, apply_target_type_boost};
+use crate::analysis::cache::RecordCache;
+
+/// Apply impact-based discounting to a single helpful synapse candidate.
+///
+/// Updates `target_neuron_impact`, `expected_creature_error_reduction`,
+/// and `expected_creature_score_gain` based on the target neuron's distance
+/// from outputs. Also applies source-type and target-type boosts (Issues #467, #468).
+fn apply_impact_to_helpful(
+    candidate: &mut CandidateSynapseJson,
+    impact_scores: &HashMap<String, f32>,
+    neuron_type_map: &HashMap<String, String>,
+    order_map: &HashMap<String, usize>,
+) {
+    // Populate indices for debugging/analysis (consistent with CandidateNeuronJson).
+    candidate.from_neuron_index = order_map.get(&candidate.from_neuron_uuid).copied();
+    candidate.to_neuron_index = order_map.get(&candidate.to_neuron_uuid).copied();
+
+    let is_hidden = neuron_type_map
+        .get(&candidate.to_neuron_uuid)
+        .map(|t| t != "output")
+        .unwrap_or(true); // Default to hidden if type unknown
+
+    let impact = if is_hidden {
+        if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
+            impact.clamp(0.0, 1.0)
+        } else {
+            // No impact score means disconnected from outputs - heavy discount
+            0.1
+        }
+    } else {
+        // Output neuron - full impact
+        1.0
+    };
+
+    // Update creature-level metrics
+    candidate.target_neuron_impact = impact;
+    let original = candidate.expected_creature_error_reduction;
+    candidate.expected_creature_error_reduction *= impact;
+    candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
+
+    // Issue #467: Apply source-type prioritisation boost for input-neuron sources.
+    candidate.expected_creature_score_gain = apply_source_type_boost(
+        candidate.expected_creature_score_gain,
+        &candidate.from_neuron_uuid,
+    );
+
+    // Issue #468: Apply target-type prioritisation boost for existing hidden targets.
+    candidate.expected_creature_score_gain = apply_target_type_boost(
+        candidate.expected_creature_score_gain,
+        &candidate.to_neuron_uuid,
+        neuron_type_map,
+    );
+
+    if verbose_enabled() && is_hidden {
+        eprintln!(
+            "[NEAT-AI-Discovery][verbose] Synapse candidate → {} impact {:.3}: \
+            {:.4}% → {:.4}%",
+            &candidate.to_neuron_uuid[..12.min(candidate.to_neuron_uuid.len())],
+            impact,
+            original * 100.0,
+            candidate.expected_creature_score_gain * 100.0
+        );
+    }
+}
+
+/// Apply impact-based discounting to a single harmful synapse candidate.
+fn apply_impact_to_harmful(
+    candidate: &mut CandidateSynapseJson,
+    impact_scores: &HashMap<String, f32>,
+    neuron_type_map: &HashMap<String, String>,
+    order_map: &HashMap<String, usize>,
+) {
+    candidate.from_neuron_index = order_map.get(&candidate.from_neuron_uuid).copied();
+    candidate.to_neuron_index = order_map.get(&candidate.to_neuron_uuid).copied();
+
+    let is_hidden = neuron_type_map
+        .get(&candidate.to_neuron_uuid)
+        .map(|t| t != "output")
+        .unwrap_or(true);
+
+    let impact = if is_hidden {
+        if let Some(&impact) = impact_scores.get(&candidate.to_neuron_uuid) {
+            impact.clamp(0.0, 1.0)
+        } else {
+            0.1
+        }
+    } else {
+        1.0
+    };
+
+    candidate.target_neuron_impact = impact;
+    candidate.expected_creature_error_reduction *= impact;
+    candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
+}
+
+/// Apply impact-based discounting to a coordinated structural candidate.
+///
+/// Uses the last operation's target neuron UUID to determine impact, since multi-op
+/// groups ultimately adjust the inputs of a target neuron.
+fn apply_impact_to_coordinated(
+    candidate: &mut crate::CoordinatedStructuralCandidateJson,
+    impact_scores: &HashMap<String, f32>,
+    neuron_type_map: &HashMap<String, String>,
+) {
+    let target_uuid = candidate
+        .operations
+        .iter()
+        .rev()
+        .map(|op| match op {
+            crate::CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. } => {
+                to_neuron_uuid.as_str()
+            }
+            crate::CoordinatedStructuralOpJson::RemoveSynapse { to_neuron_uuid, .. } => {
+                to_neuron_uuid.as_str()
+            }
+            crate::CoordinatedStructuralOpJson::SetWeight { to_neuron_uuid, .. } => {
+                to_neuron_uuid.as_str()
+            }
+            crate::CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. } => {
+                neuron_uuid.as_str()
+            }
+            crate::CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. } => neuron_uuid.as_str(),
+            crate::CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. } => {
+                neuron_uuid.as_str()
+            }
+            crate::CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } => {
+                neuron_uuid.as_str()
+            }
+        })
+        .next()
+        .unwrap_or("");
+
+    let is_hidden = neuron_type_map
+        .get(target_uuid)
+        .map(|t| t != "output")
+        .unwrap_or(true);
+    let impact = if is_hidden {
+        impact_scores
+            .get(target_uuid)
+            .copied()
+            .unwrap_or(0.1)
+            .clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+
+    candidate.expected_creature_score_gain *= impact;
+}
+
+/// Apply impact discounting, sorting, diversification, and truncation to all candidate sets.
+///
+/// This is the main post-processing entry point, called after the parallel analysis loop
+/// completes and after structural pattern discovery (collapse hidden neurons).
+pub(crate) fn apply_post_processing(
+    helpful_results: &mut Vec<CandidateSynapseJson>,
+    harmful_results: &mut Vec<CandidateSynapseJson>,
+    coordinated_structural_results: &mut Vec<crate::CoordinatedStructuralCandidateJson>,
+    input: &crate::AnalyzeSynapsesInput,
+    cache: &RecordCache,
+    order_map: &HashMap<String, usize>,
+) -> PostProcessingMetrics {
+    // Issue #128: Apply impact-based discounting and set creature-level metrics.
+    let impact_scores = compute_impact_scores_for_discounting(&input.creature, cache);
+    let neuron_type_map: HashMap<String, String> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
+        .collect();
+
+    // Apply impact discounting to helpful synapse candidates
+    for candidate in helpful_results.iter_mut() {
+        apply_impact_to_helpful(candidate, &impact_scores, &neuron_type_map, order_map);
+    }
+
+    // Apply impact discounting to harmful synapse candidates
+    for candidate in harmful_results.iter_mut() {
+        apply_impact_to_harmful(candidate, &impact_scores, &neuron_type_map, order_map);
+    }
+
+    // Apply impact discounting to coordinated candidates
+    for candidate in coordinated_structural_results.iter_mut() {
+        apply_impact_to_coordinated(candidate, &impact_scores, &neuron_type_map);
+    }
+
+    // Sort all candidate lists by expected_creature_score_gain (highest first)
+    helpful_results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    harmful_results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    coordinated_structural_results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    // Deadline coverage: diversify within the top-K for exploration diversity
+    if input.analysis_deadline_ms.is_some() {
+        use crate::analysis::constants::DIVERSIFY_TOP_K;
+        shuffle_within_top_k(
+            helpful_results.as_mut_slice(),
+            input.random_seed,
+            "synapse:helpful_candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+        shuffle_within_top_k(
+            harmful_results.as_mut_slice(),
+            input.random_seed,
+            "synapse:harmful_candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+        shuffle_within_top_k(
+            coordinated_structural_results.as_mut_slice(),
+            input.random_seed,
+            "synapse:coordinated_structural_candidates:top_k",
+            DIVERSIFY_TOP_K,
+        );
+    }
+
+    // Track candidates_found before truncation
+    let candidates_found =
+        helpful_results.len() + harmful_results.len() + coordinated_structural_results.len();
+
+    if let Some(limit) = input.max_candidates {
+        let (h1, h2, c) = truncate_combined_synapse_candidate_sets(
+            std::mem::take(helpful_results),
+            std::mem::take(harmful_results),
+            std::mem::take(coordinated_structural_results),
+            limit,
+            input.analysis_deadline_ms.is_some(),
+        );
+        *helpful_results = h1;
+        *harmful_results = h2;
+        *coordinated_structural_results = c;
+    }
+
+    let candidates_returned =
+        helpful_results.len() + harmful_results.len() + coordinated_structural_results.len();
+
+    PostProcessingMetrics {
+        candidates_found,
+        candidates_returned,
+    }
+}
+
+/// Metrics returned from post-processing for inclusion in analysis metadata.
+pub(crate) struct PostProcessingMetrics {
+    pub candidates_found: usize,
+    pub candidates_returned: usize,
+}
+
+/// Parameters for building analysis metadata.
+pub(crate) struct MetadataParams<'a> {
+    pub target_value_seen: bool,
+    pub saturation_aware_used: bool,
+    pub candidates_found: usize,
+    pub candidates_returned: usize,
+    pub analysis_timed_out: bool,
+    pub completed_focus_neurons: usize,
+    pub total_focus_neurons: usize,
+    pub saw_any_input: bool,
+    pub input_min: usize,
+    pub input_max: usize,
+    pub error_values: &'a [f32],
+    pub timing_collector: &'a crate::analysis::shared::TimingCollector,
+}
+
+/// Build the analysis metadata from collected atomic flags and timing data.
+pub(crate) fn build_metadata(
+    params: &MetadataParams<'_>,
+) -> crate::analysis::shared::SynapseAnalysisMetadata {
+    use crate::analysis::gpu::GpuAnalyzer;
+
+    let error_distribution =
+        crate::analysis::error_distribution::ErrorDistribution::from_errors(params.error_values);
+
+    crate::analysis::shared::SynapseAnalysisMetadata {
+        target_value_available: params.target_value_seen,
+        saturation_aware_simulation_used: params.saturation_aware_used,
+        candidates_found: params.candidates_found,
+        candidates_returned: params.candidates_returned,
+        timed_out: params.analysis_timed_out,
+        completed_focus_neurons: params.completed_focus_neurons,
+        total_focus_neurons: params.total_focus_neurons,
+        input_index_min_seen_with_records: if params.saw_any_input {
+            Some(params.input_min)
+        } else {
+            None
+        },
+        input_index_max_seen_with_records: if params.saw_any_input {
+            Some(params.input_max)
+        } else {
+            None
+        },
+        timing: params.timing_collector.finalize(),
+        gpu_info: GpuAnalyzer::get_adapter_info(),
+        error_distribution,
+    }
+}

--- a/src/analysis/synapse/structural_patterns.rs
+++ b/src/analysis/synapse/structural_patterns.rs
@@ -1,0 +1,411 @@
+//! Structural pattern discovery for synapse analysis
+//!
+//! This module detects coordinated structural changes in the creature topology:
+//! - Noisy vs trusted input folding (Issue #165)
+//! - Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
+//!
+//! Extracted from mod.rs as part of Issue #482.
+
+use super::scoring::compute_synapse_improvement_and_count;
+use crate::analysis::cache::RecordCache;
+use crate::analysis::constants::MIN_NEURON_SAMPLE_COUNT;
+use crate::analysis::diagnostics::TargetMap;
+use crate::analysis::samples::{EPSILON, HelpfulSample};
+use crate::analysis::weights::calculate_optimal_outgoing_weight;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, SynapseJson};
+use std::collections::{HashMap, HashSet};
+
+// =============================================================================
+// Noisy vs Trusted Input Folding (Issue #165)
+// =============================================================================
+
+/// Detect noisy vs trusted input pairs feeding the same target neuron.
+///
+/// When two input signals have the same mean and the same starting synapse weight,
+/// but one is much noisier (higher activation variance), the intended coordinated fix is:
+/// - Remove the noisy synapse
+/// - Remove the trusted synapse
+/// - Add the trusted synapse back with a higher weight (typically doubled)
+///
+/// Returns `Some(candidate)` if a beneficial noisy-vs-trusted pair is found.
+pub(crate) fn detect_noisy_vs_trusted(
+    target_uuid: &str,
+    synapses_by_target: &[SynapseJson],
+    cache: &RecordCache,
+    target_map: &TargetMap,
+    neuron_squash_map: &HashMap<String, String>,
+) -> Option<CoordinatedStructuralCandidateJson> {
+    fn activation_mean_and_variance(records: &[DiscoverRecord]) -> Option<(f32, f32)> {
+        let mut n = 0.0f32;
+        let mut sum = 0.0f32;
+        let mut sum_sq = 0.0f32;
+        for r in records {
+            if r.activation.is_finite() {
+                n += 1.0;
+                sum += r.activation;
+                sum_sq += r.activation * r.activation;
+            }
+        }
+        if n <= 0.0 {
+            return None;
+        }
+        let mean = sum / n;
+        let var = (sum_sq / n) - (mean * mean);
+        Some((mean, var.max(0.0)))
+    }
+
+    fn activation_map(records: &[DiscoverRecord]) -> HashMap<u32, f32> {
+        let mut map = HashMap::with_capacity(records.len());
+        for r in records {
+            if r.activation.is_finite() {
+                map.insert(r.obs_index, r.activation);
+            }
+        }
+        map
+    }
+
+    #[derive(Clone)]
+    struct IncomingInput {
+        from_uuid: String,
+        weight: f32,
+        mean: f32,
+        var: f32,
+    }
+
+    let mut incoming_inputs: Vec<IncomingInput> = Vec::new();
+    for syn in synapses_by_target.iter() {
+        if !syn.from_uuid.starts_with("input-") {
+            continue;
+        }
+        let Ok(from_records_arc) = cache.get(&syn.from_uuid) else {
+            continue;
+        };
+        if from_records_arc.is_empty() {
+            continue;
+        }
+        let Some((mean, var)) = activation_mean_and_variance(from_records_arc.as_ref()) else {
+            continue;
+        };
+        incoming_inputs.push(IncomingInput {
+            from_uuid: syn.from_uuid.clone(),
+            weight: syn.weight,
+            mean,
+            var,
+        });
+    }
+
+    if incoming_inputs.len() < 2 || target_map.map.is_empty() {
+        return None;
+    }
+
+    // Strict matching for the simple-case test: same weights and same means.
+    const WEIGHT_EPS: f32 = 1e-6;
+    const MEAN_EPS: f32 = 1e-3;
+    const MIN_VAR_RATIO: f32 = 10.0;
+
+    let target_squash = neuron_squash_map.get(target_uuid).map(|s| s.as_str());
+
+    let mut best: Option<(IncomingInput, IncomingInput, f32)> = None; // (noisy, trusted, gain)
+
+    for i in 0..incoming_inputs.len() {
+        for j in (i + 1)..incoming_inputs.len() {
+            let a = incoming_inputs[i].clone();
+            let b = incoming_inputs[j].clone();
+
+            if (a.weight - b.weight).abs() > WEIGHT_EPS {
+                continue;
+            }
+            if (a.mean - b.mean).abs() > MEAN_EPS {
+                continue;
+            }
+
+            let (noisy, trusted) = if a.var >= b.var { (a, b) } else { (b, a) };
+            let ratio = noisy.var / trusted.var.max(EPSILON);
+            if ratio < MIN_VAR_RATIO {
+                continue;
+            }
+
+            let Ok(noisy_records_arc) = cache.get(&noisy.from_uuid) else {
+                continue;
+            };
+            let Ok(trusted_records_arc) = cache.get(&trusted.from_uuid) else {
+                continue;
+            };
+
+            let noisy_map = activation_map(noisy_records_arc.as_ref());
+            let trusted_map = activation_map(trusted_records_arc.as_ref());
+
+            let mut delta_samples: Vec<HelpfulSample> = Vec::with_capacity(target_map.map.len());
+            for (obs_index, target) in target_map.map.iter() {
+                let Some(noisy_act) = noisy_map.get(obs_index) else {
+                    continue;
+                };
+                let Some(trusted_act) = trusted_map.get(obs_index) else {
+                    continue;
+                };
+                let Some(activation) =
+                    crate::analysis::weights::coordinated_structural_activation_delta(
+                        *trusted_act,
+                        *noisy_act,
+                        noisy.weight,
+                        trusted.weight,
+                    )
+                else {
+                    continue;
+                };
+                if !activation.is_finite() || !target.avg_error.is_finite() {
+                    continue;
+                }
+                delta_samples.push(HelpfulSample {
+                    activation,
+                    avg_error: target.avg_error,
+                    target_value: target.value,
+                    target_activation: Some(target.activation),
+                });
+            }
+
+            if delta_samples.is_empty() {
+                continue;
+            }
+
+            let baseline_sq: f32 = delta_samples
+                .iter()
+                .map(|s| s.avg_error * s.avg_error)
+                .sum();
+
+            // Move the noisy weight onto the trusted input:
+            // Δoutput = w_noisy * (trusted - noisy)
+            let moved_weight = noisy.weight;
+            let (improvement, _, _, _) = compute_synapse_improvement_and_count(
+                delta_samples.as_slice(),
+                moved_weight,
+                baseline_sq,
+                target_squash,
+            );
+
+            if improvement <= 0.0 {
+                continue;
+            }
+
+            match &best {
+                Some((_, _, best_gain)) if *best_gain >= improvement => {}
+                _ => best = Some((noisy, trusted, improvement)),
+            }
+        }
+    }
+
+    best.map(|(noisy, trusted, gain)| {
+        let new_weight = trusted.weight + noisy.weight;
+        CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid: noisy.from_uuid,
+                    to_neuron_uuid: target_uuid.to_string(),
+                },
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid: trusted.from_uuid.clone(),
+                    to_neuron_uuid: target_uuid.to_string(),
+                },
+                CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: trusted.from_uuid,
+                    to_neuron_uuid: target_uuid.to_string(),
+                    weight: new_weight,
+                },
+            ],
+            expected_creature_score_gain: gain,
+            comment: Some(
+                "Coordinated: prune noisy input (high variance), strengthen trusted input"
+                    .to_string(),
+            ),
+        }
+    })
+}
+
+// =============================================================================
+// Collapse Hidden Neuron (Issue #425)
+// =============================================================================
+
+/// Detect hidden neurons that form simple 1-in/1-out chains and propose collapsing
+/// them into direct synapses.
+///
+/// When a hidden neuron `h` has exactly one incoming synapse (a → h) and one
+/// outgoing synapse (h → b), we propose removing `h` and replacing the chain
+/// with a direct synapse (a → b). This is emitted as a coordinated-structural
+/// candidate group with 4 operations: RemoveSynapse(a→h), RemoveSynapse(h→b),
+/// RemoveNeuron(h), AddSynapse(a→b).
+pub(crate) fn detect_collapsible_hidden_neurons(
+    input: &crate::AnalyzeSynapsesInput,
+    cache: &RecordCache,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::new();
+
+    // Build incoming/outgoing synapse lists per neuron.
+    let mut incoming: HashMap<String, Vec<SynapseJson>> = HashMap::new();
+    let mut outgoing: HashMap<String, Vec<SynapseJson>> = HashMap::new();
+    for s in &input.creature.synapses {
+        incoming
+            .entry(s.to_uuid.clone())
+            .or_default()
+            .push(s.clone());
+        outgoing
+            .entry(s.from_uuid.clone())
+            .or_default()
+            .push(s.clone());
+    }
+
+    // Quick neuron-type lookup (only creature.neurons; inputs are not here).
+    let neuron_type_map_local: HashMap<String, String> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.neuron_type.clone()))
+        .collect();
+
+    // Precompute existing direct synapses so we don't propose duplicates.
+    let mut existing_edges: HashSet<(String, String)> = HashSet::new();
+    for s in &input.creature.synapses {
+        existing_edges.insert((s.from_uuid.clone(), s.to_uuid.clone()));
+    }
+
+    for neuron in &input.creature.neurons {
+        if neuron.neuron_type != "hidden" {
+            continue;
+        }
+        let h = neuron.uuid.as_str();
+        let Some(ins) = incoming.get(h) else { continue };
+        let Some(outs) = outgoing.get(h) else {
+            continue;
+        };
+        if ins.len() != 1 || outs.len() != 1 {
+            continue;
+        }
+
+        let a_syn = &ins[0];
+        let b_syn = &outs[0];
+        let a = a_syn.from_uuid.as_str();
+        let b = b_syn.to_uuid.as_str();
+
+        // Skip degenerate / non-actionable cases.
+        if a == b || a == h || b == h {
+            continue;
+        }
+        if existing_edges.contains(&(a.to_string(), b.to_string())) {
+            // A direct synapse already exists; collapsing would need additional ops (future work).
+            continue;
+        }
+
+        // Ensure the target exists (either input-* or a neuron) so the op is not stale.
+        let target_is_known = b.starts_with("input-") || neuron_type_map_local.contains_key(b);
+        if !target_is_known {
+            continue;
+        }
+
+        // Build samples: correlate a's activation to b's adjusted error after removing h→b.
+        let Ok(a_records) = cache.get(a) else {
+            continue;
+        };
+        let Ok(h_records) = cache.get(h) else {
+            continue;
+        };
+        let Ok(b_records) = cache.get(b) else {
+            continue;
+        };
+        if a_records.is_empty() || h_records.is_empty() || b_records.is_empty() {
+            continue;
+        }
+
+        let target_map_b = TargetMap::from_records(b_records.as_ref());
+        if target_map_b.map.is_empty() {
+            continue;
+        }
+        let build_act_map = |records: &[DiscoverRecord]| -> HashMap<u32, f32> {
+            let mut map: HashMap<u32, f32> = HashMap::with_capacity(records.len());
+            for r in records {
+                if r.activation.is_finite() {
+                    map.insert(r.obs_index, r.activation);
+                }
+            }
+            map
+        };
+        let a_map = build_act_map(a_records.as_ref());
+        let h_map = build_act_map(h_records.as_ref());
+
+        let mut samples: Vec<HelpfulSample> = Vec::with_capacity(target_map_b.map.len());
+        for (obs_index, target) in target_map_b.map.iter() {
+            let Some(a_act) = a_map.get(obs_index) else {
+                continue;
+            };
+            let Some(h_act) = h_map.get(obs_index) else {
+                continue;
+            };
+            if !a_act.is_finite() || !h_act.is_finite() || !target.avg_error.is_finite() {
+                continue;
+            }
+            let adjusted_error = target.avg_error + b_syn.weight * (*h_act);
+            if !adjusted_error.is_finite() {
+                continue;
+            }
+            samples.push(HelpfulSample {
+                activation: *a_act,
+                avg_error: adjusted_error,
+                target_value: None,
+                target_activation: None,
+            });
+        }
+
+        if samples.len() < MIN_NEURON_SAMPLE_COUNT {
+            continue;
+        }
+
+        let mut sum_act_sq = 0.0f32;
+        let mut sum_err_act = 0.0f32;
+        let mut baseline_sq = 0.0f32;
+        for s in &samples {
+            sum_act_sq += s.activation * s.activation;
+            sum_err_act += s.activation * s.avg_error;
+            baseline_sq += s.avg_error * s.avg_error;
+        }
+        if baseline_sq <= EPSILON {
+            continue;
+        }
+
+        let Some(weight) = calculate_optimal_outgoing_weight(sum_err_act, sum_act_sq, 1.0) else {
+            continue;
+        };
+
+        let (improvement, _improved, _worsened, _total) =
+            compute_synapse_improvement_and_count(&samples, weight, baseline_sq, None);
+        if improvement <= 0.0 {
+            continue;
+        }
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid: a.to_string(),
+                    to_neuron_uuid: h.to_string(),
+                },
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid: h.to_string(),
+                    to_neuron_uuid: b.to_string(),
+                },
+                CoordinatedStructuralOpJson::RemoveNeuron {
+                    neuron_uuid: h.to_string(),
+                },
+                CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: a.to_string(),
+                    to_neuron_uuid: b.to_string(),
+                    weight,
+                },
+            ],
+            expected_creature_score_gain: improvement,
+            comment: Some(
+                "Coordinated collapse: remove 1-in/1-out hidden neuron and add bypass synapse"
+                    .to_string(),
+            ),
+        });
+    }
+
+    results
+}

--- a/src/analysis/synapse/target_analysis.rs
+++ b/src/analysis/synapse/target_analysis.rs
@@ -1,0 +1,1020 @@
+//! Per-target synapse analysis
+//!
+//! This module contains the analysis logic for a single focus (target) neuron:
+//! - Validate target neuron eligibility
+//! - Filter and order eligible source neurons
+//! - Build samples via locality grouping
+//! - Evaluate helpful synapse candidates via GPU batching
+//! - Evaluate harmful synapse candidates via GPU batching
+//! - Detect epistatic, synergistic, and redundant path patterns
+//!
+//! Extracted from mod.rs as part of Issue #482.
+
+use crate::analysis::activation::{get_target_simulation_fn, is_saturating_target};
+use crate::analysis::confidence::compute_confidence_metrics;
+use crate::analysis::diagnostics::{TargetDiagnostics, TargetMap, ThresholdContext};
+use crate::analysis::epistatic::{
+    SourceContribution, build_source_contribution, detect_epistatic_pairs,
+    detect_synergistic_candidates, epistatic_pairs_to_coordinated_candidates,
+    filter_interfering_epistatic_pairs, filter_interfering_synergistic_candidates,
+    synergistic_to_coordinated_candidates,
+};
+use crate::analysis::gpu::GpuWorkQueue;
+use crate::analysis::redundant_path::{
+    ExistingPathContribution, detect_redundant_paths, redundant_paths_to_coordinated_candidates,
+};
+use crate::analysis::samples::{EPSILON, HelpfulSample, NeuronStats};
+use crate::analysis::shared::TimingScope;
+use crate::analysis::utils::{
+    OrderedNeuron, deadline_passed, order_eligible_sources, parse_input_index, verbose_enabled,
+};
+use crate::analysis::weights::{
+    MAX_OUTGOING_WEIGHT, calculate_optimal_outgoing_weight, clamp_weight_update_delta,
+};
+use crate::intern::NeuronIndex;
+use crate::types::DiscoverRecord;
+use crate::{AnalyzeSynapsesInput, CandidateSynapseJson, SynapseJson};
+use anyhow::{Result, anyhow};
+use rayon::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use super::candidate_generation::{
+    MIN_GROUP_SIZE_FOR_LOCALITY, build_samples_for_locality_group, group_sources_by_locality,
+};
+use super::scoring::compute_synapse_improvement_and_count;
+use crate::analysis::cache::RecordCache;
+
+/// Shared context for per-target analysis, built once in the main pipeline.
+pub(crate) struct TargetAnalysisContext {
+    pub ordered_neurons: Arc<Vec<OrderedNeuron>>,
+    pub order_map: Arc<HashMap<String, usize>>,
+    pub neuron_index: Arc<NeuronIndex>,
+    pub existing_synapses: Arc<HashSet<(u32, u32)>>,
+    pub existing_synapse_weights: Arc<HashMap<(u32, u32), f32>>,
+    pub synapses_by_target: Arc<HashMap<u32, Vec<SynapseJson>>>,
+    pub neuron_squash_map: Arc<HashMap<String, String>>,
+    pub neuron_type_map: Arc<HashMap<String, String>>,
+    pub input_neuron_uuids: Arc<HashSet<String>>,
+    pub used_inputs: Arc<HashSet<String>>,
+    pub neuron_bias_map: Arc<HashMap<String, f32>>,
+    pub constant_source_effect_threshold: Option<f32>,
+    pub diagnostics: Arc<TargetDiagnostics>,
+    pub timing_collector: Arc<crate::analysis::shared::TimingCollector>,
+    pub deadline: Option<SystemTime>,
+    pub threshold: f32,
+}
+
+/// Results from analysing a single target neuron.
+pub(crate) struct TargetAnalysisResults {
+    pub helpful: Vec<CandidateSynapseJson>,
+    pub harmful: Vec<CandidateSynapseJson>,
+    pub coordinated: Vec<crate::CoordinatedStructuralCandidateJson>,
+    /// Error values collected from target records for distribution analysis.
+    pub error_values: Vec<f32>,
+    /// Whether any samples had target_value data available.
+    pub target_value_seen: bool,
+    /// Whether saturation-aware simulation was used for any candidate.
+    pub saturation_aware_used: bool,
+    /// Input neuron index tracking for metadata.
+    pub input_metadata: InputMetadata,
+}
+
+/// Metadata about input neurons with records, for inclusion in analysis metadata.
+pub(crate) struct InputMetadata {
+    pub seen_any: bool,
+    pub min_index: usize,
+    pub max_index: usize,
+}
+
+/// Work item for helpful synapse evaluation via GPU.
+struct HelpfulWork {
+    source_uuid: String,
+    target_uuid: String,
+    samples: Vec<HelpfulSample>,
+    /// Existing synapse weight (when the synapse already exists).
+    existing_weight: Option<f32>,
+}
+
+/// Tracking result from sample building for a single source neuron.
+struct SourceWorkResult {
+    work: Option<HelpfulWork>,
+    had_samples: bool,
+    source_uuid: String,
+    record_count: usize,
+}
+
+/// Existing edge metadata for weight-update candidates.
+struct ExistingSourceToProcess<'a> {
+    source: &'a OrderedNeuron,
+    records: Arc<Vec<DiscoverRecord>>,
+    old_weight: f32,
+}
+
+/// Analyse a single target neuron: find helpful, harmful, and coordinated candidates.
+///
+/// This function encapsulates the entire per-target loop body that was previously
+/// inline in `analyze_synapses_with_cache_impl`.
+pub(crate) fn analyse_single_target(
+    target_uuid: &str,
+    input: &AnalyzeSynapsesInput,
+    cache: &RecordCache,
+    gpu: &GpuWorkQueue,
+    ctx: &TargetAnalysisContext,
+) -> Result<TargetAnalysisResults> {
+    let mut results = TargetAnalysisResults {
+        helpful: Vec::new(),
+        harmful: Vec::new(),
+        coordinated: Vec::new(),
+        error_values: Vec::new(),
+        target_value_seen: false,
+        saturation_aware_used: false,
+        input_metadata: InputMetadata {
+            seen_any: false,
+            min_index: usize::MAX,
+            max_index: 0,
+        },
+    };
+
+    crate::watchdog::beat(format!(
+        "synapse analysis → processing target {target_uuid}"
+    ));
+
+    let target_records_arc = cache.get(target_uuid)?;
+    if target_records_arc.is_empty() {
+        ctx.diagnostics.set_target_record_count(target_uuid, 0);
+        return Ok(results);
+    }
+    let target_records = target_records_arc.as_ref();
+    ctx.diagnostics
+        .set_target_record_count(target_uuid, target_records.len());
+
+    // Issue #192: Collect error values for distribution analysis
+    {
+        let errors: Vec<f32> = target_records
+            .iter()
+            .flat_map(|r| r.errors.iter().filter(|e| e.is_finite()).copied())
+            .collect();
+        if !errors.is_empty() {
+            results.error_values = errors;
+        }
+    }
+
+    let target_index = match ctx.order_map.get(target_uuid) {
+        Some(index) => *index,
+        None => {
+            if verbose_enabled() {
+                eprintln!(
+                    "[NEAT-AI-Discovery][verbose] Target {target_uuid} not found in creature neuron order map (neuron may not exist in creature definition). Skipping."
+                );
+            }
+            return Ok(results);
+        }
+    };
+
+    // Early validation: skip input and constant neurons
+    let target_neuron_type = ctx
+        .neuron_type_map
+        .get(target_uuid)
+        .ok_or_else(|| {
+            anyhow!(
+                "Invalid target neuron UUID '{}': not found in neuron type map. \
+                This indicates a serious data integrity bug. All valid neurons must be in the type map \
+                (input neurons: input-0..input-{}, or neurons from creature.neurons array).",
+                target_uuid,
+                ctx.input_neuron_uuids.len().saturating_sub(1)
+            )
+        })?;
+
+    let input_count = ctx.input_neuron_uuids.len();
+    let is_input_neuron = target_neuron_type == "input";
+    let is_constant_neuron = target_neuron_type == "constant";
+
+    if is_input_neuron || is_constant_neuron {
+        return Ok(results);
+    }
+
+    // Filter eligible sources
+    let mut eligible_sources: Vec<&OrderedNeuron> = ctx
+        .ordered_neurons
+        .iter()
+        .filter(|neuron| {
+            neuron.index < target_index
+                && {
+                    match ctx.neuron_type_map.get(&neuron.uuid) {
+                        Some(neuron_type) => neuron_type != "constant",
+                        None => {
+                            eprintln!(
+                                "[NEAT-AI-Discovery] ERROR: Invalid neuron UUID '{}' found in ordered_neurons. \
+                                Not found in comprehensive neuron type map. This indicates a serious data integrity bug.",
+                                neuron.uuid
+                            );
+                            false
+                        }
+                    }
+                }
+        })
+        .collect();
+
+    let total_eligible = eligible_sources.len() as u32;
+
+    if total_eligible == 0 {
+        let neurons_before_index = ctx
+            .ordered_neurons
+            .iter()
+            .filter(|n| n.index < target_index)
+            .count();
+        let constants_before_index = ctx
+            .ordered_neurons
+            .iter()
+            .filter(|n| {
+                n.index < target_index
+                    && ctx
+                        .neuron_type_map
+                        .get(&n.uuid)
+                        .map(|t| t == "constant")
+                        .unwrap_or(false)
+            })
+            .count();
+        let input_neurons_before_index = ctx
+            .ordered_neurons
+            .iter()
+            .filter(|n| n.index < target_index && ctx.input_neuron_uuids.contains(&n.uuid))
+            .count();
+
+        eprintln!(
+            "[NEAT-AI-Discovery] BUG: Target {target_uuid} (type: {target_neuron_type}, index: {target_index}) has no eligible upstream neurons. \
+            creature.input: {input_count}, neurons before target: {neurons_before_index}, constants before target: {constants_before_index}, \
+            input neurons before target: {input_neurons_before_index}. This should not happen for hidden/output neurons with index >= creature.input."
+        );
+
+        return Ok(results);
+    }
+
+    let input_neuron_count = eligible_sources
+        .iter()
+        .filter(|neuron| ctx.input_neuron_uuids.contains(&neuron.uuid))
+        .count() as u32;
+    ctx.diagnostics
+        .set_total_eligible_sources(target_uuid, total_eligible);
+    ctx.diagnostics
+        .set_input_neuron_count(target_uuid, input_neuron_count);
+
+    let context = format!("synapse:eligible_sources:{target_uuid}");
+    order_eligible_sources(
+        &mut eligible_sources,
+        input.random_seed,
+        &context,
+        input.creature.input,
+        Some(&*ctx.used_inputs),
+    );
+
+    // Pre-filter sources and collect their records
+    let mut already_connected_count = 0u32;
+    let mut load_failure_count = 0u32;
+    let mut empty_record_sources: Vec<String> = Vec::new();
+
+    let mut sources_to_process: Vec<(&OrderedNeuron, Arc<Vec<DiscoverRecord>>)> =
+        Vec::with_capacity(eligible_sources.len());
+    let mut existing_sources_to_process: Vec<ExistingSourceToProcess> =
+        Vec::with_capacity(eligible_sources.len());
+
+    for source in &eligible_sources {
+        if deadline_passed(&ctx.deadline) {
+            break;
+        }
+        let source_uuid = source.uuid.as_str();
+
+        let source_idx = ctx.neuron_index.get_index(source_uuid);
+        let target_idx = ctx.neuron_index.get_index(target_uuid);
+        let is_connected = match (source_idx, target_idx) {
+            (Some(s), Some(t)) => ctx.existing_synapses.contains(&(s, t)),
+            _ => false,
+        };
+        if is_connected {
+            already_connected_count += 1;
+        };
+        let existing_weight = if is_connected {
+            match (source_idx, target_idx) {
+                (Some(s), Some(t)) => ctx.existing_synapse_weights.get(&(s, t)).copied(),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        match cache.get(source_uuid) {
+            Ok(records) => {
+                if !records.is_empty() {
+                    if let Some(input_index) = parse_input_index(source_uuid) {
+                        results.input_metadata.seen_any = true;
+                        if input_index < results.input_metadata.min_index {
+                            results.input_metadata.min_index = input_index;
+                        }
+                        if input_index > results.input_metadata.max_index {
+                            results.input_metadata.max_index = input_index;
+                        }
+                    }
+                    if let Some(old_weight) = existing_weight {
+                        existing_sources_to_process.push(ExistingSourceToProcess {
+                            source,
+                            records,
+                            old_weight,
+                        });
+                    } else if !is_connected {
+                        sources_to_process.push((source, records));
+                    }
+                } else {
+                    empty_record_sources.push(source_uuid.to_string());
+                    let is_input = ctx.input_neuron_uuids.contains(source_uuid);
+                    if verbose_enabled() && !is_input {
+                        eprintln!(
+                            "[NEAT-AI-Discovery][verbose] Source {source_uuid} (target {target_uuid}) has no records in parquet file."
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                load_failure_count += 1;
+                if verbose_enabled() {
+                    eprintln!(
+                        "[NEAT-AI-Discovery][verbose] Failed to load records for source {source_uuid} (target {target_uuid}): {err}"
+                    );
+                }
+            }
+        };
+    }
+
+    // Log empty input neuron summary
+    let empty_input_neuron_count = empty_record_sources
+        .iter()
+        .filter(|uuid| ctx.input_neuron_uuids.contains(uuid.as_str()))
+        .count();
+    let empty_non_input_count = empty_record_sources.len() - empty_input_neuron_count;
+
+    if verbose_enabled() && empty_input_neuron_count > 0 {
+        eprintln!(
+            "[NEAT-AI-Discovery][verbose] Target {target_uuid}: {} of {} input neurons have no records in parquet file (plus {} non-input sources). This may indicate incomplete parquet data.",
+            empty_input_neuron_count,
+            ctx.input_neuron_uuids.len(),
+            empty_non_input_count
+        );
+    }
+
+    // Update diagnostics
+    if already_connected_count > 0 || load_failure_count > 0 || !empty_record_sources.is_empty() {
+        for _ in 0..already_connected_count {
+            ctx.diagnostics.record_already_connected(target_uuid);
+        }
+        for _ in 0..load_failure_count {
+            ctx.diagnostics.record_load_failure(target_uuid);
+        }
+        for source_uuid in &empty_record_sources {
+            ctx.diagnostics.record_candidate_attempt(target_uuid, false);
+            ctx.diagnostics
+                .record_no_samples(target_uuid, source_uuid, 0);
+        }
+    }
+
+    // Build target map once, reuse for all sources
+    let target_map = TargetMap::from_records(target_records);
+    let target_map_ref = &target_map;
+
+    // Noisy vs trusted input detection (Issue #165)
+    let target_idx_for_synapses = ctx.neuron_index.get_index(target_uuid);
+    if let Some(existing) = target_idx_for_synapses.and_then(|idx| ctx.synapses_by_target.get(&idx))
+        && let Some(candidate) = super::structural_patterns::detect_noisy_vs_trusted(
+            target_uuid,
+            existing,
+            cache,
+            target_map_ref,
+            &ctx.neuron_squash_map,
+        )
+    {
+        results.coordinated.push(candidate);
+    }
+
+    // Issue #221: Sample Locality Optimisation
+    let source_results: Vec<SourceWorkResult> = {
+        let _timing = TimingScope::sample_building(&ctx.timing_collector);
+
+        let locality_groups = group_sources_by_locality(&sources_to_process);
+
+        if verbose_enabled() && sources_to_process.len() >= MIN_GROUP_SIZE_FOR_LOCALITY {
+            let group_sizes: Vec<usize> = locality_groups.iter().map(|g| g.sources.len()).collect();
+            let max_group = group_sizes.iter().max().copied().unwrap_or(0);
+            let avg_group = if !group_sizes.is_empty() {
+                group_sizes.iter().sum::<usize>() as f32 / group_sizes.len() as f32
+            } else {
+                0.0
+            };
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Target {}: {} sources grouped into {} locality groups (max={}, avg={:.1})",
+                target_uuid,
+                sources_to_process.len(),
+                locality_groups.len(),
+                max_group,
+                avg_group
+            );
+        }
+
+        locality_groups
+            .par_iter()
+            .flat_map(|group| {
+                let group_results = build_samples_for_locality_group(group, target_map_ref);
+                group_results
+                    .into_iter()
+                    .map(|(source_uuid, samples, record_count)| {
+                        let had_samples = !samples.is_empty();
+                        let work = if had_samples {
+                            Some(HelpfulWork {
+                                source_uuid: source_uuid.clone(),
+                                target_uuid: target_uuid.to_string(),
+                                samples,
+                                existing_weight: None,
+                            })
+                        } else {
+                            None
+                        };
+                        SourceWorkResult {
+                            work,
+                            had_samples,
+                            source_uuid,
+                            record_count,
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    };
+
+    // Extract work batch and batch diagnostics updates
+    let mut helpful_work_batch: Vec<HelpfulWork> = Vec::new();
+    let mut diagnostics_updates: Vec<(String, String, bool, usize)> = Vec::new();
+
+    for result in source_results {
+        if let Some(work) = result.work {
+            helpful_work_batch.push(work);
+        }
+        diagnostics_updates.push((
+            target_uuid.to_string(),
+            result.source_uuid,
+            result.had_samples,
+            result.record_count,
+        ));
+    }
+
+    for (target, source, had_samples, record_count) in diagnostics_updates {
+        ctx.diagnostics
+            .record_candidate_attempt(&target, had_samples);
+        if !had_samples {
+            ctx.diagnostics
+                .record_no_samples(&target, &source, record_count);
+        }
+    }
+
+    // Append existing edges for weight-update evaluation
+    let mut existing_path_contributions: Vec<ExistingPathContribution> = Vec::new();
+    if !existing_sources_to_process.is_empty() {
+        let existing_work: Vec<HelpfulWork> = existing_sources_to_process
+            .par_iter()
+            .filter_map(|item| {
+                let source_uuid = item.source.uuid.as_str();
+                let from_records = item.records.as_ref();
+                let samples = target_map_ref.build_samples_from(from_records);
+                if samples.is_empty() {
+                    return None;
+                }
+                Some(HelpfulWork {
+                    source_uuid: source_uuid.to_string(),
+                    target_uuid: target_uuid.to_string(),
+                    samples,
+                    existing_weight: Some(item.old_weight),
+                })
+            })
+            .collect();
+
+        for work in &existing_work {
+            existing_path_contributions.push(ExistingPathContribution {
+                source_uuid: work.source_uuid.clone(),
+                existing_weight: work.existing_weight.unwrap_or(0.0),
+                samples: work.samples.clone(),
+            });
+        }
+
+        helpful_work_batch.extend(existing_work);
+    }
+
+    // Process helpful synapse candidates via GPU batching
+    if !helpful_work_batch.is_empty() {
+        process_helpful_batch(
+            &helpful_work_batch,
+            target_uuid,
+            cache,
+            gpu,
+            ctx,
+            &existing_path_contributions,
+            &mut results,
+        )?;
+    }
+
+    // Process harmful synapses
+    if !deadline_passed(&ctx.deadline) {
+        let target_idx_for_harmful = ctx.neuron_index.get_index(target_uuid);
+        if let Some(existing) =
+            target_idx_for_harmful.and_then(|idx| ctx.synapses_by_target.get(&idx))
+        {
+            process_harmful_batch(
+                target_uuid,
+                existing,
+                cache,
+                gpu,
+                ctx,
+                target_map_ref,
+                &mut results,
+            )?;
+        }
+    }
+
+    Ok(results)
+}
+
+/// Process a batch of helpful synapse candidates via GPU evaluation.
+fn process_helpful_batch(
+    helpful_work_batch: &[HelpfulWork],
+    target_uuid: &str,
+    cache: &RecordCache,
+    gpu: &GpuWorkQueue,
+    ctx: &TargetAnalysisContext,
+    existing_path_contributions: &[ExistingPathContribution],
+    results: &mut TargetAnalysisResults,
+) -> Result<()> {
+    let helpful_samples: Vec<Vec<HelpfulSample>> = helpful_work_batch
+        .iter()
+        .map(|w| w.samples.clone())
+        .collect();
+
+    // Track metadata
+    for samples in &helpful_samples {
+        if samples.iter().any(|s| s.target_value.is_some()) {
+            results.target_value_seen = true;
+            break;
+        }
+    }
+
+    let helpful_stats_batch = {
+        let _timing = TimingScope::shader(&ctx.timing_collector, "helpful");
+        gpu.evaluate_helpful_batch(helpful_samples, &ctx.deadline)?
+    };
+
+    let mut candidates_to_add = Vec::new();
+    let mut coordinated_to_add = Vec::new();
+    let mut diagnostics_zero_improvements = Vec::new();
+    let mut diagnostics_below_threshold = Vec::new();
+    let mut diagnostics_selected = Vec::new();
+    let mut source_contributions: Vec<SourceContribution> = Vec::new();
+
+    {
+        let _timing = TimingScope::result_processing(&ctx.timing_collector);
+        for (work, stats) in helpful_work_batch.iter().zip(helpful_stats_batch.iter()) {
+            let positive_is_better = stats.positive_count >= stats.negative_count;
+            let gpu_improved_count = if positive_is_better {
+                stats.positive_count
+            } else {
+                stats.negative_count
+            };
+            if gpu_improved_count == 0 {
+                diagnostics_zero_improvements.push((
+                    work.target_uuid.clone(),
+                    work.source_uuid.clone(),
+                    work.samples.len(),
+                    stats.positive_count,
+                    stats.negative_count,
+                ));
+                continue;
+            }
+
+            let total_count = work.samples.len() as u32;
+            if total_count == 0 {
+                continue;
+            }
+
+            let weight = match calculate_optimal_outgoing_weight(
+                stats.error_activation_sum,
+                stats.activation_sq_sum,
+                1.0,
+            ) {
+                Some(w) => w,
+                None => continue,
+            };
+
+            let target_squash = ctx
+                .neuron_squash_map
+                .get(&work.target_uuid)
+                .map(|s| s.as_str());
+
+            if get_target_simulation_fn(&work.samples, target_squash).is_some() {
+                results.saturation_aware_used = true;
+            }
+
+            let baseline_error_sq = stats.error_sq_sum;
+
+            let (applied_weight, neuron_error_improvement, improved_count, worsened_count) =
+                if let Some(old_weight) = work.existing_weight {
+                    let Some((_new_weight, delta_weight)) =
+                        clamp_weight_update_delta(old_weight, weight)
+                    else {
+                        continue;
+                    };
+                    let (improvement, improved, worsened, _) =
+                        compute_synapse_improvement_and_count(
+                            &work.samples,
+                            delta_weight,
+                            baseline_error_sq,
+                            target_squash,
+                        );
+                    (delta_weight, improvement, improved, worsened)
+                } else if is_saturating_target(&work.samples, target_squash) {
+                    // Issue #413: Search over scaled weights for saturating targets
+                    let weight_candidates: [f32; 9] = [
+                        weight * 0.1,
+                        weight * 0.25,
+                        weight * 0.5,
+                        weight * 0.75,
+                        weight,
+                        weight * 1.5,
+                        weight * 2.0,
+                        -weight * 0.5,
+                        -weight,
+                    ];
+
+                    let mut best_weight = weight;
+                    let mut best_improvement = f32::NEG_INFINITY;
+                    let mut best_improved = 0u32;
+                    let mut best_worsened = 0u32;
+
+                    for &w in &weight_candidates {
+                        let clamped = w.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                        if clamped.abs() <= EPSILON {
+                            continue;
+                        }
+                        let (imp, improved, worsened, _) = compute_synapse_improvement_and_count(
+                            &work.samples,
+                            clamped,
+                            baseline_error_sq,
+                            target_squash,
+                        );
+                        if imp > best_improvement {
+                            best_improvement = imp;
+                            best_weight = clamped;
+                            best_improved = improved;
+                            best_worsened = worsened;
+                        }
+                    }
+                    (best_weight, best_improvement, best_improved, best_worsened)
+                } else {
+                    let (improvement, improved, worsened, _) =
+                        compute_synapse_improvement_and_count(
+                            &work.samples,
+                            weight,
+                            baseline_error_sq,
+                            target_squash,
+                        );
+                    (weight, improvement, improved, worsened)
+                };
+
+            // Issue #202: Track source contribution for epistatic pair detection
+            if work.existing_weight.is_none() {
+                source_contributions.push(build_source_contribution(
+                    &work.source_uuid,
+                    work.samples.clone(),
+                    stats.clone(),
+                    applied_weight,
+                    neuron_error_improvement,
+                ));
+            }
+
+            if neuron_error_improvement <= 0.0 {
+                continue;
+            }
+
+            if neuron_error_improvement <= ctx.threshold {
+                diagnostics_below_threshold.push((
+                    work.target_uuid.clone(),
+                    work.source_uuid.clone(),
+                    ThresholdContext {
+                        sample_count: work.samples.len(),
+                        expected_improvement: neuron_error_improvement,
+                        threshold: ctx.threshold,
+                        improved_count,
+                        worsened_count,
+                        weight: applied_weight,
+                    },
+                ));
+            }
+
+            let target_stats = cache
+                .get(&work.target_uuid)
+                .ok()
+                .and_then(|records| NeuronStats::from_records(records.as_ref()))
+                .map(|s| s.to_json());
+            if let Some(old_weight) = work.existing_weight {
+                let Some((new_weight, delta_weight)) =
+                    clamp_weight_update_delta(old_weight, weight)
+                else {
+                    continue;
+                };
+                coordinated_to_add.push(crate::CoordinatedStructuralCandidateJson {
+                    operations: vec![crate::CoordinatedStructuralOpJson::SetWeight {
+                        from_neuron_uuid: work.source_uuid.clone(),
+                        to_neuron_uuid: work.target_uuid.clone(),
+                        weight: new_weight,
+                    }],
+                    expected_creature_score_gain: neuron_error_improvement,
+                    comment: Some(format!(
+                        "Adjust synapse weight: old={old_weight:.6}, new={new_weight:.6}, delta={delta_weight:.6}"
+                    )),
+                });
+            } else {
+                diagnostics_selected.push(work.target_uuid.clone());
+                // Issue #178: constant source folding into setBias
+                if let Some(threshold) = ctx.constant_source_effect_threshold {
+                    let mut act_min = f32::INFINITY;
+                    let mut act_max = f32::NEG_INFINITY;
+                    let mut act_sum = 0.0f64;
+                    let mut act_count: u32 = 0;
+                    for s in &work.samples {
+                        if s.activation.is_finite() {
+                            act_min = act_min.min(s.activation);
+                            act_max = act_max.max(s.activation);
+                            act_sum += s.activation as f64;
+                            act_count += 1;
+                        }
+                    }
+
+                    if act_count > 0 {
+                        let mean_activation = (act_sum / act_count as f64) as f32;
+                        let activation_range = (act_max - act_min).abs();
+                        let effect_range = applied_weight.abs() * activation_range;
+
+                        if mean_activation.is_finite()
+                            && activation_range.is_finite()
+                            && effect_range.is_finite()
+                            && effect_range <= threshold
+                        {
+                            let old_bias = ctx
+                                .neuron_bias_map
+                                .get(&work.target_uuid)
+                                .copied()
+                                .unwrap_or(0.0);
+                            let new_bias = old_bias + (applied_weight * mean_activation);
+                            if new_bias.is_finite() {
+                                coordinated_to_add.push(
+                                    crate::CoordinatedStructuralCandidateJson {
+                                        operations: vec![
+                                            crate::CoordinatedStructuralOpJson::SetBias {
+                                                neuron_uuid: work.target_uuid.clone(),
+                                                bias: new_bias,
+                                            },
+                                        ],
+                                        expected_creature_score_gain: neuron_error_improvement,
+                                        comment: Some(format!(
+                                            "Fold constant source into setBias: old_bias={old_bias:.6}, new_bias={new_bias:.6}, weight={applied_weight:.6}, mean_act={mean_activation:.6}, act_range={activation_range:.6e}, effect_range={effect_range:.6e}"
+                                        )),
+                                    },
+                                );
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                let confidence_metrics =
+                    compute_confidence_metrics(&work.samples, neuron_error_improvement, None);
+                candidates_to_add.push(CandidateSynapseJson {
+                    from_neuron_uuid: work.source_uuid.clone(),
+                    to_neuron_uuid: work.target_uuid.clone(),
+                    from_neuron_index: None,
+                    to_neuron_index: None,
+                    weight: applied_weight,
+                    target_neuron_impact: 1.0,
+                    expected_creature_error_reduction: neuron_error_improvement,
+                    expected_creature_score_gain: neuron_error_improvement,
+                    improved_count,
+                    total_count,
+                    target_neuron_stats: target_stats,
+                    outlier_reduction_info: None,
+                    prediction_confidence: confidence_metrics.prediction_confidence,
+                    expected_score_gain_confidence_interval: confidence_metrics
+                        .expected_score_gain_confidence_interval,
+                });
+            }
+        } // End timing scope for result processing
+    }
+
+    // Apply diagnostics updates
+    for (target, source, sample_count, pos, neg) in diagnostics_zero_improvements {
+        ctx.diagnostics
+            .record_zero_improvement(&target, &source, sample_count, pos, neg);
+    }
+    for (target, source, context) in diagnostics_below_threshold {
+        ctx.diagnostics
+            .record_below_threshold(&target, &source, context);
+    }
+    for target in diagnostics_selected {
+        ctx.diagnostics.mark_candidate_selected(&target);
+    }
+
+    results.helpful.extend(candidates_to_add);
+    results.coordinated.extend(coordinated_to_add);
+
+    // Issue #202: Detect epistatic neuron pairs
+    if verbose_enabled() {
+        eprintln!(
+            "[NEAT-AI-Discovery][verbose] Target {target_uuid}: collected {} source contributions for epistatic detection",
+            source_contributions.len()
+        );
+    }
+    if source_contributions.len() >= 2 {
+        let target_is_output = ctx
+            .neuron_type_map
+            .get(target_uuid)
+            .map(|t| t == "output")
+            .unwrap_or(false);
+        let target_impact = if target_is_output { 1.0 } else { 0.5 };
+
+        let epistatic_pairs =
+            detect_epistatic_pairs(target_uuid, &source_contributions, target_impact);
+
+        if !epistatic_pairs.is_empty() {
+            let filtered_pairs =
+                filter_interfering_epistatic_pairs(epistatic_pairs, &source_contributions);
+
+            if !filtered_pairs.is_empty() {
+                let epistatic_candidates =
+                    epistatic_pairs_to_coordinated_candidates(&filtered_pairs);
+                if !epistatic_candidates.is_empty() {
+                    results.coordinated.extend(epistatic_candidates);
+
+                    if verbose_enabled() {
+                        eprintln!(
+                            "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} epistatic pair(s)",
+                            filtered_pairs.len()
+                        );
+                    }
+                }
+            }
+        }
+
+        // Issue #189: Detect synergistic candidates via residual analysis
+        let synergistic_candidates =
+            detect_synergistic_candidates(target_uuid, &source_contributions, target_impact);
+
+        if !synergistic_candidates.is_empty() {
+            let filtered_synergistic = filter_interfering_synergistic_candidates(
+                synergistic_candidates,
+                &source_contributions,
+            );
+
+            if !filtered_synergistic.is_empty() {
+                let synergistic_coordinated =
+                    synergistic_to_coordinated_candidates(&filtered_synergistic);
+                if !synergistic_coordinated.is_empty() {
+                    results.coordinated.extend(synergistic_coordinated);
+
+                    if verbose_enabled() {
+                        eprintln!(
+                            "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} synergistic candidate(s)",
+                            filtered_synergistic.len()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Issue #164: Detect redundant paths
+    if existing_path_contributions.len() >= 2 {
+        let target_is_output = ctx
+            .neuron_type_map
+            .get(target_uuid)
+            .map(|t| t == "output")
+            .unwrap_or(false);
+        let target_impact = if target_is_output { 1.0 } else { 0.5 };
+
+        let redundant_paths =
+            detect_redundant_paths(target_uuid, existing_path_contributions, target_impact);
+
+        if !redundant_paths.is_empty() {
+            let redundant_coordinated = redundant_paths_to_coordinated_candidates(&redundant_paths);
+            if !redundant_coordinated.is_empty() {
+                results.coordinated.extend(redundant_coordinated);
+
+                if verbose_enabled() {
+                    eprintln!(
+                        "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} redundant path(s) for pruning",
+                        redundant_paths.len()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Process harmful synapses for a single target neuron via batched GPU evaluation.
+fn process_harmful_batch(
+    target_uuid: &str,
+    existing_synapses: &[SynapseJson],
+    cache: &RecordCache,
+    gpu: &GpuWorkQueue,
+    ctx: &TargetAnalysisContext,
+    target_map_ref: &TargetMap,
+    results: &mut TargetAnalysisResults,
+) -> Result<()> {
+    struct HarmfulWork {
+        synapse: SynapseJson,
+        samples: Vec<HelpfulSample>,
+    }
+    let mut harmful_work: Vec<HarmfulWork> = Vec::with_capacity(existing_synapses.len());
+
+    for synapse in existing_synapses {
+        let from_records_arc = match cache.get(&synapse.from_uuid) {
+            Ok(records) => records,
+            Err(_) => continue,
+        };
+        if from_records_arc.is_empty() {
+            continue;
+        }
+        let from_records = from_records_arc.as_ref();
+        let samples = target_map_ref.build_samples_from(from_records);
+        if samples.is_empty() {
+            continue;
+        }
+
+        harmful_work.push(HarmfulWork {
+            synapse: synapse.clone(),
+            samples,
+        });
+    }
+
+    if harmful_work.is_empty() {
+        return Ok(());
+    }
+
+    let batch_input: Vec<(Vec<HelpfulSample>, f32)> = harmful_work
+        .iter()
+        .map(|w| (w.samples.clone(), w.synapse.weight))
+        .collect();
+
+    let batch_stats = {
+        let _timing = TimingScope::shader(&ctx.timing_collector, "harmful");
+        gpu.evaluate_harmful_batch(batch_input, &ctx.deadline)?
+    };
+
+    let mut harmful_candidates = Vec::with_capacity(batch_stats.len());
+    let target_stats = cache
+        .get(target_uuid)
+        .ok()
+        .and_then(|records| NeuronStats::from_records(records.as_ref()))
+        .map(|s| s.to_json());
+
+    for (work, stats) in harmful_work.iter().zip(batch_stats.iter()) {
+        let total_count = work.samples.len() as u32;
+        if total_count == 0 {
+            continue;
+        }
+
+        let neuron_error_improvement =
+            (stats.harmful_count as f32 - stats.helpful_count as f32) / total_count as f32;
+
+        if neuron_error_improvement <= 0.0 {
+            continue;
+        }
+
+        let confidence_metrics =
+            compute_confidence_metrics(&work.samples, neuron_error_improvement, None);
+        harmful_candidates.push(CandidateSynapseJson {
+            from_neuron_uuid: work.synapse.from_uuid.clone(),
+            to_neuron_uuid: work.synapse.to_uuid.clone(),
+            from_neuron_index: None,
+            to_neuron_index: None,
+            weight: work.synapse.weight,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: neuron_error_improvement,
+            expected_creature_score_gain: neuron_error_improvement,
+            improved_count: stats.harmful_count,
+            total_count,
+            target_neuron_stats: target_stats.clone(),
+            outlier_reduction_info: None,
+            prediction_confidence: confidence_metrics.prediction_confidence,
+            expected_score_gain_confidence_interval: confidence_metrics
+                .expected_score_gain_confidence_interval,
+        });
+    }
+
+    results.harmful.extend(harmful_candidates);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Further split the synapse analysis submodules to bring all files under the ~1,500-line target (Issue #482). The previous PR (#495) split the monolithic `synapse.rs` into submodules but left `mod.rs` at 2,485 lines. This PR extracts three new focused modules, reducing `mod.rs` from 2,485 to 860 lines — a 65% reduction.

### New Module Structure

| File | Lines | Responsibility |
|------|------:|----------------|
| `synapse/mod.rs` | 860 | Orchestration, public API, re-exports, tests |
| `synapse/target_analysis.rs` | 1,020 | Per-target analysis loop (helpful, harmful, coordinated) |
| `synapse/gpu_evaluation.rs` | 975 | ReLU/activation candidate evaluation, batched GPU processing |
| `synapse/scoring.rs` | 532 | Improvement calculation, saturation-aware simulation, boosting |
| `synapse/structural_patterns.rs` | 411 | Noisy vs trusted input folding, collapse hidden neurons |
| `synapse/post_processing.rs` | 315 | Impact discounting, sorting, diversification, metadata |
| `synapse/filtering.rs` | 243 | Candidate truncation, deduplication |
| `synapse/candidate_generation.rs` | 220 | Sample locality grouping, ordered neuron building |
| **Total** | **4,576** | All files under 1,500-line target |

### Extractions in this PR

1. **`target_analysis.rs`** — Extracted the 1,200-line per-target parallel loop body into `analyse_single_target()`. Uses a `TargetAnalysisContext` struct to share pre-computed data across targets, and returns `TargetAnalysisResults` for the orchestrator to merge.

2. **`structural_patterns.rs`** — Extracted coordinated structural discovery:
   - Noisy vs trusted input folding (Issue #165)
   - Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)

3. **`post_processing.rs`** — Extracted all post-analysis processing:
   - Impact-based discounting for helpful, harmful, and coordinated candidates
   - Source-type and target-type boosting (Issues #467, #468)
   - Sorting, diversification, truncation
   - Metadata assembly via `MetadataParams` struct

### Design Constraints

- No changes to the public API — NEAT-AI does not need to change
- All `pub(crate)` items used by `analysis/mod.rs` and `neuron.rs` are re-exported from `synapse/mod.rs`
- All existing candidate types are reused unchanged
- All existing tests continue to pass without modification
- Updated AGENTS.md source layout to reflect new module structure

## Evidence

This is a backend/CLI change with no visual UI. Evidence is provided via:
- All existing unit and integration tests continue to pass
- `quality.sh` passes cleanly (fmt, clippy, check, test, release build)
- Zero compilation warnings
- No logic changes — behaviour is preserved

## Test Plan

No new tests required — this is a pure structural refactoring. The existing test suite validates that the split preserves all behaviour:

- 13 inline unit tests in `synapse/mod.rs` (Issue #413 prediction accuracy)
- 11 implementation test files in `implementation_tests/` (GPU batch, diagnostics, prediction accuracy, etc.)
- Integration tests across `tests/` directory (synapse analysis, impact discounting, target map optimisation, etc.)

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #482: **Split synapse.rs into focused submodules (4,383 lines → ~1,000 each)**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #482