### PR TITLE
Replace unsafe unwrap_unchecked() in synapse scoring with safe alternatives (#521)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.14"
+version = "0.14.15"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.14.15"
+version = "0.15.0"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-521.md
+++ b/docs/pr-summary-521.md
@@ -1,0 +1,27 @@
+## Summary
+
+Replace 4 `unsafe { sample.target_value.unwrap_unchecked() }` and `unsafe { sample.target_activation.unwrap_unchecked() }` calls in `src/analysis/synapse/scoring.rs` with safe `debug_assert!` + `unwrap()` alternatives. This eliminates undefined behaviour risk in two critical scoring functions (`compute_relu_improvement_and_count` and `compute_activation_improvement_and_count`) while preserving the invariant documentation. Closes #521.
+
+### Changes
+
+- **`src/analysis/synapse/scoring.rs`**: Replaced all 4 `unsafe { ... unwrap_unchecked() }` calls with `debug_assert!` guards and safe `.unwrap()`. The `debug_assert!` messages document the invariant: `get_target_simulation_fn()` only returns `Some` when all samples have `target_value` and `target_activation` set.
+- **`src/analysis/implementation_tests/safe_unwrap_tests.rs`** (new): 4 tests exercising the target simulation code paths in both `compute_relu_improvement_and_count` and `compute_activation_improvement_and_count`.
+- **`src/analysis/implementation_tests/mod.rs`**: Registered the new test module.
+
+### Approach
+
+Used **Option A** from the issue: `debug_assert!` + safe `unwrap()`. This gives:
+- Clean panics instead of undefined behaviour if the invariant is violated
+- Debug-mode assertions that catch violations early during development
+- Explicit documentation of the invariant and where it is established
+
+## Evidence
+
+This is a backend code safety improvement with no UI changes. All 478 unit tests and 97 integration test files pass. `./quality.sh` passes cleanly including fmt, clippy, check, tests, and release build.
+
+## Test Plan
+
+- `safe_unwrap_tests::relu_improvement_with_target_simulation_uses_safe_access` — exercises `compute_relu_improvement_and_count` with `target_activation_fn = Some(...)`, verifying correct results via the safe unwrap path
+- `safe_unwrap_tests::relu_improvement_target_simulation_activation_domain` — verifies saturation-aware vs linear approximation near boundaries
+- `safe_unwrap_tests::activation_improvement_with_target_simulation_uses_safe_access` — exercises `compute_activation_improvement_and_count` with target simulation
+- `safe_unwrap_tests::activation_improvement_target_simulation_near_saturation` — verifies finite results near saturation boundaries

--- a/src/analysis/implementation_tests/mod.rs
+++ b/src/analysis/implementation_tests/mod.rs
@@ -84,5 +84,6 @@ mod improvement_model_tests;
 mod optimal_weight_tests;
 mod prediction_accuracy_tests;
 mod relu_evaluation_tests;
+mod safe_unwrap_tests;
 mod sample_matching_tests;
 mod synapse_analysis_tests;

--- a/src/analysis/implementation_tests/safe_unwrap_tests.rs
+++ b/src/analysis/implementation_tests/safe_unwrap_tests.rs
@@ -1,0 +1,189 @@
+//! Issue #521: Tests verifying safe unwrap in synapse scoring functions.
+//!
+//! These tests exercise the target simulation code paths in
+//! `compute_relu_improvement_and_count` and `compute_activation_improvement_and_count`
+//! that access `sample.target_value` and `sample.target_activation`.
+//! The functions must use safe unwraps (not `unwrap_unchecked`) to avoid
+//! undefined behaviour if invariants are ever violated.
+
+use super::common::*;
+use crate::analysis::synapse::scoring::{
+    compute_activation_improvement_and_count, compute_relu_improvement_and_count,
+};
+
+/// Hard tanh activation for testing (matches production).
+fn test_hard_tanh(x: f32) -> f32 {
+    x.clamp(-1.0, 1.0)
+}
+
+/// Logistic activation for testing activation-function candidates.
+fn test_logistic(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+// =============================================================================
+// compute_relu_improvement_and_count — target simulation path
+// =============================================================================
+
+/// Verifies that `compute_relu_improvement_and_count` correctly accesses
+/// `target_value` and `target_activation` via safe unwrap when
+/// `target_activation_fn` is `Some`.
+#[test]
+fn relu_improvement_with_target_simulation_uses_safe_access() {
+    let samples: Vec<HelpfulSample> = (0..10)
+        .map(|_| HelpfulSample {
+            activation: 1.0,
+            avg_error: 0.2,
+            target_value: Some(0.3),
+            target_activation: Some(test_hard_tanh(0.3)),
+        })
+        .collect();
+
+    let baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error.powi(2)).sum();
+
+    let (improvement, improved_count, total_count) = compute_relu_improvement_and_count(
+        &samples,
+        1.0, // incoming_weight
+        0.2, // outgoing_weight
+        0.0, // bias
+        baseline_error_sq,
+        Some(test_hard_tanh),
+    );
+
+    assert_eq!(total_count, 10);
+    assert!(improved_count > 0, "should improve some samples");
+    assert!(improvement > 0.0, "improvement should be positive");
+    assert!(improvement.is_finite(), "improvement must be finite");
+}
+
+/// Verifies that the ReLU function correctly computes improvement in the
+/// activation domain when target simulation is enabled.
+#[test]
+fn relu_improvement_target_simulation_activation_domain() {
+    // Place target near the saturation boundary to exercise the
+    // activation-domain computation path.
+    let target_value = 0.9;
+    let samples: Vec<HelpfulSample> = (0..20)
+        .map(|_| HelpfulSample {
+            activation: 0.5,
+            avg_error: 0.3, // Pushes into saturation: 0.9 + 0.3 = 1.2 → clamped to 1.0
+            target_value: Some(target_value),
+            target_activation: Some(test_hard_tanh(target_value)),
+        })
+        .collect();
+
+    let baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error.powi(2)).sum();
+
+    // Without target simulation (linear approximation)
+    let (improvement_linear, _, _) =
+        compute_relu_improvement_and_count(&samples, 1.0, 0.3, 0.0, baseline_error_sq, None);
+
+    // With target simulation (saturation-aware)
+    let (improvement_sim, _, _) = compute_relu_improvement_and_count(
+        &samples,
+        1.0,
+        0.3,
+        0.0,
+        baseline_error_sq,
+        Some(test_hard_tanh),
+    );
+
+    // Both should be positive but the saturation-aware model should differ
+    // from the linear one near boundaries.
+    assert!(
+        improvement_linear > 0.0,
+        "linear improvement should be positive"
+    );
+    assert!(
+        improvement_sim > 0.0,
+        "simulated improvement should be positive"
+    );
+    assert!(
+        (improvement_linear - improvement_sim).abs() > EPSILON,
+        "saturation-aware model should differ from linear near boundary"
+    );
+}
+
+// =============================================================================
+// compute_activation_improvement_and_count — target simulation path
+// =============================================================================
+
+/// Verifies that `compute_activation_improvement_and_count` correctly accesses
+/// `target_value` and `target_activation` via safe unwrap when
+/// `target_activation_fn` is `Some`.
+#[test]
+fn activation_improvement_with_target_simulation_uses_safe_access() {
+    let samples: Vec<HelpfulSample> = (0..10)
+        .map(|_| HelpfulSample {
+            activation: 1.0,
+            avg_error: 0.2,
+            target_value: Some(0.3),
+            target_activation: Some(test_hard_tanh(0.3)),
+        })
+        .collect();
+
+    let baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error.powi(2)).sum();
+
+    let (improvement, improved_count, total_count) = compute_activation_improvement_and_count(
+        &samples,
+        1.0,           // incoming_weight
+        0.2,           // outgoing_weight
+        0.0,           // bias
+        test_logistic, // activation_fn (the candidate neuron's squash)
+        baseline_error_sq,
+        Some(test_hard_tanh), // target_activation_fn
+    );
+
+    assert_eq!(total_count, 10);
+    assert!(improved_count > 0, "should improve some samples");
+    assert!(improvement > 0.0, "improvement should be positive");
+    assert!(improvement.is_finite(), "improvement must be finite");
+}
+
+/// Verifies that the activation function correctly computes improvement in the
+/// activation domain when target simulation is enabled near saturation.
+#[test]
+fn activation_improvement_target_simulation_near_saturation() {
+    let target_value = 0.9;
+    let samples: Vec<HelpfulSample> = (0..20)
+        .map(|_| HelpfulSample {
+            activation: 0.5,
+            avg_error: 0.3,
+            target_value: Some(target_value),
+            target_activation: Some(test_hard_tanh(target_value)),
+        })
+        .collect();
+
+    let baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error.powi(2)).sum();
+
+    // Without target simulation
+    let (improvement_linear, _, _) = compute_activation_improvement_and_count(
+        &samples,
+        1.0,
+        0.3,
+        0.0,
+        test_logistic,
+        baseline_error_sq,
+        None,
+    );
+
+    // With target simulation
+    let (improvement_sim, _, _) = compute_activation_improvement_and_count(
+        &samples,
+        1.0,
+        0.3,
+        0.0,
+        test_logistic,
+        baseline_error_sq,
+        Some(test_hard_tanh),
+    );
+
+    assert!(
+        improvement_linear.is_finite(),
+        "linear improvement must be finite"
+    );
+    assert!(
+        improvement_sim.is_finite(),
+        "simulated improvement must be finite"
+    );
+}

--- a/src/analysis/synapse/scoring.rs
+++ b/src/analysis/synapse/scoring.rs
@@ -157,8 +157,18 @@ pub(crate) fn compute_relu_improvement_and_count(
 
         let (baseline_error, new_error) = if let Some(target_fn) = target_activation_fn {
             // CRITICAL: Use ACTIVATION domain for BOTH baseline and new error.
-            let target_value = unsafe { sample.target_value.unwrap_unchecked() };
-            let target_activation = unsafe { sample.target_activation.unwrap_unchecked() };
+            // SAFETY INVARIANT: get_target_simulation_fn() only returns Some when
+            // all samples have target_value and target_activation set.
+            debug_assert!(
+                sample.target_value.is_some(),
+                "target_value must be set when target_activation_fn is Some"
+            );
+            debug_assert!(
+                sample.target_activation.is_some(),
+                "target_activation must be set when target_activation_fn is Some"
+            );
+            let target_value = sample.target_value.unwrap();
+            let target_activation = sample.target_activation.unwrap();
             let desired_value = target_value + sample.avg_error;
             let expected = target_fn(desired_value);
 
@@ -251,8 +261,18 @@ pub(crate) fn compute_activation_improvement_and_count(
 
         let (baseline_error, new_error) = if let Some(target_fn) = target_activation_fn {
             // CRITICAL: Use ACTIVATION domain for BOTH baseline and new error.
-            let target_value = unsafe { sample.target_value.unwrap_unchecked() };
-            let target_activation = unsafe { sample.target_activation.unwrap_unchecked() };
+            // SAFETY INVARIANT: get_target_simulation_fn() only returns Some when
+            // all samples have target_value and target_activation set.
+            debug_assert!(
+                sample.target_value.is_some(),
+                "target_value must be set when target_activation_fn is Some"
+            );
+            debug_assert!(
+                sample.target_activation.is_some(),
+                "target_activation must be set when target_activation_fn is Some"
+            );
+            let target_value = sample.target_value.unwrap();
+            let target_activation = sample.target_activation.unwrap();
             let desired_value = target_value + sample.avg_error;
             let expected = target_fn(desired_value);
 


### PR DESCRIPTION
## Summary

Replace 4 `unsafe { sample.target_value.unwrap_unchecked() }` and `unsafe { sample.target_activation.unwrap_unchecked() }` calls in `src/analysis/synapse/scoring.rs` with safe `debug_assert!` + `unwrap()` alternatives. This eliminates undefined behaviour risk in two critical scoring functions (`compute_relu_improvement_and_count` and `compute_activation_improvement_and_count`) while preserving the invariant documentation. Closes #521.

### Changes

- **`src/analysis/synapse/scoring.rs`**: Replaced all 4 `unsafe { ... unwrap_unchecked() }` calls with `debug_assert!` guards and safe `.unwrap()`. The `debug_assert!` messages document the invariant: `get_target_simulation_fn()` only returns `Some` when all samples have `target_value` and `target_activation` set.
- **`src/analysis/implementation_tests/safe_unwrap_tests.rs`** (new): 4 tests exercising the target simulation code paths in both `compute_relu_improvement_and_count` and `compute_activation_improvement_and_count`.
- **`src/analysis/implementation_tests/mod.rs`**: Registered the new test module.

### Approach

Used **Option A** from the issue: `debug_assert!` + safe `unwrap()`. This gives:
- Clean panics instead of undefined behaviour if the invariant is violated
- Debug-mode assertions that catch violations early during development
- Explicit documentation of the invariant and where it is established

## Evidence

This is a backend code safety improvement with no UI changes. All 478 unit tests and 97 integration test files pass. `./quality.sh` passes cleanly including fmt, clippy, check, tests, and release build.

## Test Plan

- `safe_unwrap_tests::relu_improvement_with_target_simulation_uses_safe_access` — exercises `compute_relu_improvement_and_count` with `target_activation_fn = Some(...)`, verifying correct results via the safe unwrap path
- `safe_unwrap_tests::relu_improvement_target_simulation_activation_domain` — verifies saturation-aware vs linear approximation near boundaries
- `safe_unwrap_tests::activation_improvement_with_target_simulation_uses_safe_access` — exercises `compute_activation_improvement_and_count` with target simulation
- `safe_unwrap_tests::activation_improvement_target_simulation_near_saturation` — verifies finite results near saturation boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)