### PR TITLE
Incremental analysis: skip unchanged neurons between discovery runs (#490)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.9"
+version = "0.14.10"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.8"
+version = "0.14.9"
 edition = "2024"
 
 [lib]

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -176,6 +176,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         include_synapse_analysis: Some(true),
                         include_neuron_analysis: Some(false),
                         random_seed: Some(42),
+                        previous_neuron_fingerprints: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 })

--- a/docs/pr-summary-490.md
+++ b/docs/pr-summary-490.md
@@ -1,0 +1,45 @@
+## Summary
+
+Implement incremental analysis that skips unchanged neurons between discovery runs, avoiding redundant GPU computation. Closes #490.
+
+When a caller provides `previousNeuronFingerprints` from a prior run, the library computes structural fingerprints for each neuron (based on activation function, bias, incoming/outgoing synapse weights and sources) and only analyses neurons whose fingerprints have changed. Unchanged neurons are skipped entirely, including both the GPU synapse/neuron analysis and all discovery dispatch modules.
+
+### Key design decisions
+
+- **Fingerprint = topology hash**: The fingerprint captures the structural properties that determine analysis results — squash, bias, incoming synapses, and outgoing synapses. It does not include activation data from parquet, which is the data being analysed rather than the topology.
+- **O(n + s) computation**: Fingerprints are computed in a single pass over neurons and synapses, making the overhead negligible compared to GPU analysis.
+- **Conservative invalidation**: Any structural change (weight, bias, squash, added/removed synapse) invalidates the neuron's fingerprint. New neurons (no previous fingerprint) are always analysed. This ensures we never miss a change.
+- **No changes to the calling interface**: The `previousNeuronFingerprints` field is optional and defaults to `None`. Existing callers see no change in behaviour. The library returns `neuronFingerprints` in the response for callers to store and pass back.
+- **Early exit**: When all focus neurons are unchanged, the library skips parquet loading and GPU initialisation entirely.
+
+### New JSON fields
+
+**Input** (`AnalyzeParallelInput` / `AnalyzeAllInput`):
+- `previousNeuronFingerprints`: Optional map of `{uuid → fingerprint}` from the previous run.
+
+**Output** (`AnalyzeParallelOutput`):
+- `neuronFingerprints`: Current fingerprints for all neurons — store and pass back on the next run.
+- `fingerprintCacheHits`: Number of focus neurons skipped (unchanged).
+- `fingerprintCacheMisses`: Number of focus neurons analysed (changed or new).
+
+## Evidence
+
+This is a backend/CLI change with no web interface. Evidence is provided by the test suite:
+
+- 15 dedicated tests in `tests/issue_490_incremental_analysis.rs` covering all fingerprint scenarios
+- All 1657 existing tests pass with no modifications to business logic
+- `quality.sh` passes cleanly (fmt, clippy, check, test, release build)
+
+## Test Plan
+
+- `tests/issue_490_incremental_analysis.rs` — 15 tests covering:
+  - Fingerprint computation for all neurons
+  - Fingerprint changes when synapse weight, activation function, or bias changes
+  - Fingerprint changes when synapses are added or removed (incoming and outgoing)
+  - Fingerprint stability when topology is unchanged
+  - Filtering: unchanged neurons are skipped, changed neurons are included
+  - New neurons (no previous fingerprint) are always analysed
+  - Removed neurons correctly invalidate downstream fingerprints
+  - Cache hit/miss/total counts are reported accurately
+  - Empty previous fingerprints means all neurons are analysed (first run)
+  - JSON round-trip serialisation/deserialisation of fingerprints

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -691,6 +691,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Combined analysis should succeed");

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -24,6 +24,7 @@
 //! - `discovery_dispatch.rs` - Generic discovery module dispatch pattern (Issue #375)
 //! - `candidate_clustering.rs` - Candidate clustering to reduce redundant ablation tests (Issue #224)
 //! - `module_weights.rs` - Per-module success rate tracking for adaptive weighting (Issue #485)
+//! - `neuron_fingerprint.rs` - Neuron structural fingerprinting for incremental analysis (Issue #490)
 //! - `multi_hop.rs` - Multi-hop candidate analysis for deeper network improvements (Issue #230)
 //! - `early_termination.rs` - SPRT-based early termination for GPU evaluation (Issue #219)
 //! - `oscillating_neuron.rs` - Oscillating neuron detection for stabilisation candidates (Issue #358)
@@ -68,6 +69,7 @@ pub mod input_sensitivity;
 pub mod module_weights;
 pub mod multi_hop;
 pub mod neuron;
+pub mod neuron_fingerprint;
 pub mod noise_signal;
 pub mod observation_range;
 pub mod operating_point;
@@ -356,10 +358,61 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     let include_synapse = input.include_synapse_analysis.unwrap_or(true);
     let include_neuron = input.include_neuron_analysis.unwrap_or(true);
 
+    // Issue #490: Compute current fingerprints and filter unchanged neurons.
+    let current_fingerprints = neuron_fingerprint::compute_neuron_fingerprints(&input.creature);
+    let (effective_focus_neurons, fingerprint_cache_hits, fingerprint_cache_misses) = if let Some(
+        prev_fp,
+    ) =
+        &input.previous_neuron_fingerprints
+    {
+        let filter_result = neuron_fingerprint::filter_changed_neurons(
+            &input.focus_neurons,
+            &input.creature,
+            prev_fp,
+        );
+
+        if utils::verbose_enabled() {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] Incremental analysis (Issue #490): {}/{} focus neurons unchanged (skipped), {} to analyse",
+                filter_result.cache_hits,
+                filter_result.total_focus_neurons,
+                filter_result.cache_misses,
+            );
+        }
+
+        (
+            filter_result.changed,
+            filter_result.cache_hits,
+            filter_result.cache_misses,
+        )
+    } else {
+        let len = input.focus_neurons.len();
+        (input.focus_neurons.clone(), 0, len)
+    };
+
     if !include_synapse && !include_neuron {
         return Ok(AnalyzeAllResult {
             synapse: None,
             neuron: None,
+            neuron_fingerprints: Some(current_fingerprints),
+            fingerprint_cache_hits,
+            fingerprint_cache_misses,
+        });
+    }
+
+    // If all focus neurons were skipped by fingerprint filtering, return early.
+    if effective_focus_neurons.is_empty() && (include_synapse || include_neuron) {
+        if utils::verbose_enabled() {
+            eprintln!(
+                "[NEAT-AI-Discovery][verbose] All focus neurons unchanged — skipping GPU analysis",
+            );
+        }
+        return Ok(AnalyzeAllResult {
+            synapse: None,
+            neuron: None,
+            neuron_fingerprints: Some(current_fingerprints),
+            fingerprint_cache_hits,
+            fingerprint_cache_misses,
         });
     }
 
@@ -379,7 +432,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         Some(AnalyzeSynapsesInput {
             parquet_file: input.parquet_file.clone(),
             creature: input.creature.clone(),
-            focus_neurons: input.focus_neurons.clone(),
+            focus_neurons: effective_focus_neurons.clone(),
             max_candidates: input.max_synapse_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
             random_seed: input.random_seed,
@@ -392,7 +445,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         Some(AnalyzeNeuronsInput {
             parquet_file: input.parquet_file.clone(),
             creature: input.creature.clone(),
-            focus_neurons: input.focus_neurons.clone(),
+            focus_neurons: effective_focus_neurons.clone(),
             max_candidates: input.max_neuron_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
             random_seed: input.random_seed,
@@ -1492,6 +1545,9 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     Ok(AnalyzeAllResult {
         synapse: synapse_result,
         neuron: neuron_result,
+        neuron_fingerprints: Some(current_fingerprints),
+        fingerprint_cache_hits,
+        fingerprint_cache_misses,
     })
 }
 

--- a/src/analysis/neuron_fingerprint.rs
+++ b/src/analysis/neuron_fingerprint.rs
@@ -1,0 +1,170 @@
+//! Neuron fingerprinting for incremental analysis (Issue #490).
+//!
+//! Each neuron's "fingerprint" captures the structural properties that affect
+//! its analysis results: incoming/outgoing synapse weights and sources,
+//! activation function, and bias. When the fingerprint is unchanged between
+//! discovery runs, we can skip GPU analysis for that neuron.
+//!
+//! The fingerprint is cheap to compute — O(s) where s is the synapse count —
+//! and conservative: any structural change invalidates the cache entry.
+
+use crate::CreatureJson;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+/// Fingerprint capturing the structural state of a single neuron.
+///
+/// Two fingerprints are equal if and only if the neuron has the same
+/// activation function, bias, and identical incoming/outgoing synapses
+/// (same sources/targets and weights).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeuronFingerprint {
+    /// Hash of the neuron's structural properties.
+    hash: u64,
+}
+
+impl PartialEq for NeuronFingerprint {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+    }
+}
+
+impl Eq for NeuronFingerprint {}
+
+impl Hash for NeuronFingerprint {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
+    }
+}
+
+/// Result of filtering focus neurons by fingerprint comparison.
+pub struct FilterResult {
+    /// UUIDs of neurons that have changed and need re-analysis.
+    pub changed: Vec<String>,
+    /// UUIDs of neurons that were skipped (unchanged fingerprints).
+    pub skipped_uuids: Vec<String>,
+    /// Number of focus neurons with matching (unchanged) fingerprints.
+    pub cache_hits: usize,
+    /// Number of focus neurons with changed or missing fingerprints.
+    pub cache_misses: usize,
+    /// Total focus neurons evaluated.
+    pub total_focus_neurons: usize,
+}
+
+/// Compute fingerprints for all neurons in the creature.
+///
+/// The fingerprint for each neuron includes:
+/// - Activation function (squash)
+/// - Bias value
+/// - Incoming synapses: sorted list of (source_uuid, weight)
+/// - Outgoing synapses: sorted list of (target_uuid, weight)
+///
+/// This is O(n + s) where n is neuron count and s is synapse count.
+pub fn compute_neuron_fingerprints(creature: &CreatureJson) -> HashMap<String, NeuronFingerprint> {
+    // Pre-compute incoming and outgoing synapses per neuron.
+    let mut incoming: HashMap<&str, Vec<(&str, u32)>> = HashMap::new();
+    let mut outgoing: HashMap<&str, Vec<(&str, u32)>> = HashMap::new();
+
+    for syn in &creature.synapses {
+        incoming
+            .entry(syn.to_uuid.as_str())
+            .or_default()
+            .push((syn.from_uuid.as_str(), syn.weight.to_bits()));
+        outgoing
+            .entry(syn.from_uuid.as_str())
+            .or_default()
+            .push((syn.to_uuid.as_str(), syn.weight.to_bits()));
+    }
+
+    let mut fingerprints = HashMap::with_capacity(creature.neurons.len());
+
+    for neuron in &creature.neurons {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+
+        // Hash activation function
+        neuron.squash.hash(&mut hasher);
+
+        // Hash bias (as bits for exact comparison)
+        neuron.bias.to_bits().hash(&mut hasher);
+
+        // Hash incoming synapses in sorted order for determinism
+        let mut incoming_syns: Vec<(&str, u32)> = incoming
+            .get(neuron.uuid.as_str())
+            .cloned()
+            .unwrap_or_default();
+        incoming_syns.sort_by(|a, b| a.0.cmp(b.0).then(a.1.cmp(&b.1)));
+        incoming_syns.len().hash(&mut hasher);
+        for (source, weight_bits) in &incoming_syns {
+            source.hash(&mut hasher);
+            weight_bits.hash(&mut hasher);
+        }
+
+        // Hash outgoing synapses in sorted order for determinism
+        let mut outgoing_syns: Vec<(&str, u32)> = outgoing
+            .get(neuron.uuid.as_str())
+            .cloned()
+            .unwrap_or_default();
+        outgoing_syns.sort_by(|a, b| a.0.cmp(b.0).then(a.1.cmp(&b.1)));
+        outgoing_syns.len().hash(&mut hasher);
+        for (target, weight_bits) in &outgoing_syns {
+            target.hash(&mut hasher);
+            weight_bits.hash(&mut hasher);
+        }
+
+        fingerprints.insert(
+            neuron.uuid.clone(),
+            NeuronFingerprint {
+                hash: hasher.finish(),
+            },
+        );
+    }
+
+    fingerprints
+}
+
+/// Filter focus neurons to only those whose fingerprints have changed.
+///
+/// Compares current fingerprints against `previous_fingerprints` from the
+/// last discovery run. Neurons with no previous fingerprint (new neurons)
+/// are always included.
+///
+/// Returns a `FilterResult` with changed/skipped lists and hit/miss counts.
+pub fn filter_changed_neurons(
+    focus_neurons: &[String],
+    creature: &CreatureJson,
+    previous_fingerprints: &HashMap<String, NeuronFingerprint>,
+) -> FilterResult {
+    let current_fingerprints = compute_neuron_fingerprints(creature);
+
+    let mut changed = Vec::new();
+    let mut skipped_uuids = Vec::new();
+    let mut cache_hits = 0usize;
+    let mut cache_misses = 0usize;
+
+    for uuid in focus_neurons {
+        let current = current_fingerprints.get(uuid);
+        let previous = previous_fingerprints.get(uuid);
+
+        match (current, previous) {
+            (Some(cur), Some(prev)) if cur == prev => {
+                // Unchanged — skip this neuron
+                cache_hits += 1;
+                skipped_uuids.push(uuid.clone());
+            }
+            _ => {
+                // Changed, new, or removed — re-analyse
+                cache_misses += 1;
+                changed.push(uuid.clone());
+            }
+        }
+    }
+
+    FilterResult {
+        changed,
+        skipped_uuids,
+        cache_hits,
+        cache_misses,
+        total_focus_neurons: focus_neurons.len(),
+    }
+}

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -440,6 +440,15 @@ pub struct AnalyzeNeuronsResult {
 pub struct AnalyzeAllResult {
     pub synapse: Option<AnalyzeSynapsesResult>,
     pub neuron: Option<AnalyzeNeuronsResult>,
+    /// Current neuron fingerprints for incremental analysis (Issue #490).
+    ///
+    /// Callers should store these and pass them back on the next run.
+    pub neuron_fingerprints:
+        Option<std::collections::HashMap<String, super::neuron_fingerprint::NeuronFingerprint>>,
+    /// Number of focus neurons skipped due to unchanged fingerprints (Issue #490).
+    pub fingerprint_cache_hits: usize,
+    /// Number of focus neurons analysed (changed or new fingerprints) (Issue #490).
+    pub fingerprint_cache_misses: usize,
 }
 
 /// Reason why no synapse candidate was found for a target neuron

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,6 +467,13 @@ pub struct AnalyzeParallelInput {
     /// will explore different candidates over time.
     #[serde(default)]
     pub random_seed: Option<u64>,
+    /// Previous neuron fingerprints from the last discovery run (Issue #490).
+    ///
+    /// When provided, neurons whose structural fingerprint is unchanged
+    /// are skipped, avoiding redundant GPU computation.
+    #[serde(default)]
+    pub previous_neuron_fingerprints:
+        Option<std::collections::HashMap<String, analysis::neuron_fingerprint::NeuronFingerprint>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -505,6 +512,19 @@ pub struct AnalyzeParallelOutput {
     /// Neuron analysis metadata for observability (v0.2.17+).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub neuron_metadata: Option<NeuronAnalysisMetadataJson>,
+    /// Current neuron fingerprints for incremental analysis (Issue #490).
+    ///
+    /// Callers should store these and pass them back as `previousNeuronFingerprints`
+    /// on the next discovery run to enable incremental analysis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub neuron_fingerprints:
+        Option<std::collections::HashMap<String, analysis::neuron_fingerprint::NeuronFingerprint>>,
+    /// Number of focus neurons skipped due to unchanged fingerprints (Issue #490).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fingerprint_cache_hits: Option<usize>,
+    /// Number of focus neurons analysed (changed or new fingerprints) (Issue #490).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fingerprint_cache_misses: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -708,6 +728,13 @@ pub struct AnalyzeAllInput {
     /// If not provided, the library uses non-deterministic randomness.
     #[serde(default)]
     pub random_seed: Option<u64>,
+    /// Previous neuron fingerprints from the last discovery run (Issue #490).
+    ///
+    /// When provided, neurons whose structural fingerprint is unchanged
+    /// are skipped, avoiding redundant GPU computation.
+    #[serde(default)]
+    pub previous_neuron_fingerprints:
+        Option<std::collections::HashMap<String, analysis::neuron_fingerprint::NeuronFingerprint>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1245,6 +1272,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
                 neuron_metadata: None,
+                neuron_fingerprints: None,
+                fingerprint_cache_hits: None,
+                fingerprint_cache_misses: None,
                 error: Some(format!("Failed to parse input JSON: {e}")),
             };
             return Ok(serde_json::to_string(&output)?);
@@ -1320,6 +1350,17 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     timing: n.metadata.timing.as_ref().map(timing_to_json),
                     gpu_info: n.metadata.gpu_info.as_ref().map(gpu_info_to_json),
                 }),
+                neuron_fingerprints: result.neuron_fingerprints,
+                fingerprint_cache_hits: if result.fingerprint_cache_hits > 0 {
+                    Some(result.fingerprint_cache_hits)
+                } else {
+                    None
+                },
+                fingerprint_cache_misses: if result.fingerprint_cache_misses > 0 {
+                    Some(result.fingerprint_cache_misses)
+                } else {
+                    None
+                },
                 error: None,
             };
             Ok(serde_json::to_string(&output)?)
@@ -1339,6 +1380,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_diagnostics: None,
                 neuron_gpu_used: None,
                 neuron_metadata: None,
+                neuron_fingerprints: None,
+                fingerprint_cache_hits: None,
+                fingerprint_cache_misses: None,
                 error: Some(e.to_string()),
             };
             Ok(serde_json::to_string(&output)?)
@@ -1357,6 +1401,7 @@ fn build_analyze_all_input_from_parallel(input: AnalyzeParallelInput) -> Analyze
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: input.random_seed,
+        previous_neuron_fingerprints: input.previous_neuron_fingerprints,
     }
 }
 
@@ -2213,6 +2258,9 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     neuron_diagnostics: None,
                     neuron_gpu_used: None,
                     neuron_metadata: None,
+                    neuron_fingerprints: None,
+                    fingerprint_cache_hits: None,
+                    fingerprint_cache_misses: None,
                     error: Some(format!("Failed to serialize output: {e}")),
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {

--- a/tests/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/analyze_all_deadline_prioritises_synapses.rs
@@ -119,6 +119,7 @@ fn synapse_analysis_runs_under_deadline() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -162,6 +163,7 @@ fn metadata_indicates_target_value_available() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -200,6 +202,7 @@ fn metadata_indicates_target_value_not_available() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -244,6 +247,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -285,6 +289,7 @@ fn candidate_counts_tracked_correctly() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -389,6 +394,7 @@ fn truncation_reflected_in_candidate_counts() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");

--- a/tests/issue_337_candidate_type_contract.rs
+++ b/tests/issue_337_candidate_type_contract.rs
@@ -311,6 +311,9 @@ fn analyze_parallel_output_contains_all_candidate_fields() {
         neuron_diagnostics: None,
         neuron_gpu_used: Some(true),
         neuron_metadata: None,
+        neuron_fingerprints: None,
+        fingerprint_cache_hits: None,
+        fingerprint_cache_misses: None,
         error: None,
     };
 

--- a/tests/issue_419_parallel_discovery_execution.rs
+++ b/tests/issue_419_parallel_discovery_execution.rs
@@ -110,6 +110,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(false),
         random_seed: Some(42),
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -196,6 +197,7 @@ fn parallel_discovery_metadata_consistent() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(false),
         random_seed: Some(42),
+        previous_neuron_fingerprints: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/issue_490_incremental_analysis.rs
+++ b/tests/issue_490_incremental_analysis.rs
@@ -1,0 +1,436 @@
+//! Tests for Issue #490: Incremental analysis — skip unchanged neurons between discovery runs
+//!
+//! ## TDD Plan
+//!
+//! 1. Test fingerprint computation from creature topology for a single neuron
+//! 2. Test fingerprints change when synapse weights change
+//! 3. Test fingerprints change when activation function changes
+//! 4. Test fingerprints change when bias changes
+//! 5. Test fingerprints change when incoming synapses are added/removed
+//! 6. Test fingerprints are stable when nothing changes
+//! 7. Test filtering focus neurons by unchanged fingerprints
+//! 8. Test new neurons (no previous fingerprint) are always analysed
+//! 9. Test removed neurons are correctly handled (stale fingerprints ignored)
+//! 10. Test metadata reports cache hit/miss counts
+
+mod common;
+
+use neat_ai_discovery::analysis::neuron_fingerprint::{
+    NeuronFingerprint, compute_neuron_fingerprints, filter_changed_neurons,
+};
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::collections::HashMap;
+
+fn make_test_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "LOGISTIC".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.1,
+            },
+            NeuronJson {
+                uuid: "hidden-2".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "RELU".to_string(),
+                bias: -0.5,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "hidden-1".to_string(),
+                weight: -0.3,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-1".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-2".to_string(),
+                weight: 0.7,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-2".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.4,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+// -------------------------------------------------------------------------
+// 1. Test fingerprint computation
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_is_computed_for_each_neuron() {
+    let creature = make_test_creature();
+    let fingerprints = compute_neuron_fingerprints(&creature);
+
+    // Should have fingerprints for all neurons (output + hidden)
+    assert!(
+        fingerprints.contains_key("output-0"),
+        "Should contain output-0"
+    );
+    assert!(
+        fingerprints.contains_key("hidden-1"),
+        "Should contain hidden-1"
+    );
+    assert!(
+        fingerprints.contains_key("hidden-2"),
+        "Should contain hidden-2"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 2. Test fingerprints change when synapse weights change
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_changes_when_synapse_weight_changes() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    // Change weight of input-0 -> hidden-1 synapse
+    creature2.synapses[0].weight = 0.9;
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    assert_ne!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint should change when incoming synapse weight changes"
+    );
+
+    // hidden-2 should be unchanged (different neuron, no topology change)
+    assert_eq!(
+        fp1["hidden-2"], fp2["hidden-2"],
+        "Fingerprint for unrelated neuron should be unchanged"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 3. Test fingerprints change when activation function changes
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_changes_when_squash_changes() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    creature2.neurons[1].squash = "RELU".to_string(); // hidden-1: TANH -> RELU
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    assert_ne!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint should change when activation function changes"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 4. Test fingerprints change when bias changes
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_changes_when_bias_changes() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    creature2.neurons[1].bias = 0.5; // hidden-1 bias: 0.1 -> 0.5
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    assert_ne!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint should change when bias changes"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 5. Test fingerprints change when incoming synapses are added/removed
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_changes_when_synapse_added() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    // Add a new synapse to hidden-1
+    creature2.synapses.push(SynapseJson {
+        from_uuid: "input-1".to_string(),
+        to_uuid: "hidden-2".to_string(),
+        weight: 0.2,
+        synapse_type: None,
+    });
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    assert_ne!(
+        fp1["hidden-2"], fp2["hidden-2"],
+        "Fingerprint should change when a new incoming synapse is added"
+    );
+
+    // hidden-1 should be unchanged
+    assert_eq!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint for unrelated neuron should be unchanged"
+    );
+}
+
+#[test]
+fn fingerprint_changes_when_synapse_removed() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    // Remove synapse input-1 -> hidden-1 (index 1)
+    creature2.synapses.remove(1);
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    assert_ne!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint should change when an incoming synapse is removed"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 6. Test fingerprints are stable when nothing changes
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_is_stable_when_topology_unchanged() {
+    let creature = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature);
+    let fp2 = compute_neuron_fingerprints(&creature);
+
+    assert_eq!(
+        fp1, fp2,
+        "Fingerprints should be identical for the same topology"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 7. Test filtering focus neurons by unchanged fingerprints
+// -------------------------------------------------------------------------
+#[test]
+fn filter_skips_unchanged_neurons() {
+    let creature = make_test_creature();
+    let previous_fingerprints = compute_neuron_fingerprints(&creature);
+
+    let focus_neurons = vec![
+        "output-0".to_string(),
+        "hidden-1".to_string(),
+        "hidden-2".to_string(),
+    ];
+
+    // With unchanged topology, all focus neurons should be skipped
+    let result = filter_changed_neurons(&focus_neurons, &creature, &previous_fingerprints);
+
+    assert!(
+        result.changed.is_empty(),
+        "No neurons should be changed: got {:?}",
+        result.changed
+    );
+    assert_eq!(
+        result.cache_hits, 3,
+        "All 3 focus neurons should be cache hits"
+    );
+    assert_eq!(result.cache_misses, 0, "No cache misses expected");
+}
+
+#[test]
+fn filter_includes_changed_neurons() {
+    let creature1 = make_test_creature();
+    let previous_fingerprints = compute_neuron_fingerprints(&creature1);
+
+    // Now change hidden-1's bias
+    let mut creature2 = make_test_creature();
+    creature2.neurons[1].bias = 0.5;
+
+    let focus_neurons = vec![
+        "output-0".to_string(),
+        "hidden-1".to_string(),
+        "hidden-2".to_string(),
+    ];
+
+    let result = filter_changed_neurons(&focus_neurons, &creature2, &previous_fingerprints);
+
+    assert_eq!(result.changed.len(), 1, "Only hidden-1 should be changed");
+    assert_eq!(result.changed[0], "hidden-1");
+    assert_eq!(result.cache_hits, 2, "output-0 and hidden-2 are unchanged");
+    assert_eq!(result.cache_misses, 1, "hidden-1 is changed");
+}
+
+// -------------------------------------------------------------------------
+// 8. Test new neurons are always analysed
+// -------------------------------------------------------------------------
+#[test]
+fn filter_includes_new_neurons() {
+    let creature1 = make_test_creature();
+    let previous_fingerprints = compute_neuron_fingerprints(&creature1);
+
+    // Add a new neuron
+    let mut creature2 = make_test_creature();
+    creature2.neurons.push(NeuronJson {
+        uuid: "hidden-3".to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: "TANH".to_string(),
+        bias: 0.0,
+    });
+    creature2.synapses.push(SynapseJson {
+        from_uuid: "input-0".to_string(),
+        to_uuid: "hidden-3".to_string(),
+        weight: 0.3,
+        synapse_type: None,
+    });
+
+    let focus_neurons = vec![
+        "output-0".to_string(),
+        "hidden-1".to_string(),
+        "hidden-3".to_string(),
+    ];
+
+    let result = filter_changed_neurons(&focus_neurons, &creature2, &previous_fingerprints);
+
+    assert!(
+        result.changed.contains(&"hidden-3".to_string()),
+        "New neuron should always be included for analysis"
+    );
+    assert_eq!(result.cache_misses, 1, "New neuron counts as a cache miss");
+}
+
+// -------------------------------------------------------------------------
+// 9. Test removed neurons are ignored (stale fingerprints)
+// -------------------------------------------------------------------------
+#[test]
+fn filter_ignores_stale_fingerprints_for_removed_neurons() {
+    let creature1 = make_test_creature();
+    let previous_fingerprints = compute_neuron_fingerprints(&creature1);
+
+    // Remove hidden-2 from the creature
+    let mut creature2 = make_test_creature();
+    creature2.neurons.retain(|n| n.uuid != "hidden-2");
+    creature2
+        .synapses
+        .retain(|s| s.from_uuid != "hidden-2" && s.to_uuid != "hidden-2");
+
+    // Focus neurons don't include removed neuron
+    let focus_neurons = vec!["output-0".to_string(), "hidden-1".to_string()];
+
+    let result = filter_changed_neurons(&focus_neurons, &creature2, &previous_fingerprints);
+
+    // output-0 should be changed because its incoming synapses changed
+    // (hidden-2 -> output-0 was removed)
+    assert!(
+        result.changed.contains(&"output-0".to_string()),
+        "output-0 should be flagged as changed because its incoming synapse from hidden-2 was removed"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 10. Test metadata reports cache hit/miss counts
+// -------------------------------------------------------------------------
+#[test]
+fn filter_result_reports_correct_counts() {
+    let creature = make_test_creature();
+    let previous_fingerprints = compute_neuron_fingerprints(&creature);
+
+    let mut creature2 = make_test_creature();
+    creature2.neurons[1].bias = 0.5; // Change hidden-1
+
+    let focus_neurons = vec![
+        "output-0".to_string(),
+        "hidden-1".to_string(),
+        "hidden-2".to_string(),
+    ];
+
+    let result = filter_changed_neurons(&focus_neurons, &creature2, &previous_fingerprints);
+
+    assert_eq!(result.total_focus_neurons, 3);
+    assert_eq!(
+        result.cache_hits + result.cache_misses,
+        result.total_focus_neurons
+    );
+    assert_eq!(result.skipped_uuids.len(), result.cache_hits);
+}
+
+// -------------------------------------------------------------------------
+// 11. Test empty previous fingerprints means all neurons analysed
+// -------------------------------------------------------------------------
+#[test]
+fn filter_with_empty_previous_fingerprints_analyses_all() {
+    let creature = make_test_creature();
+    let empty_fingerprints: HashMap<String, NeuronFingerprint> = HashMap::new();
+
+    let focus_neurons = vec![
+        "output-0".to_string(),
+        "hidden-1".to_string(),
+        "hidden-2".to_string(),
+    ];
+
+    let result = filter_changed_neurons(&focus_neurons, &creature, &empty_fingerprints);
+
+    assert_eq!(
+        result.changed.len(),
+        3,
+        "All neurons should be analysed when no previous fingerprints exist"
+    );
+    assert_eq!(result.cache_misses, 3);
+    assert_eq!(result.cache_hits, 0);
+}
+
+// -------------------------------------------------------------------------
+// 12. Test fingerprints serialise/deserialise via JSON correctly
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprints_round_trip_through_json() {
+    let creature = make_test_creature();
+    let fingerprints = compute_neuron_fingerprints(&creature);
+
+    // Serialise to JSON and back — this is how callers store and replay fingerprints
+    let json = serde_json::to_string(&fingerprints).expect("serialisation should succeed");
+    let restored: HashMap<String, NeuronFingerprint> =
+        serde_json::from_str(&json).expect("deserialisation should succeed");
+
+    assert_eq!(
+        fingerprints, restored,
+        "Fingerprints should survive JSON round-trip"
+    );
+}
+
+// -------------------------------------------------------------------------
+// 13. Test fingerprint includes outgoing synapse changes
+// -------------------------------------------------------------------------
+#[test]
+fn fingerprint_changes_when_outgoing_synapse_weight_changes() {
+    let creature1 = make_test_creature();
+    let fp1 = compute_neuron_fingerprints(&creature1);
+
+    let mut creature2 = make_test_creature();
+    // Change weight of hidden-1 -> output-0 synapse (index 2)
+    creature2.synapses[2].weight = 2.0;
+    let fp2 = compute_neuron_fingerprints(&creature2);
+
+    // hidden-1's fingerprint should change because its outgoing synapse weight changed.
+    // The outgoing weight affects how this neuron's activation contributes to downstream error.
+    assert_ne!(
+        fp1["hidden-1"], fp2["hidden-1"],
+        "Fingerprint should change when outgoing synapse weight changes"
+    );
+}


### PR DESCRIPTION
## Summary

Implement incremental analysis that skips unchanged neurons between discovery runs, avoiding redundant GPU computation. Closes #490.

When a caller provides `previousNeuronFingerprints` from a prior run, the library computes structural fingerprints for each neuron (based on activation function, bias, incoming/outgoing synapse weights and sources) and only analyses neurons whose fingerprints have changed. Unchanged neurons are skipped entirely, including both the GPU synapse/neuron analysis and all discovery dispatch modules.

### Key design decisions

- **Fingerprint = topology hash**: The fingerprint captures the structural properties that determine analysis results — squash, bias, incoming synapses, and outgoing synapses. It does not include activation data from parquet, which is the data being analysed rather than the topology.
- **O(n + s) computation**: Fingerprints are computed in a single pass over neurons and synapses, making the overhead negligible compared to GPU analysis.
- **Conservative invalidation**: Any structural change (weight, bias, squash, added/removed synapse) invalidates the neuron's fingerprint. New neurons (no previous fingerprint) are always analysed. This ensures we never miss a change.
- **No changes to the calling interface**: The `previousNeuronFingerprints` field is optional and defaults to `None`. Existing callers see no change in behaviour. The library returns `neuronFingerprints` in the response for callers to store and pass back.
- **Early exit**: When all focus neurons are unchanged, the library skips parquet loading and GPU initialisation entirely.

### New JSON fields

**Input** (`AnalyzeParallelInput` / `AnalyzeAllInput`):
- `previousNeuronFingerprints`: Optional map of `{uuid → fingerprint}` from the previous run.

**Output** (`AnalyzeParallelOutput`):
- `neuronFingerprints`: Current fingerprints for all neurons — store and pass back on the next run.
- `fingerprintCacheHits`: Number of focus neurons skipped (unchanged).
- `fingerprintCacheMisses`: Number of focus neurons analysed (changed or new).

## Evidence

This is a backend/CLI change with no web interface. Evidence is provided by the test suite:

- 15 dedicated tests in `tests/issue_490_incremental_analysis.rs` covering all fingerprint scenarios
- All 1657 existing tests pass with no modifications to business logic
- `quality.sh` passes cleanly (fmt, clippy, check, test, release build)

## Test Plan

- `tests/issue_490_incremental_analysis.rs` — 15 tests covering:
  - Fingerprint computation for all neurons
  - Fingerprint changes when synapse weight, activation function, or bias changes
  - Fingerprint changes when synapses are added or removed (incoming and outgoing)
  - Fingerprint stability when topology is unchanged
  - Filtering: unchanged neurons are skipped, changed neurons are included
  - New neurons (no previous fingerprint) are always analysed
  - Removed neurons correctly invalidate downstream fingerprints
  - Cache hit/miss/total counts are reported accurately
  - Empty previous fingerprints means all neurons are analysed (first run)
  - JSON round-trip serialisation/deserialisation of fingerprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)