### PR TITLE
Fix: Cross-module candidate deduplication — avoid redundant ablation tests (#489)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.12.15"
+version = "0.13.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.12.14"
+version = "0.12.15"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-489.md
+++ b/docs/pr-summary-489.md
@@ -1,0 +1,53 @@
+## Summary
+
+Cross-module candidate deduplication for coordinated structural candidates (Issue #489).
+
+When 25+ discovery modules run in parallel, different modules can independently propose
+candidates targeting the same neuron with the same operation (e.g., both saturation and
+oscillating detection propose `changeSquash` for neuron X). Previously, candidate
+clustering (Issue #224) only reduced redundancy **within** synapse candidates but did
+not deduplicate **across** discovery modules' coordinated structural candidates.
+
+This PR adds a post-merge deduplication pass that:
+
+1. **Groups candidates by operation signature** — target neuron + operation type + similar
+   parameters (weights/biases bucketed within 5% tolerance)
+2. **Keeps the best representative** — highest `expected_creature_score_gain` per group
+3. **Detects conflicts** — flags when different operation types target the same neuron
+   (e.g., `removeNeuron` vs `changeSquash`), reported via verbose logging for diagnostics
+
+The deduplication runs after all discovery modules have contributed candidates but before
+the existing within-module clustering (Issue #224), ensuring both mechanisms work together.
+
+No changes to the NEAT-AI calling interface. Reuses existing candidate types.
+
+## Evidence
+
+This is a backend/library change with no UI. Evidence is provided by the test suite:
+
+- 16 integration tests covering all deduplication scenarios
+- All 463 unit tests + 97 integration test files pass
+- `quality.sh` passes cleanly (fmt, clippy, check, test, release build)
+
+## Test Plan
+
+New test file: `tests/issue_489_cross_module_deduplication.rs` (16 tests)
+
+| Test | Scenario |
+|------|----------|
+| `test_identical_change_squash_deduplicated` | Same ChangeSquash for same neuron from two modules |
+| `test_best_candidate_kept` | Highest improvement is selected as representative |
+| `test_different_op_types_not_deduplicated` | Different operations on same neuron both kept |
+| `test_different_targets_not_deduplicated` | Different target neurons both kept |
+| `test_empty_input` | Empty input produces empty output |
+| `test_single_candidate_passthrough` | Single candidate unchanged |
+| `test_multi_op_candidates_deduplicated` | Multi-operation candidates with identical ops |
+| `test_conflicting_ops_flagged` | Remove vs modify conflicts detected |
+| `test_deduplication_metadata_counts` | Correct duplicate/original counts |
+| `test_large_candidate_set_deduplication` | 100 candidates across 5 neurons → 5 unique |
+| `test_different_squash_values_not_deduplicated` | Different activation targets kept |
+| `test_different_bias_values_not_deduplicated` | Different bias values kept |
+| `test_similar_bias_values_deduplicated` | Similar bias values (within 5%) deduplicated |
+| `test_add_synapse_different_weights_not_deduplicated` | Different weights kept |
+| `test_add_synapse_similar_weights_deduplicated` | Similar weights deduplicated |
+| `test_output_sorted_by_improvement` | Output sorted best-first |

--- a/src/analysis/candidate_clustering.rs
+++ b/src/analysis/candidate_clustering.rs
@@ -1,11 +1,13 @@
-//! Candidate clustering module (Issue #224).
+//! Candidate clustering module (Issue #224) and cross-module deduplication (Issue #489).
+//!
+//! ## Within-module clustering (Issue #224)
 //!
 //! Groups similar discovery candidates to reduce redundant ablation tests. When
 //! discovery returns many candidates targeting the same neuron from similar source
 //! regions, clustering identifies these groups so the TypeScript controller can test
 //! a representative candidate first and skip the rest if it fails.
 //!
-//! ## Clustering Criteria
+//! ### Clustering Criteria
 //!
 //! Candidates are grouped by:
 //! 1. **Same target neuron** (`to_neuron_uuid`) — candidates must target the same neuron.
@@ -14,7 +16,7 @@
 //! 3. **Similar improvement prediction** — candidates with very different expected
 //!    improvements are unlikely to be truly redundant.
 //!
-//! ## Output
+//! ### Output
 //!
 //! Each cluster contains:
 //! - A **representative** (the highest-improvement candidate in the cluster).
@@ -25,7 +27,15 @@
 //! The controller tests the representative first. If it fails, all members are
 //! skipped (high correlation implies they would also fail). If it succeeds, the
 //! controller may test additional members with lower priority.
+//!
+//! ## Cross-module deduplication (Issue #489)
+//!
+//! When 25+ discovery modules run in parallel, different modules can independently
+//! propose coordinated structural candidates targeting the same neuron with the same
+//! operation. Cross-module deduplication removes these redundancies after all modules
+//! have contributed their candidates.
 
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -215,6 +225,228 @@ fn compute_internal_correlation(candidates: &[&ClusterableCandidate]) -> f32 {
 
     // Map CV to correlation: CV=0 → 1.0, CV≥1 → 0.0
     (1.0 - cv.min(1.0)).max(0.0)
+}
+
+// =============================================================================
+// Cross-module deduplication (Issue #489)
+// =============================================================================
+
+/// Relative tolerance for comparing floating-point parameters (weights, biases).
+/// Two values are considered "similar" when they differ by less than this fraction
+/// of the larger absolute value.
+const PARAM_SIMILARITY_TOLERANCE: f32 = 0.05;
+
+/// Result of cross-module deduplication.
+#[derive(Debug)]
+pub struct CrossModuleDeduplicationResult {
+    /// Deduplicated candidates, sorted by expected improvement (best first).
+    pub candidates: Vec<CoordinatedStructuralCandidateJson>,
+    /// Number of duplicate candidates removed.
+    pub duplicates_removed: usize,
+    /// Total number of candidates before deduplication.
+    pub original_count: usize,
+    /// Number of conflict pairs detected (different operation types on same neuron).
+    pub conflicts_detected: usize,
+}
+
+/// Deduplicate coordinated structural candidates across discovery modules (Issue #489).
+///
+/// Groups candidates by their operation signature (target neuron + operation type +
+/// similar parameters). For each group of duplicates, keeps only the candidate with
+/// the highest `expected_creature_score_gain`.
+///
+/// Also detects conflicts: when different operation types target the same neuron
+/// (e.g., `RemoveNeuron` vs `ChangeSquash`), all are kept but the conflict count
+/// is reported for diagnostics.
+pub fn deduplicate_cross_module_candidates(
+    candidates: Vec<CoordinatedStructuralCandidateJson>,
+) -> CrossModuleDeduplicationResult {
+    let original_count = candidates.len();
+
+    if candidates.len() <= 1 {
+        return CrossModuleDeduplicationResult {
+            candidates,
+            duplicates_removed: 0,
+            original_count,
+            conflicts_detected: 0,
+        };
+    }
+
+    // Step 1: Group candidates by operation signature.
+    // The signature captures what the candidate does (ignoring minor parameter differences).
+    let mut groups: HashMap<String, Vec<CoordinatedStructuralCandidateJson>> = HashMap::new();
+    for c in candidates {
+        let sig = operation_signature(&c);
+        groups.entry(sig).or_default().push(c);
+    }
+
+    // Step 2: For each group, keep only the candidate with the highest expected gain.
+    let mut deduplicated: Vec<CoordinatedStructuralCandidateJson> =
+        Vec::with_capacity(groups.len());
+    let mut duplicates_removed: usize = 0;
+
+    for (_sig, mut group) in groups {
+        // Sort by expected gain descending, keep the best.
+        group.sort_by(|a, b| {
+            b.expected_creature_score_gain
+                .total_cmp(&a.expected_creature_score_gain)
+        });
+        duplicates_removed += group.len() - 1;
+        deduplicated.push(group.into_iter().next().expect("group is non-empty"));
+    }
+
+    // Step 3: Sort output by expected improvement (best first).
+    deduplicated.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    // Step 4: Detect conflicts — different operation types targeting the same neuron.
+    let conflicts_detected = count_neuron_conflicts(&deduplicated);
+
+    CrossModuleDeduplicationResult {
+        candidates: deduplicated,
+        duplicates_removed,
+        original_count,
+        conflicts_detected,
+    }
+}
+
+/// Produce a string signature that identifies the "identity" of a candidate.
+///
+/// Two candidates with the same signature are considered duplicates (targeting the
+/// same neuron with the same operation). Parameters like weight and bias use
+/// bucketed comparison so that minor floating-point differences don't prevent
+/// deduplication.
+fn operation_signature(candidate: &CoordinatedStructuralCandidateJson) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(candidate.operations.len());
+
+    for op in &candidate.operations {
+        let part = match op {
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+            } => format!("RS:{from_neuron_uuid}->{to_neuron_uuid}"),
+
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                weight,
+            } => {
+                let w_bucket = param_bucket(*weight);
+                format!("AS:{from_neuron_uuid}->{to_neuron_uuid}@{w_bucket}")
+            }
+
+            CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid,
+                neuron_type,
+                squash,
+                bias,
+                insert_before_neuron_uuid,
+            } => {
+                let b_bucket = param_bucket(*bias);
+                let before = insert_before_neuron_uuid.as_deref().unwrap_or("none");
+                format!("AN:{neuron_uuid}:{neuron_type}:{squash}:{b_bucket}:{before}")
+            }
+
+            CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } => {
+                format!("RN:{neuron_uuid}")
+            }
+
+            CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid,
+                squash,
+            } => format!("CS:{neuron_uuid}:{squash}"),
+
+            CoordinatedStructuralOpJson::SetBias { neuron_uuid, bias } => {
+                let b_bucket = param_bucket(*bias);
+                format!("SB:{neuron_uuid}:{b_bucket}")
+            }
+
+            CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                weight,
+            } => {
+                let w_bucket = param_bucket(*weight);
+                format!("SW:{from_neuron_uuid}->{to_neuron_uuid}@{w_bucket}")
+            }
+        };
+        parts.push(part);
+    }
+
+    // Sort operation parts for order-independent comparison.
+    parts.sort();
+    parts.join("|")
+}
+
+/// Bucket a floating-point parameter for similarity comparison.
+///
+/// Values within [`PARAM_SIMILARITY_TOLERANCE`] of each other map to the same bucket.
+/// Uses fixed-precision rounding: bucket = round(value / tolerance) * tolerance.
+fn param_bucket(value: f32) -> String {
+    if value.abs() < PARAM_SIMILARITY_TOLERANCE {
+        return "0.00".to_string();
+    }
+    let bucket = (value / PARAM_SIMILARITY_TOLERANCE).round() * PARAM_SIMILARITY_TOLERANCE;
+    format!("{bucket:.2}")
+}
+
+/// Count conflict pairs: different operation types targeting the same neuron.
+///
+/// A conflict arises when one candidate proposes removing a neuron while another
+/// proposes modifying it (change squash, set bias, etc.). These represent
+/// contradictory interventions that the controller should be aware of.
+fn count_neuron_conflicts(candidates: &[CoordinatedStructuralCandidateJson]) -> usize {
+    // Collect (neuron_uuid, operation_category) pairs.
+    let mut neuron_ops: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for c in candidates {
+        for op in &c.operations {
+            let (uuid, category) = op_neuron_and_category(op);
+            if let Some(uuid) = uuid {
+                neuron_ops.entry(uuid).or_default().push(category);
+            }
+        }
+    }
+
+    // Count neurons where we see both "remove" and "modify" categories.
+    let mut conflicts = 0;
+    for ops in neuron_ops.values() {
+        let has_remove = ops.contains(&"remove");
+        let has_modify = ops.contains(&"modify");
+        if has_remove && has_modify {
+            conflicts += 1;
+        }
+    }
+
+    conflicts
+}
+
+/// Extract the target neuron UUID and operation category from an operation.
+///
+/// Categories are "remove" (destructive) or "modify" (non-destructive changes).
+/// Returns `(Some(uuid), category)` for neuron-targeting ops, `(None, _)` for
+/// synapse-only ops that don't target a specific neuron for conflict detection.
+fn op_neuron_and_category(op: &CoordinatedStructuralOpJson) -> (Option<&str>, &'static str) {
+    match op {
+        CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid } => {
+            (Some(neuron_uuid.as_str()), "remove")
+        }
+        CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. } => {
+            (Some(neuron_uuid.as_str()), "modify")
+        }
+        CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. } => {
+            (Some(neuron_uuid.as_str()), "modify")
+        }
+        CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. } => {
+            (Some(neuron_uuid.as_str()), "modify")
+        }
+        // Synapse-only operations don't create neuron-level conflicts.
+        CoordinatedStructuralOpJson::RemoveSynapse { .. }
+        | CoordinatedStructuralOpJson::AddSynapse { .. }
+        | CoordinatedStructuralOpJson::SetWeight { .. } => (None, "synapse"),
+    }
 }
 
 #[cfg(test)]

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1387,6 +1387,45 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         discovery_dispatch::run_discovery_modules_parallel(syn, modules, max_candidates, diversify);
     }
 
+    // Issue #489: Cross-module candidate deduplication.
+    // After all discovery modules have contributed coordinated structural candidates,
+    // deduplicate across module boundaries to avoid redundant ablation tests.
+    if let Some(syn) = synapse_result.as_mut()
+        && !syn.coordinated_structural_candidates.is_empty()
+    {
+        crate::watchdog::beat("analysis::analyze_all → cross-module deduplication starting");
+        let _dedup_timer = PhaseTimer::new("cross_module_deduplication");
+
+        let before_count = syn.coordinated_structural_candidates.len();
+        let dedup_result = candidate_clustering::deduplicate_cross_module_candidates(mem::take(
+            &mut syn.coordinated_structural_candidates,
+        ));
+        syn.coordinated_structural_candidates = dedup_result.candidates;
+
+        if dedup_result.duplicates_removed > 0 && utils::verbose_enabled() {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Cross-module deduplication: removed {} duplicate(s) from {} coordinated candidate(s) → {} remaining",
+                dedup_result.duplicates_removed,
+                before_count,
+                syn.coordinated_structural_candidates.len()
+            );
+        }
+
+        if dedup_result.conflicts_detected > 0 && utils::verbose_enabled() {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Cross-module deduplication: {} neuron conflict(s) detected (remove vs modify)",
+                dedup_result.conflicts_detected
+            );
+        }
+
+        // Update metadata to reflect the deduplicated count.
+        syn.metadata.candidates_returned = syn.helpful_synapses.len()
+            + syn.harmful_synapses.len()
+            + syn.coordinated_structural_candidates.len();
+
+        crate::watchdog::beat("analysis::analyze_all → cross-module deduplication finished");
+    }
+
     // Issue #224: Candidate clustering to reduce redundant ablation tests.
     // Groups similar candidates by target neuron, source type, and improvement
     // similarity so the controller can test a representative first and skip

--- a/tests/issue_489_cross_module_deduplication.rs
+++ b/tests/issue_489_cross_module_deduplication.rs
@@ -1,0 +1,437 @@
+//! Tests for Issue #489: Cross-module candidate deduplication.
+//!
+//! When 25+ discovery modules run in parallel, different modules can independently
+//! propose candidates targeting the same neuron or synapse with the same operation.
+//! Cross-module deduplication removes these redundancies to avoid wasted ablation tests.
+//!
+//! ## TDD Plan
+//! 1. Identical single-op candidates from different modules are deduplicated
+//! 2. Best candidate (highest expected improvement) is kept as representative
+//! 3. Candidates with different operation types are NOT deduplicated
+//! 4. Candidates targeting different neurons are NOT deduplicated
+//! 5. Empty input produces empty output
+//! 6. Single candidate passes through unchanged
+//! 7. Multi-operation candidates with identical ops are deduplicated
+//! 8. Conflicting operations on same neuron are flagged in metadata
+//! 9. Deduplication metadata reports counts correctly
+//! 10. Large candidate sets are handled efficiently
+
+use neat_ai_discovery::CoordinatedStructuralCandidateJson;
+use neat_ai_discovery::CoordinatedStructuralOpJson;
+use neat_ai_discovery::analysis::candidate_clustering::deduplicate_cross_module_candidates;
+
+/// Helper: create a single-op ChangeSquash candidate.
+fn change_squash_candidate(
+    neuron_uuid: &str,
+    squash: &str,
+    gain: f32,
+    comment: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+            neuron_uuid: neuron_uuid.to_string(),
+            squash: squash.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}
+
+/// Helper: create a single-op RemoveNeuron candidate.
+fn remove_neuron_candidate(
+    neuron_uuid: &str,
+    gain: f32,
+    comment: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+            neuron_uuid: neuron_uuid.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}
+
+/// Helper: create a single-op SetBias candidate.
+fn set_bias_candidate(
+    neuron_uuid: &str,
+    bias: f32,
+    gain: f32,
+    comment: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: neuron_uuid.to_string(),
+            bias,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}
+
+/// Helper: create an AddSynapse candidate.
+fn add_synapse_candidate(
+    from: &str,
+    to: &str,
+    weight: f32,
+    gain: f32,
+    comment: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: from.to_string(),
+            to_neuron_uuid: to.to_string(),
+            weight,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}
+
+/// Test 1: Identical single-op candidates from different modules are deduplicated.
+/// Both saturation and oscillating detection propose changeSquash for the same neuron
+/// with the same activation — only the best should survive.
+#[test]
+fn test_identical_change_squash_deduplicated() {
+    let candidates = vec![
+        change_squash_candidate("neuron-5", "TANH", 0.05, "saturation"),
+        change_squash_candidate("neuron-5", "TANH", 0.048, "oscillating"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        1,
+        "Identical changeSquash for same neuron should be deduplicated to 1"
+    );
+    assert_eq!(
+        result.candidates[0].expected_creature_score_gain, 0.05,
+        "Should keep the candidate with highest expected improvement"
+    );
+    assert_eq!(result.duplicates_removed, 1);
+}
+
+/// Test 2: Best candidate (highest expected improvement) is kept as representative.
+#[test]
+fn test_best_candidate_kept() {
+    let candidates = vec![
+        change_squash_candidate("neuron-5", "RELU", 0.02, "module-A"),
+        change_squash_candidate("neuron-5", "RELU", 0.08, "module-B"),
+        change_squash_candidate("neuron-5", "RELU", 0.05, "module-C"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(result.candidates.len(), 1);
+    assert_eq!(result.candidates[0].expected_creature_score_gain, 0.08);
+    assert_eq!(result.duplicates_removed, 2);
+}
+
+/// Test 3: Candidates with different operation types targeting the same neuron
+/// are NOT deduplicated — they represent genuinely different interventions.
+#[test]
+fn test_different_op_types_not_deduplicated() {
+    let candidates = vec![
+        change_squash_candidate("neuron-5", "TANH", 0.05, "saturation"),
+        remove_neuron_candidate("neuron-5", 0.03, "dead-neuron"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        2,
+        "Different operation types should both be kept"
+    );
+    // Conflicts should be flagged
+    assert!(
+        result.conflicts_detected > 0,
+        "Contradictory operations on same neuron should be flagged as conflicts"
+    );
+}
+
+/// Test 4: Candidates targeting different neurons are NOT deduplicated.
+#[test]
+fn test_different_targets_not_deduplicated() {
+    let candidates = vec![
+        change_squash_candidate("neuron-5", "TANH", 0.05, "saturation"),
+        change_squash_candidate("neuron-10", "TANH", 0.04, "saturation"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        2,
+        "Different target neurons should both be kept"
+    );
+    assert_eq!(result.duplicates_removed, 0);
+}
+
+/// Test 5: Empty input produces empty output.
+#[test]
+fn test_empty_input() {
+    let result = deduplicate_cross_module_candidates(vec![]);
+
+    assert!(result.candidates.is_empty());
+    assert_eq!(result.duplicates_removed, 0);
+    assert_eq!(result.conflicts_detected, 0);
+}
+
+/// Test 6: Single candidate passes through unchanged.
+#[test]
+fn test_single_candidate_passthrough() {
+    let candidates = vec![change_squash_candidate(
+        "neuron-5",
+        "TANH",
+        0.05,
+        "saturation",
+    )];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(result.candidates.len(), 1);
+    assert_eq!(result.duplicates_removed, 0);
+}
+
+/// Test 7: Multi-operation candidates with identical operation lists are deduplicated.
+#[test]
+fn test_multi_op_candidates_deduplicated() {
+    let candidate1 = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "hidden-1".to_string(),
+                weight: 0.5,
+            },
+        ],
+        expected_creature_score_gain: 0.10,
+        comment: Some("module-A".to_string()),
+    };
+
+    let candidate2 = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "hidden-1".to_string(),
+                weight: 0.5,
+            },
+        ],
+        expected_creature_score_gain: 0.12,
+        comment: Some("module-B".to_string()),
+    };
+
+    let result = deduplicate_cross_module_candidates(vec![candidate1, candidate2]);
+
+    assert_eq!(
+        result.candidates.len(),
+        1,
+        "Identical multi-op candidates should be deduplicated"
+    );
+    assert_eq!(result.candidates[0].expected_creature_score_gain, 0.12);
+    assert_eq!(result.duplicates_removed, 1);
+}
+
+/// Test 8: Conflicting operations on the same neuron are flagged in metadata.
+/// e.g., one module says "remove neuron-5" and another says "change its activation".
+#[test]
+fn test_conflicting_ops_flagged() {
+    let candidates = vec![
+        remove_neuron_candidate("neuron-5", 0.10, "dead-neuron"),
+        change_squash_candidate("neuron-5", "TANH", 0.08, "saturation"),
+        set_bias_candidate("neuron-5", 0.1, 0.06, "bias-drift"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    // All three should be kept (different operations)
+    assert_eq!(result.candidates.len(), 3);
+    // But conflicts involving the remove vs modify should be detected
+    assert!(
+        result.conflicts_detected > 0,
+        "RemoveNeuron vs modify operations on same neuron should flag conflicts"
+    );
+}
+
+/// Test 9: Deduplication metadata reports counts correctly.
+#[test]
+fn test_deduplication_metadata_counts() {
+    let candidates = vec![
+        // Group 1: three identical changeSquash for neuron-5 → 2 removed
+        change_squash_candidate("neuron-5", "TANH", 0.05, "module-A"),
+        change_squash_candidate("neuron-5", "TANH", 0.048, "module-B"),
+        change_squash_candidate("neuron-5", "TANH", 0.04, "module-C"),
+        // Group 2: two identical removeNeuron for neuron-10 → 1 removed
+        remove_neuron_candidate("neuron-10", 0.03, "module-D"),
+        remove_neuron_candidate("neuron-10", 0.025, "module-E"),
+        // Unique candidate
+        change_squash_candidate("neuron-20", "RELU", 0.07, "module-F"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        3,
+        "Should have 3 unique candidates after deduplication"
+    );
+    assert_eq!(
+        result.duplicates_removed, 3,
+        "Should have removed 3 duplicates (2 from group 1 + 1 from group 2)"
+    );
+    assert_eq!(
+        result.original_count, 6,
+        "Original count should reflect total input"
+    );
+}
+
+/// Test 10: Large candidate sets are handled correctly.
+#[test]
+fn test_large_candidate_set_deduplication() {
+    let mut candidates = Vec::new();
+
+    // 20 modules each propose changeSquash for the same 5 neurons
+    for module_idx in 0..20 {
+        for neuron_idx in 0..5 {
+            candidates.push(change_squash_candidate(
+                &format!("neuron-{neuron_idx}"),
+                "TANH",
+                0.05 + (module_idx as f32 * 0.001),
+                &format!("module-{module_idx}"),
+            ));
+        }
+    }
+
+    assert_eq!(candidates.len(), 100);
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        5,
+        "Should deduplicate to 5 unique candidates (one per neuron)"
+    );
+    assert_eq!(result.duplicates_removed, 95);
+    assert_eq!(result.original_count, 100);
+}
+
+/// Test 11: ChangeSquash with different target squash values are NOT deduplicated
+/// (they represent different proposed activations).
+#[test]
+fn test_different_squash_values_not_deduplicated() {
+    let candidates = vec![
+        change_squash_candidate("neuron-5", "TANH", 0.05, "module-A"),
+        change_squash_candidate("neuron-5", "RELU", 0.04, "module-B"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        2,
+        "Different squash targets should both be kept"
+    );
+    assert_eq!(result.duplicates_removed, 0);
+}
+
+/// Test 12: SetBias candidates with very different bias values are NOT deduplicated.
+#[test]
+fn test_different_bias_values_not_deduplicated() {
+    let candidates = vec![
+        set_bias_candidate("neuron-5", 0.1, 0.05, "module-A"),
+        set_bias_candidate("neuron-5", -0.5, 0.04, "module-B"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        2,
+        "SetBias with different bias values should both be kept"
+    );
+}
+
+/// Test 13: SetBias candidates with similar bias values ARE deduplicated.
+#[test]
+fn test_similar_bias_values_deduplicated() {
+    let candidates = vec![
+        set_bias_candidate("neuron-5", 0.100, 0.05, "module-A"),
+        set_bias_candidate("neuron-5", 0.101, 0.04, "module-B"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        1,
+        "SetBias with very similar bias values should be deduplicated"
+    );
+    assert_eq!(result.candidates[0].expected_creature_score_gain, 0.05);
+}
+
+/// Test 14: AddSynapse candidates with same endpoints but very different weights
+/// are NOT deduplicated.
+#[test]
+fn test_add_synapse_different_weights_not_deduplicated() {
+    let candidates = vec![
+        add_synapse_candidate("input-0", "output-0", 0.5, 0.05, "module-A"),
+        add_synapse_candidate("input-0", "output-0", -0.5, 0.04, "module-B"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        2,
+        "AddSynapse with very different weights should both be kept"
+    );
+}
+
+/// Test 15: AddSynapse candidates with same endpoints and similar weights
+/// ARE deduplicated.
+#[test]
+fn test_add_synapse_similar_weights_deduplicated() {
+    let candidates = vec![
+        add_synapse_candidate("input-0", "output-0", 0.50, 0.05, "module-A"),
+        add_synapse_candidate("input-0", "output-0", 0.51, 0.04, "module-B"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(
+        result.candidates.len(),
+        1,
+        "AddSynapse with similar weights should be deduplicated"
+    );
+}
+
+/// Test 16: Output is sorted by expected improvement (best first).
+#[test]
+fn test_output_sorted_by_improvement() {
+    let candidates = vec![
+        change_squash_candidate("neuron-1", "TANH", 0.02, "module-A"),
+        change_squash_candidate("neuron-2", "RELU", 0.08, "module-B"),
+        change_squash_candidate("neuron-3", "TANH", 0.05, "module-C"),
+    ];
+
+    let result = deduplicate_cross_module_candidates(candidates);
+
+    assert_eq!(result.candidates.len(), 3);
+    assert!(
+        result.candidates[0].expected_creature_score_gain
+            >= result.candidates[1].expected_creature_score_gain
+    );
+    assert!(
+        result.candidates[1].expected_creature_score_gain
+            >= result.candidates[2].expected_creature_score_gain
+    );
+}


### PR DESCRIPTION
## Summary

Cross-module candidate deduplication for coordinated structural candidates (Issue #489).

When 25+ discovery modules run in parallel, different modules can independently propose
candidates targeting the same neuron with the same operation (e.g., both saturation and
oscillating detection propose `changeSquash` for neuron X). Previously, candidate
clustering (Issue #224) only reduced redundancy **within** synapse candidates but did
not deduplicate **across** discovery modules' coordinated structural candidates.

This PR adds a post-merge deduplication pass that:

1. **Groups candidates by operation signature** — target neuron + operation type + similar
   parameters (weights/biases bucketed within 5% tolerance)
2. **Keeps the best representative** — highest `expected_creature_score_gain` per group
3. **Detects conflicts** — flags when different operation types target the same neuron
   (e.g., `removeNeuron` vs `changeSquash`), reported via verbose logging for diagnostics

The deduplication runs after all discovery modules have contributed candidates but before
the existing within-module clustering (Issue #224), ensuring both mechanisms work together.

No changes to the NEAT-AI calling interface. Reuses existing candidate types.

## Evidence

This is a backend/library change with no UI. Evidence is provided by the test suite:

- 16 integration tests covering all deduplication scenarios
- All 463 unit tests + 97 integration test files pass
- `quality.sh` passes cleanly (fmt, clippy, check, test, release build)

## Test Plan

New test file: `tests/issue_489_cross_module_deduplication.rs` (16 tests)

| Test | Scenario |
|------|----------|
| `test_identical_change_squash_deduplicated` | Same ChangeSquash for same neuron from two modules |
| `test_best_candidate_kept` | Highest improvement is selected as representative |
| `test_different_op_types_not_deduplicated` | Different operations on same neuron both kept |
| `test_different_targets_not_deduplicated` | Different target neurons both kept |
| `test_empty_input` | Empty input produces empty output |
| `test_single_candidate_passthrough` | Single candidate unchanged |
| `test_multi_op_candidates_deduplicated` | Multi-operation candidates with identical ops |
| `test_conflicting_ops_flagged` | Remove vs modify conflicts detected |
| `test_deduplication_metadata_counts` | Correct duplicate/original counts |
| `test_large_candidate_set_deduplication` | 100 candidates across 5 neurons → 5 unique |
| `test_different_squash_values_not_deduplicated` | Different activation targets kept |
| `test_different_bias_values_not_deduplicated` | Different bias values kept |
| `test_similar_bias_values_deduplicated` | Similar bias values (within 5%) deduplicated |
| `test_add_synapse_different_weights_not_deduplicated` | Different weights kept |
| `test_add_synapse_similar_weights_deduplicated` | Similar weights deduplicated |
| `test_output_sorted_by_improvement` | Output sorted best-first |

---

## Automated Fix Details
This PR addresses issue #489: **Cross-module candidate deduplication — avoid redundant ablation tests**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #489