### PR TITLE
Fix: Implement error distribution computation for neuron analysis (Issue #192) (#486)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.9"
+version = "0.13.10"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-486.md
+++ b/docs/pr-summary-486.md
@@ -1,0 +1,21 @@
+## Summary
+
+Implement error distribution computation for neuron analysis, completing the long-standing TODO from Issue #192. Closes #486.
+
+The `error_distribution` field in `NeuronAnalysisMetadata` was always set to `None`. This PR wires it up by collecting error values from target neuron records during the parallel analysis loop and computing `ErrorDistribution::from_errors()` from the aggregated samples — the same pattern already used by synapse analysis.
+
+### Changes
+
+- **`src/analysis/neuron.rs`**: Collect error values from each focus target neuron's records during the parallel loop via a shared `Mutex<Vec<f32>>`, then compute `ErrorDistribution::from_errors()` and populate the metadata field.
+
+## Evidence
+
+This is a backend-only change with no UI impact. Verified by:
+- 3 new integration tests covering the main scenarios
+- Full `quality.sh` pass (fmt, clippy, check, tests, release build)
+
+## Test Plan
+
+- `test_neuron_analysis_populates_error_distribution` — verifies error distribution is populated with correct statistical properties (mean, std_dev, skewness, percentiles) for a known outlier pattern
+- `test_neuron_analysis_no_errors_returns_none` — verifies `None` is returned when target records have empty error vectors
+- `test_neuron_analysis_error_distribution_multiple_targets` — verifies error samples are aggregated across multiple focus target neurons

--- a/src/analysis/neuron.rs
+++ b/src/analysis/neuron.rs
@@ -367,6 +367,9 @@ pub(crate) fn analyze_neurons_with_cache(
         .collect();
     let used_inputs_arc = Arc::new(used_inputs);
 
+    // Issue #486 / #192: Collect error values from focus target neurons for distribution analysis.
+    let error_values_for_distribution = Arc::new(Mutex::new(Vec::<f32>::new()));
+
     // Create a shared GPU work queue ONCE before the parallel loop.
     // This eliminates the overhead of creating multiple GPU devices (one per thread).
     // All GPU operations are processed by a single dedicated thread, improving utilisation.
@@ -409,6 +412,20 @@ pub(crate) fn analyze_neurons_with_cache(
             }
             let target_records = target_records_arc.as_ref();
             diagnostics.set_target_record_count(target_uuid, target_records.len());
+
+            // Issue #486 / #192: Collect error values for distribution analysis
+            {
+                let errors: Vec<f32> = target_records
+                    .iter()
+                    .flat_map(|r| r.errors.iter().filter(|e| e.is_finite()).copied())
+                    .collect();
+                if !errors.is_empty() {
+                    error_values_for_distribution
+                        .lock()
+                        .expect("Mutex poisoned")
+                        .extend(errors);
+                }
+            }
 
             // Log target neuron obs_index range for debugging sample matching
             if verbose_enabled() && !target_records.is_empty() {
@@ -846,6 +863,16 @@ pub(crate) fn analyze_neurons_with_cache(
     let no_candidate_reasons = diagnostics.no_candidate_summaries();
     diagnostics.emit_logs();
 
+    // Issue #486 / #192: Compute error distribution from collected target neuron error samples.
+    let error_distribution = {
+        let error_values = std::mem::take(
+            &mut *error_values_for_distribution
+                .lock()
+                .expect("Mutex poisoned"),
+        );
+        super::error_distribution::ErrorDistribution::from_errors(&error_values)
+    };
+
     Ok(AnalyzeNeuronsResult {
         helpful_neurons: helpful_results,
         gpu_used,
@@ -863,7 +890,7 @@ pub(crate) fn analyze_neurons_with_cache(
             total_focus_neurons: original_focus_count,
             timing: timing_collector.finalize(),
             gpu_info: GpuAnalyzer::get_adapter_info(),
-            error_distribution: None, // TODO: Compute from target neuron samples (Issue #192)
+            error_distribution,
         },
     })
 }

--- a/tests/issue_486_neuron_error_distribution.rs
+++ b/tests/issue_486_neuron_error_distribution.rs
@@ -1,0 +1,333 @@
+//! Tests for error distribution computation in neuron analysis (Issue #486).
+//!
+//! Verifies that `analyze_neurons()` populates the `error_distribution` field
+//! in `NeuronAnalysisMetadata` by computing `ErrorDistribution::from_errors()`
+//! from the target neuron records' error samples.
+
+mod common;
+
+use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_neurons};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Skip test if no GPU available.
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+/// Helper to build a simple creature with 2 inputs, 1 output.
+fn simple_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "HARD_TANH".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![SynapseJson {
+            from_uuid: "input-0".to_string(),
+            to_uuid: "output-0".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        }],
+        input: 2,
+        output: 1,
+    }
+}
+
+// =============================================================================
+// Test: neuron analysis populates error_distribution for focus target neurons
+// =============================================================================
+
+/// Test: `analyze_neurons` populates the `error_distribution` field in metadata
+/// when the focus target neurons have error samples.
+#[test]
+fn test_neuron_analysis_populates_error_distribution() {
+    skip_without_gpu!();
+
+    let creature = simple_creature();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let mut records = Vec::new();
+
+    // Create 100 observations with known error pattern:
+    // 90 samples with low error (0.1), 10 samples with high error (1.0)
+    for i in 0..100u32 {
+        let error = if i < 90 { 0.1 } else { 1.0 };
+
+        // Target (output) neuron records with errors
+        records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![error],
+        ));
+
+        // Source input neurons (needed for the analysis pipeline)
+        records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "input-1".to_string(),
+            Some(0.3),
+            0.3,
+            vec![0.0],
+        ));
+    }
+
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: file_path.to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+        random_seed: Some(42),
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // The error_distribution field MUST be populated (this is the Issue #486 fix)
+    assert!(
+        result.metadata.error_distribution.is_some(),
+        "Neuron analysis should populate error_distribution in metadata"
+    );
+
+    let dist = result.metadata.error_distribution.as_ref().unwrap();
+
+    // Verify basic statistical properties
+    assert!(
+        dist.mean > 0.0,
+        "Mean error should be positive, got {}",
+        dist.mean
+    );
+    assert!(
+        dist.std_dev > 0.0,
+        "Std dev should be positive, got {}",
+        dist.std_dev
+    );
+    assert_eq!(dist.percentiles.len(), 5, "Should have 5 percentiles");
+    assert!(dist.sample_count > 0, "Sample count should be positive");
+
+    // With 90% at 0.1 and 10% at 1.0, the distribution should be right-skewed
+    assert!(
+        dist.skewness > 0.0,
+        "Distribution with outliers should have positive skewness, got {}",
+        dist.skewness
+    );
+
+    // Max should be significantly higher than mean due to outliers
+    assert!(
+        dist.max > dist.mean * 2.0,
+        "Max ({}) should be much higher than mean ({}) due to outliers",
+        dist.max,
+        dist.mean
+    );
+
+    eprintln!(
+        "Error distribution: mean={:.4}, std_dev={:.4}, skewness={:.4}, kurtosis={:.4}, samples={}",
+        dist.mean, dist.std_dev, dist.skewness, dist.kurtosis, dist.sample_count
+    );
+}
+
+// =============================================================================
+// Test: neuron analysis returns None when no error samples exist
+// =============================================================================
+
+/// Test: `analyze_neurons` returns `None` for `error_distribution` when
+/// target neurons have no error data.
+#[test]
+fn test_neuron_analysis_no_errors_returns_none() {
+    skip_without_gpu!();
+
+    let creature = simple_creature();
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let mut records = Vec::new();
+
+    // Create records with EMPTY error vectors for target neurons
+    for i in 0..50u32 {
+        records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![], // No errors
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![],
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "input-1".to_string(),
+            Some(0.3),
+            0.3,
+            vec![],
+        ));
+    }
+
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: file_path.to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+        random_seed: Some(42),
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    // With no errors, distribution should be None
+    assert!(
+        result.metadata.error_distribution.is_none(),
+        "Neuron analysis with no errors should have None error_distribution"
+    );
+}
+
+// =============================================================================
+// Test: error distribution aggregates across multiple focus targets
+// =============================================================================
+
+/// Test: When multiple focus neurons are analysed, error distribution is
+/// computed from the combined error samples of all focus targets.
+#[test]
+fn test_neuron_analysis_error_distribution_multiple_targets() {
+    skip_without_gpu!();
+
+    // Creature with 2 output neurons (both as focus targets)
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "HARD_TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-1".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "HARD_TANH".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "output-1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 2,
+    };
+
+    let temp_file = NamedTempFile::new().unwrap();
+    let file_path = temp_file.path().to_str().unwrap();
+
+    let mut records = Vec::new();
+
+    for i in 0..100u32 {
+        // output-0 has errors ~0.2
+        records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(0.0),
+            0.0,
+            vec![0.2],
+        ));
+
+        // output-1 has errors ~0.8
+        records.push(DiscoverRecord::new(
+            i,
+            "output-1".to_string(),
+            Some(0.0),
+            0.0,
+            vec![0.8],
+        ));
+
+        records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.0],
+        ));
+        records.push(DiscoverRecord::new(
+            i,
+            "input-1".to_string(),
+            Some(0.3),
+            0.3,
+            vec![0.0],
+        ));
+    }
+
+    write_records_to_parquet(file_path, &records).unwrap();
+
+    let input = AnalyzeNeuronsInput {
+        parquet_file: file_path.to_string(),
+        creature,
+        focus_neurons: vec!["output-0".to_string(), "output-1".to_string()],
+        max_candidates: Some(10),
+        analysis_deadline_ms: None,
+        random_seed: Some(42),
+    };
+
+    let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
+
+    assert!(
+        result.metadata.error_distribution.is_some(),
+        "Neuron analysis with multiple targets should populate error_distribution"
+    );
+
+    let dist = result.metadata.error_distribution.as_ref().unwrap();
+
+    // Combined distribution should have samples from both targets (200 total)
+    assert!(
+        dist.sample_count >= 100,
+        "Should have samples from multiple targets, got {}",
+        dist.sample_count
+    );
+
+    // Mean should be between 0.2 and 0.8 (combined from both targets)
+    assert!(
+        dist.mean > 0.1 && dist.mean < 0.9,
+        "Combined mean should be between 0.1 and 0.9, got {}",
+        dist.mean
+    );
+
+    eprintln!(
+        "Multi-target distribution: mean={:.4}, samples={}, skewness={:.4}",
+        dist.mean, dist.sample_count, dist.skewness
+    );
+}


### PR DESCRIPTION
## Summary

Implement error distribution computation for neuron analysis, completing the long-standing TODO from Issue #192. Closes #486.

The `error_distribution` field in `NeuronAnalysisMetadata` was always set to `None`. This PR wires it up by collecting error values from target neuron records during the parallel analysis loop and computing `ErrorDistribution::from_errors()` from the aggregated samples — the same pattern already used by synapse analysis.

### Changes

- **`src/analysis/neuron.rs`**: Collect error values from each focus target neuron's records during the parallel loop via a shared `Mutex<Vec<f32>>`, then compute `ErrorDistribution::from_errors()` and populate the metadata field.

## Evidence

This is a backend-only change with no UI impact. Verified by:
- 3 new integration tests covering the main scenarios
- Full `quality.sh` pass (fmt, clippy, check, tests, release build)

## Test Plan

- `test_neuron_analysis_populates_error_distribution` — verifies error distribution is populated with correct statistical properties (mean, std_dev, skewness, percentiles) for a known outlier pattern
- `test_neuron_analysis_no_errors_returns_none` — verifies `None` is returned when target records have empty error vectors
- `test_neuron_analysis_error_distribution_multiple_targets` — verifies error samples are aggregated across multiple focus target neurons

---

## Automated Fix Details
This PR addresses issue #486: **Implement error distribution computation for neuron analysis (Issue #192)**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #486