### PR TITLE
Add targeted tests for focus sub-modules (allocation, gradient, layers, ranking) (#523)

### DIFF
--- a/docs/pr-summary-523.md
+++ b/docs/pr-summary-523.md
@@ -1,0 +1,72 @@
+## Summary
+
+Add targeted tests for 4 focus sub-modules: `layers`, `allocation`, `gradient`, and `ranking`. These sub-modules were split out in Issue #491 but lacked dedicated test files. Closes #523.
+
+## Evidence
+
+This is a test-only change with no UI or performance implications. All 48 new tests pass across 4 test files:
+
+- `tests/focus_layers.rs` — 10 tests
+- `tests/focus_allocation.rs` — 14 tests
+- `tests/focus_gradient.rs` — 11 tests
+- `tests/focus_ranking.rs` — 13 tests
+
+`./quality.sh` passes cleanly (fmt, clippy, check, tests, release build).
+
+## Test Plan
+
+### `tests/focus_layers.rs` (10 tests)
+- Linear chain assigns increasing BFS depths
+- Fan-out groups sibling neurons at same depth
+- Skip connections use maximum depth (not shortest path)
+- Skip connections don't affect intermediate depths
+- Multiple inputs contribute to depth calculation
+- Disconnected neurons assigned to unreachable layer
+- Input and constant neurons excluded from layers
+- Empty creature returns no layers
+- Output-only creature produces a layer
+- Diamond topology assigns correct depths
+
+### `tests/focus_allocation.rs` (14 tests)
+- Equal distributes budget evenly across layers
+- Equal distributes remainder to deeper layers
+- Proportional gives more to larger layers
+- Proportional handles uneven division
+- OutputFirst prioritises deeper layers
+- OutputFirst fills deep layers before shallow
+- Zero budget returns empty
+- Empty layers returns empty
+- Budget exceeding total neurons selects all
+- Single layer gets entire budget
+- Higher-scored neurons selected first within layer
+- Neurons with no score treated as zero
+- All strategies respect max_focus
+- All strategies return unique neurons
+
+### `tests/focus_gradient.rs` (11 tests)
+- RELU all-negative values fully dead (dead_ratio ≈ 1.0)
+- RELU all-positive values not dead (gradient = 1.0)
+- RELU mixed values partial dead (dead_ratio ≈ 0.5)
+- TANH extreme values saturated
+- TANH moderate values not saturated
+- LOGISTIC extreme values saturated
+- IDENTITY always has gradient 1.0
+- Mixed activations produce independent stats
+- Default GradientFlowStats assumes full flow
+- Neuron with no finite values gets default stats
+- ELU negative values have non-zero gradient (never dead)
+
+### `tests/focus_ranking.rs` (13 tests)
+- SynapseCounts correct for simple chain
+- SynapseCounts for hub neuron (3 incoming, 2 outgoing)
+- SynapseCounts returns zero for nonexistent neuron
+- Removal savings matches NEAT-AI formula
+- Removal savings scales with growth_cost
+- Output neuron has impact 1.0
+- Hidden neuron impact bounded (0, 1]
+- Disconnected neuron has zero impact
+- High error + high impact neuron ranked first
+- Low impact neuron identified as removal candidate
+- High impact neuron not a removal candidate
+- max_results limits output size
+- Ranked neurons have correct error and impact

--- a/tests/focus_allocation.rs
+++ b/tests/focus_allocation.rs
@@ -1,0 +1,382 @@
+//! Issue #523: Targeted tests for the focus `allocation` sub-module.
+//!
+//! Tests budget allocation strategies with different neuron counts and budget sizes:
+//! - Equal allocation across layers
+//! - Proportional allocation (larger layers get more)
+//! - OutputFirst allocation (deeper layers prioritised)
+//! - Edge cases: zero budget, single layer, budget exceeding neuron count
+
+mod common;
+
+use neat_ai_discovery::CreatureJson;
+use neat_ai_discovery::focus::{
+    AllocationStrategy, NeuronInfo, NeuronLayer, hierarchical_focus_selection,
+};
+use std::collections::{HashMap, HashSet};
+
+/// Build layers directly for allocation-focused tests.
+fn make_layers(sizes: &[usize]) -> Vec<NeuronLayer> {
+    sizes
+        .iter()
+        .enumerate()
+        .map(|(depth, &count)| NeuronLayer {
+            depth: depth + 1,
+            neurons: (0..count)
+                .map(|i| NeuronInfo {
+                    uuid: format!("L{depth}-n{i}"),
+                    neuron_type: "hidden".to_string(),
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+/// Build a minimal creature (allocation tests do not depend on creature topology).
+fn dummy_creature() -> CreatureJson {
+    CreatureJson {
+        input: 1,
+        output: 0,
+        neurons: vec![],
+        synapses: vec![],
+    }
+}
+
+/// Helper: run selection and return per-layer selected counts.
+fn per_layer_counts(
+    layers: &[NeuronLayer],
+    max_focus: usize,
+    strategy: AllocationStrategy,
+    scores: &HashMap<String, f32>,
+) -> Vec<usize> {
+    let creature = dummy_creature();
+    let selected = hierarchical_focus_selection(&creature, layers, max_focus, strategy, scores);
+
+    layers
+        .iter()
+        .map(|layer| {
+            layer
+                .neurons
+                .iter()
+                .filter(|n| selected.contains(&n.uuid))
+                .count()
+        })
+        .collect()
+}
+
+/// Build uniform scores for all neurons across layers.
+fn uniform_scores(layers: &[NeuronLayer], score: f32) -> HashMap<String, f32> {
+    layers
+        .iter()
+        .flat_map(|l| l.neurons.iter())
+        .map(|n| (n.uuid.clone(), score))
+        .collect()
+}
+
+// =============================================================================
+// Equal allocation
+// =============================================================================
+
+#[test]
+fn equal_distributes_budget_evenly() {
+    // 3 layers, 10 neurons each, budget = 9 → 3 per layer
+    let layers = make_layers(&[10, 10, 10]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 9, AllocationStrategy::Equal, &scores);
+
+    assert_eq!(counts, vec![3, 3, 3], "Equal should give 3 per layer");
+}
+
+#[test]
+fn equal_distributes_remainder_to_deeper_layers() {
+    // 3 layers, 10 neurons each, budget = 10 → 3+3+4 or 3+3+4 (remainder to last)
+    let layers = make_layers(&[10, 10, 10]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 10, AllocationStrategy::Equal, &scores);
+
+    let total: usize = counts.iter().sum();
+    assert_eq!(total, 10, "Total selected should equal budget");
+
+    // Last layer (deepest, index 2) should get the extra slot(s)
+    assert!(
+        counts[2] >= counts[0],
+        "Deeper layer should get remainder: {counts:?}"
+    );
+}
+
+// =============================================================================
+// Proportional allocation
+// =============================================================================
+
+#[test]
+fn proportional_gives_more_to_larger_layers() {
+    // Layer 0: 2 neurons, Layer 1: 8 neurons. Budget = 10
+    // Proportional: layer 0 gets 2/10 * 10 = 2, layer 1 gets 8/10 * 10 = 8
+    let layers = make_layers(&[2, 8]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 10, AllocationStrategy::Proportional, &scores);
+
+    assert_eq!(counts[0], 2, "Small layer should get ~2");
+    assert_eq!(counts[1], 8, "Large layer should get ~8");
+}
+
+#[test]
+fn proportional_handles_uneven_division() {
+    // 3 layers with sizes 3, 3, 4. Budget = 5.
+    // Proportional: 3/10*5=1.5→1, 3/10*5=1.5→1, 4/10*5=2.0→2 => allocated 4, remainder 1
+    let layers = make_layers(&[3, 3, 4]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 5, AllocationStrategy::Proportional, &scores);
+
+    let total: usize = counts.iter().sum();
+    assert_eq!(total, 5, "Total should match budget");
+}
+
+// =============================================================================
+// OutputFirst allocation
+// =============================================================================
+
+#[test]
+fn output_first_prioritises_deeper_layers() {
+    // 3 layers, 5 neurons each, budget = 5
+    // OutputFirst allocates from deepest to shallowest
+    let layers = make_layers(&[5, 5, 5]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 5, AllocationStrategy::OutputFirst, &scores);
+
+    let total: usize = counts.iter().sum();
+    assert_eq!(total, 5, "Total should match budget");
+
+    // Deepest layer should get the most (or equal) allocation
+    assert!(
+        counts[2] >= counts[0],
+        "Deepest layer ({}) should get >= shallowest ({})",
+        counts[2],
+        counts[0]
+    );
+}
+
+#[test]
+fn output_first_fills_deep_before_shallow() {
+    // 2 layers: shallow has 10, deep has 3. Budget = 4.
+    // OutputFirst: deep layer gets up to its size first (3), then shallow gets 1.
+    let layers = make_layers(&[10, 3]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 4, AllocationStrategy::OutputFirst, &scores);
+
+    let total: usize = counts.iter().sum();
+    assert_eq!(total, 4, "Total should match budget");
+
+    // Deep layer (index 1) should get all 3 of its neurons
+    assert!(
+        counts[1] >= 2,
+        "Deep layer should get at least 2, got {}",
+        counts[1]
+    );
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn zero_budget_returns_empty() {
+    let layers = make_layers(&[5, 5]);
+    let scores = uniform_scores(&layers, 1.0);
+    let creature = dummy_creature();
+
+    let selected =
+        hierarchical_focus_selection(&creature, &layers, 0, AllocationStrategy::Equal, &scores);
+
+    assert!(selected.is_empty(), "Zero budget should select nothing");
+}
+
+#[test]
+fn empty_layers_returns_empty() {
+    let layers: Vec<NeuronLayer> = vec![];
+    let creature = dummy_creature();
+
+    let selected = hierarchical_focus_selection(
+        &creature,
+        &layers,
+        10,
+        AllocationStrategy::Equal,
+        &HashMap::new(),
+    );
+
+    assert!(
+        selected.is_empty(),
+        "Empty layers should produce empty selection"
+    );
+}
+
+#[test]
+fn budget_exceeding_total_neurons_selects_all() {
+    // 2 layers with 3 neurons each (6 total), budget = 20
+    let layers = make_layers(&[3, 3]);
+    let scores = uniform_scores(&layers, 1.0);
+    let creature = dummy_creature();
+
+    let selected =
+        hierarchical_focus_selection(&creature, &layers, 20, AllocationStrategy::Equal, &scores);
+
+    // Should select all 6 neurons (can't exceed what exists)
+    assert_eq!(
+        selected.len(),
+        6,
+        "Should select all 6 neurons when budget > total"
+    );
+}
+
+#[test]
+fn single_layer_gets_entire_budget() {
+    // One layer with 10 neurons, budget = 5
+    let layers = make_layers(&[10]);
+    let scores = uniform_scores(&layers, 1.0);
+
+    let counts = per_layer_counts(&layers, 5, AllocationStrategy::Equal, &scores);
+
+    assert_eq!(counts[0], 5, "Single layer should get entire budget");
+}
+
+// =============================================================================
+// Score-based selection within layers
+// =============================================================================
+
+#[test]
+fn higher_scored_neurons_selected_first_within_layer() {
+    // Single layer with 5 neurons, budget = 2
+    let layers = vec![NeuronLayer {
+        depth: 1,
+        neurons: vec![
+            NeuronInfo {
+                uuid: "low-1".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+            NeuronInfo {
+                uuid: "high-1".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+            NeuronInfo {
+                uuid: "low-2".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+            NeuronInfo {
+                uuid: "high-2".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+            NeuronInfo {
+                uuid: "medium".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+        ],
+    }];
+
+    let mut scores = HashMap::new();
+    scores.insert("low-1".to_string(), 1.0_f32);
+    scores.insert("high-1".to_string(), 10.0);
+    scores.insert("low-2".to_string(), 2.0);
+    scores.insert("high-2".to_string(), 9.0);
+    scores.insert("medium".to_string(), 5.0);
+
+    let creature = dummy_creature();
+    let selected =
+        hierarchical_focus_selection(&creature, &layers, 2, AllocationStrategy::Equal, &scores);
+
+    assert!(
+        selected.contains(&"high-1".to_string()),
+        "Highest-scored neuron should be selected"
+    );
+    assert!(
+        selected.contains(&"high-2".to_string()),
+        "Second highest-scored neuron should be selected"
+    );
+}
+
+#[test]
+fn neurons_with_no_score_treated_as_zero() {
+    // Layer with scored and unscored neurons
+    let layers = vec![NeuronLayer {
+        depth: 1,
+        neurons: vec![
+            NeuronInfo {
+                uuid: "scored".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+            NeuronInfo {
+                uuid: "unscored".to_string(),
+                neuron_type: "hidden".to_string(),
+            },
+        ],
+    }];
+
+    let mut scores = HashMap::new();
+    scores.insert("scored".to_string(), 5.0_f32);
+    // "unscored" has no entry → defaults to 0.0
+
+    let creature = dummy_creature();
+    let selected =
+        hierarchical_focus_selection(&creature, &layers, 1, AllocationStrategy::Equal, &scores);
+
+    assert_eq!(
+        selected,
+        vec!["scored".to_string()],
+        "Scored neuron should be preferred over unscored"
+    );
+}
+
+// =============================================================================
+// All strategies respect max_focus
+// =============================================================================
+
+#[test]
+fn all_strategies_respect_max_focus() {
+    let layers = make_layers(&[20, 20, 20]);
+    let scores = uniform_scores(&layers, 1.0);
+    let max_focus = 10;
+
+    for strategy in [
+        AllocationStrategy::Equal,
+        AllocationStrategy::Proportional,
+        AllocationStrategy::OutputFirst,
+    ] {
+        let creature = dummy_creature();
+        let selected =
+            hierarchical_focus_selection(&creature, &layers, max_focus, strategy, &scores);
+
+        assert!(
+            selected.len() <= max_focus,
+            "{strategy:?} exceeded max_focus: {} > {max_focus}",
+            selected.len()
+        );
+    }
+}
+
+#[test]
+fn all_strategies_return_unique_neurons() {
+    let layers = make_layers(&[10, 10, 10]);
+    let scores = uniform_scores(&layers, 1.0);
+    let max_focus = 15;
+
+    for strategy in [
+        AllocationStrategy::Equal,
+        AllocationStrategy::Proportional,
+        AllocationStrategy::OutputFirst,
+    ] {
+        let creature = dummy_creature();
+        let selected =
+            hierarchical_focus_selection(&creature, &layers, max_focus, strategy, &scores);
+
+        let unique: HashSet<_> = selected.iter().collect();
+        assert_eq!(
+            unique.len(),
+            selected.len(),
+            "{strategy:?} returned duplicate neurons"
+        );
+    }
+}

--- a/tests/focus_gradient.rs
+++ b/tests/focus_gradient.rs
@@ -1,0 +1,402 @@
+//! Issue #523: Targeted tests for the focus `gradient` sub-module.
+//!
+//! Tests gradient flow analysis with known activation functions and weights:
+//! - RELU dead neuron detection
+//! - TANH saturation detection
+//! - LOGISTIC saturation detection
+//! - IDENTITY (always gradient = 1.0)
+//! - Mixed activation creatures
+//!
+//! Since `compute_activation_gradient` and `compute_gradient_flow_factor` are
+//! not public, we test them indirectly via `compute_gradient_flow_stats` which
+//! reads from a parquet file.
+
+mod common;
+
+use neat_ai_discovery::focus::{GradientFlowStats, compute_gradient_flow_stats};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Build a creature with the given hidden neurons (each with a specified squash)
+/// plus one output neuron.
+fn make_creature_with_squashes(neurons: &[(&str, &str)]) -> CreatureJson {
+    let mut all_neurons: Vec<NeuronJson> = neurons
+        .iter()
+        .map(|(uuid, squash)| NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: "hidden".to_string(),
+            squash: squash.to_string(),
+            bias: 0.0,
+        })
+        .collect();
+
+    all_neurons.push(NeuronJson {
+        uuid: "out".to_string(),
+        neuron_type: "output".to_string(),
+        squash: "IDENTITY".to_string(),
+        bias: 0.0,
+    });
+
+    let mut synapses: Vec<SynapseJson> = neurons
+        .iter()
+        .map(|(uuid, _)| SynapseJson {
+            from_uuid: "input-0".to_string(),
+            to_uuid: uuid.to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        })
+        .collect();
+
+    for (uuid, _) in neurons {
+        synapses.push(SynapseJson {
+            from_uuid: uuid.to_string(),
+            to_uuid: "out".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        });
+    }
+
+    CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: all_neurons,
+        synapses,
+    }
+}
+
+/// Write records to a temporary parquet file and return the path.
+fn write_temp_parquet(records: &[DiscoverRecord]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().expect("create temp file");
+    write_records_to_parquet(tmp.path().to_str().unwrap(), records).expect("write parquet");
+    tmp
+}
+
+/// Create records for a neuron with given pre-activation values and activations.
+fn make_records(uuid: &str, values_and_activations: &[(f32, f32)]) -> Vec<DiscoverRecord> {
+    values_and_activations
+        .iter()
+        .enumerate()
+        .map(|(i, &(value, activation))| DiscoverRecord {
+            obs_index: i as u32,
+            neuron_uuid: uuid.to_string(),
+            value: Some(value),
+            activation,
+            errors: vec![0.1],
+        })
+        .collect()
+}
+
+// =============================================================================
+// RELU — dead neuron detection
+// =============================================================================
+
+#[test]
+fn relu_all_negative_values_fully_dead() {
+    let creature = make_creature_with_squashes(&[("relu-1", "RELU")]);
+
+    // All pre-activation values negative → gradient = 0, dead = true
+    let mut records = make_records("relu-1", &[(-5.0, 0.0), (-2.0, 0.0), (-0.1, 0.0)]);
+    // Output neuron needs records too
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let relu_stats = stats.get("relu-1").expect("relu-1 stats present");
+    assert!(
+        relu_stats.dead_ratio > 0.99,
+        "All-negative RELU should be fully dead, got dead_ratio={}",
+        relu_stats.dead_ratio
+    );
+    assert!(
+        relu_stats.avg_gradient_magnitude < 0.01,
+        "All-negative RELU should have near-zero gradient, got {}",
+        relu_stats.avg_gradient_magnitude
+    );
+}
+
+#[test]
+fn relu_all_positive_values_not_dead() {
+    let creature = make_creature_with_squashes(&[("relu-1", "RELU")]);
+
+    let mut records = make_records("relu-1", &[(1.0, 1.0), (5.0, 5.0), (0.5, 0.5)]);
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let relu_stats = stats.get("relu-1").expect("relu-1 stats present");
+    assert!(
+        relu_stats.dead_ratio < 0.01,
+        "All-positive RELU should have zero dead ratio, got {}",
+        relu_stats.dead_ratio
+    );
+    assert!(
+        (relu_stats.avg_gradient_magnitude - 1.0).abs() < 0.01,
+        "Positive RELU gradient should be 1.0, got {}",
+        relu_stats.avg_gradient_magnitude
+    );
+}
+
+#[test]
+fn relu_mixed_values_partial_dead() {
+    let creature = make_creature_with_squashes(&[("relu-1", "RELU")]);
+
+    // 2 positive, 2 negative → 50% dead
+    let mut records = make_records(
+        "relu-1",
+        &[(1.0, 1.0), (-1.0, 0.0), (2.0, 2.0), (-3.0, 0.0)],
+    );
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let relu_stats = stats.get("relu-1").expect("relu-1 stats present");
+    assert!(
+        (relu_stats.dead_ratio - 0.5).abs() < 0.01,
+        "Half-dead RELU should have dead_ratio ≈ 0.5, got {}",
+        relu_stats.dead_ratio
+    );
+}
+
+// =============================================================================
+// TANH — saturation detection
+// =============================================================================
+
+#[test]
+fn tanh_extreme_values_saturated() {
+    let creature = make_creature_with_squashes(&[("tanh-1", "TANH")]);
+
+    // |value| > 3.0 → saturated for TANH
+    let mut records = make_records(
+        "tanh-1",
+        &[(10.0, 1.0), (-10.0, -1.0), (5.0, 1.0), (-5.0, -1.0)],
+    );
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let tanh_stats = stats.get("tanh-1").expect("tanh-1 stats present");
+    assert!(
+        tanh_stats.saturation_ratio > 0.99,
+        "Extreme TANH values should be fully saturated, got {}",
+        tanh_stats.saturation_ratio
+    );
+}
+
+#[test]
+fn tanh_moderate_values_not_saturated() {
+    let creature = make_creature_with_squashes(&[("tanh-1", "TANH")]);
+
+    // |value| < 1.0 → good gradient region for TANH
+    let mut records = make_records(
+        "tanh-1",
+        &[(0.1, 0.1), (-0.2, -0.2), (0.5, 0.46), (-0.5, -0.46)],
+    );
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let tanh_stats = stats.get("tanh-1").expect("tanh-1 stats present");
+    assert!(
+        tanh_stats.saturation_ratio < 0.01,
+        "Moderate TANH values should not be saturated, got {}",
+        tanh_stats.saturation_ratio
+    );
+    assert!(
+        tanh_stats.avg_gradient_magnitude > 0.5,
+        "Moderate TANH should have good gradient flow, got {}",
+        tanh_stats.avg_gradient_magnitude
+    );
+}
+
+// =============================================================================
+// LOGISTIC — saturation detection
+// =============================================================================
+
+#[test]
+fn logistic_extreme_values_saturated() {
+    let creature = make_creature_with_squashes(&[("sig-1", "LOGISTIC")]);
+
+    // |value| > 5.0 → saturated for LOGISTIC
+    let mut records = make_records("sig-1", &[(20.0, 1.0), (-20.0, 0.0), (10.0, 1.0)]);
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let sig_stats = stats.get("sig-1").expect("sig-1 stats present");
+    assert!(
+        sig_stats.saturation_ratio > 0.99,
+        "Extreme LOGISTIC values should be fully saturated, got {}",
+        sig_stats.saturation_ratio
+    );
+}
+
+// =============================================================================
+// IDENTITY — constant gradient
+// =============================================================================
+
+#[test]
+fn identity_always_has_gradient_one() {
+    let creature = make_creature_with_squashes(&[("id-1", "IDENTITY")]);
+
+    let mut records = make_records("id-1", &[(100.0, 100.0), (-50.0, -50.0), (0.0, 0.0)]);
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let id_stats = stats.get("id-1").expect("id-1 stats present");
+    assert!(
+        (id_stats.avg_gradient_magnitude - 1.0).abs() < 0.01,
+        "IDENTITY gradient should be 1.0, got {}",
+        id_stats.avg_gradient_magnitude
+    );
+    assert!(
+        id_stats.dead_ratio < 0.01,
+        "IDENTITY should never be dead, got {}",
+        id_stats.dead_ratio
+    );
+}
+
+// =============================================================================
+// Mixed activations
+// =============================================================================
+
+#[test]
+fn mixed_activations_produce_independent_stats() {
+    let creature = make_creature_with_squashes(&[
+        ("relu-1", "RELU"),
+        ("tanh-1", "TANH"),
+        ("id-1", "IDENTITY"),
+    ]);
+
+    let mut records = Vec::new();
+    // RELU with all-negative → fully dead
+    records.extend(make_records("relu-1", &[(-1.0, 0.0), (-5.0, 0.0)]));
+    // TANH with moderate values → good gradient
+    records.extend(make_records("tanh-1", &[(0.1, 0.1), (0.2, 0.2)]));
+    // IDENTITY → always gradient 1.0
+    records.extend(make_records("id-1", &[(3.0, 3.0), (7.0, 7.0)]));
+    // Output
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    // RELU should be fully dead
+    let relu = stats.get("relu-1").expect("relu-1");
+    assert!(relu.dead_ratio > 0.99, "RELU should be dead");
+
+    // TANH should have good gradient and no dead
+    let tanh = stats.get("tanh-1").expect("tanh-1");
+    assert!(tanh.dead_ratio < 0.01, "TANH should not be dead");
+    assert!(
+        tanh.avg_gradient_magnitude > 0.5,
+        "TANH should have decent gradient"
+    );
+
+    // IDENTITY should have gradient 1.0
+    let id = stats.get("id-1").expect("id-1");
+    assert!(
+        (id.avg_gradient_magnitude - 1.0).abs() < 0.01,
+        "IDENTITY gradient should be 1.0"
+    );
+}
+
+// =============================================================================
+// GradientFlowStats default values
+// =============================================================================
+
+#[test]
+fn gradient_flow_stats_default_assumes_full_flow() {
+    let default = GradientFlowStats::default();
+
+    assert!(
+        (default.avg_gradient_magnitude - 1.0).abs() < f32::EPSILON,
+        "Default gradient magnitude should be 1.0 (assume full gradient)"
+    );
+    assert!(
+        default.saturation_ratio.abs() < f32::EPSILON,
+        "Default saturation should be 0.0 (assume not saturated)"
+    );
+    assert!(
+        default.dead_ratio.abs() < f32::EPSILON,
+        "Default dead ratio should be 0.0 (assume not dead)"
+    );
+}
+
+// =============================================================================
+// Edge: neuron with no finite values
+// =============================================================================
+
+#[test]
+fn neuron_with_no_finite_values_gets_default_stats() {
+    let creature = make_creature_with_squashes(&[("nan-1", "RELU")]);
+
+    let mut records: Vec<DiscoverRecord> = (0..3)
+        .map(|i| DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "nan-1".to_string(),
+            value: Some(f32::NAN), // Non-finite values
+            activation: 0.0,
+            errors: vec![0.1],
+        })
+        .collect();
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let nan_stats = stats.get("nan-1").expect("nan-1 should be present");
+    // With no valid samples, should get default stats
+    assert!(
+        (nan_stats.avg_gradient_magnitude - 1.0).abs() < f32::EPSILON,
+        "No valid samples should use default gradient (1.0), got {}",
+        nan_stats.avg_gradient_magnitude
+    );
+}
+
+// =============================================================================
+// ELU — non-zero gradient for negative values
+// =============================================================================
+
+#[test]
+fn elu_negative_values_have_non_zero_gradient() {
+    let creature = make_creature_with_squashes(&[("elu-1", "ELU")]);
+
+    // ELU has exp(x) gradient for negative values → never truly dead
+    let mut records = make_records("elu-1", &[(-0.5, -0.39), (-1.0, -0.63), (-2.0, -0.86)]);
+    records.extend(make_records("out", &[(1.0, 1.0)]));
+
+    let tmp = write_temp_parquet(&records);
+    let stats = compute_gradient_flow_stats(tmp.path().to_str().unwrap(), &creature)
+        .expect("compute gradient stats");
+
+    let elu_stats = stats.get("elu-1").expect("elu-1 present");
+    assert!(
+        elu_stats.dead_ratio < 0.01,
+        "ELU should never be dead (has non-zero gradient for negative), got {}",
+        elu_stats.dead_ratio
+    );
+    assert!(
+        elu_stats.avg_gradient_magnitude > 0.0,
+        "ELU should have positive gradient for negative values, got {}",
+        elu_stats.avg_gradient_magnitude
+    );
+}

--- a/tests/focus_layers.rs
+++ b/tests/focus_layers.rs
@@ -1,0 +1,425 @@
+//! Issue #523: Targeted tests for the focus `layers` sub-module.
+//!
+//! Tests BFS layer computation with known network topologies:
+//! - Linear chains
+//! - Fan-out networks
+//! - Skip connections
+//! - Multiple inputs
+//! - Disconnected neurons
+
+mod common;
+
+use neat_ai_discovery::focus::{NeuronLayer, compute_network_layers};
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::collections::HashSet;
+
+/// Helper to build a creature from neurons and synapses.
+/// Input neurons are identified by type "input" and excluded from `creature.neurons`.
+fn make_creature(
+    neurons: Vec<(&str, &str, &str)>, // (uuid, type, squash)
+    synapses: Vec<(&str, &str, f32)>, // (from, to, weight)
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t, _)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t, _)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .filter(|(_, t, _)| *t != "input")
+            .map(|(uuid, ntype, squash)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: ntype.to_string(),
+                squash: squash.to_string(),
+                bias: 0.0,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, w)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight: w,
+                synapse_type: None,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Collect all neuron UUIDs across all layers.
+fn all_uuids(layers: &[NeuronLayer]) -> HashSet<String> {
+    layers
+        .iter()
+        .flat_map(|l| l.neurons.iter().map(|n| n.uuid.clone()))
+        .collect()
+}
+
+/// Find the depth assigned to a specific neuron UUID.
+fn depth_of(layers: &[NeuronLayer], uuid: &str) -> Option<usize> {
+    layers
+        .iter()
+        .find(|l| l.neurons.iter().any(|n| n.uuid == uuid))
+        .map(|l| l.depth)
+}
+
+// =============================================================================
+// Linear chain topology
+// =============================================================================
+
+#[test]
+fn linear_chain_assigns_increasing_depths() {
+    // input-0 -> h1 -> h2 -> h3 -> out
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("h3", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("h1", "h2", 1.0),
+            ("h2", "h3", 1.0),
+            ("h3", "out", 1.0),
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    // Each neuron should be at strictly increasing depth
+    assert_eq!(depth_of(&layers, "h1"), Some(1));
+    assert_eq!(depth_of(&layers, "h2"), Some(2));
+    assert_eq!(depth_of(&layers, "h3"), Some(3));
+    assert_eq!(depth_of(&layers, "out"), Some(4));
+
+    // Layers should be sorted by depth
+    for i in 1..layers.len() {
+        assert!(layers[i].depth >= layers[i - 1].depth);
+    }
+}
+
+// =============================================================================
+// Fan-out topology
+// =============================================================================
+
+#[test]
+fn fan_out_groups_siblings_at_same_depth() {
+    // input-0 fans out to h1, h2, h3 (all at depth 1), then all connect to out (depth 2)
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("h3", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("input-0", "h2", 1.0),
+            ("input-0", "h3", 1.0),
+            ("h1", "out", 0.5),
+            ("h2", "out", 0.3),
+            ("h3", "out", 0.8),
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    // All three hidden neurons should be at the same depth
+    let h1_depth = depth_of(&layers, "h1").expect("h1 should have a depth");
+    let h2_depth = depth_of(&layers, "h2").expect("h2 should have a depth");
+    let h3_depth = depth_of(&layers, "h3").expect("h3 should have a depth");
+
+    assert_eq!(h1_depth, h2_depth, "h1 and h2 should be at same depth");
+    assert_eq!(h2_depth, h3_depth, "h2 and h3 should be at same depth");
+    assert_eq!(h1_depth, 1, "Fan-out hidden neurons should be at depth 1");
+
+    // Output should be deeper than hidden neurons
+    let out_depth = depth_of(&layers, "out").expect("out should have a depth");
+    assert!(
+        out_depth > h1_depth,
+        "Output ({out_depth}) should be deeper than hidden ({h1_depth})"
+    );
+}
+
+// =============================================================================
+// Skip connections
+// =============================================================================
+
+#[test]
+fn skip_connection_uses_maximum_depth() {
+    // input-0 -> h1 -> h2 -> out
+    //   AND input-0 -> out (skip connection)
+    //
+    // BFS uses MAXIMUM depth, so `out` should be at depth 3 (via h1 -> h2 -> out),
+    // not depth 1 (via the skip connection).
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("h1", "h2", 1.0),
+            ("h2", "out", 1.0),
+            ("input-0", "out", 0.1), // Skip connection
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    // Output should be at the maximum depth (3), not depth 1
+    let out_depth = depth_of(&layers, "out").expect("out should have a depth");
+    assert_eq!(
+        out_depth, 3,
+        "Output should be at maximum depth 3 (not short-path depth 1), got {out_depth}"
+    );
+}
+
+#[test]
+fn skip_connection_does_not_affect_intermediate_depths() {
+    // input-0 -> h1 -> h2 -> out
+    //        \-> h2 (skip connection from input directly to h2)
+    //
+    // h2 has two paths: depth 1 (direct) and depth 2 (via h1).
+    // With maximum depth, h2 should be at depth 2.
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("input-0", "h2", 0.5), // Skip: direct to h2
+            ("h1", "h2", 1.0),      // Normal: h1 -> h2
+            ("h2", "out", 1.0),
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    let h1_depth = depth_of(&layers, "h1").expect("h1 present");
+    let h2_depth = depth_of(&layers, "h2").expect("h2 present");
+
+    assert_eq!(h1_depth, 1);
+    assert_eq!(h2_depth, 2, "h2 should be at max depth 2 (via h1), not 1");
+}
+
+// =============================================================================
+// Multiple inputs
+// =============================================================================
+
+#[test]
+fn multiple_inputs_all_contribute_to_depth() {
+    // input-0 -> h1 -> out
+    // input-1 -> h2 -> h1 -> out
+    //
+    // h1 receives from input-0 (depth 1) and from h2 (depth 2).
+    // Maximum depth: h1 should be at depth 2.
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("input-1", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("input-1", "h2", 1.0),
+            ("h2", "h1", 1.0),
+            ("h1", "out", 1.0),
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    let h2_depth = depth_of(&layers, "h2").expect("h2 present");
+    let h1_depth = depth_of(&layers, "h1").expect("h1 present");
+
+    assert_eq!(h2_depth, 1, "h2 direct from input should be at depth 1");
+    assert_eq!(
+        h1_depth, 2,
+        "h1 should be at max depth 2 (via input-1 -> h2 -> h1)"
+    );
+}
+
+// =============================================================================
+// Disconnected / orphan neurons
+// =============================================================================
+
+#[test]
+fn disconnected_neuron_assigned_to_unreachable_layer() {
+    // input-0 -> h1 -> out, orphan is disconnected
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("orphan", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![("input-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    let uuids = all_uuids(&layers);
+    assert!(
+        uuids.contains("orphan"),
+        "Orphan neuron should still appear in layers"
+    );
+
+    // Orphan should be in a layer deeper than all connected neurons (usize::MAX)
+    let orphan_depth = depth_of(&layers, "orphan").expect("orphan present");
+    let out_depth = depth_of(&layers, "out").expect("out present");
+    assert!(
+        orphan_depth > out_depth,
+        "Orphan ({orphan_depth}) should be deeper than output ({out_depth})"
+    );
+}
+
+// =============================================================================
+// Input and constant neurons excluded from layers
+// =============================================================================
+
+#[test]
+fn input_and_constant_neurons_excluded_from_layers() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "const-1".to_string(),
+                neuron_type: "constant".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 1.0,
+            },
+            NeuronJson {
+                uuid: "h1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "out".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "LOGISTIC".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "h1".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "const-1".to_string(),
+                to_uuid: "h1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h1".to_string(),
+                to_uuid: "out".to_string(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+    };
+
+    let layers = compute_network_layers(&creature);
+    let uuids = all_uuids(&layers);
+
+    // Constant neurons should be filtered out of layers (not selectable)
+    assert!(
+        !uuids.contains("const-1"),
+        "Constant neuron should not appear in layers"
+    );
+
+    // Hidden and output should still be present
+    assert!(uuids.contains("h1"));
+    assert!(uuids.contains("out"));
+}
+
+// =============================================================================
+// Empty / minimal creatures
+// =============================================================================
+
+#[test]
+fn empty_creature_returns_no_layers() {
+    let creature = CreatureJson {
+        input: 0,
+        output: 0,
+        neurons: vec![],
+        synapses: vec![],
+    };
+
+    let layers = compute_network_layers(&creature);
+    assert!(layers.is_empty(), "Empty creature should produce no layers");
+}
+
+#[test]
+fn output_only_creature_produces_single_layer() {
+    // A creature with just an output neuron and no synapses
+    let creature = CreatureJson {
+        input: 0,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "out".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "LOGISTIC".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![],
+    };
+
+    let layers = compute_network_layers(&creature);
+
+    // Output neuron is disconnected (unreachable from inputs since there are none)
+    // but should still appear in layers
+    assert!(!layers.is_empty(), "Should have at least one layer");
+    let uuids = all_uuids(&layers);
+    assert!(uuids.contains("out"), "Output should be in layers");
+}
+
+// =============================================================================
+// Diamond topology
+// =============================================================================
+
+#[test]
+fn diamond_topology_assigns_correct_depths() {
+    // input -> h1 -> h3 -> out
+    //     \-> h2 -> h3 -> out
+    //
+    // h3 should be at depth 2 (max of paths through h1 and h2)
+    let creature = make_creature(
+        vec![
+            ("input-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("h3", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("input-0", "h1", 1.0),
+            ("input-0", "h2", 1.0),
+            ("h1", "h3", 1.0),
+            ("h2", "h3", 1.0),
+            ("h3", "out", 1.0),
+        ],
+    );
+
+    let layers = compute_network_layers(&creature);
+
+    assert_eq!(depth_of(&layers, "h1"), Some(1));
+    assert_eq!(depth_of(&layers, "h2"), Some(1));
+    assert_eq!(depth_of(&layers, "h3"), Some(2));
+    assert_eq!(depth_of(&layers, "out"), Some(3));
+}

--- a/tests/focus_ranking.rs
+++ b/tests/focus_ranking.rs
@@ -1,0 +1,484 @@
+//! Issue #523: Targeted tests for the focus `ranking` sub-module.
+//!
+//! Tests neuron ranking with known impact scores and verifies:
+//! - Ranking order respects error × impact weighting
+//! - Removal candidate selection based on activation-weighted impact vs savings
+//! - SynapseCounts correctness for various topologies
+//! - calculate_removal_savings formula
+//! - Ranking with known parquet data
+
+mod common;
+
+use neat_ai_discovery::focus::{
+    SynapseCounts, calculate_removal_savings, compute_impacts_public, rank_focus_neurons,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Build a creature from (uuid, type, squash) neurons and (from, to, weight) synapses.
+fn make_creature(
+    neurons: Vec<(&str, &str, &str)>,
+    synapses: Vec<(&str, &str, f32)>,
+) -> CreatureJson {
+    let input_count = neurons.iter().filter(|(_, t, _)| *t == "input").count();
+    let output_count = neurons.iter().filter(|(_, t, _)| *t == "output").count();
+    CreatureJson {
+        neurons: neurons
+            .into_iter()
+            .filter(|(_, t, _)| *t != "input")
+            .map(|(uuid, ntype, squash)| NeuronJson {
+                uuid: uuid.to_string(),
+                neuron_type: ntype.to_string(),
+                squash: squash.to_string(),
+                bias: 0.0,
+            })
+            .collect(),
+        synapses: synapses
+            .into_iter()
+            .map(|(from, to, w)| SynapseJson {
+                from_uuid: from.to_string(),
+                to_uuid: to.to_string(),
+                weight: w,
+                synapse_type: None,
+            })
+            .collect(),
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Create discovery records for a neuron with the given error and activation values.
+fn make_records(uuid: &str, error: f32, activation: f32, count: u32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: uuid.to_string(),
+            value: Some(0.5),
+            activation,
+            errors: vec![error],
+        })
+        .collect()
+}
+
+/// Write records to a temporary parquet file.
+fn write_temp_parquet(records: &[DiscoverRecord]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().expect("create temp file");
+    write_records_to_parquet(tmp.path().to_str().unwrap(), records).expect("write parquet");
+    tmp
+}
+
+// =============================================================================
+// SynapseCounts
+// =============================================================================
+
+#[test]
+fn synapse_counts_correct_for_simple_chain() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![("in-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+
+    let (h1_in, h1_out) = counts.get("h1");
+    assert_eq!(h1_in, 1, "h1 should have 1 incoming");
+    assert_eq!(h1_out, 1, "h1 should have 1 outgoing");
+
+    let (out_in, out_out) = counts.get("out");
+    assert_eq!(out_in, 1, "out should have 1 incoming");
+    assert_eq!(out_out, 0, "out should have 0 outgoing");
+}
+
+#[test]
+fn synapse_counts_for_hub_neuron() {
+    // h1 receives from 3 inputs and sends to 2 outputs
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("in-1", "input", "IDENTITY"),
+            ("in-2", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("out-0", "output", "LOGISTIC"),
+            ("out-1", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("in-0", "h1", 1.0),
+            ("in-1", "h1", 1.0),
+            ("in-2", "h1", 1.0),
+            ("h1", "out-0", 1.0),
+            ("h1", "out-1", 1.0),
+        ],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+    let (incoming, outgoing) = counts.get("h1");
+
+    assert_eq!(incoming, 3, "Hub should have 3 incoming");
+    assert_eq!(outgoing, 2, "Hub should have 2 outgoing");
+}
+
+#[test]
+fn synapse_counts_nonexistent_neuron_returns_zero() {
+    let creature = make_creature(
+        vec![("in-0", "input", "IDENTITY"), ("out", "output", "LOGISTIC")],
+        vec![("in-0", "out", 1.0)],
+    );
+
+    let counts = SynapseCounts::new(&creature);
+    let (incoming, outgoing) = counts.get("does-not-exist");
+
+    assert_eq!(incoming, 0);
+    assert_eq!(outgoing, 0);
+}
+
+// =============================================================================
+// calculate_removal_savings
+// =============================================================================
+
+#[test]
+fn removal_savings_matches_neat_ai_formula() {
+    // Formula: growth_cost × (1 + (incoming + outgoing) / 10)
+    let growth_cost = 1e-7;
+
+    // 0 synapses: savings = 1e-7 × 1.0 = 1e-7
+    let s0 = calculate_removal_savings(0, 0, growth_cost);
+    assert!((s0 - 1e-7).abs() < 1e-15, "0 synapses: {s0}");
+
+    // 5 incoming + 5 outgoing = 10: savings = 1e-7 × 2.0 = 2e-7
+    let s10 = calculate_removal_savings(5, 5, growth_cost);
+    assert!((s10 - 2e-7).abs() < 1e-15, "10 synapses: {s10}");
+
+    // 1 incoming + 0 outgoing = 1: savings = 1e-7 × 1.1 = 1.1e-7
+    let s1 = calculate_removal_savings(1, 0, growth_cost);
+    let expected = growth_cost * 1.1;
+    assert!((s1 - expected).abs() < 1e-15, "1 synapse: {s1}");
+}
+
+#[test]
+fn removal_savings_scales_with_growth_cost() {
+    let s_small = calculate_removal_savings(2, 3, 1e-7);
+    let s_large = calculate_removal_savings(2, 3, 1e-5);
+
+    // Same synapse counts, but 100x larger growth cost → 100x larger savings
+    assert!(
+        (s_large / s_small - 100.0).abs() < 0.01,
+        "Savings should scale linearly with growth_cost"
+    );
+}
+
+// =============================================================================
+// Impact calculation
+// =============================================================================
+
+#[test]
+fn output_neuron_has_impact_one() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![("in-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let impacts = compute_impacts_public(&creature);
+
+    let out_impact = impacts.get("out").copied().unwrap_or(0.0);
+    assert!(
+        (out_impact - 1.0).abs() < f32::EPSILON,
+        "Output impact should be 1.0, got {out_impact}"
+    );
+}
+
+#[test]
+fn hidden_neuron_impact_bounded_zero_to_one() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("h2", "hidden", "TANH"),
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![
+            ("in-0", "h1", 3.0),
+            ("in-0", "h2", 2.0),
+            ("h1", "out", 0.7),
+            ("h2", "out", 0.3),
+        ],
+    );
+
+    let impacts = compute_impacts_public(&creature);
+
+    for uuid in ["h1", "h2"] {
+        let impact = impacts.get(uuid).copied().unwrap_or(-1.0);
+        assert!(
+            impact > 0.0 && impact <= 1.0,
+            "{uuid} impact should be in (0, 1], got {impact}"
+        );
+    }
+}
+
+#[test]
+fn disconnected_neuron_has_zero_impact() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "TANH"),
+            ("orphan", "hidden", "TANH"), // No connections
+            ("out", "output", "LOGISTIC"),
+        ],
+        vec![("in-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let impacts = compute_impacts_public(&creature);
+
+    let orphan_impact = impacts.get("orphan").copied().unwrap_or(-1.0);
+    assert!(
+        orphan_impact.abs() < f32::EPSILON,
+        "Disconnected neuron should have zero impact, got {orphan_impact}"
+    );
+}
+
+// =============================================================================
+// rank_focus_neurons — ranking order
+// =============================================================================
+
+#[test]
+fn high_error_high_impact_neuron_ranked_first() {
+    // h1: high error, directly connected to output → high impact
+    // h2: low error, directly connected to output → high impact
+    // Both connect to the same output so impact is similar.
+    // h1 should rank higher because of higher error.
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "IDENTITY"),
+            ("h2", "hidden", "IDENTITY"),
+            ("out", "output", "IDENTITY"),
+        ],
+        vec![
+            ("in-0", "h1", 0.5),
+            ("in-0", "h2", 0.5),
+            ("h1", "out", 0.5),
+            ("h2", "out", 0.5),
+        ],
+    );
+
+    let mut records = Vec::new();
+    records.extend(make_records("h1", 0.9, 0.5, 10)); // High error
+    records.extend(make_records("h2", 0.1, 0.5, 10)); // Low error
+    records.extend(make_records("out", 0.5, 0.5, 10));
+
+    let tmp = write_temp_parquet(&records);
+    let result = rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None)
+        .expect("rank focus neurons");
+
+    assert!(result.neurons.len() >= 2, "Should rank at least 2 neurons");
+
+    // h1 (high error) should appear before h2 (low error)
+    let h1_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h1")
+        .expect("h1 ranked");
+    let h2_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h2")
+        .expect("h2 ranked");
+
+    assert!(
+        h1_pos < h2_pos,
+        "High-error h1 (pos {h1_pos}) should rank before low-error h2 (pos {h2_pos})"
+    );
+}
+
+// =============================================================================
+// rank_focus_neurons — removal candidates
+// =============================================================================
+
+#[test]
+fn low_impact_neuron_identified_as_removal_candidate() {
+    // h1 has very low weight to output → low structural impact
+    // h2 has higher weight → higher structural impact
+    // With low activation, h1's activation_weighted_impact should be below removal savings.
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "IDENTITY"),
+            ("h2", "hidden", "IDENTITY"),
+            ("out", "output", "IDENTITY"),
+        ],
+        vec![
+            ("in-0", "h1", 0.001),
+            ("in-0", "h2", 1.0),
+            ("h1", "out", 0.001), // Very weak connection
+            ("h2", "out", 1.0),
+        ],
+    );
+
+    let mut records = Vec::new();
+    // h1: near-zero activation → very low activation_weighted_impact
+    records.extend(make_records("h1", 0.01, 0.001, 10));
+    records.extend(make_records("h2", 0.5, 5.0, 10));
+    records.extend(make_records("out", 0.3, 3.0, 10));
+
+    let tmp = write_temp_parquet(&records);
+    // Use a larger cost_of_growth so removal_savings exceeds h1's tiny impact
+    let result = rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, Some(0.01))
+        .expect("rank focus neurons");
+
+    // h1 should be a removal candidate (low impact × low activation < savings)
+    let h1_removal = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "h1");
+
+    assert!(
+        h1_removal.is_some(),
+        "h1 with near-zero impact should be a removal candidate. Candidates: {:?}",
+        result
+            .removal_candidates
+            .iter()
+            .map(|c| &c.neuron_uuid)
+            .collect::<Vec<_>>()
+    );
+
+    let candidate = h1_removal.unwrap();
+    assert!(
+        candidate.removal_savings > candidate.activation_weighted_impact,
+        "Removal savings ({}) should exceed impact ({})",
+        candidate.removal_savings,
+        candidate.activation_weighted_impact
+    );
+}
+
+#[test]
+fn high_impact_neuron_not_removal_candidate() {
+    // h1 is the sole path from input to output with strong weight
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "IDENTITY"),
+            ("out", "output", "IDENTITY"),
+        ],
+        vec![("in-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let mut records = Vec::new();
+    records.extend(make_records("h1", 0.5, 5.0, 10)); // High activation
+    records.extend(make_records("out", 0.3, 3.0, 10));
+
+    let tmp = write_temp_parquet(&records);
+    let result = rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None)
+        .expect("rank focus neurons");
+
+    let h1_removal = result
+        .removal_candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "h1");
+
+    assert!(
+        h1_removal.is_none(),
+        "High-impact h1 should NOT be a removal candidate"
+    );
+}
+
+// =============================================================================
+// rank_focus_neurons — max_results
+// =============================================================================
+
+#[test]
+fn max_results_limits_output_size() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "IDENTITY"),
+            ("h2", "hidden", "IDENTITY"),
+            ("h3", "hidden", "IDENTITY"),
+            ("out", "output", "IDENTITY"),
+        ],
+        vec![
+            ("in-0", "h1", 1.0),
+            ("in-0", "h2", 1.0),
+            ("in-0", "h3", 1.0),
+            ("h1", "out", 1.0),
+            ("h2", "out", 1.0),
+            ("h3", "out", 1.0),
+        ],
+    );
+
+    let mut records = Vec::new();
+    for uuid in ["h1", "h2", "h3", "out"] {
+        records.extend(make_records(uuid, 0.5, 0.5, 5));
+    }
+
+    let tmp = write_temp_parquet(&records);
+    let result = rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, Some(2), None)
+        .expect("rank focus neurons");
+
+    assert!(
+        result.neurons.len() <= 2,
+        "max_results=2 should limit to 2 neurons, got {}",
+        result.neurons.len()
+    );
+}
+
+// =============================================================================
+// rank_focus_neurons — basic statistics
+// =============================================================================
+
+#[test]
+fn ranked_neurons_have_correct_error_and_impact() {
+    let creature = make_creature(
+        vec![
+            ("in-0", "input", "IDENTITY"),
+            ("h1", "hidden", "IDENTITY"),
+            ("out", "output", "IDENTITY"),
+        ],
+        vec![("in-0", "h1", 1.0), ("h1", "out", 1.0)],
+    );
+
+    let mut records = Vec::new();
+    // h1: error = 0.3, activation = 2.0
+    records.extend(make_records("h1", 0.3, 2.0, 10));
+    // Output error must be >= h1 error to avoid clamping h1's total_error
+    records.extend(make_records("out", 0.5, 1.0, 10));
+
+    let tmp = write_temp_parquet(&records);
+    let result = rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None)
+        .expect("rank focus neurons");
+
+    let h1 = result
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h1")
+        .expect("h1 should be ranked");
+
+    // raw_error should be approximately 0.3 (total_error may be clamped to max_output_error)
+    assert!(
+        (h1.raw_error - 0.3).abs() < 0.05,
+        "h1 raw_error should be ~0.3, got {}",
+        h1.raw_error
+    );
+
+    // Impact should be positive (sole path to output)
+    assert!(
+        h1.impact > 0.0,
+        "h1 impact should be positive, got {}",
+        h1.impact
+    );
+
+    // Mean activation should be approximately 2.0
+    assert!(
+        (h1.mean_activation - 2.0).abs() < 0.1,
+        "h1 mean_activation should be ~2.0, got {}",
+        h1.mean_activation
+    );
+}


### PR DESCRIPTION
## Summary

Add targeted tests for 4 focus sub-modules: `layers`, `allocation`, `gradient`, and `ranking`. These sub-modules were split out in Issue #491 but lacked dedicated test files. Closes #523.

## Evidence

This is a test-only change with no UI or performance implications. All 48 new tests pass across 4 test files:

- `tests/focus_layers.rs` — 10 tests
- `tests/focus_allocation.rs` — 14 tests
- `tests/focus_gradient.rs` — 11 tests
- `tests/focus_ranking.rs` — 13 tests

`./quality.sh` passes cleanly (fmt, clippy, check, tests, release build).

## Test Plan

### `tests/focus_layers.rs` (10 tests)
- Linear chain assigns increasing BFS depths
- Fan-out groups sibling neurons at same depth
- Skip connections use maximum depth (not shortest path)
- Skip connections don't affect intermediate depths
- Multiple inputs contribute to depth calculation
- Disconnected neurons assigned to unreachable layer
- Input and constant neurons excluded from layers
- Empty creature returns no layers
- Output-only creature produces a layer
- Diamond topology assigns correct depths

### `tests/focus_allocation.rs` (14 tests)
- Equal distributes budget evenly across layers
- Equal distributes remainder to deeper layers
- Proportional gives more to larger layers
- Proportional handles uneven division
- OutputFirst prioritises deeper layers
- OutputFirst fills deep layers before shallow
- Zero budget returns empty
- Empty layers returns empty
- Budget exceeding total neurons selects all
- Single layer gets entire budget
- Higher-scored neurons selected first within layer
- Neurons with no score treated as zero
- All strategies respect max_focus
- All strategies return unique neurons

### `tests/focus_gradient.rs` (11 tests)
- RELU all-negative values fully dead (dead_ratio ≈ 1.0)
- RELU all-positive values not dead (gradient = 1.0)
- RELU mixed values partial dead (dead_ratio ≈ 0.5)
- TANH extreme values saturated
- TANH moderate values not saturated
- LOGISTIC extreme values saturated
- IDENTITY always has gradient 1.0
- Mixed activations produce independent stats
- Default GradientFlowStats assumes full flow
- Neuron with no finite values gets default stats
- ELU negative values have non-zero gradient (never dead)

### `tests/focus_ranking.rs` (13 tests)
- SynapseCounts correct for simple chain
- SynapseCounts for hub neuron (3 incoming, 2 outgoing)
- SynapseCounts returns zero for nonexistent neuron
- Removal savings matches NEAT-AI formula
- Removal savings scales with growth_cost
- Output neuron has impact 1.0
- Hidden neuron impact bounded (0, 1]
- Disconnected neuron has zero impact
- High error + high impact neuron ranked first
- Low impact neuron identified as removal candidate
- High impact neuron not a removal candidate
- max_results limits output size
- Ranked neurons have correct error and impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)