### PR TITLE
Fix: Deduplicate coordinated-structural candidates sharing a dominant neuron (#509)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-509.md
+++ b/docs/pr-summary-509.md
@@ -1,0 +1,34 @@
+## Summary
+
+Deduplicate coordinated-structural candidates that share a common dominant neuron. Closes #509.
+
+In GRQ-sampler commit `a1340f8d` (creature `b2ff6e45`), 10 out of 20 candidates (50% of the budget) were coordinated-structural pairs all sharing the same dominant neuron (`e8480883`). All 10 failed with nearly identical results. This change caps pairs per dominant neuron to 3, freeing candidate slots for alternative sources.
+
+### Changes
+
+- **`src/analysis/epistatic.rs`**: Added `deduplicate_by_dominant_neuron()` and `deduplicate_synergistic_by_dominant_neuron()` functions. These group pairs by the neuron with the larger individual improvement and keep at most 3 diverse pairs per group (sorted by combined improvement).
+- **`src/analysis/synapse/target_analysis.rs`**: Applied deduplication in the pipeline after interference filtering and before conversion to coordinated candidates, for both epistatic and synergistic paths.
+
+### Expected impact
+
+- For the issue scenario: reduces coordinated-structural from 10 to 3 candidates, freeing 7 slots.
+- No loss of coverage since all 10 were redundant (same dominant neuron, same outcome).
+- Pairs with distinct dominant neurons are completely unaffected.
+
+## Evidence
+
+This is a backend logic change with no UI component. Verified by 9 new integration tests and all 474 existing unit tests passing.
+
+## Test Plan
+
+- Added `tests/issue_509_deduplicate_dominant_neuron.rs` with 9 tests:
+  - `epistatic_pairs_with_shared_dominant_neuron_are_capped` — 10 pairs sharing one dominant capped to 3
+  - `epistatic_pairs_with_distinct_dominant_neurons_unchanged` — distinct groups unaffected
+  - `epistatic_deduplication_keeps_best_combined_improvement` — best pairs retained
+  - `epistatic_deduplication_empty_input` — empty input returns empty
+  - `epistatic_deduplication_single_pair` — single pair passes through
+  - `epistatic_deduplication_mixed_groups` — mixed shared/unique groups handled correctly
+  - `synergistic_with_shared_primary_are_capped` — synergistic candidates capped per primary
+  - `synergistic_with_distinct_primaries_unchanged` — distinct primaries unaffected
+  - `epistatic_dominant_is_higher_individual_improvement` — dominant determined by higher individual improvement, not position
+- All existing tests pass (`./quality.sh` clean)

--- a/src/analysis/epistatic.rs
+++ b/src/analysis/epistatic.rs
@@ -28,7 +28,7 @@ use crate::CoordinatedStructuralCandidateJson;
 use crate::CoordinatedStructuralOpJson;
 use crate::analysis::samples::{HelpfulSample, HelpfulStats};
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 // MIN_SAMPLES_FOR_EPISTATIC_DETECTION moved to constants.rs (Issue #424)
 use super::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES_FOR_EPISTATIC_DETECTION;
@@ -1024,6 +1024,102 @@ pub fn filter_interfering_synergistic_candidates(
             true
         })
         .collect()
+}
+
+// ============================================================================
+// Issue #509: Deduplicate candidates sharing a dominant neuron
+// ============================================================================
+
+/// Maximum number of coordinated-structural pairs per dominant neuron.
+///
+/// When many epistatic or synergistic pairs share the same dominant source neuron
+/// (the one with the larger individual improvement), only this many diverse pairs
+/// are kept per group. The rest are discarded to free candidate budget for
+/// alternative sources, activation functions, or weight ranges.
+///
+/// Production analysis (creature b2ff6e45, GRQ-sampler commit a1340f8d) showed
+/// 10 pairs sharing the same dominant neuron, all failing identically. Capping
+/// to 3 frees 7 candidate slots with no loss of coverage.
+const MAX_PAIRS_PER_DOMINANT_NEURON: usize = 3;
+
+/// Deduplicate epistatic pairs that share a common dominant neuron (Issue #509).
+///
+/// Groups pairs by the neuron with the larger individual improvement (the
+/// "dominant" neuron). From each group, keeps at most
+/// [`MAX_PAIRS_PER_DOMINANT_NEURON`] pairs, selecting by highest combined
+/// improvement to maximise diversity and expected benefit.
+///
+/// # Arguments
+/// * `pairs` - Epistatic pair candidates to deduplicate.
+///
+/// # Returns
+/// A deduplicated list of pairs, capped per dominant neuron group.
+pub fn deduplicate_by_dominant_neuron(
+    mut pairs: Vec<EpistaticPairCandidate>,
+) -> Vec<EpistaticPairCandidate> {
+    if pairs.len() <= MAX_PAIRS_PER_DOMINANT_NEURON {
+        return pairs;
+    }
+
+    // Group by dominant neuron (higher individual improvement determines dominance)
+    let mut groups: HashMap<String, Vec<EpistaticPairCandidate>> = HashMap::new();
+    for pair in pairs.drain(..) {
+        let dominant = if pair.individual_improvement_a >= pair.individual_improvement_b {
+            pair.source_a_uuid.clone()
+        } else {
+            pair.source_b_uuid.clone()
+        };
+        groups.entry(dominant).or_default().push(pair);
+    }
+
+    let mut result = Vec::new();
+    for (_dominant, mut group) in groups {
+        // Sort by combined improvement descending — keep the best
+        group.sort_by(|a, b| b.combined_improvement.total_cmp(&a.combined_improvement));
+        group.truncate(MAX_PAIRS_PER_DOMINANT_NEURON);
+        result.extend(group);
+    }
+
+    // Maintain overall ordering by combined improvement
+    result.sort_by(|a, b| b.combined_improvement.total_cmp(&a.combined_improvement));
+    result
+}
+
+/// Deduplicate synergistic candidates that share a common dominant neuron (Issue #509).
+///
+/// For synergistic candidates, the primary source is the dominant neuron (it was
+/// chosen as the best single-source candidate). Groups by primary source and
+/// keeps at most [`MAX_PAIRS_PER_DOMINANT_NEURON`] per group.
+///
+/// # Arguments
+/// * `candidates` - Synergistic candidates to deduplicate.
+///
+/// # Returns
+/// A deduplicated list of candidates, capped per primary source group.
+pub fn deduplicate_synergistic_by_dominant_neuron(
+    mut candidates: Vec<SynergisticCandidate>,
+) -> Vec<SynergisticCandidate> {
+    if candidates.len() <= MAX_PAIRS_PER_DOMINANT_NEURON {
+        return candidates;
+    }
+
+    let mut groups: HashMap<String, Vec<SynergisticCandidate>> = HashMap::new();
+    for candidate in candidates.drain(..) {
+        groups
+            .entry(candidate.primary_source_uuid.clone())
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut result = Vec::new();
+    for (_primary, mut group) in groups {
+        group.sort_by(|a, b| b.combined_improvement.total_cmp(&a.combined_improvement));
+        group.truncate(MAX_PAIRS_PER_DOMINANT_NEURON);
+        result.extend(group);
+    }
+
+    result.sort_by(|a, b| b.combined_improvement.total_cmp(&a.combined_improvement));
+    result
 }
 
 #[cfg(test)]

--- a/src/analysis/synapse/target_analysis.rs
+++ b/src/analysis/synapse/target_analysis.rs
@@ -14,7 +14,8 @@ use crate::analysis::activation::{get_target_simulation_fn, is_saturating_target
 use crate::analysis::confidence::compute_confidence_metrics;
 use crate::analysis::diagnostics::{TargetDiagnostics, TargetMap, ThresholdContext};
 use crate::analysis::epistatic::{
-    SourceContribution, build_source_contribution, detect_epistatic_pairs,
+    SourceContribution, build_source_contribution, deduplicate_by_dominant_neuron,
+    deduplicate_synergistic_by_dominant_neuron, detect_epistatic_pairs,
     detect_synergistic_candidates, epistatic_pairs_to_coordinated_candidates,
     filter_interfering_epistatic_pairs, filter_interfering_synergistic_candidates,
     synergistic_to_coordinated_candidates,
@@ -849,16 +850,19 @@ fn process_helpful_batch(
             let filtered_pairs =
                 filter_interfering_epistatic_pairs(epistatic_pairs, &source_contributions);
 
-            if !filtered_pairs.is_empty() {
+            // Issue #509: Deduplicate pairs sharing a dominant neuron
+            let deduped_pairs = deduplicate_by_dominant_neuron(filtered_pairs);
+
+            if !deduped_pairs.is_empty() {
                 let epistatic_candidates =
-                    epistatic_pairs_to_coordinated_candidates(&filtered_pairs);
+                    epistatic_pairs_to_coordinated_candidates(&deduped_pairs);
                 if !epistatic_candidates.is_empty() {
                     results.coordinated.extend(epistatic_candidates);
 
                     if verbose_enabled() {
                         eprintln!(
                             "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} epistatic pair(s)",
-                            filtered_pairs.len()
+                            deduped_pairs.len()
                         );
                     }
                 }
@@ -875,16 +879,20 @@ fn process_helpful_batch(
                 &source_contributions,
             );
 
-            if !filtered_synergistic.is_empty() {
+            // Issue #509: Deduplicate candidates sharing a dominant (primary) neuron
+            let deduped_synergistic =
+                deduplicate_synergistic_by_dominant_neuron(filtered_synergistic);
+
+            if !deduped_synergistic.is_empty() {
                 let synergistic_coordinated =
-                    synergistic_to_coordinated_candidates(&filtered_synergistic);
+                    synergistic_to_coordinated_candidates(&deduped_synergistic);
                 if !synergistic_coordinated.is_empty() {
                     results.coordinated.extend(synergistic_coordinated);
 
                     if verbose_enabled() {
                         eprintln!(
                             "[NEAT-AI-Discovery][verbose] Target {target_uuid}: found {} synergistic candidate(s)",
-                            filtered_synergistic.len()
+                            deduped_synergistic.len()
                         );
                     }
                 }

--- a/tests/issue_509_deduplicate_dominant_neuron.rs
+++ b/tests/issue_509_deduplicate_dominant_neuron.rs
@@ -1,0 +1,273 @@
+//! Issue #509: Coordinated-structural: deduplicate candidates sharing a dominant neuron.
+//!
+//! When generating epistatic/synergistic coordinated-structural candidates, many pairs
+//! can share the same "dominant" neuron (the source with the larger individual improvement).
+//! This wastes candidate budget with essentially the same experiment repeated with
+//! trivially different partners.
+//!
+//! ## Scenario from the issue
+//!
+//! In GRQ-sampler commit a1340f8d (creature b2ff6e45), 10 out of 20 candidates were
+//! coordinated-structural pairs all sharing the same dominant neuron (e8480883 → output-0).
+//! All 10 failed with nearly identical results (−0.042 ± 0.001). 50% of the discovery
+//! budget was consumed by essentially the same experiment repeated 10 times.
+//!
+//! ## What this fixes
+//!
+//! After detecting epistatic pairs, group by dominant neuron and emit at most
+//! `MAX_PAIRS_PER_DOMINANT_NEURON` diverse pairs per group (varying the partner,
+//! complementarity, etc.) rather than all N×M combinations.
+
+use neat_ai_discovery::analysis::epistatic::{
+    EpistaticPairCandidate, SynergisticCandidate, deduplicate_by_dominant_neuron,
+    deduplicate_synergistic_by_dominant_neuron,
+};
+
+/// Helper: create an epistatic pair candidate with specified parameters.
+fn make_pair(
+    source_a: &str,
+    source_b: &str,
+    improvement_a: f32,
+    improvement_b: f32,
+    combined: f32,
+    complementarity: f32,
+) -> EpistaticPairCandidate {
+    EpistaticPairCandidate {
+        source_a_uuid: source_a.to_string(),
+        source_b_uuid: source_b.to_string(),
+        target_uuid: "output-0".to_string(),
+        weight_a: 0.1,
+        weight_b: 0.1,
+        combined_improvement: combined,
+        individual_improvement_a: improvement_a,
+        individual_improvement_b: improvement_b,
+        complementarity_score: complementarity,
+        reason: "Test pair".to_string(),
+    }
+}
+
+/// Helper: create a synergistic candidate with specified parameters.
+fn make_synergistic(
+    primary: &str,
+    complement: &str,
+    primary_improvement: f32,
+    complement_improvement: f32,
+    combined: f32,
+) -> SynergisticCandidate {
+    SynergisticCandidate {
+        primary_source_uuid: primary.to_string(),
+        complement_source_uuid: complement.to_string(),
+        target_uuid: "output-0".to_string(),
+        primary_weight: 0.1,
+        complement_weight: 0.1,
+        combined_improvement: combined,
+        primary_improvement,
+        complement_improvement,
+        residual_reduction: 0.3,
+        synergy_ratio: 1.5,
+        reason: "Test synergistic".to_string(),
+    }
+}
+
+/// Test: Many pairs sharing one dominant neuron are reduced to at most 3.
+///
+/// Reproduces the core issue scenario: 10 pairs all share the same dominant
+/// neuron. After deduplication, at most 3 should remain.
+#[test]
+fn epistatic_pairs_with_shared_dominant_neuron_are_capped() {
+    // Create 10 pairs where "dominant" always has the higher individual improvement
+    let pairs: Vec<EpistaticPairCandidate> = (0..10)
+        .map(|i| {
+            make_pair(
+                "dominant",
+                &format!("partner-{i}"),
+                0.05,                    // dominant has higher improvement
+                0.01 + i as f32 * 0.001, // partners vary slightly
+                0.08 + i as f32 * 0.001, // combined varies slightly
+                0.85 + i as f32 * 0.005, // complementarity varies
+            )
+        })
+        .collect();
+
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+
+    assert!(
+        deduplicated.len() <= 3,
+        "Expected at most 3 pairs for the same dominant neuron, got {}",
+        deduplicated.len()
+    );
+    assert!(
+        !deduplicated.is_empty(),
+        "Deduplication should keep at least one pair"
+    );
+}
+
+/// Test: Pairs with different dominant neurons are not affected.
+///
+/// When each pair has a distinct dominant neuron, no deduplication should occur.
+#[test]
+fn epistatic_pairs_with_distinct_dominant_neurons_unchanged() {
+    let pairs = vec![
+        make_pair("dominant-a", "partner-a", 0.05, 0.01, 0.08, 0.9),
+        make_pair("dominant-b", "partner-b", 0.05, 0.01, 0.08, 0.9),
+        make_pair("dominant-c", "partner-c", 0.05, 0.01, 0.08, 0.9),
+    ];
+
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+
+    assert_eq!(
+        deduplicated.len(),
+        3,
+        "All pairs have distinct dominant neurons — none should be removed"
+    );
+}
+
+/// Test: Deduplication selects the best pairs by combined improvement.
+///
+/// The kept pairs should be the ones with the highest combined improvement
+/// from each dominant group.
+#[test]
+fn epistatic_deduplication_keeps_best_combined_improvement() {
+    let pairs = vec![
+        make_pair("dominant", "partner-worst", 0.05, 0.01, 0.06, 0.85),
+        make_pair("dominant", "partner-middle", 0.05, 0.01, 0.08, 0.85),
+        make_pair("dominant", "partner-best", 0.05, 0.01, 0.10, 0.85),
+        make_pair("dominant", "partner-low", 0.05, 0.01, 0.04, 0.85),
+        make_pair("dominant", "partner-medium", 0.05, 0.01, 0.07, 0.85),
+    ];
+
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+
+    assert!(
+        deduplicated.len() <= 3,
+        "Expected at most 3, got {}",
+        deduplicated.len()
+    );
+
+    // The best combined improvement (0.10) should be present
+    assert!(
+        deduplicated
+            .iter()
+            .any(|p| (p.combined_improvement - 0.10).abs() < 0.001),
+        "Best pair (combined 0.10) should be kept"
+    );
+}
+
+/// Test: Empty input returns empty output.
+#[test]
+fn epistatic_deduplication_empty_input() {
+    let deduplicated = deduplicate_by_dominant_neuron(Vec::new());
+    assert!(deduplicated.is_empty());
+}
+
+/// Test: Single pair passes through unchanged.
+#[test]
+fn epistatic_deduplication_single_pair() {
+    let pairs = vec![make_pair("a", "b", 0.05, 0.01, 0.08, 0.9)];
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+    assert_eq!(deduplicated.len(), 1);
+}
+
+/// Test: Mixed groups — some dominant neurons are shared, some are unique.
+#[test]
+fn epistatic_deduplication_mixed_groups() {
+    let pairs = vec![
+        // Group 1: "dominant-x" has 5 pairs — should be capped to 3
+        make_pair("dominant-x", "partner-0", 0.05, 0.01, 0.08, 0.85),
+        make_pair("dominant-x", "partner-1", 0.05, 0.01, 0.09, 0.85),
+        make_pair("dominant-x", "partner-2", 0.05, 0.01, 0.07, 0.85),
+        make_pair("dominant-x", "partner-3", 0.05, 0.01, 0.10, 0.85),
+        make_pair("dominant-x", "partner-4", 0.05, 0.01, 0.06, 0.85),
+        // Group 2: "dominant-y" has 2 pairs — both should survive
+        make_pair("dominant-y", "partner-5", 0.04, 0.01, 0.07, 0.85),
+        make_pair("dominant-y", "partner-6", 0.04, 0.01, 0.06, 0.85),
+        // Group 3: "dominant-z" has 1 pair — passes through
+        make_pair("dominant-z", "partner-7", 0.03, 0.01, 0.05, 0.85),
+    ];
+
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+
+    // Group 1: capped to 3, Group 2: keeps 2, Group 3: keeps 1 → total ≤ 6
+    assert!(
+        deduplicated.len() <= 6,
+        "Expected at most 6, got {}",
+        deduplicated.len()
+    );
+    // Group 3 should still have its unique pair
+    assert!(
+        deduplicated
+            .iter()
+            .any(|p| p.source_a_uuid == "dominant-z" || p.source_b_uuid == "dominant-z"),
+        "Unique group (dominant-z) should survive"
+    );
+}
+
+/// Test: Synergistic candidates with shared dominant (primary) are capped.
+#[test]
+fn synergistic_with_shared_primary_are_capped() {
+    let candidates: Vec<SynergisticCandidate> = (0..8)
+        .map(|i| {
+            make_synergistic(
+                "primary-dominant",
+                &format!("complement-{i}"),
+                0.05,
+                0.01 + i as f32 * 0.001,
+                0.08 + i as f32 * 0.001,
+            )
+        })
+        .collect();
+
+    let deduplicated = deduplicate_synergistic_by_dominant_neuron(candidates);
+
+    assert!(
+        deduplicated.len() <= 3,
+        "Expected at most 3 synergistic candidates for same primary, got {}",
+        deduplicated.len()
+    );
+    assert!(
+        !deduplicated.is_empty(),
+        "Should keep at least one synergistic candidate"
+    );
+}
+
+/// Test: Synergistic candidates with distinct primaries are not affected.
+#[test]
+fn synergistic_with_distinct_primaries_unchanged() {
+    let candidates = vec![
+        make_synergistic("primary-a", "complement-a", 0.05, 0.01, 0.08),
+        make_synergistic("primary-b", "complement-b", 0.05, 0.01, 0.08),
+        make_synergistic("primary-c", "complement-c", 0.05, 0.01, 0.08),
+    ];
+
+    let deduplicated = deduplicate_synergistic_by_dominant_neuron(candidates);
+
+    assert_eq!(
+        deduplicated.len(),
+        3,
+        "All synergistic candidates have distinct primaries — none should be removed"
+    );
+}
+
+/// Test: Dominant neuron is determined by higher individual improvement.
+///
+/// When source_a has lower improvement than source_b, source_b is the dominant.
+/// Pairs should be grouped by actual dominant neuron, not always by source_a.
+#[test]
+fn epistatic_dominant_is_higher_individual_improvement() {
+    // Here "partner-x" is actually the dominant because it has higher improvement
+    let pairs = vec![
+        make_pair("weak", "partner-x", 0.01, 0.06, 0.08, 0.85),
+        make_pair("also-weak", "partner-x", 0.01, 0.06, 0.09, 0.85),
+        make_pair("another-weak", "partner-x", 0.01, 0.06, 0.07, 0.85),
+        make_pair("yet-another", "partner-x", 0.01, 0.06, 0.10, 0.85),
+        make_pair("one-more", "partner-x", 0.01, 0.06, 0.06, 0.85),
+    ];
+
+    let deduplicated = deduplicate_by_dominant_neuron(pairs);
+
+    assert!(
+        deduplicated.len() <= 3,
+        "partner-x is the dominant neuron in all pairs — should be capped to 3, got {}",
+        deduplicated.len()
+    );
+}


### PR DESCRIPTION
## Summary

Deduplicate coordinated-structural candidates that share a common dominant neuron. Closes #509.

In GRQ-sampler commit `a1340f8d` (creature `b2ff6e45`), 10 out of 20 candidates (50% of the budget) were coordinated-structural pairs all sharing the same dominant neuron (`e8480883`). All 10 failed with nearly identical results. This change caps pairs per dominant neuron to 3, freeing candidate slots for alternative sources.

### Changes

- **`src/analysis/epistatic.rs`**: Added `deduplicate_by_dominant_neuron()` and `deduplicate_synergistic_by_dominant_neuron()` functions. These group pairs by the neuron with the larger individual improvement and keep at most 3 diverse pairs per group (sorted by combined improvement).
- **`src/analysis/synapse/target_analysis.rs`**: Applied deduplication in the pipeline after interference filtering and before conversion to coordinated candidates, for both epistatic and synergistic paths.

### Expected impact

- For the issue scenario: reduces coordinated-structural from 10 → 3 candidates, freeing 7 slots.
- No loss of coverage since all 10 were redundant (same dominant neuron, same outcome).
- Pairs with distinct dominant neurons are completely unaffected.

## Evidence

This is a backend logic change with no UI component. Verified by 9 new integration tests and all 474 existing unit tests passing.

## Test Plan

- Added `tests/issue_509_deduplicate_dominant_neuron.rs` with 9 tests:
  - `epistatic_pairs_with_shared_dominant_neuron_are_capped` — 10 pairs sharing one dominant capped to 3
  - `epistatic_pairs_with_distinct_dominant_neurons_unchanged` — distinct groups unaffected
  - `epistatic_deduplication_keeps_best_combined_improvement` — best pairs retained
  - `epistatic_deduplication_empty_input` — empty input returns empty
  - `epistatic_deduplication_single_pair` — single pair passes through
  - `epistatic_deduplication_mixed_groups` — mixed shared/unique groups handled correctly
  - `synergistic_with_shared_primary_are_capped` — synergistic candidates capped per primary
  - `synergistic_with_distinct_primaries_unchanged` — distinct primaries unaffected
  - `epistatic_dominant_is_higher_individual_improvement` — dominant determined by higher individual improvement, not position
- All existing tests pass (`./quality.sh` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)