### PR TITLE
Fix: Add ultra-conservative 'micro-nudge' weight variant for add-neuron candidates (#507)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.12"
+version = "0.13.13"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.13.13"
+version = "0.14.0"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-507.md
+++ b/docs/pr-summary-507.md
@@ -1,0 +1,43 @@
+## Summary
+
+Add ultra-conservative "Micro-Nudge" weight variant for add-neuron candidates. Closes #507.
+
+Production evidence showed several conservative and gentle-nudge candidates narrowly missing success (within 0.0003 of zero score delta). The micro-nudge variant targets the sweet spot with outgoing weights in the ±0.002–0.005 range — half the conservative variant's scale.
+
+### Key parameters
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `MICRO_NUDGE_INCOMING_ABS_MAX` | 2.0 | Same as conservative |
+| `MICRO_NUDGE_BIAS_ABS_MAX` | 1.0 | Same as conservative |
+| `MICRO_NUDGE_OUTGOING_ABS_MAX` | 0.005 | Half of conservative (0.05 → 0.005) |
+| `MICRO_NUDGE_OUTGOING_SCALE` | 0.05 | Half of conservative (0.2 → 0.05) |
+| `MICRO_NUDGE_EXPECTED_MULTIPLIER` | 0.25 | Ranked below other variants |
+
+### Mitigation
+The micro-nudge variant is only generated when the conservative variant's outgoing weight exceeds 0.005 (the micro-nudge max). This avoids wasting the candidate budget on near-identical variants when the conservative outgoing weight is already small.
+
+### Changes
+- `src/analysis/utils/mod.rs`: Added micro-nudge constants, factory function (`make_micro_nudge_add_neuron_variant`), guard function (`should_generate_micro_nudge`), and integration into `pair_extreme_candidates_with_conservative_variants`. Updated comment generation to use dynamic formatting for 1–3 variant labels.
+- `tests/coordinated_structural_replace_synapse_with_relu.rs`: Increased `maxNeuronCandidates` from 32 to 48 to accommodate the 4th variant per extreme candidate.
+- `tests/extreme_candidate_pairing.rs`: Updated deduplication test limit from 6 to 8 (2 candidates × 4 variants).
+- `tests/neuron_metadata_candidates_found_includes_pairing.rs`: Updated expected counts (3→4 per extreme, 9→12 for 3 extremes).
+
+## Evidence
+
+This is a backend/CLI change with no UI components. Evidence is provided by the test suite:
+- 10 new tests in `tests/issue_507_micro_nudge_variant.rs` covering all micro-nudge behaviour
+- All 472 unit tests + 97 integration tests pass via `./quality.sh`
+
+## Test Plan
+
+New test file `tests/issue_507_micro_nudge_variant.rs` with 10 tests:
+- `micro_nudge_variant_is_generated_for_extreme_candidates` — verifies 4 variants are returned
+- `micro_nudge_outgoing_weight_is_in_expected_range` — checks outgoing ≈ 0.005
+- `micro_nudge_not_generated_when_conservative_outgoing_already_small` — mitigation guard
+- `micro_nudge_expected_improvement_is_scaled_down` — 0.25× multiplier
+- `micro_nudge_preserves_negative_outgoing_weight_sign` — sign preservation
+- `extreme_candidate_comment_reflects_all_four_variants` — comment accuracy
+- `micro_nudge_skipped_when_limit_too_small` — budget-constrained behaviour
+- `micro_nudge_deduplication_across_different_neuron_pairs` — no cross-pair dedup
+- `micro_nudge_minimum_outgoing_weight_when_scale_produces_near_zero` — guard mitigation
+- `total_candidate_count_with_micro_nudge_is_four_per_extreme` — 3 × 4 = 12 total

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -145,6 +145,21 @@ const GENTLE_NUDGE_OUTGOING_ABS_MAX: f32 = 0.02;
 const GENTLE_NUDGE_OUTGOING_SCALE: f32 = 0.1;
 const GENTLE_NUDGE_EXPECTED_MULTIPLIER: f32 = 0.75;
 
+/// Guard rails for the "Micro-Nudge" safety variant (Issue #507).
+///
+/// Ultra-conservative variant targeting the ±0.002–0.005 outgoing weight range.
+/// Production evidence (Feb 2026): several conservative and gentle-nudge candidates
+/// narrowly missed success with score deltas within 0.0003 of zero. The micro-nudge
+/// variant explores even smaller outgoing weights where the sweet spot likely lies.
+///
+/// Only generated when the conservative variant's outgoing weight exceeds
+/// `MICRO_NUDGE_OUTGOING_ABS_MAX` (i.e. when it would meaningfully differ).
+const MICRO_NUDGE_INCOMING_ABS_MAX: f32 = 2.0;
+const MICRO_NUDGE_BIAS_ABS_MAX: f32 = 1.0;
+const MICRO_NUDGE_OUTGOING_ABS_MAX: f32 = 0.005;
+const MICRO_NUDGE_OUTGOING_SCALE: f32 = 0.05;
+const MICRO_NUDGE_EXPECTED_MULTIPLIER: f32 = 0.25;
+
 /// Returns true if this add-neuron candidate is "extreme" enough to warrant a conservative pair.
 ///
 /// We intentionally base this on incoming weight and bias (not outgoing), because outgoing
@@ -248,6 +263,61 @@ fn make_gentle_nudge_add_neuron_variant(candidate: &CandidateNeuronJson) -> Cand
     gentle
 }
 
+/// Create a "Micro-Nudge" variant of an add-neuron candidate (Issue #507).
+///
+/// Ultra-conservative: the outgoing weight is halved again from the conservative variant,
+/// targeting the ±0.002–0.005 range where near-miss production candidates clustered.
+fn make_micro_nudge_add_neuron_variant(candidate: &CandidateNeuronJson) -> CandidateNeuronJson {
+    let incoming_sign = if candidate.incoming_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+    let outgoing_sign = if candidate.outgoing_weight >= 0.0 {
+        1.0
+    } else {
+        -1.0
+    };
+
+    let incoming_weight = incoming_sign
+        * candidate
+            .incoming_weight
+            .abs()
+            .min(MICRO_NUDGE_INCOMING_ABS_MAX);
+    let bias = candidate
+        .bias
+        .clamp(-MICRO_NUDGE_BIAS_ABS_MAX, MICRO_NUDGE_BIAS_ABS_MAX);
+
+    let mut outgoing_weight = (candidate.outgoing_weight * MICRO_NUDGE_OUTGOING_SCALE)
+        .clamp(-MICRO_NUDGE_OUTGOING_ABS_MAX, MICRO_NUDGE_OUTGOING_ABS_MAX);
+    // Keep a small non-zero weight so the candidate actually does something.
+    if outgoing_weight.abs() <= 1e-6 {
+        outgoing_weight = outgoing_sign * 0.002;
+    }
+
+    let mut micro = candidate.clone();
+    micro.incoming_weight = incoming_weight;
+    micro.bias = bias;
+    micro.outgoing_weight = outgoing_weight;
+    micro.expected_creature_error_reduction *= MICRO_NUDGE_EXPECTED_MULTIPLIER;
+    micro.expected_creature_score_gain = micro.expected_creature_error_reduction;
+    micro.comment =
+        Some("Micro-Nudge variant (ultra-conservative outgoing, tight incoming/bias)".to_string());
+    micro
+}
+
+/// Check whether the micro-nudge variant would meaningfully differ from the conservative variant.
+///
+/// Only generate micro-nudge when the conservative outgoing weight exceeds the micro-nudge max.
+/// This avoids wasting the candidate budget on near-identical variants.
+fn should_generate_micro_nudge(candidate: &CandidateNeuronJson) -> bool {
+    let conservative_outgoing = (candidate.outgoing_weight * CONSERVATIVE_OUTGOING_SCALE).clamp(
+        -CONSERVATIVE_OUTGOING_ABS_MAX,
+        CONSERVATIVE_OUTGOING_ABS_MAX,
+    );
+    conservative_outgoing.abs() > MICRO_NUDGE_OUTGOING_ABS_MAX
+}
+
 fn candidates_meaningfully_differ(a: &CandidateNeuronJson, b: &CandidateNeuronJson) -> bool {
     // Two candidates connecting different neuron pairs (or using different neuron squash)
     // are fundamentally different operations, even if clamping produces identical weights.
@@ -291,6 +361,7 @@ pub fn pair_extreme_candidates_with_conservative_variants(
 
         let mut added_conservative = false;
         let mut added_gentle_nudge = false;
+        let mut added_micro_nudge = false;
         if should_pair && output.len() < limit {
             let conservative = make_conservative_add_neuron_variant(&candidate);
             // Only add if it meaningfully differs (avoid duplicates).
@@ -313,20 +384,43 @@ pub fn pair_extreme_candidates_with_conservative_variants(
             }
         }
 
+        // Issue #507: Micro-Nudge variant — only when conservative outgoing exceeds
+        // the micro-nudge max (otherwise the two variants would be near-identical).
+        if should_pair && output.len() < limit && should_generate_micro_nudge(&candidate) {
+            let micro = make_micro_nudge_add_neuron_variant(&candidate);
+            if candidates_meaningfully_differ(&micro, &candidate)
+                && output
+                    .iter()
+                    .all(|existing| candidates_meaningfully_differ(existing, &micro))
+            {
+                output.push(micro);
+                added_micro_nudge = true;
+            }
+        }
+
         // Avoid misleading diagnostics: only claim pairing once we have actually returned
         // variants (and we had room under max_candidates).
         if should_pair && output[original_index].comment.is_none() {
-            output[original_index].comment = Some(
-                match (added_conservative, added_gentle_nudge) {
-                    (true, true) => {
-                        "Extreme candidate (paired with Conservative + Gentle Nudge variants)"
-                    }
-                    (true, false) => "Extreme candidate (paired with Conservative variant only)",
-                    (false, true) => "Extreme candidate (paired with Gentle Nudge variant only)",
-                    (false, false) => "Extreme candidate (no safety variants included)",
-                }
-                .to_string(),
-            );
+            let mut parts = Vec::new();
+            if added_conservative {
+                parts.push("Conservative");
+            }
+            if added_gentle_nudge {
+                parts.push("Gentle Nudge");
+            }
+            if added_micro_nudge {
+                parts.push("Micro-Nudge");
+            }
+            output[original_index].comment = Some(if parts.is_empty() {
+                "Extreme candidate (no safety variants included)".to_string()
+            } else if parts.len() == 1 {
+                format!("Extreme candidate (paired with {} variant only)", parts[0])
+            } else {
+                format!(
+                    "Extreme candidate (paired with {} variants)",
+                    parts.join(" + ")
+                )
+            });
         }
     }
 

--- a/tests/coordinated_structural_replace_synapse_with_relu.rs
+++ b/tests/coordinated_structural_replace_synapse_with_relu.rs
@@ -81,8 +81,10 @@ fn coordinated_structural_can_replace_synapse_with_hidden_relu_neuron() {
         "creature": creature,
         "focusNeurons": ["output-0"],
         // Coordinated structural candidates are part of the synapse candidate budget.
+        // Issue #507: Micro-nudge variant adds a 4th variant per extreme candidate,
+        // so we need a larger neuron budget to ensure the ReLU candidate is not truncated.
         "maxSynapseCandidates": 32,
-        "maxNeuronCandidates": 32,
+        "maxNeuronCandidates": 48,
         "randomSeed": 1
     })
     .to_string();

--- a/tests/extreme_candidate_pairing.rs
+++ b/tests/extreme_candidate_pairing.rs
@@ -200,14 +200,15 @@ fn gentle_nudge_variants_are_not_deduped_across_different_neuron_pairs() {
         expected_score_gain_confidence_interval: [0.0, 0.0],
     };
 
-    // Limit allows both originals plus both safety variants per candidate.
+    // Limit allows both originals plus all safety variants per candidate.
+    // Issue #507: 4 variants per extreme candidate (original + conservative + gentle nudge + micro-nudge).
     let paired =
-        pair_extreme_candidates_with_conservative_variants(vec![candidate_a, candidate_b], Some(6));
+        pair_extreme_candidates_with_conservative_variants(vec![candidate_a, candidate_b], Some(8));
 
     assert_eq!(
         paired.len(),
-        6,
-        "expected two originals + two conservative + two Gentle Nudge variants"
+        8,
+        "expected two originals + two conservative + two Gentle Nudge + two Micro-Nudge variants"
     );
 
     // Expect a Gentle Nudge variant for each distinct neuron pair.

--- a/tests/issue_507_micro_nudge_variant.rs
+++ b/tests/issue_507_micro_nudge_variant.rs
@@ -1,0 +1,336 @@
+//! Tests for ultra-conservative 'micro-nudge' weight variant (Issue #507).
+//!
+//! When an add-neuron candidate is extreme, we already generate conservative and gentle-nudge
+//! variants. The micro-nudge variant goes even smaller: outgoing weight in the ±0.002–0.005
+//! range, targeting the near-miss sweet spot observed in production.
+//!
+//! The micro-nudge variant is only generated when the conservative variant's outgoing weight
+//! exceeds the micro-nudge max (i.e. when it would meaningfully differ from conservative).
+
+use neat_ai_discovery::{
+    CandidateNeuronJson, analysis::utils::pair_extreme_candidates_with_conservative_variants,
+};
+
+/// Helper to build an extreme add-neuron candidate for testing.
+fn make_extreme_candidate(
+    source: &str,
+    target: &str,
+    incoming: f32,
+    outgoing: f32,
+    bias: f32,
+) -> CandidateNeuronJson {
+    CandidateNeuronJson {
+        source_neuron_uuid: source.to_string(),
+        target_neuron_uuid: target.to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: incoming,
+        outgoing_weight: outgoing,
+        squash: "TANH".to_string(),
+        bias,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.2,
+        expected_creature_score_gain: 0.2,
+        improved_count: 10,
+        total_count: 20,
+        target_neuron_stats: None,
+        prediction_confidence: 0.0,
+        expected_score_gain_confidence_interval: [0.0, 0.0],
+    }
+}
+
+#[test]
+fn micro_nudge_variant_is_generated_for_extreme_candidates() {
+    // Extreme candidate with large incoming weight and outgoing weight.
+    // Conservative outgoing = 0.1 * 0.2 = 0.02 (above micro-nudge max of 0.005).
+    // So the micro-nudge variant should meaningfully differ and be included.
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.1, 50.0);
+
+    // Limit allows all 4 variants: original + conservative + gentle nudge + micro-nudge
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(4));
+
+    assert_eq!(
+        paired.len(),
+        4,
+        "expected original + conservative + gentle nudge + micro-nudge"
+    );
+
+    // Find the micro-nudge variant
+    let micro_nudge = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .expect("expected a Micro-Nudge variant");
+
+    // Micro-nudge outgoing weight should be very small (±0.005 max)
+    assert!(
+        micro_nudge.outgoing_weight.abs() <= 0.005 + 1e-6,
+        "micro-nudge outgoing weight {} should be at most 0.005",
+        micro_nudge.outgoing_weight
+    );
+
+    // Micro-nudge should preserve the sign of the outgoing weight
+    // Original has positive outgoing (0.1), so micro-nudge should also be positive
+    assert!(
+        micro_nudge.outgoing_weight > 0.0,
+        "micro-nudge should preserve outgoing weight sign"
+    );
+
+    // Micro-nudge incoming should be clamped (like conservative)
+    assert!(
+        micro_nudge.incoming_weight.abs() <= 2.0 + 1e-6,
+        "micro-nudge incoming weight {} should be clamped to 2.0",
+        micro_nudge.incoming_weight
+    );
+
+    // Micro-nudge bias should be tightly clamped
+    assert!(
+        micro_nudge.bias.abs() <= 1.0 + 1e-6,
+        "micro-nudge bias {} should be clamped to 1.0",
+        micro_nudge.bias
+    );
+}
+
+#[test]
+fn micro_nudge_outgoing_weight_is_in_expected_range() {
+    // Conservative outgoing = 0.1 * 0.2 = 0.02, well above micro-nudge max of 0.005.
+    // Micro-nudge outgoing = 0.1 * 0.05 = 0.005, clamped to 0.005.
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.1, 50.0);
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    let micro_nudge = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .expect("expected a Micro-Nudge variant");
+
+    // With outgoing_weight=0.1, micro-nudge scale=0.05: 0.1 * 0.05 = 0.005
+    assert!(
+        (micro_nudge.outgoing_weight - 0.005).abs() < 1e-6,
+        "expected micro-nudge outgoing ~0.005, got {}",
+        micro_nudge.outgoing_weight
+    );
+}
+
+#[test]
+fn micro_nudge_not_generated_when_conservative_outgoing_already_small() {
+    // When the conservative variant's outgoing weight is already within the micro-nudge
+    // range (≤0.005), the micro-nudge would not meaningfully differ and should be skipped.
+    //
+    // Original outgoing = 0.01, conservative outgoing = 0.01 * 0.2 = 0.002 (within 0.005).
+    // Micro-nudge outgoing = 0.01 * 0.05 = 0.0005 (would differ, but very close).
+    // However, the issue specifies: only generate when conservative outgoing > micro-nudge max.
+    // Conservative outgoing (0.002) ≤ micro-nudge max (0.005), so skip micro-nudge.
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.01, 50.0);
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    let micro_nudge_count = paired
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .count();
+
+    assert_eq!(
+        micro_nudge_count, 0,
+        "micro-nudge should not be generated when conservative outgoing is already small"
+    );
+}
+
+#[test]
+fn micro_nudge_expected_improvement_is_scaled_down() {
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.1, 50.0);
+    let original_expected = candidate.expected_creature_error_reduction;
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    let micro_nudge = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .expect("expected a Micro-Nudge variant");
+
+    // Micro-nudge expected multiplier is 0.25 (from issue spec)
+    let expected = original_expected * 0.25;
+    assert!(
+        (micro_nudge.expected_creature_error_reduction - expected).abs() < 1e-6,
+        "expected micro-nudge error reduction {expected}, got {}",
+        micro_nudge.expected_creature_error_reduction
+    );
+    assert!(
+        (micro_nudge.expected_creature_score_gain - expected).abs() < 1e-6,
+        "expected micro-nudge score gain {expected}, got {}",
+        micro_nudge.expected_creature_score_gain
+    );
+}
+
+#[test]
+fn micro_nudge_preserves_negative_outgoing_weight_sign() {
+    // Candidate with negative outgoing weight
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, -0.1, 50.0);
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    let micro_nudge = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .expect("expected a Micro-Nudge variant");
+
+    assert!(
+        micro_nudge.outgoing_weight < 0.0,
+        "micro-nudge should preserve negative outgoing weight sign, got {}",
+        micro_nudge.outgoing_weight
+    );
+    assert!(
+        (micro_nudge.outgoing_weight - (-0.005)).abs() < 1e-6,
+        "expected micro-nudge outgoing ~-0.005, got {}",
+        micro_nudge.outgoing_weight
+    );
+}
+
+#[test]
+fn extreme_candidate_comment_reflects_all_four_variants() {
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.1, 50.0);
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    // Original candidate should mention all three variant types
+    let original_comment = paired[0].comment.as_deref().unwrap_or_default();
+    assert!(
+        original_comment.contains("Conservative")
+            && original_comment.contains("Gentle Nudge")
+            && original_comment.contains("Micro-Nudge"),
+        "original comment should mention all three variants: {original_comment}"
+    );
+}
+
+#[test]
+fn micro_nudge_skipped_when_limit_too_small() {
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.1, 50.0);
+
+    // Limit of 3 leaves room for original + conservative + gentle nudge only
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(3));
+
+    assert_eq!(paired.len(), 3, "expected 3 candidates at limit of 3");
+
+    let micro_nudge_count = paired
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .count();
+
+    assert_eq!(
+        micro_nudge_count, 0,
+        "micro-nudge should be skipped when limit prevents it"
+    );
+}
+
+#[test]
+fn micro_nudge_deduplication_across_different_neuron_pairs() {
+    // Two extreme candidates connecting different neuron pairs should each get
+    // their own micro-nudge variant (not deduped across pairs).
+    let candidate_a = make_extreme_candidate("source-a", "target-a", 200.0, 0.1, 50.0);
+    let candidate_b = make_extreme_candidate("source-b", "target-b", 200.0, 0.1, 50.0);
+
+    let paired =
+        pair_extreme_candidates_with_conservative_variants(vec![candidate_a, candidate_b], None);
+
+    let micro_nudge_pairs: Vec<(&str, &str)> = paired
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .map(|c| (c.source_neuron_uuid.as_str(), c.target_neuron_uuid.as_str()))
+        .collect();
+
+    assert_eq!(
+        micro_nudge_pairs.len(),
+        2,
+        "expected two micro-nudge variants (one per neuron pair)"
+    );
+    assert!(
+        micro_nudge_pairs.contains(&("source-a", "target-a")),
+        "expected micro-nudge for candidate_a"
+    );
+    assert!(
+        micro_nudge_pairs.contains(&("source-b", "target-b")),
+        "expected micro-nudge for candidate_b"
+    );
+}
+
+#[test]
+fn micro_nudge_minimum_outgoing_weight_when_scale_produces_near_zero() {
+    // When the scaled outgoing weight is near zero, micro-nudge should use a
+    // small non-zero fallback to ensure the candidate actually does something.
+    let candidate = make_extreme_candidate("source-1", "target-1", 200.0, 0.0001, 50.0);
+
+    let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], None);
+
+    let micro_nudge = paired.iter().find(|c| {
+        c.comment
+            .as_deref()
+            .unwrap_or_default()
+            .starts_with("Micro-Nudge")
+    });
+
+    // Even with near-zero outgoing weight, the micro-nudge (if generated) should have
+    // a non-zero weight. However, conservative outgoing = 0.0001 * 0.2 = 0.00002 which
+    // is ≤ 0.005, so micro-nudge should NOT be generated per the mitigation rule.
+    assert!(
+        micro_nudge.is_none(),
+        "micro-nudge should not be generated when conservative outgoing is within micro-nudge range"
+    );
+}
+
+#[test]
+fn total_candidate_count_with_micro_nudge_is_four_per_extreme() {
+    // 3 extreme candidates with large outgoing weights should produce 12 total:
+    // 3 originals + 3 conservative + 3 gentle nudge + 3 micro-nudge
+    let candidates: Vec<CandidateNeuronJson> = (0..3)
+        .map(|i| {
+            let mut c =
+                make_extreme_candidate(&format!("source-{i}"), "target-1", 200.0, 0.1, 50.0);
+            c.expected_creature_error_reduction = 0.2 - (i as f32 * 0.01);
+            c.expected_creature_score_gain = 0.2 - (i as f32 * 0.01);
+            c
+        })
+        .collect();
+
+    let paired = pair_extreme_candidates_with_conservative_variants(candidates, None);
+
+    assert_eq!(
+        paired.len(),
+        12,
+        "expected 12 candidates (3 extreme × 4 variants each)"
+    );
+}

--- a/tests/neuron_metadata_candidates_found_includes_pairing.rs
+++ b/tests/neuron_metadata_candidates_found_includes_pairing.rs
@@ -69,9 +69,10 @@ fn candidates_found_includes_paired_variants() {
     );
 
     // Verify actual values
+    // Issue #507: 4 variants per extreme candidate (original + conservative + gentle nudge + micro-nudge)
     assert_eq!(
-        candidates_found, 3,
-        "Expected 3 candidates found (original + conservative + gentle nudge)"
+        candidates_found, 4,
+        "Expected 4 candidates found (original + conservative + gentle nudge + micro-nudge)"
     );
     assert_eq!(
         candidates_returned, 2,
@@ -177,7 +178,7 @@ fn truncation_respects_invariant_with_multiple_extreme_candidates() {
     // CORRECT approach: pair first (no limit), then count, then truncate
     let paired = pair_extreme_candidates_with_conservative_variants(extreme_candidates, None);
 
-    // candidates_found = total after pairing (3 originals × 3 variants each = 9)
+    // Issue #507: candidates_found = total after pairing (3 originals × 4 variants each = 12)
     let candidates_found = paired.len();
 
     // Truncate to max_candidates=5
@@ -193,8 +194,8 @@ fn truncation_respects_invariant_with_multiple_extreme_candidates() {
 
     // Verify actual values
     assert_eq!(
-        candidates_found, 9,
-        "Expected 9 candidates found (3 extreme × 3 variants each)"
+        candidates_found, 12,
+        "Expected 12 candidates found (3 extreme × 4 variants each)"
     );
     assert_eq!(
         candidates_returned, 5,


### PR DESCRIPTION
## Summary

Add ultra-conservative "Micro-Nudge" weight variant for add-neuron candidates. Closes #507.

Production evidence showed several conservative and gentle-nudge candidates narrowly missing success (within 0.0003 of zero score delta). The micro-nudge variant targets the sweet spot with outgoing weights in the ±0.002–0.005 range — half the conservative variant's scale.

### Key parameters
| Parameter | Value | Rationale |
|-----------|-------|-----------|
| `MICRO_NUDGE_INCOMING_ABS_MAX` | 2.0 | Same as conservative |
| `MICRO_NUDGE_BIAS_ABS_MAX` | 1.0 | Same as conservative |
| `MICRO_NUDGE_OUTGOING_ABS_MAX` | 0.005 | Half of conservative (0.05 → 0.005) |
| `MICRO_NUDGE_OUTGOING_SCALE` | 0.05 | Half of conservative (0.2 → 0.05) |
| `MICRO_NUDGE_EXPECTED_MULTIPLIER` | 0.25 | Ranked below other variants |

### Mitigation
The micro-nudge variant is only generated when the conservative variant's outgoing weight exceeds 0.005 (the micro-nudge max). This avoids wasting the candidate budget on near-identical variants when the conservative outgoing weight is already small.

### Changes
- `src/analysis/utils/mod.rs`: Added micro-nudge constants, factory function (`make_micro_nudge_add_neuron_variant`), guard function (`should_generate_micro_nudge`), and integration into `pair_extreme_candidates_with_conservative_variants`. Updated comment generation to use dynamic formatting for 1–3 variant labels.
- `tests/coordinated_structural_replace_synapse_with_relu.rs`: Increased `maxNeuronCandidates` from 32 to 48 to accommodate the 4th variant per extreme candidate.
- `tests/extreme_candidate_pairing.rs`: Updated deduplication test limit from 6 to 8 (2 candidates × 4 variants).
- `tests/neuron_metadata_candidates_found_includes_pairing.rs`: Updated expected counts (3→4 per extreme, 9→12 for 3 extremes).

## Evidence

This is a backend/CLI change with no UI components. Evidence is provided by the test suite:
- 10 new tests in `tests/issue_507_micro_nudge_variant.rs` covering all micro-nudge behaviour
- All 472 unit tests + 97 integration tests pass via `./quality.sh`

## Test Plan

New test file `tests/issue_507_micro_nudge_variant.rs` with 10 tests:
- `micro_nudge_variant_is_generated_for_extreme_candidates` — verifies 4 variants are returned
- `micro_nudge_outgoing_weight_is_in_expected_range` — checks outgoing ≈ 0.005
- `micro_nudge_not_generated_when_conservative_outgoing_already_small` — mitigation guard
- `micro_nudge_expected_improvement_is_scaled_down` — 0.25× multiplier
- `micro_nudge_preserves_negative_outgoing_weight_sign` — sign preservation
- `extreme_candidate_comment_reflects_all_four_variants` — comment accuracy
- `micro_nudge_skipped_when_limit_too_small` — budget-constrained behaviour
- `micro_nudge_deduplication_across_different_neuron_pairs` — no cross-pair dedup
- `micro_nudge_minimum_outgoing_weight_when_scale_produces_near_zero` — guard mitigation
- `total_candidate_count_with_micro_nudge_is_four_per_extreme` — 3 × 4 = 12 total

> **Screenshot evidence not provided**: This appears to be a UI-related change but no screenshots were included. For UI changes, use Playwright MCP to capture screenshots as evidence: `browser_navigate` to open a relevant URL, then `browser_take_screenshot` to save to `docs/evidence/`.

---

## Automated Fix Details
This PR addresses issue #507: **Add ultra-conservative 'micro-nudge' weight variant for add-neuron candidates**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #507