### PR TITLE
Replace production panic calls with proper error handling (#525)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-525.md
+++ b/docs/pr-summary-525.md
@@ -1,0 +1,47 @@
+## Summary
+
+Replace all production `panic!` paths from mutex `.expect("Mutex poisoned")` and `.unwrap()` calls with graceful error handling. Closes #525.
+
+An FFI library must never panic — a panic unwinds across the FFI boundary and causes the calling process (NEAT-AI via Deno) to abort unexpectedly. This PR replaces **31 mutex `.expect()` calls** and **4 mutex `.unwrap()` calls** across 5 production source files with safe alternatives that return errors via the JSON `success: false` mechanism instead of crashing.
+
+### Approach
+
+1. **`lock_or_bail()`** — new helper in `analysis/utils/mod.rs` that converts `PoisonError` into `anyhow::Error`, propagating gracefully to the FFI boundary.
+
+2. **`into_inner_or_bail()`** — companion helper for consuming a mutex.
+
+3. **Poison-recovery pattern** — for code paths that cannot return `Result` (e.g. `par_iter().for_each()` closures, diagnostic `.len()` methods), uses `Err(poisoned) => poisoned.into_inner()` to recover the data from a poisoned mutex rather than panicking.
+
+4. **`debug_assert!`** — invariants that "should never" fail are checked in debug builds but gracefully handled in release.
+
+### Files changed
+
+| File | Changes |
+|------|---------|
+| `src/analysis/utils/mod.rs` | Added `lock_or_bail()` and `into_inner_or_bail()` helpers |
+| `src/analysis/neuron.rs` | Replaced 13 `.expect("Mutex poisoned")` calls with `lock_or_bail()` |
+| `src/analysis/synapse/mod.rs` | Replaced 12 `.expect("Mutex poisoned")` calls with `lock_or_bail()` |
+| `src/focus/ranking.rs` | Replaced 3 `.expect("lazy record cache poisoned")` calls; `len()` uses poison-recovery |
+| `src/analysis/shared.rs` | Replaced 2 `.expect("Mutex poisoned")` in `TimingCollector` with `let Ok(...)` pattern |
+| `src/focus/impact.rs` | Replaced 4 `.unwrap()` calls with poison-recovery pattern; replaced `.expect()` with `debug_assert!` + `unwrap_or_default()` |
+| `tests/issue_525_graceful_mutex_handling.rs` | 4 new tests verifying graceful handling |
+
+## Evidence
+
+This is a backend/library change with no UI. Evidence is provided by the test suite:
+
+- `test_poisoned_mutex_returns_error_instead_of_panic` — verifies `lock_or_bail()` returns `Err` (not panic) for a poisoned mutex
+- `test_healthy_mutex_returns_guard` — verifies `lock_or_bail()` works normally
+- `test_poisoned_mutex_into_inner_returns_error` — verifies `into_inner_or_bail()` returns `Err` for a poisoned mutex
+- `test_healthy_mutex_into_inner_returns_value` — verifies `into_inner_or_bail()` works normally
+- All 478 unit tests + 97 integration test files pass
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)
+
+## Test Plan
+
+- Added `tests/issue_525_graceful_mutex_handling.rs` with 4 tests covering:
+  - Poisoned mutex lock returns error instead of panicking
+  - Healthy mutex lock returns guard normally
+  - Poisoned mutex `into_inner` returns error instead of panicking
+  - Healthy mutex `into_inner` returns value normally
+- All existing tests continue to pass unchanged

--- a/src/analysis/neuron.rs
+++ b/src/analysis/neuron.rs
@@ -18,9 +18,9 @@ use crate::analysis::activation::is_threshold_activation;
 
 // Import utilities
 use crate::analysis::utils::{
-    OrderedNeuron, build_deadline, deadline_passed, log_analysis_start, log_analysis_timeout,
-    order_eligible_sources, parse_input_index, shuffle_slice, shuffle_within_top_k,
-    verbose_enabled,
+    OrderedNeuron, build_deadline, deadline_passed, lock_or_bail, log_analysis_start,
+    log_analysis_timeout, order_eligible_sources, parse_input_index, shuffle_slice,
+    shuffle_within_top_k, verbose_enabled,
 };
 
 // Import sample data structures (Issue #269)
@@ -387,8 +387,8 @@ pub(crate) fn analyze_neurons_with_cache(
     focus_order_arc
         .par_iter()
         .try_for_each(|target_uuid| -> Result<()> {
-            if *analysis_timed_out.lock().expect("Mutex poisoned") || deadline_passed(&deadline) {
-                *analysis_timed_out.lock().expect("Mutex poisoned") = true;
+            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? || deadline_passed(&deadline) {
+                *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
                 return Ok(());
             }
 
@@ -425,7 +425,7 @@ pub(crate) fn analyze_neurons_with_cache(
                 if !errors.is_empty() {
                     error_values_for_distribution
                         .lock()
-                        .expect("Mutex poisoned")
+                        .map_err(|_| anyhow::anyhow!("Mutex poisoned (error_values_for_distribution)"))?
                         .extend(errors);
                 }
             }
@@ -504,7 +504,7 @@ pub(crate) fn analyze_neurons_with_cache(
             for source in &eligible_sources {
                 // Check deadline during pre-filtering
                 if deadline_passed(&deadline) {
-                    *analysis_timed_out.lock().expect("Mutex poisoned") = true;
+                    *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
                     break;
                 }
                 let source_uuid = source.uuid.as_str();
@@ -534,7 +534,7 @@ pub(crate) fn analyze_neurons_with_cache(
 
             // Log summary of source loading results for debugging
             let sources_checked = sources_to_process.len() + empty_record_sources.len() + load_failure_count as usize;
-            let timed_out_during_loading = *analysis_timed_out.lock().expect("Mutex poisoned");
+            let timed_out_during_loading = *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?;
             if verbose_enabled() && (sources_to_process.is_empty() || load_failure_count > 0 || !empty_record_sources.is_empty() || timed_out_during_loading) {
                 let sources_with_records = sources_to_process.len();
                 let empty_count = empty_record_sources.len();
@@ -560,7 +560,7 @@ pub(crate) fn analyze_neurons_with_cache(
             }
 
             // Check if timed out during pre-filtering
-            if *analysis_timed_out.lock().expect("Mutex poisoned") {
+            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? {
                 return Ok(());
             }
 
@@ -641,7 +641,7 @@ pub(crate) fn analyze_neurons_with_cache(
                 for result in work_results {
                     // Check deadline before each evaluation batch
                     if deadline_passed(&deadline) {
-                        *analysis_timed_out.lock().expect("Mutex poisoned") = true;
+                        *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
                         break;
                     }
 
@@ -701,7 +701,7 @@ pub(crate) fn analyze_neurons_with_cache(
                         }
                         // Issue #216: Direct method call - no lock needed with DashMap-based diagnostics
                         diagnostics.mark_candidate_selected(target_uuid);
-                        let mut map = helpful_map.lock().expect("Mutex poisoned: helpful_map");
+                        let mut map = lock_or_bail(&helpful_map, "helpful_map")?;
                         upsert_candidate(&mut map, candidate);
                     }
 
@@ -721,7 +721,7 @@ pub(crate) fn analyze_neurons_with_cache(
                         }
                         // Issue #216: Direct method call - no lock needed with DashMap-based diagnostics
                         diagnostics.mark_candidate_selected(target_uuid);
-                        let mut map = helpful_map.lock().expect("Mutex poisoned: helpful_map");
+                        let mut map = lock_or_bail(&helpful_map, "helpful_map")?;
                         upsert_candidate(&mut map, candidate);
                     }
 
@@ -746,7 +746,7 @@ pub(crate) fn analyze_neurons_with_cache(
 
                         // Issue #216: Direct method call - no lock needed with DashMap-based diagnostics
                         diagnostics.mark_candidate_selected(target_uuid);
-                        let mut map = helpful_map.lock().expect("Mutex poisoned: helpful_map");
+                        let mut map = lock_or_bail(&helpful_map, "helpful_map")?;
                         upsert_candidate(&mut map, candidate);
                     }
                 }
@@ -761,13 +761,8 @@ pub(crate) fn analyze_neurons_with_cache(
             Ok(())
         })?;
 
-    let analysis_timed_out = *analysis_timed_out
-        .lock()
-        .expect("Mutex poisoned: analysis_timed_out");
-    let helpful_map = helpful_map
-        .lock()
-        .expect("Mutex poisoned: helpful_map")
-        .clone();
+    let analysis_timed_out = *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?;
+    let helpful_map = lock_or_bail(&helpful_map, "helpful_map")?.clone();
 
     // Log timeout with completion stats (always visible, not just verbose)
     if analysis_timed_out {
@@ -875,11 +870,10 @@ pub(crate) fn analyze_neurons_with_cache(
 
     // Issue #486 / #192: Compute error distribution from collected target neuron error samples.
     let error_distribution = {
-        let error_values = std::mem::take(
-            &mut *error_values_for_distribution
-                .lock()
-                .expect("Mutex poisoned"),
-        );
+        let error_values = std::mem::take(&mut *lock_or_bail(
+            &error_values_for_distribution,
+            "error_values_for_distribution",
+        )?);
         super::error_distribution::ErrorDistribution::from_errors(&error_values)
     };
 

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -122,7 +122,12 @@ impl TimingCollector {
         if !self.enabled {
             return;
         }
-        let mut timings = self.shader_timings.lock().expect("Mutex poisoned");
+        let Ok(mut timings) = self.shader_timings.lock() else {
+            eprintln!(
+                "[NEAT-AI-Discovery] Warning: shader_timings mutex poisoned, skipping timing record"
+            );
+            return;
+        };
         let entry = timings.entry(shader_name.to_string()).or_insert((0, 0));
         entry.0 += 1;
         entry.1 += duration_ns;
@@ -165,7 +170,12 @@ impl TimingCollector {
 
         let total_analysis_ms = self.start_time.elapsed().as_secs_f64() * 1000.0;
 
-        let shader_timings_lock = self.shader_timings.lock().expect("Mutex poisoned");
+        let Ok(shader_timings_lock) = self.shader_timings.lock() else {
+            eprintln!(
+                "[NEAT-AI-Discovery] Warning: shader_timings mutex poisoned, returning partial timing data"
+            );
+            return None;
+        };
         let mut shader_timings = HashMap::new();
         let mut total_shader_ns: u64 = 0;
 

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -82,8 +82,8 @@ use crate::analysis::shared::AnalyzeSynapsesResult;
 use crate::analysis::diagnostics::{TargetDiagnostics, require_unique_focus};
 
 use crate::analysis::utils::{
-    build_deadline, deadline_passed, log_analysis_start, log_analysis_timeout, order_focus_targets,
-    verbose_enabled,
+    build_deadline, deadline_passed, lock_or_bail, log_analysis_start, log_analysis_timeout,
+    order_focus_targets, verbose_enabled,
 };
 
 use crate::analysis::samples::{compute_source_std_dev, get_constant_source_threshold};
@@ -316,8 +316,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     focus_order
         .par_iter()
         .try_for_each(|target_uuid| -> Result<()> {
-            if *analysis_timed_out.lock().expect("Mutex poisoned") || deadline_passed(&deadline) {
-                *analysis_timed_out.lock().expect("Mutex poisoned") = true;
+            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?
+                || deadline_passed(&deadline)
+            {
+                *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
                 return Ok(());
             }
 
@@ -331,27 +333,19 @@ pub(crate) fn analyze_synapses_with_cache_impl(
 
             // Merge results into shared collections
             if !target_results.helpful.is_empty() {
-                helpful_results
-                    .lock()
-                    .expect("Mutex poisoned")
+                lock_or_bail(&helpful_results, "helpful_results")?
                     .extend(target_results.helpful);
             }
             if !target_results.harmful.is_empty() {
-                harmful_results
-                    .lock()
-                    .expect("Mutex poisoned")
+                lock_or_bail(&harmful_results, "harmful_results")?
                     .extend(target_results.harmful);
             }
             if !target_results.coordinated.is_empty() {
-                coordinated_structural_results
-                    .lock()
-                    .expect("Mutex poisoned")
+                lock_or_bail(&coordinated_structural_results, "coordinated_structural_results")?
                     .extend(target_results.coordinated);
             }
             if !target_results.error_values.is_empty() {
-                error_values_for_distribution
-                    .lock()
-                    .expect("Mutex poisoned")
+                lock_or_bail(&error_values_for_distribution, "error_values_for_distribution")?
                     .extend(target_results.error_values);
             }
             if target_results.target_value_seen {
@@ -381,15 +375,16 @@ pub(crate) fn analyze_synapses_with_cache_impl(
             Ok(())
         })?;
 
-    let analysis_timed_out = *analysis_timed_out.lock().expect("Mutex poisoned");
-    let mut helpful_results = std::mem::take(&mut *helpful_results.lock().expect("Mutex poisoned"));
-    let mut harmful_results = std::mem::take(&mut *harmful_results.lock().expect("Mutex poisoned"));
-    let mut coordinated_structural_results = std::mem::take(
-        &mut *coordinated_structural_results
-            .lock()
-            .expect("Mutex poisoned"),
-    );
-    let mut helpful_fallback = helpful_fallback.lock().expect("Mutex poisoned").take();
+    let analysis_timed_out = *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?;
+    let mut helpful_results =
+        std::mem::take(&mut *lock_or_bail(&helpful_results, "helpful_results")?);
+    let mut harmful_results =
+        std::mem::take(&mut *lock_or_bail(&harmful_results, "harmful_results")?);
+    let mut coordinated_structural_results = std::mem::take(&mut *lock_or_bail(
+        &coordinated_structural_results,
+        "coordinated_structural_results",
+    )?);
+    let mut helpful_fallback = lock_or_bail(&helpful_fallback, "helpful_fallback")?.take();
 
     if analysis_timed_out {
         let completed = completed_count.load(std::sync::atomic::Ordering::Relaxed);
@@ -427,11 +422,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     let input_min = metadata_input_min_with_records.load(std::sync::atomic::Ordering::Relaxed);
     let input_max = metadata_input_max_with_records.load(std::sync::atomic::Ordering::Relaxed);
 
-    let error_vec = std::mem::take(
-        &mut *error_values_for_distribution
-            .lock()
-            .expect("Mutex poisoned"),
-    );
+    let error_vec = std::mem::take(&mut *lock_or_bail(
+        &error_values_for_distribution,
+        "error_values_for_distribution",
+    )?);
 
     let metadata = post_processing::build_metadata(&post_processing::MetadataParams {
         target_value_seen: metadata_target_value_seen.load(std::sync::atomic::Ordering::Relaxed),

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -13,6 +13,41 @@ pub mod deadline;
 pub mod memory;
 pub mod platform;
 
+// ============================================================================
+// Mutex helpers — graceful handling of poisoned mutexes (Issue #525)
+// ============================================================================
+
+use std::sync::Mutex;
+
+/// Lock a mutex, returning an `anyhow::Error` instead of panicking if poisoned.
+///
+/// In an FFI library a panic unwinds into the calling process (Deno / NEAT-AI)
+/// and causes an unexpected abort. This helper converts a `PoisonError` into a
+/// recoverable `anyhow::Error` that propagates to the JSON `success: false`
+/// boundary.
+///
+/// The `context` parameter is included in the error message for diagnostics.
+pub fn lock_or_bail<'a, T>(
+    mutex: &'a Mutex<T>,
+    context: &str,
+) -> anyhow::Result<std::sync::MutexGuard<'a, T>> {
+    mutex.lock().map_err(|_| {
+        anyhow::anyhow!("Mutex poisoned ({context}): a thread panicked while holding this lock")
+    })
+}
+
+/// Consume a mutex and return its inner value, or an error if poisoned.
+///
+/// Equivalent to `Mutex::into_inner().unwrap()` but returns an error instead
+/// of panicking.
+pub fn into_inner_or_bail<T>(mutex: Mutex<T>, context: &str) -> anyhow::Result<T> {
+    mutex.into_inner().map_err(|_| {
+        anyhow::anyhow!(
+            "Mutex poisoned on into_inner ({context}): a thread panicked while holding this lock"
+        )
+    })
+}
+
 // Re-export key memory functions for convenience
 pub use memory::{
     DEFAULT_GPU_BATCH_SIZE, HIGH_PERF_GPU_BATCH_SIZE, LOW_MEMORY_GPU_BATCH_SIZE, MemoryPressure,

--- a/src/focus/impact.rs
+++ b/src/focus/impact.rs
@@ -429,8 +429,14 @@ fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)
 }
 
 fn compute_impacts_internal(creature: &CreatureJson) -> HashMap<String, f32> {
-    compute_impacts_internal_with_stats(creature, None)
-        .expect("impact computation without records should not fail")
+    // Issue #525: Replace expect() with graceful fallback.
+    // This call with None records should never fail (no I/O, no external data),
+    // but if it does we return an empty map rather than panicking in FFI context.
+    debug_assert!(
+        compute_impacts_internal_with_stats(creature, None).is_ok(),
+        "impact computation without records should not fail"
+    );
+    compute_impacts_internal_with_stats(creature, None).unwrap_or_default()
 }
 
 /// Compute impacts with optional activation-based selection statistics.
@@ -507,9 +513,13 @@ fn compute_impacts_internal_with_stats(
     let shared_cache: Mutex<HashMap<String, f32>> = Mutex::new(HashMap::new());
 
     all_neurons.par_iter().for_each(|neuron| {
-        // Check if already computed (another thread might have done it)
+        // Check if already computed (another thread might have done it).
+        // Issue #525: Recover from poisoned mutex instead of panicking.
         {
-            let cache = shared_cache.lock().unwrap();
+            let cache = match shared_cache.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
             if cache.contains_key(&neuron.uuid) {
                 return;
             }
@@ -523,11 +533,16 @@ fn compute_impacts_internal_with_stats(
             compute_impact_with_shared_cache(&neuron.uuid, &ctx, &shared_cache, &mut visiting);
 
         // Store result
-        let mut cache = shared_cache.lock().unwrap();
+        let mut cache = match shared_cache.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         cache.insert(neuron.uuid.clone(), impact);
     });
 
-    Ok(shared_cache.into_inner().unwrap())
+    Ok(shared_cache
+        .into_inner()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()))
 }
 
 /// Compute impact with a shared cache for parallel execution.
@@ -537,9 +552,12 @@ fn compute_impact_with_shared_cache(
     shared_cache: &Mutex<HashMap<String, f32>>,
     visiting: &mut HashSet<String>,
 ) -> f32 {
-    // Check cache first
+    // Check cache first. Issue #525: recover from poisoned mutex.
     {
-        let cache = shared_cache.lock().unwrap();
+        let cache = match shared_cache.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         if let Some(&value) = cache.get(uuid) {
             return value;
         }
@@ -624,9 +642,12 @@ fn compute_impact_with_shared_cache(
 
     visiting.remove(uuid);
 
-    // Cache the result
+    // Cache the result. Issue #525: recover from poisoned mutex.
     {
-        let mut cache = shared_cache.lock().unwrap();
+        let mut cache = match shared_cache.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         cache.insert(uuid.to_string(), impact);
     }
 

--- a/src/focus/ranking.rs
+++ b/src/focus/ranking.rs
@@ -9,6 +9,7 @@ use super::gradient::{
     compute_gradient_flow_for_neuron,
 };
 use super::impact::compute_impacts_with_activations;
+use crate::analysis::utils::lock_or_bail;
 use crate::analysis::{check_memory_for_parquet, verbose_enabled};
 use crate::discovery_history::DiscoveryHistory;
 use crate::parquet_format::{read_all_records_grouped_by_neuron, read_records_from_parquet};
@@ -136,7 +137,7 @@ impl LazyRecordProvider {
 impl RecordProvider for LazyRecordProvider {
     fn get(&self, neuron_uuid: &str) -> Result<Option<Arc<Vec<DiscoverRecord>>>> {
         {
-            let cache = self.cache.lock().expect("lazy record cache poisoned");
+            let cache = lock_or_bail(&self.cache, "lazy record cache")?;
             if let Some(records) = cache.entries.get(neuron_uuid) {
                 return Ok(Some(Arc::clone(records)));
             }
@@ -154,14 +155,17 @@ impl RecordProvider for LazyRecordProvider {
         records.sort_by_key(|r| r.obs_index);
         let arc_records = Arc::new(records);
 
-        let mut cache = self.cache.lock().expect("lazy record cache poisoned");
+        let mut cache = lock_or_bail(&self.cache, "lazy record cache")?;
         cache.insert(neuron_uuid.to_string(), Arc::clone(&arc_records));
         Ok(Some(arc_records))
     }
 
     fn len(&self) -> usize {
-        let cache = self.cache.lock().expect("lazy record cache poisoned");
-        cache.entries.len()
+        // len() is diagnostic-only; recover data from a poisoned mutex if needed
+        match self.cache.lock() {
+            Ok(cache) => cache.entries.len(),
+            Err(poisoned) => poisoned.into_inner().entries.len(),
+        }
     }
 }
 

--- a/tests/issue_525_graceful_mutex_handling.rs
+++ b/tests/issue_525_graceful_mutex_handling.rs
@@ -1,0 +1,82 @@
+//! Issue #525: Replace production panic! calls with proper error handling
+//!
+//! Tests that mutex lock failures are handled gracefully (returning errors)
+//! rather than panicking, which would crash the FFI caller process.
+
+use std::sync::{Arc, Mutex};
+
+/// Verify that `lock_or_bail` returns an error instead of panicking
+/// when a mutex is poisoned.
+#[test]
+fn test_poisoned_mutex_returns_error_instead_of_panic() {
+    let mutex = Arc::new(Mutex::new(42_i32));
+
+    // Poison the mutex by panicking inside a lock scope
+    let mutex_clone = Arc::clone(&mutex);
+    let _ = std::thread::spawn(move || {
+        let _guard = mutex_clone.lock().unwrap();
+        panic!("intentional panic to poison the mutex");
+    })
+    .join();
+
+    // The mutex should now be poisoned
+    assert!(
+        mutex.lock().is_err(),
+        "Mutex should be poisoned after thread panic"
+    );
+
+    // Using lock_or_bail should return an Err, not panic
+    let result = neat_ai_discovery::analysis::utils::lock_or_bail(&mutex, "test mutex");
+    assert!(
+        result.is_err(),
+        "lock_or_bail should return Err for a poisoned mutex, not panic"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("poisoned"),
+        "Error message should mention poisoning: {err_msg}"
+    );
+}
+
+/// Verify that `lock_or_bail` works normally for a healthy mutex.
+#[test]
+fn test_healthy_mutex_returns_guard() {
+    let mutex = Mutex::new(99_i32);
+    let result = neat_ai_discovery::analysis::utils::lock_or_bail(&mutex, "healthy mutex");
+    assert!(
+        result.is_ok(),
+        "lock_or_bail should succeed for a healthy mutex"
+    );
+    assert_eq!(*result.unwrap(), 99);
+}
+
+/// Verify that `into_inner_or_bail` returns an error for a poisoned mutex.
+#[test]
+fn test_poisoned_mutex_into_inner_returns_error() {
+    let mutex = Arc::new(Mutex::new(vec![1, 2, 3]));
+
+    // Poison the mutex
+    let mutex_clone = Arc::clone(&mutex);
+    let _ = std::thread::spawn(move || {
+        let _guard = mutex_clone.lock().unwrap();
+        panic!("intentional panic to poison the mutex");
+    })
+    .join();
+
+    // into_inner_or_bail should return Err, not panic
+    let owned = Arc::try_unwrap(mutex).unwrap();
+    let result = neat_ai_discovery::analysis::utils::into_inner_or_bail(owned, "test vec mutex");
+    assert!(
+        result.is_err(),
+        "into_inner_or_bail should return Err for a poisoned mutex"
+    );
+}
+
+/// Verify that `into_inner_or_bail` works normally for a healthy mutex.
+#[test]
+fn test_healthy_mutex_into_inner_returns_value() {
+    let mutex = Mutex::new(vec![10, 20, 30]);
+    let result = neat_ai_discovery::analysis::utils::into_inner_or_bail(mutex, "healthy vec mutex");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), vec![10, 20, 30]);
+}


### PR DESCRIPTION
## Summary

Replace all production `panic!` paths from mutex `.expect("Mutex poisoned")` and `.unwrap()` calls with graceful error handling. Closes #525.

An FFI library must never panic — a panic unwinds across the FFI boundary and causes the calling process (NEAT-AI via Deno) to abort unexpectedly. This PR replaces **31 mutex `.expect()` calls** and **4 mutex `.unwrap()` calls** across 5 production source files with safe alternatives that return errors via the JSON `success: false` mechanism instead of crashing.

### Approach

1. **`lock_or_bail()`** — new helper in `analysis/utils/mod.rs` that converts `PoisonError` into `anyhow::Error`, propagating gracefully to the FFI boundary.

2. **`into_inner_or_bail()`** — companion helper for consuming a mutex.

3. **Poison-recovery pattern** — for code paths that cannot return `Result` (e.g. `par_iter().for_each()` closures, diagnostic `.len()` methods), uses `Err(poisoned) => poisoned.into_inner()` to recover the data from a poisoned mutex rather than panicking.

4. **`debug_assert!`** — invariants that "should never" fail are checked in debug builds but gracefully handled in release.

### Files changed

| File | Changes |
|------|---------|
| `src/analysis/utils/mod.rs` | Added `lock_or_bail()` and `into_inner_or_bail()` helpers |
| `src/analysis/neuron.rs` | Replaced 13 `.expect("Mutex poisoned")` calls with `lock_or_bail()` |
| `src/analysis/synapse/mod.rs` | Replaced 12 `.expect("Mutex poisoned")` calls with `lock_or_bail()` |
| `src/focus/ranking.rs` | Replaced 3 `.expect("lazy record cache poisoned")` calls; `len()` uses poison-recovery |
| `src/analysis/shared.rs` | Replaced 2 `.expect("Mutex poisoned")` in `TimingCollector` with `let Ok(...)` pattern |
| `src/focus/impact.rs` | Replaced 4 `.unwrap()` calls with poison-recovery pattern; replaced `.expect()` with `debug_assert!` + `unwrap_or_default()` |
| `tests/issue_525_graceful_mutex_handling.rs` | 4 new tests verifying graceful handling |

## Evidence

This is a backend/library change with no UI. Evidence is provided by the test suite:

- `test_poisoned_mutex_returns_error_instead_of_panic` — verifies `lock_or_bail()` returns `Err` (not panic) for a poisoned mutex
- `test_healthy_mutex_returns_guard` — verifies `lock_or_bail()` works normally
- `test_poisoned_mutex_into_inner_returns_error` — verifies `into_inner_or_bail()` returns `Err` for a poisoned mutex
- `test_healthy_mutex_into_inner_returns_value` — verifies `into_inner_or_bail()` works normally
- All 478 unit tests + 97 integration test files pass
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

## Test Plan

- Added `tests/issue_525_graceful_mutex_handling.rs` with 4 tests covering:
  - Poisoned mutex lock returns error instead of panicking
  - Healthy mutex lock returns guard normally
  - Poisoned mutex `into_inner` returns error instead of panicking
  - Healthy mutex `into_inner` returns value normally
- All existing tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)