### PR TITLE
Fix: Apply conservative weight variants to coordinated-structural candidates (#510)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-510.md
+++ b/docs/pr-summary-510.md
@@ -1,0 +1,42 @@
+## Summary
+
+Apply conservative weight variants to coordinated-structural candidates, matching the
+strategy already proven successful for add-neuron and synapse candidates. Closes #510.
+
+Production evidence (creature b2ff6e45, GRQ-sampler commit a1340f8d) showed that all 10
+coordinated-structural candidates used a fixed weight of 0.1 for AddSynapse operations
+and all failed. Meanwhile, conservative add-neuron variants with ~0.008 outgoing weight
+succeeded. This change generates three additional weight variants for each coordinated-
+structural candidate:
+
+| Variant | Scale | Target weight (from 0.1) | Expected gain multiplier |
+|---------|-------|--------------------------|--------------------------|
+| Conservative | 0.2x | ~0.02 | 0.5x |
+| Gentle Nudge | 0.1x | ~0.01 | 0.75x |
+| Micro-Nudge | 0.05x | ~0.005 | 0.25x |
+
+Each AddSynapse operation in the coordinated group is scaled independently. Non-AddSynapse
+operations (RemoveSynapse, RemoveNeuron, etc.) are preserved unchanged. Candidates without
+any AddSynapse operations are returned as-is with no variants.
+
+## Evidence
+
+This is a backend logic change with no UI component. Evidence is provided via comprehensive
+tests that verify the weight scaling, sign preservation, comment handling, limit enforcement,
+and correct handling of mixed operation types.
+
+## Test Plan
+
+- Added `tests/issue_510_coordinated_structural_weight_variants.rs` with 11 tests:
+  - `coordinated_generates_four_variants` — original + 3 variants
+  - `coordinated_conservative_variant_scales_add_synapse_weights` — 0.2x scaling
+  - `coordinated_gentle_nudge_variant_scales_weights` — 0.1x scaling
+  - `coordinated_micro_nudge_variant_scales_weights` — 0.05x scaling
+  - `coordinated_variant_scales_expected_gain` — gain multipliers for each variant
+  - `coordinated_variant_preserves_non_add_synapse_operations` — mixed ops preserved
+  - `coordinated_variant_preserves_negative_weight_sign` — sign integrity
+  - `coordinated_variant_respects_max_candidates_limit` — budget enforcement
+  - `coordinated_variant_skips_candidates_without_add_synapse` — no spurious variants
+  - `coordinated_variant_original_comment_lists_included_variants` — comment annotation
+  - `coordinated_variant_multiple_candidates_each_get_variants` — per-candidate variants
+- All existing tests continue to pass (474 unit tests + 97 integration test files)

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -234,6 +234,14 @@ pub(crate) fn apply_post_processing(
         input.max_candidates,
     );
 
+    // Issue #510: Generate conservative weight variants for coordinated-structural candidates.
+    // AddSynapse weights are scaled to 0.2× (conservative), 0.1× (gentle nudge), 0.05× (micro-nudge).
+    *coordinated_structural_results =
+        crate::analysis::utils::pair_coordinated_structural_with_weight_variants(
+            std::mem::take(coordinated_structural_results),
+            input.max_candidates,
+        );
+
     // Deadline coverage: diversify within the top-K for exploration diversity
     if input.analysis_deadline_ms.is_some() {
         use crate::analysis::constants::DIVERSIFY_TOP_K;

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -62,6 +62,8 @@ pub fn gpu_timing_enabled() -> bool {
 
 use crate::CandidateNeuronJson;
 use crate::CandidateSynapseJson;
+use crate::CoordinatedStructuralCandidateJson;
+use crate::CoordinatedStructuralOpJson;
 
 // ============================================================================
 // Sensible-range filtering (production guard rails)
@@ -586,6 +588,194 @@ pub fn pair_synapse_candidates_with_weight_variants(
                     format!("Original (paired with {} variants)", parts.join(" + "))
                 });
             }
+        }
+    }
+
+    output
+}
+
+// ============================================================================
+// Coordinated-structural weight variant generation (Issue #510)
+// ============================================================================
+
+/// Weight scaling factors for coordinated-structural candidate variants.
+///
+/// Coordinated-structural candidates contain AddSynapse operations whose weights
+/// are derived from `source.optimal_weight` (often 0.1). Production evidence
+/// (creature b2ff6e45, GRQ-sampler commit a1340f8d) showed that this magnitude
+/// consistently fails — the same pattern seen with add-neuron extreme candidates.
+///
+/// We reuse the same conservative scaling strategy as synapse candidates (#513),
+/// generating scaled-down variants so the TypeScript controller can test multiple
+/// weight magnitudes for the same coordinated pair.
+const COORDINATED_CONSERVATIVE_WEIGHT_SCALE: f32 = 0.2;
+const COORDINATED_CONSERVATIVE_EXPECTED_MULTIPLIER: f32 = 0.5;
+
+const COORDINATED_GENTLE_NUDGE_WEIGHT_SCALE: f32 = 0.1;
+const COORDINATED_GENTLE_NUDGE_EXPECTED_MULTIPLIER: f32 = 0.75;
+
+const COORDINATED_MICRO_NUDGE_WEIGHT_SCALE: f32 = 0.05;
+const COORDINATED_MICRO_NUDGE_EXPECTED_MULTIPLIER: f32 = 0.25;
+
+/// Minimum absolute weight for a coordinated-structural AddSynapse variant.
+/// Below this, the variant is indistinguishable from zero and would be wasted.
+const COORDINATED_VARIANT_MIN_WEIGHT: f32 = 1e-6;
+
+/// Scale AddSynapse weights in a coordinated-structural candidate by the given factor.
+///
+/// Non-AddSynapse operations (RemoveSynapse, RemoveNeuron, etc.) are preserved
+/// unchanged. Returns `None` if the candidate has no AddSynapse operations or
+/// the scaled weights are too close to the originals to be meaningful.
+fn scale_coordinated_add_synapse_weights(
+    original: &CoordinatedStructuralCandidateJson,
+    scale: f32,
+    expected_multiplier: f32,
+    comment: &str,
+) -> Option<CoordinatedStructuralCandidateJson> {
+    let mut has_add_synapse = false;
+    let mut differs = false;
+
+    let scaled_ops: Vec<CoordinatedStructuralOpJson> = original
+        .operations
+        .iter()
+        .map(|op| match op {
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                weight,
+            } => {
+                has_add_synapse = true;
+                let scaled_weight = weight * scale;
+                if (scaled_weight - weight).abs() > COORDINATED_VARIANT_MIN_WEIGHT {
+                    differs = true;
+                }
+                CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: from_neuron_uuid.clone(),
+                    to_neuron_uuid: to_neuron_uuid.clone(),
+                    weight: scaled_weight,
+                }
+            }
+            other => other.clone(),
+        })
+        .collect();
+
+    if !has_add_synapse || !differs {
+        return None;
+    }
+
+    // Check all AddSynapse weights are above minimum threshold
+    let all_above_min = scaled_ops.iter().all(|op| match op {
+        CoordinatedStructuralOpJson::AddSynapse { weight, .. } => {
+            weight.abs() > COORDINATED_VARIANT_MIN_WEIGHT
+        }
+        _ => true,
+    });
+
+    if !all_above_min {
+        return None;
+    }
+
+    Some(CoordinatedStructuralCandidateJson {
+        operations: scaled_ops,
+        expected_creature_score_gain: original.expected_creature_score_gain * expected_multiplier,
+        comment: Some(comment.to_string()),
+    })
+}
+
+/// Pair each coordinated-structural candidate with weight variants (Issue #510).
+///
+/// For every coordinated-structural candidate that contains AddSynapse operations,
+/// generates up to three additional variants with progressively smaller weights.
+/// The scaling factors match the conservative strategy proven successful for
+/// add-neuron candidates: 0.2× (conservative), 0.1× (gentle nudge), 0.05× (micro-nudge).
+///
+/// Non-AddSynapse operations (RemoveSynapse, RemoveNeuron, etc.) are preserved
+/// unchanged in all variants. Candidates without any AddSynapse operations are
+/// returned as-is with no variants.
+///
+/// Input is expected to be pre-sorted by expected_creature_score_gain (highest first).
+#[doc(hidden)]
+pub fn pair_coordinated_structural_with_weight_variants(
+    sorted_candidates: Vec<CoordinatedStructuralCandidateJson>,
+    max_candidates: Option<usize>,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let limit = max_candidates.unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let mut output = Vec::with_capacity(sorted_candidates.len().min(limit));
+
+    for candidate in sorted_candidates.into_iter() {
+        if output.len() >= limit {
+            break;
+        }
+
+        let original_index = output.len();
+        output.push(candidate.clone());
+
+        let mut added_conservative = false;
+        let mut added_gentle_nudge = false;
+        let mut added_micro_nudge = false;
+
+        // Conservative variant (0.2× weight — targeting ~0.02 for 0.1 originals)
+        if output.len() < limit
+            && let Some(conservative) = scale_coordinated_add_synapse_weights(
+                &candidate,
+                COORDINATED_CONSERVATIVE_WEIGHT_SCALE,
+                COORDINATED_CONSERVATIVE_EXPECTED_MULTIPLIER,
+                "Conservative variant (AddSynapse weights scaled to 0.2×)",
+            )
+        {
+            output.push(conservative);
+            added_conservative = true;
+        }
+
+        // Gentle Nudge variant (0.1× weight — targeting ~0.01 for 0.1 originals)
+        if output.len() < limit
+            && let Some(gentle) = scale_coordinated_add_synapse_weights(
+                &candidate,
+                COORDINATED_GENTLE_NUDGE_WEIGHT_SCALE,
+                COORDINATED_GENTLE_NUDGE_EXPECTED_MULTIPLIER,
+                "Gentle Nudge variant (AddSynapse weights scaled to 0.1×)",
+            )
+        {
+            output.push(gentle);
+            added_gentle_nudge = true;
+        }
+
+        // Micro-Nudge variant (0.05× weight — targeting ~0.005 for 0.1 originals)
+        if output.len() < limit
+            && let Some(micro) = scale_coordinated_add_synapse_weights(
+                &candidate,
+                COORDINATED_MICRO_NUDGE_WEIGHT_SCALE,
+                COORDINATED_MICRO_NUDGE_EXPECTED_MULTIPLIER,
+                "Micro-Nudge variant (AddSynapse weights scaled to 0.05×)",
+            )
+        {
+            output.push(micro);
+            added_micro_nudge = true;
+        }
+
+        // Append variant info to the original's comment (preserve existing context).
+        let mut parts = Vec::new();
+        if added_conservative {
+            parts.push("Conservative");
+        }
+        if added_gentle_nudge {
+            parts.push("Gentle Nudge");
+        }
+        if added_micro_nudge {
+            parts.push("Micro-Nudge");
+        }
+        if !parts.is_empty() {
+            let variant_suffix = if parts.len() == 1 {
+                format!(" (paired with {} variant only)", parts[0])
+            } else {
+                format!(" (paired with {} variants)", parts.join(" + "))
+            };
+            let existing = output[original_index].comment.take().unwrap_or_default();
+            output[original_index].comment = Some(format!("{existing}{variant_suffix}"));
         }
     }
 

--- a/tests/issue_510_coordinated_structural_weight_variants.rs
+++ b/tests/issue_510_coordinated_structural_weight_variants.rs
@@ -1,0 +1,380 @@
+//! Tests for coordinated-structural conservative weight variants (Issue #510).
+//!
+//! Coordinated-structural candidates (epistatic/synergistic pairs) previously used a
+//! fixed weight of 0.1 for addSynapse operations. Production evidence showed this
+//! magnitude consistently fails, while conservative variants (~0.02) succeed.
+//!
+//! This test file verifies that the weight variant generation for coordinated-structural
+//! candidates produces conservative, gentle-nudge, and micro-nudge variants with
+//! progressively smaller weights — the same strategy used for synapse candidates (#513).
+
+use neat_ai_discovery::CoordinatedStructuralCandidateJson;
+use neat_ai_discovery::CoordinatedStructuralOpJson;
+use neat_ai_discovery::analysis::utils::pair_coordinated_structural_with_weight_variants;
+
+/// Helper to build a coordinated-structural candidate with two AddSynapse operations.
+fn make_coordinated_candidate(
+    source_a: &str,
+    source_b: &str,
+    target: &str,
+    weight_a: f32,
+    weight_b: f32,
+    expected_gain: f32,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: source_a.to_string(),
+                to_neuron_uuid: target.to_string(),
+                weight: weight_a,
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: source_b.to_string(),
+                to_neuron_uuid: target.to_string(),
+                weight: weight_b,
+            },
+        ],
+        expected_creature_score_gain: expected_gain,
+        comment: Some("Epistatic pair: test".to_string()),
+    }
+}
+
+// =========================================================================
+// Core variant generation tests
+// =========================================================================
+
+#[test]
+fn coordinated_generates_four_variants() {
+    // A coordinated candidate with weight 0.1 should produce 4 variants:
+    // original + conservative + gentle-nudge + micro-nudge.
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    assert_eq!(
+        paired.len(),
+        4,
+        "expected original + 3 variants, got {}",
+        paired.len()
+    );
+}
+
+#[test]
+fn coordinated_conservative_variant_scales_add_synapse_weights() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    let conservative = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Conservative")
+        })
+        .expect("expected a Conservative variant");
+
+    // Conservative scales AddSynapse weights by CONSERVATIVE_OUTGOING_SCALE (0.2)
+    let weights: Vec<f32> = conservative
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            CoordinatedStructuralOpJson::AddSynapse { weight, .. } => Some(*weight),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(weights.len(), 2, "should have 2 AddSynapse operations");
+    assert!(
+        (weights[0] - 0.1 * 0.2).abs() < 1e-6,
+        "conservative weight_a should be 0.1 * 0.2 = 0.02, got {}",
+        weights[0]
+    );
+    assert!(
+        (weights[1] - 0.08 * 0.2).abs() < 1e-6,
+        "conservative weight_b should be 0.08 * 0.2 = 0.016, got {}",
+        weights[1]
+    );
+}
+
+#[test]
+fn coordinated_gentle_nudge_variant_scales_weights() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    let gentle = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Gentle Nudge")
+        })
+        .expect("expected a Gentle Nudge variant");
+
+    let weights: Vec<f32> = gentle
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            CoordinatedStructuralOpJson::AddSynapse { weight, .. } => Some(*weight),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(weights.len(), 2);
+    assert!(
+        (weights[0] - 0.1 * 0.1).abs() < 1e-6,
+        "gentle nudge weight_a should be 0.1 * 0.1 = 0.01, got {}",
+        weights[0]
+    );
+    assert!(
+        (weights[1] - 0.08 * 0.1).abs() < 1e-6,
+        "gentle nudge weight_b should be 0.08 * 0.1 = 0.008, got {}",
+        weights[1]
+    );
+}
+
+#[test]
+fn coordinated_micro_nudge_variant_scales_weights() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    let micro = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .expect("expected a Micro-Nudge variant");
+
+    let weights: Vec<f32> = micro
+        .operations
+        .iter()
+        .filter_map(|op| match op {
+            CoordinatedStructuralOpJson::AddSynapse { weight, .. } => Some(*weight),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(weights.len(), 2);
+    assert!(
+        (weights[0] - 0.1 * 0.05).abs() < 1e-6,
+        "micro-nudge weight_a should be 0.1 * 0.05 = 0.005, got {}",
+        weights[0]
+    );
+    assert!(
+        (weights[1] - 0.08 * 0.05).abs() < 1e-6,
+        "micro-nudge weight_b should be 0.08 * 0.05 = 0.004, got {}",
+        weights[1]
+    );
+}
+
+#[test]
+fn coordinated_variant_scales_expected_gain() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    // Original keeps full gain
+    assert!(
+        (paired[0].expected_creature_score_gain - 0.05).abs() < 1e-6,
+        "original should keep full gain"
+    );
+
+    let conservative = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Conservative")
+        })
+        .unwrap();
+    assert!(
+        (conservative.expected_creature_score_gain - 0.05 * 0.5).abs() < 1e-6,
+        "conservative gain should be 0.5x, got {}",
+        conservative.expected_creature_score_gain
+    );
+
+    let gentle = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Gentle Nudge")
+        })
+        .unwrap();
+    assert!(
+        (gentle.expected_creature_score_gain - 0.05 * 0.75).abs() < 1e-6,
+        "gentle nudge gain should be 0.75x, got {}",
+        gentle.expected_creature_score_gain
+    );
+
+    let micro = paired
+        .iter()
+        .find(|c| {
+            c.comment
+                .as_deref()
+                .unwrap_or_default()
+                .starts_with("Micro-Nudge")
+        })
+        .unwrap();
+    assert!(
+        (micro.expected_creature_score_gain - 0.05 * 0.25).abs() < 1e-6,
+        "micro-nudge gain should be 0.25x, got {}",
+        micro.expected_creature_score_gain
+    );
+}
+
+#[test]
+fn coordinated_variant_preserves_non_add_synapse_operations() {
+    // A coordinated candidate with mixed ops (RemoveSynapse + AddSynapse)
+    // should only scale AddSynapse weights, leaving other ops untouched.
+    let candidate = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "input-1".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+                weight: 0.1,
+            },
+        ],
+        expected_creature_score_gain: 0.05,
+        comment: Some("Noisy vs trusted".to_string()),
+    };
+
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    // Should still generate variants
+    assert!(
+        paired.len() >= 2,
+        "should generate at least original + conservative, got {}",
+        paired.len()
+    );
+
+    // Each variant should preserve the RemoveSynapse operation
+    for variant in &paired {
+        let has_remove = variant.operations.iter().any(|op| {
+            matches!(
+                op,
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid,
+                    ..
+                } if from_neuron_uuid == "input-0"
+            )
+        });
+        assert!(
+            has_remove,
+            "all variants must preserve RemoveSynapse operations"
+        );
+    }
+}
+
+#[test]
+fn coordinated_variant_preserves_negative_weight_sign() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", -0.06, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    for variant in &paired {
+        let weights: Vec<f32> = variant
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid,
+                    weight,
+                    ..
+                } if from_neuron_uuid == "input-0" => Some(*weight),
+                _ => None,
+            })
+            .collect();
+
+        for w in &weights {
+            assert!(
+                *w < 0.0 || w.abs() < 1e-6,
+                "weight sign for input-0 should remain negative, got {w}"
+            );
+        }
+    }
+}
+
+#[test]
+fn coordinated_variant_respects_max_candidates_limit() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], Some(2));
+
+    assert_eq!(
+        paired.len(),
+        2,
+        "should respect max_candidates limit of 2, got {}",
+        paired.len()
+    );
+}
+
+#[test]
+fn coordinated_variant_skips_candidates_without_add_synapse() {
+    // A candidate with only RemoveSynapse ops has no weights to scale.
+    let candidate = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "hidden-0".to_string(),
+            },
+        ],
+        expected_creature_score_gain: 0.05,
+        comment: None,
+    };
+
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    // No AddSynapse ops → no weight variants to generate, just the original
+    assert_eq!(
+        paired.len(),
+        1,
+        "candidate without AddSynapse ops should not generate variants, got {}",
+        paired.len()
+    );
+}
+
+#[test]
+fn coordinated_variant_original_comment_lists_included_variants() {
+    let candidate = make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05);
+    let paired = pair_coordinated_structural_with_weight_variants(vec![candidate], None);
+
+    // The original should preserve existing context and append variant info
+    let original_comment = paired[0].comment.as_deref().unwrap_or_default();
+    assert!(
+        original_comment.contains("Epistatic pair: test"),
+        "original comment should preserve existing context: {original_comment}"
+    );
+    assert!(
+        original_comment.contains("Conservative")
+            && original_comment.contains("Gentle Nudge")
+            && original_comment.contains("Micro-Nudge"),
+        "original comment should mention all variants: {original_comment}"
+    );
+}
+
+#[test]
+fn coordinated_variant_multiple_candidates_each_get_variants() {
+    let candidates = vec![
+        make_coordinated_candidate("input-0", "input-1", "output-0", 0.1, 0.08, 0.05),
+        make_coordinated_candidate("input-2", "input-3", "output-0", 0.06, 0.04, 0.03),
+    ];
+    let paired = pair_coordinated_structural_with_weight_variants(candidates, None);
+
+    // 2 candidates × 4 variants = 8
+    assert_eq!(
+        paired.len(),
+        8,
+        "expected 8 candidates (2 × 4 variants each), got {}",
+        paired.len()
+    );
+}


### PR DESCRIPTION
## Summary

Apply conservative weight variants to coordinated-structural candidates, matching the
strategy already proven successful for add-neuron and synapse candidates. Closes #510.

Production evidence (creature b2ff6e45, GRQ-sampler commit a1340f8d) showed that all 10
coordinated-structural candidates used a fixed weight of 0.1 for AddSynapse operations
and all failed. Meanwhile, conservative add-neuron variants with ~0.008 outgoing weight
succeeded. This change generates three additional weight variants for each coordinated-
structural candidate:

| Variant | Scale | Target weight (from 0.1) | Expected gain multiplier |
|---------|-------|--------------------------|--------------------------|
| Conservative | 0.2x | ~0.02 | 0.5x |
| Gentle Nudge | 0.1x | ~0.01 | 0.75x |
| Micro-Nudge | 0.05x | ~0.005 | 0.25x |

Each AddSynapse operation in the coordinated group is scaled independently. Non-AddSynapse
operations (RemoveSynapse, RemoveNeuron, etc.) are preserved unchanged. Existing comments
are preserved with variant info appended.

## Evidence

Backend logic change with no UI component. Evidence is provided via 11 comprehensive
tests that verify weight scaling, sign preservation, comment handling, limit enforcement,
and correct handling of mixed operation types.

## Test Plan

- Added `tests/issue_510_coordinated_structural_weight_variants.rs` with 11 tests:
  - `coordinated_generates_four_variants` — original + 3 variants
  - `coordinated_conservative_variant_scales_add_synapse_weights` — 0.2x scaling
  - `coordinated_gentle_nudge_variant_scales_weights` — 0.1x scaling
  - `coordinated_micro_nudge_variant_scales_weights` — 0.05x scaling
  - `coordinated_variant_scales_expected_gain` — gain multipliers for each variant
  - `coordinated_variant_preserves_non_add_synapse_operations` — mixed ops preserved
  - `coordinated_variant_preserves_negative_weight_sign` — sign integrity
  - `coordinated_variant_respects_max_candidates_limit` — budget enforcement
  - `coordinated_variant_skips_candidates_without_add_synapse` — no spurious variants
  - `coordinated_variant_original_comment_lists_included_variants` — comment annotation
  - `coordinated_variant_multiple_candidates_each_get_variants` — per-candidate variants
- All existing tests continue to pass (474 unit tests + 97 integration test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)