### PR TITLE
Extract creature-aware record-loading helpers to eliminate boilerplate (#493)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-493.md
+++ b/docs/pr-summary-493.md
@@ -1,0 +1,30 @@
+## Summary
+
+Extract creature-aware record-loading helpers into `RecordCache` to eliminate UUID-collection boilerplate across 14 discovery module dispatch blocks in `analyze_all()`.
+
+Three new methods added to `RecordCache` (in `cache.rs`):
+- `load_records_for_all_neurons(&creature)` — replaces 8 blocks that collected all neuron UUIDs
+- `load_records_for_neuron_types(&creature, &["output", "input"])` — replaces 5 blocks that filtered by neuron type
+- `load_records_for_synapse_sources(&creature)` — replaces 1 block that collected unique synapse source UUIDs
+
+Net effect: 70 lines of duplicated UUID-collection logic removed from `mod.rs`, replaced by single-line helper calls. Each dispatch block now reads the records in one call instead of building an intermediate UUID vector first.
+
+## Evidence
+
+This is a backend/refactoring change with no UI impact. Verified by:
+- All 8 new integration tests pass (see test plan below)
+- All 4 existing `issue_481_record_loading_helper` tests still pass
+- Full `quality.sh` passes (fmt, clippy, check, 1000+ tests, release build)
+- `mod.rs` reduced from ~1,588 to ~1,518 lines
+
+## Test Plan
+
+- Added `tests/issue_493_creature_record_loading.rs` with 8 tests:
+  - `test_load_all_neurons_returns_records_for_every_neuron` — all neuron UUIDs loaded
+  - `test_load_all_neurons_empty_creature` — empty creature returns empty
+  - `test_load_by_type_filters_correctly` — single-type filtering (output, input)
+  - `test_load_by_type_multiple_types` — multi-type filtering (input+output, input+hidden)
+  - `test_load_by_type_no_matching_types` — no matches returns empty
+  - `test_load_synapse_sources_returns_unique_sources` — deduplicates source UUIDs
+  - `test_load_synapse_sources_empty_synapses` — empty synapses returns empty
+  - `test_load_hidden_returns_correct_records` — existing `load_records_for_hidden` works correctly

--- a/src/analysis/cache.rs
+++ b/src/analysis/cache.rs
@@ -33,6 +33,7 @@
 //! - **LruCache**: For medium files (keeps frequently-accessed neurons in memory)
 //! - **Streaming**: For very large files (block-based loading with LRU eviction)
 
+use crate::CreatureJson;
 use crate::types::DiscoverRecord;
 use anyhow::{Context, Result};
 use once_cell::sync::OnceCell;
@@ -251,6 +252,54 @@ impl RecordCache {
                     .map(|r| (uuid.clone(), r.as_ref().to_vec()))
             })
             .collect()
+    }
+
+    /// Load records for every neuron in the creature (Issue #493).
+    ///
+    /// Extracts all neuron UUIDs from the creature and loads their records in one call.
+    pub fn load_records_for_all_neurons(
+        &self,
+        creature: &CreatureJson,
+    ) -> Vec<(String, Vec<DiscoverRecord>)> {
+        let uuids: Vec<String> = creature.neurons.iter().map(|n| n.uuid.clone()).collect();
+        self.load_records_for_uuids(&uuids)
+    }
+
+    /// Load records for neurons matching any of the given type names (Issue #493).
+    ///
+    /// Filters the creature's neurons by `neuron_type` then loads their records.
+    /// Common usage: `&["output"]`, `&["input"]`, `&["input", "output"]`,
+    /// `&["input", "hidden"]`.
+    pub fn load_records_for_neuron_types(
+        &self,
+        creature: &CreatureJson,
+        types: &[&str],
+    ) -> Vec<(String, Vec<DiscoverRecord>)> {
+        let uuids: Vec<String> = creature
+            .neurons
+            .iter()
+            .filter(|n| types.contains(&n.neuron_type.as_str()))
+            .map(|n| n.uuid.clone())
+            .collect();
+        self.load_records_for_uuids(&uuids)
+    }
+
+    /// Load records for the unique set of synapse source neuron UUIDs (Issue #493).
+    ///
+    /// Collects the deduplicated `from_uuid` values from all creature synapses,
+    /// then loads their records.
+    pub fn load_records_for_synapse_sources(
+        &self,
+        creature: &CreatureJson,
+    ) -> Vec<(String, Vec<DiscoverRecord>)> {
+        let source_uuids: Vec<String> = creature
+            .synapses
+            .iter()
+            .map(|s| s.from_uuid.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        self.load_records_for_uuids(&source_uuids)
     }
 
     /// Create a cache with a custom loader function.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -735,13 +735,8 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     if output_count < 2 {
                         return None;
                     }
-                    let uuids: Vec<String> = creature
-                        .neurons
-                        .iter()
-                        .filter(|n| n.neuron_type == "output" || n.neuron_type == "input")
-                        .map(|n| n.uuid.clone())
-                        .collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records =
+                        cache.load_records_for_neuron_types(&creature, &["output", "input"]);
                     let detected =
                         correlated_error::detect_correlated_error_patterns(&creature, &records);
                     if detected.is_empty() {
@@ -770,9 +765,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     if hidden.is_empty() {
                         return None;
                     }
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let detected = multi_hop::detect_multi_hop_candidates(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -824,14 +817,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "dormant synapse detection".to_string(),
                 phase_name: "dormant_synapse_detection",
                 detect_fn: Box::new(move || {
-                    let source_uuids: Vec<String> = creature
-                        .synapses
-                        .iter()
-                        .map(|s| s.from_uuid.clone())
-                        .collect::<std::collections::HashSet<_>>()
-                        .into_iter()
-                        .collect();
-                    let records = cache.load_records_for_uuids(&source_uuids);
+                    let records = cache.load_records_for_synapse_sources(&creature);
                     let detected = dormant_synapse::detect_dormant_synapses(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -854,9 +840,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "opposing synapse detection".to_string(),
                 phase_name: "opposing_synapse_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let detected = opposing_synapse::detect_opposing_synapses(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -879,13 +863,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "output bias drift detection".to_string(),
                 phase_name: "output_bias_drift_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> = creature
-                        .neurons
-                        .iter()
-                        .filter(|n| n.neuron_type == "output")
-                        .map(|n| n.uuid.clone())
-                        .collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_neuron_types(&creature, &["output"]);
                     let detected = output_bias_drift::detect_output_bias_drift(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -908,16 +886,11 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "bounded range detection".to_string(),
                 phase_name: "bounded_range_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> = creature
-                        .neurons
-                        .iter()
-                        .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
-                        .map(|n| n.uuid.clone())
-                        .collect();
-                    if uuids.is_empty() {
+                    let records =
+                        cache.load_records_for_neuron_types(&creature, &["input", "hidden"]);
+                    if records.is_empty() {
                         return None;
                     }
-                    let records = cache.load_records_for_uuids(&uuids);
                     let detected = bounded_range::detect_bounded_range_neurons(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -940,16 +913,10 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "sentinel value gating".to_string(),
                 phase_name: "sentinel_value_gating",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> = creature
-                        .neurons
-                        .iter()
-                        .filter(|n| n.neuron_type == "input")
-                        .map(|n| n.uuid.clone())
-                        .collect();
-                    if uuids.is_empty() {
+                    let records = cache.load_records_for_neuron_types(&creature, &["input"]);
+                    if records.is_empty() {
                         return None;
                     }
-                    let records = cache.load_records_for_uuids(&uuids);
                     let detected =
                         sentinel_gating::detect_sentinel_gating_candidates(&creature, &records);
                     if detected.is_empty() {
@@ -1090,9 +1057,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "noisy synapse detection".to_string(),
                 phase_name: "noisy_synapse_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let detected = noise_signal::detect_noisy_synapses(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -1115,16 +1080,11 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "dominant input detection".to_string(),
                 phase_name: "dominant_input_detection",
                 detect_fn: Box::new(move || {
-                    let input_uuids: Vec<String> = creature
-                        .neurons
-                        .iter()
-                        .filter(|n| n.neuron_type == "input" || n.neuron_type == "output")
-                        .map(|n| n.uuid.clone())
-                        .collect();
-                    if input_uuids.is_empty() {
+                    let records =
+                        cache.load_records_for_neuron_types(&creature, &["input", "output"]);
+                    if records.is_empty() {
                         return None;
                     }
-                    let records = cache.load_records_for_uuids(&input_uuids);
                     let config = input_sensitivity::InputSensitivityConfig::default();
                     let detected =
                         input_sensitivity::detect_dominant_inputs(&creature, &records, &config);
@@ -1149,9 +1109,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "threshold effect detection".to_string(),
                 phase_name: "threshold_effect_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let config = input_sensitivity::InputSensitivityConfig::default();
                     let detected =
                         input_sensitivity::detect_threshold_effects(&creature, &records, &config);
@@ -1235,9 +1193,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "symmetric cancellation detection".to_string(),
                 phase_name: "symmetric_cancellation_detection",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let config = weight_coherence::WeightCoherenceConfig::default();
                     let detected = weight_coherence::detect_symmetric_cancellation(
                         &creature, &records, &config,
@@ -1308,9 +1264,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     if hidden.is_empty() {
                         return None;
                     }
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     let detected = topology::detect_topology_issues(&creature, &records);
                     if detected.is_empty() {
                         return None;
@@ -1333,9 +1287,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "sample-weighted discovery".to_string(),
                 phase_name: "sample_weighted_discovery",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     if records.is_empty() {
                         return None;
                     }
@@ -1362,9 +1314,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_name: "gradient-based discovery".to_string(),
                 phase_name: "gradient_based_discovery",
                 detect_fn: Box::new(move || {
-                    let uuids: Vec<String> =
-                        creature.neurons.iter().map(|n| n.uuid.clone()).collect();
-                    let records = cache.load_records_for_uuids(&uuids);
+                    let records = cache.load_records_for_all_neurons(&creature);
                     if records.is_empty() {
                         return None;
                     }

--- a/tests/issue_493_creature_record_loading.rs
+++ b/tests/issue_493_creature_record_loading.rs
@@ -1,0 +1,235 @@
+//! Tests for Issue #493: Creature-aware record-loading helpers on RecordCache.
+//!
+//! Validates that the new convenience methods correctly combine UUID extraction
+//! from `CreatureJson` with record loading, eliminating the repeated
+//! UUID-collection boilerplate in `analyze_all()`.
+
+mod common;
+
+use common::{hidden, make_creature, neuron, output, record, synapse};
+use neat_ai_discovery::analysis::cache::RecordCache;
+use neat_ai_discovery::types::DiscoverRecord;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Helper to create a test cache backed by in-memory data.
+fn test_cache_with_data(data: Vec<(String, Vec<DiscoverRecord>)>) -> RecordCache {
+    let data_map: HashMap<String, Vec<DiscoverRecord>> = data.into_iter().collect();
+    let data_map = Arc::new(data_map);
+
+    RecordCache::with_loader(
+        "test.parquet",
+        Arc::new(move |_file: &str, neuron_uuid: &str| {
+            Ok(data_map.get(neuron_uuid).cloned().unwrap_or_default())
+        }),
+    )
+}
+
+// =============================================================================
+// load_records_for_all_neurons
+// =============================================================================
+
+/// Verify that load_records_for_all_neurons returns records for every neuron in the creature.
+#[test]
+fn test_load_all_neurons_returns_records_for_every_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("i1", "input", "IDENTITY"),
+            neuron("i2", "input", "IDENTITY"),
+            hidden("h1", "LOGISTIC"),
+            output("o1", "LOGISTIC"),
+        ],
+        vec![synapse("i1", "h1", 0.5), synapse("h1", "o1", 0.8)],
+    );
+
+    let cache = test_cache_with_data(vec![
+        ("i1".to_string(), vec![record("i1", 0, 0.1, Some(1.0))]),
+        ("i2".to_string(), vec![record("i2", 0, 0.2, Some(2.0))]),
+        ("h1".to_string(), vec![record("h1", 0, 0.5, None)]),
+        ("o1".to_string(), vec![record("o1", 0, 0.9, None)]),
+    ]);
+
+    let records = cache.load_records_for_all_neurons(&creature);
+
+    // Should return records for all 4 neurons
+    assert_eq!(records.len(), 4);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"i1".to_string()));
+    assert!(uuids.contains(&&"i2".to_string()));
+    assert!(uuids.contains(&&"h1".to_string()));
+    assert!(uuids.contains(&&"o1".to_string()));
+}
+
+/// Verify that load_records_for_all_neurons handles a creature with no neurons.
+#[test]
+fn test_load_all_neurons_empty_creature() {
+    let creature = make_creature(vec![], vec![]);
+    let cache = test_cache_with_data(vec![("n1".to_string(), vec![record("n1", 0, 0.5, None)])]);
+
+    let records = cache.load_records_for_all_neurons(&creature);
+    assert!(records.is_empty());
+}
+
+// =============================================================================
+// load_records_for_neuron_types
+// =============================================================================
+
+/// Verify that load_records_for_neuron_types returns only the requested types.
+#[test]
+fn test_load_by_type_filters_correctly() {
+    let creature = make_creature(
+        vec![
+            neuron("i1", "input", "IDENTITY"),
+            neuron("i2", "input", "IDENTITY"),
+            hidden("h1", "LOGISTIC"),
+            output("o1", "LOGISTIC"),
+        ],
+        vec![synapse("i1", "h1", 0.5), synapse("h1", "o1", 0.8)],
+    );
+
+    let cache = test_cache_with_data(vec![
+        ("i1".to_string(), vec![record("i1", 0, 0.1, Some(1.0))]),
+        ("i2".to_string(), vec![record("i2", 0, 0.2, Some(2.0))]),
+        ("h1".to_string(), vec![record("h1", 0, 0.5, None)]),
+        ("o1".to_string(), vec![record("o1", 0, 0.9, None)]),
+    ]);
+
+    // Request only output neurons
+    let records = cache.load_records_for_neuron_types(&creature, &["output"]);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].0, "o1");
+
+    // Request only input neurons
+    let records = cache.load_records_for_neuron_types(&creature, &["input"]);
+    assert_eq!(records.len(), 2);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"i1".to_string()));
+    assert!(uuids.contains(&&"i2".to_string()));
+}
+
+/// Verify that load_records_for_neuron_types supports multiple type filters.
+#[test]
+fn test_load_by_type_multiple_types() {
+    let creature = make_creature(
+        vec![
+            neuron("i1", "input", "IDENTITY"),
+            hidden("h1", "LOGISTIC"),
+            output("o1", "LOGISTIC"),
+        ],
+        vec![synapse("i1", "h1", 0.5), synapse("h1", "o1", 0.8)],
+    );
+
+    let cache = test_cache_with_data(vec![
+        ("i1".to_string(), vec![record("i1", 0, 0.1, Some(1.0))]),
+        ("h1".to_string(), vec![record("h1", 0, 0.5, None)]),
+        ("o1".to_string(), vec![record("o1", 0, 0.9, None)]),
+    ]);
+
+    // Request input + output
+    let records = cache.load_records_for_neuron_types(&creature, &["input", "output"]);
+    assert_eq!(records.len(), 2);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"i1".to_string()));
+    assert!(uuids.contains(&&"o1".to_string()));
+
+    // Request input + hidden
+    let records = cache.load_records_for_neuron_types(&creature, &["input", "hidden"]);
+    assert_eq!(records.len(), 2);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"i1".to_string()));
+    assert!(uuids.contains(&&"h1".to_string()));
+}
+
+/// Verify that load_records_for_neuron_types with no matching types returns empty.
+#[test]
+fn test_load_by_type_no_matching_types() {
+    let creature = make_creature(
+        vec![neuron("i1", "input", "IDENTITY"), output("o1", "LOGISTIC")],
+        vec![],
+    );
+
+    let cache = test_cache_with_data(vec![
+        ("i1".to_string(), vec![record("i1", 0, 0.1, Some(1.0))]),
+        ("o1".to_string(), vec![record("o1", 0, 0.9, None)]),
+    ]);
+
+    let records = cache.load_records_for_neuron_types(&creature, &["hidden"]);
+    assert!(records.is_empty());
+}
+
+// =============================================================================
+// load_records_for_synapse_sources
+// =============================================================================
+
+/// Verify that load_records_for_synapse_sources returns unique source UUIDs.
+#[test]
+fn test_load_synapse_sources_returns_unique_sources() {
+    let creature = make_creature(
+        vec![
+            neuron("i1", "input", "IDENTITY"),
+            neuron("i2", "input", "IDENTITY"),
+            hidden("h1", "LOGISTIC"),
+            output("o1", "LOGISTIC"),
+        ],
+        vec![
+            synapse("i1", "h1", 0.5),
+            synapse("i1", "o1", 0.3), // i1 appears twice as source
+            synapse("i2", "h1", 0.7),
+            synapse("h1", "o1", 0.8),
+        ],
+    );
+
+    let cache = test_cache_with_data(vec![
+        ("i1".to_string(), vec![record("i1", 0, 0.1, Some(1.0))]),
+        ("i2".to_string(), vec![record("i2", 0, 0.2, Some(2.0))]),
+        ("h1".to_string(), vec![record("h1", 0, 0.5, None)]),
+    ]);
+
+    let records = cache.load_records_for_synapse_sources(&creature);
+
+    // Should return records for 3 unique source UUIDs: i1, i2, h1
+    assert_eq!(records.len(), 3);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"i1".to_string()));
+    assert!(uuids.contains(&&"i2".to_string()));
+    assert!(uuids.contains(&&"h1".to_string()));
+}
+
+/// Verify that load_records_for_synapse_sources handles empty synapses.
+#[test]
+fn test_load_synapse_sources_empty_synapses() {
+    let creature = make_creature(vec![neuron("i1", "input", "IDENTITY")], vec![]);
+    let cache = test_cache_with_data(vec![(
+        "i1".to_string(),
+        vec![record("i1", 0, 0.1, Some(1.0))],
+    )]);
+
+    let records = cache.load_records_for_synapse_sources(&creature);
+    assert!(records.is_empty());
+}
+
+// =============================================================================
+// load_records_for_hidden consistency
+// =============================================================================
+
+/// Verify that load_records_for_hidden returns records matching the hidden neuron tuples.
+#[test]
+fn test_load_hidden_returns_correct_records() {
+    let cache = test_cache_with_data(vec![
+        ("h1".to_string(), vec![record("h1", 0, 0.5, None)]),
+        ("h2".to_string(), vec![record("h2", 0, 0.7, None)]),
+        ("o1".to_string(), vec![record("o1", 0, 0.9, None)]),
+    ]);
+
+    let hidden_neurons = vec![
+        ("h1".to_string(), "LOGISTIC".to_string(), 0.0_f32),
+        ("h2".to_string(), "TANH".to_string(), 0.1_f32),
+    ];
+
+    let records = cache.load_records_for_hidden(&hidden_neurons);
+
+    assert_eq!(records.len(), 2);
+    let uuids: Vec<&String> = records.iter().map(|(u, _)| u).collect();
+    assert!(uuids.contains(&&"h1".to_string()));
+    assert!(uuids.contains(&&"h2".to_string()));
+}


### PR DESCRIPTION
## Summary

Extract creature-aware record-loading helpers into `RecordCache` to eliminate UUID-collection boilerplate across 14 discovery module dispatch blocks in `analyze_all()`.

Three new methods added to `RecordCache` (in `cache.rs`):
- `load_records_for_all_neurons(&creature)` — replaces 8 blocks that collected all neuron UUIDs
- `load_records_for_neuron_types(&creature, &["output", "input"])` — replaces 5 blocks that filtered by neuron type
- `load_records_for_synapse_sources(&creature)` — replaces 1 block that collected unique synapse source UUIDs

Net effect: 70 lines of duplicated UUID-collection logic removed from `mod.rs`, replaced by single-line helper calls. Each dispatch block now reads the records in one call instead of building an intermediate UUID vector first.

## Evidence

This is a backend/refactoring change with no UI impact. Verified by:
- All 8 new integration tests pass (see test plan below)
- All 4 existing `issue_481_record_loading_helper` tests still pass
- Full `quality.sh` passes (fmt, clippy, check, 1000+ tests, release build)
- `mod.rs` reduced from ~1,588 to ~1,518 lines

## Test plan
- Added `tests/issue_493_creature_record_loading.rs` with 8 tests:
  - `test_load_all_neurons_returns_records_for_every_neuron` — all neuron UUIDs loaded
  - `test_load_all_neurons_empty_creature` — empty creature returns empty
  - `test_load_by_type_filters_correctly` — single-type filtering (output, input)
  - `test_load_by_type_multiple_types` — multi-type filtering (input+output, input+hidden)
  - `test_load_by_type_no_matching_types` — no matches returns empty
  - `test_load_synapse_sources_returns_unique_sources` — deduplicates source UUIDs
  - `test_load_synapse_sources_empty_synapses` — empty synapses returns empty
  - `test_load_hidden_returns_correct_records` — existing `load_records_for_hidden` works correctly

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)