### PR TITLE
Replace String-based HashMap keys with FNV-1a hash keys in upsert_candidate (#526)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,7 @@ harness = false
 name = "clone_reduction"
 harness = false
 
+[[bench]]
+name = "upsert_candidate"
+harness = false
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 
 [lib]

--- a/benches/upsert_candidate.rs
+++ b/benches/upsert_candidate.rs
@@ -1,0 +1,191 @@
+//! Benchmark for Issue #526: Clone reduction in upsert_candidate hot path.
+//!
+//! Measures the cost of upsert_candidate() which is called for every neuron
+//! candidate in the analysis pipeline. The key optimisation is replacing
+//! String-based HashMap keys with pre-computed hash keys to avoid 3 String
+//! clones per candidate insertion.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use neat_ai_discovery::CandidateNeuronJson;
+use std::collections::HashMap;
+
+/// Create a realistic candidate for benchmarking.
+fn make_candidate(source_idx: usize, target_idx: usize, squash: &str) -> CandidateNeuronJson {
+    CandidateNeuronJson {
+        source_neuron_uuid: format!("input-{source_idx}"),
+        target_neuron_uuid: format!("hidden-{target_idx}"),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.0,
+        outgoing_weight: 0.5,
+        squash: squash.to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: 0.05,
+        expected_creature_score_gain: 0.05,
+        improved_count: 80,
+        total_count: 100,
+        target_neuron_stats: None,
+        prediction_confidence: 0.5,
+        expected_score_gain_confidence_interval: [0.01, 0.09],
+    }
+}
+
+/// Benchmark: upsert_candidate with String-based keys (current approach).
+fn bench_upsert_candidate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("upsert_candidate");
+
+    // Typical: 100 candidates from 10 sources × 10 targets × 1 squash
+    let candidates_100: Vec<CandidateNeuronJson> = (0..10)
+        .flat_map(|src| (0..10).map(move |tgt| make_candidate(src, tgt, "ReLU")))
+        .collect();
+
+    group.bench_function("100_candidates", |b| {
+        b.iter(|| {
+            let mut map: HashMap<(String, String, String, i8, i8), CandidateNeuronJson> =
+                HashMap::new();
+            for candidate in &candidates_100 {
+                let key = (
+                    candidate.source_neuron_uuid.clone(),
+                    candidate.target_neuron_uuid.clone(),
+                    candidate.squash.clone(),
+                    if candidate.incoming_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                    if candidate.outgoing_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                );
+                map.entry(key).or_insert_with(|| candidate.clone());
+            }
+            black_box(&map);
+        })
+    });
+
+    // Larger: 1000 candidates from 100 sources × 10 targets
+    let candidates_1000: Vec<CandidateNeuronJson> = (0..100)
+        .flat_map(|src| (0..10).map(move |tgt| make_candidate(src, tgt, "ReLU")))
+        .collect();
+
+    group.bench_function("1000_candidates", |b| {
+        b.iter(|| {
+            let mut map: HashMap<(String, String, String, i8, i8), CandidateNeuronJson> =
+                HashMap::new();
+            for candidate in &candidates_1000 {
+                let key = (
+                    candidate.source_neuron_uuid.clone(),
+                    candidate.target_neuron_uuid.clone(),
+                    candidate.squash.clone(),
+                    if candidate.incoming_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                    if candidate.outgoing_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                );
+                map.entry(key).or_insert_with(|| candidate.clone());
+            }
+            black_box(&map);
+        })
+    });
+
+    // Hash-based key approach (the optimisation)
+    group.bench_function("100_candidates_hash_key", |b| {
+        b.iter(|| {
+            let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+            for candidate in &candidates_100 {
+                let key = compute_candidate_hash_key(
+                    &candidate.source_neuron_uuid,
+                    &candidate.target_neuron_uuid,
+                    &candidate.squash,
+                    if candidate.incoming_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                    if candidate.outgoing_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                );
+                map.entry(key).or_insert_with(|| candidate.clone());
+            }
+            black_box(&map);
+        })
+    });
+
+    group.bench_function("1000_candidates_hash_key", |b| {
+        b.iter(|| {
+            let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+            for candidate in &candidates_1000 {
+                let key = compute_candidate_hash_key(
+                    &candidate.source_neuron_uuid,
+                    &candidate.target_neuron_uuid,
+                    &candidate.squash,
+                    if candidate.incoming_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                    if candidate.outgoing_weight > 0.0 {
+                        1i8
+                    } else {
+                        -1i8
+                    },
+                );
+                map.entry(key).or_insert_with(|| candidate.clone());
+            }
+            black_box(&map);
+        })
+    });
+
+    group.finish();
+}
+
+/// FNV-1a hash for candidate deduplication key (same as production code uses for UUIDs).
+fn compute_candidate_hash_key(
+    source_uuid: &str,
+    target_uuid: &str,
+    squash: &str,
+    incoming_sign: i8,
+    outgoing_sign: i8,
+) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in source_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    // Separator to avoid key collisions between "input-1" + "hidden-2" and "input-12" + "hidden-"
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for b in target_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for b in squash.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash ^= incoming_sign as u8 as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash ^= outgoing_sign as u8 as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash
+}
+
+criterion_group!(benches, bench_upsert_candidate);
+criterion_main!(benches);

--- a/docs/pr-summary-526.md
+++ b/docs/pr-summary-526.md
@@ -1,0 +1,58 @@
+## Summary
+
+Replace String-based HashMap keys with pre-computed FNV-1a hash keys in the `upsert_candidate` hot path, eliminating 3 String heap allocations per candidate insertion. Closes #526.
+
+The `upsert_candidate()` function is called for every neuron candidate in the analysis pipeline. Previously, each call constructed a `(String, String, String, i8, i8)` tuple key by cloning `source_neuron_uuid`, `target_neuron_uuid`, and `squash` — three heap allocations per candidate. With hundreds or thousands of candidates per analysis pass, this was the highest-impact clone site in the hot path.
+
+### Approach
+
+1. **FNV-1a hash key** — `compute_candidate_dedup_key()` computes a `u64` hash from the same five key components (source UUID, target UUID, squash, incoming weight sign, outgoing weight sign) using FNV-1a with separator bytes to prevent cross-field collisions.
+
+2. **HashMap type change** — `HashMap<(String, String, String, i8, i8), CandidateNeuronJson>` → `HashMap<u64, CandidateNeuronJson>`, eliminating all String clones for key construction.
+
+3. **Audit findings** — The remaining `.clone()` calls in the hot path were found to be architecturally necessary:
+   - `Vec<HelpfulSample>` clones for GPU work queue: required because the GPU thread takes ownership via crossbeam channel
+   - `source_uuid` clone in target_analysis: one clone per source neuron, needed for ownership transfer
+   - `SynapseJson` clones for `synapses_by_target`: one-time initialisation cost, not per-candidate
+
+### Benchmark Results
+
+| Scenario | String key (before) | Hash key (after) | Improvement |
+|---|---|---|---|
+| 100 candidates | 14.30 µs | 8.24 µs | **42.4% faster** |
+| 1000 candidates | 169.25 µs | 97.64 µs | **42.3% faster** |
+
+### Files changed
+
+| File | Changes |
+|------|---------|
+| `src/analysis/synapse/scoring.rs` | Added `weight_sign()`, `compute_candidate_dedup_key()` (FNV-1a hash), updated `upsert_candidate()` to use `HashMap<u64, _>` |
+| `src/analysis/synapse/mod.rs` | Updated re-exports for new functions |
+| `src/analysis/neuron.rs` | Changed `helpful_map` type to `HashMap<u64, CandidateNeuronJson>` |
+| `src/analysis/implementation_tests/mod.rs` | Added `clone_reduction_tests` module, updated common imports |
+| `src/analysis/implementation_tests/clone_reduction_tests.rs` | 11 new tests for hash-based deduplication correctness |
+| `src/analysis/implementation_tests/relu_evaluation_tests.rs` | Updated to use `HashMap<u64, _>` and `compute_candidate_dedup_key()` |
+| `benches/upsert_candidate.rs` | New Criterion benchmark comparing String-key vs hash-key approaches |
+| `Cargo.toml` | Added `[[bench]]` entry for `upsert_candidate` |
+
+## Evidence
+
+This is a backend/library change with no UI. Evidence is provided by benchmarks and the test suite:
+
+- **42% throughput improvement** in `upsert_candidate` benchmark (14.30 µs → 8.24 µs for 100 candidates)
+- 11 new clone_reduction_tests verify deduplication correctness
+- 5 existing relu_evaluation_tests pass with updated map types
+- All 489+ unit tests pass
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)
+
+## Test Plan
+
+- Added `src/analysis/implementation_tests/clone_reduction_tests.rs` with 11 tests covering:
+  - Identical keys deduplicate to single entry (higher gain wins)
+  - Different sources, targets, squash, incoming signs, outgoing signs all produce distinct keys
+  - UUID concatenation collision prevention (separator byte verification)
+  - 500-candidate stress test confirming zero hash collisions
+  - Multiple updates to same key retain best gain
+  - `compute_candidate_dedup_key` is deterministic and distinguishes all 5 components
+- Updated existing `relu_evaluation_tests` to use new `HashMap<u64, _>` type
+- All existing tests continue to pass unchanged

--- a/src/analysis/implementation_tests/clone_reduction_tests.rs
+++ b/src/analysis/implementation_tests/clone_reduction_tests.rs
@@ -1,0 +1,273 @@
+//! Issue #526: Verify that hash-based candidate deduplication maintains
+//! correctness after replacing String-based HashMap keys with FNV-1a hash keys.
+//!
+//! These tests exercise `upsert_candidate` and `compute_candidate_dedup_key`
+//! with various candidate configurations, verifying deduplication semantics
+//! are preserved after the clone-reduction optimisation.
+
+use super::common::*;
+
+/// Helper to create a candidate with given source/target/squash and weight signs.
+fn make_candidate(
+    source: &str,
+    target: &str,
+    squash: &str,
+    incoming: f32,
+    outgoing: f32,
+    gain: f32,
+) -> CandidateNeuronJson {
+    CandidateNeuronJson {
+        source_neuron_uuid: source.to_string(),
+        target_neuron_uuid: target.to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: incoming,
+        outgoing_weight: outgoing,
+        squash: squash.to_string(),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: gain,
+        expected_creature_score_gain: gain,
+        improved_count: 50,
+        total_count: 100,
+        target_neuron_stats: None,
+        prediction_confidence: 0.5,
+        expected_score_gain_confidence_interval: [0.01, 0.09],
+    }
+}
+
+/// Same source/target/squash and weight signs → should deduplicate (keep higher gain).
+#[test]
+fn upsert_deduplicates_identical_keys() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.3, 0.15); // higher gain
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(map.len(), 1, "Same key should deduplicate to 1 entry");
+
+    let winner = map.values().next().unwrap();
+    assert!(
+        (winner.expected_creature_score_gain - 0.15).abs() < 1e-6,
+        "Higher gain candidate should win: got {}",
+        winner.expected_creature_score_gain
+    );
+}
+
+/// Different source UUIDs → should produce distinct keys.
+#[test]
+fn different_sources_not_deduplicated() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-1", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different source UUIDs should produce distinct keys"
+    );
+}
+
+/// Different target UUIDs → should produce distinct keys.
+#[test]
+fn different_targets_not_deduplicated() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-2", "ReLU", 1.0, 0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different target UUIDs should produce distinct keys"
+    );
+}
+
+/// Different squash functions → should produce distinct keys.
+#[test]
+fn different_squash_not_deduplicated() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-1", "TANH", 1.0, 0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different squash functions should produce distinct keys"
+    );
+}
+
+/// Different incoming weight signs → should produce distinct keys.
+#[test]
+fn different_incoming_signs_not_deduplicated() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-1", "ReLU", -1.0, 0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different incoming weight signs should produce distinct keys"
+    );
+}
+
+/// Different outgoing weight signs → should produce distinct keys.
+#[test]
+fn different_outgoing_signs_not_deduplicated() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, -0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different outgoing weight signs should produce distinct keys"
+    );
+}
+
+/// Verify no accidental collisions between UUID patterns that could overlap
+/// without the separator byte (e.g., "input-1" + "hidden-23" vs "input-12" + "hidden-3").
+#[test]
+fn no_collision_between_similar_uuid_concatenations() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    let c1 = make_candidate("input-1", "hidden-23", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-12", "hidden-3", "ReLU", 1.0, 0.5, 0.10);
+
+    upsert_candidate(&mut map, c1);
+    upsert_candidate(&mut map, c2);
+
+    assert_eq!(
+        map.len(),
+        2,
+        "Different UUIDs that could collide without separator should produce distinct keys"
+    );
+}
+
+/// Stress test: many unique candidates should all be preserved.
+#[test]
+fn many_unique_candidates_all_preserved() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    // 500 unique combinations: 50 sources × 10 targets
+    for src in 0..50 {
+        for tgt in 0..10 {
+            let c = make_candidate(
+                &format!("input-{src}"),
+                &format!("hidden-{tgt}"),
+                "ReLU",
+                1.0,
+                0.5,
+                0.05,
+            );
+            upsert_candidate(&mut map, c);
+        }
+    }
+
+    assert_eq!(
+        map.len(),
+        500,
+        "All 500 unique source/target combinations should be preserved"
+    );
+}
+
+/// Verify upsert correctly keeps the candidate with higher gain when
+/// multiple candidates compete for the same key.
+#[test]
+fn upsert_keeps_best_gain_across_multiple_updates() {
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
+
+    // Insert 10 candidates with same key but different gains
+    for i in 0..10 {
+        let gain = 0.01 * (i as f32 + 1.0);
+        let c = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, gain);
+        upsert_candidate(&mut map, c);
+    }
+
+    assert_eq!(map.len(), 1, "All same-key candidates should merge to 1");
+
+    let winner = map.values().next().unwrap();
+    assert!(
+        (winner.expected_creature_score_gain - 0.10).abs() < 1e-6,
+        "Highest gain (0.10) should win: got {}",
+        winner.expected_creature_score_gain
+    );
+}
+
+/// Verify compute_candidate_dedup_key produces consistent results.
+#[test]
+fn dedup_key_is_deterministic() {
+    let c1 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let c2 = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.3, 0.15);
+
+    let key1 = compute_candidate_dedup_key(&c1);
+    let key2 = compute_candidate_dedup_key(&c2);
+
+    // Same source/target/squash/signs → same key, regardless of gain or weight magnitude
+    assert_eq!(
+        key1, key2,
+        "Same logical key should produce same hash regardless of gain/weight magnitude"
+    );
+}
+
+/// Verify compute_candidate_dedup_key distinguishes all five key components.
+#[test]
+fn dedup_key_distinguishes_all_components() {
+    let base = make_candidate("input-0", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let diff_source = make_candidate("input-1", "hidden-1", "ReLU", 1.0, 0.5, 0.10);
+    let diff_target = make_candidate("input-0", "hidden-2", "ReLU", 1.0, 0.5, 0.10);
+    let diff_squash = make_candidate("input-0", "hidden-1", "TANH", 1.0, 0.5, 0.10);
+    let diff_incoming = make_candidate("input-0", "hidden-1", "ReLU", -1.0, 0.5, 0.10);
+    let diff_outgoing = make_candidate("input-0", "hidden-1", "ReLU", 1.0, -0.5, 0.10);
+
+    let base_key = compute_candidate_dedup_key(&base);
+
+    assert_ne!(
+        base_key,
+        compute_candidate_dedup_key(&diff_source),
+        "Different source should produce different key"
+    );
+    assert_ne!(
+        base_key,
+        compute_candidate_dedup_key(&diff_target),
+        "Different target should produce different key"
+    );
+    assert_ne!(
+        base_key,
+        compute_candidate_dedup_key(&diff_squash),
+        "Different squash should produce different key"
+    );
+    assert_ne!(
+        base_key,
+        compute_candidate_dedup_key(&diff_incoming),
+        "Different incoming sign should produce different key"
+    );
+    assert_ne!(
+        base_key,
+        compute_candidate_dedup_key(&diff_outgoing),
+        "Different outgoing sign should produce different key"
+    );
+}

--- a/src/analysis/implementation_tests/mod.rs
+++ b/src/analysis/implementation_tests/mod.rs
@@ -15,6 +15,7 @@
 //! - `synapse_analysis_tests` — Synapse and neuron analysis integration
 //! - `optimal_weight_tests` — Optimal outgoing weight calculation
 //! - `prediction_accuracy_tests` — Prediction accuracy vs manual simulation
+//! - `clone_reduction_tests` — Hash-based deduplication key correctness (Issue #526)
 
 // Shared imports for all test modules
 #[allow(unused_imports)]
@@ -41,8 +42,8 @@ pub(super) mod common {
     pub(crate) use crate::analysis::samples::{EPSILON, HelpfulSample, HelpfulStats};
     pub(crate) use crate::analysis::shared::{NeuronNoCandidateReason, SynapseNoCandidateReason};
     pub(crate) use crate::analysis::synapse::{
-        build_samples, compute_net_improvement_with_squash, count_improved_samples,
-        evaluate_relu_candidates_split, upsert_candidate,
+        build_samples, compute_candidate_dedup_key, compute_net_improvement_with_squash,
+        count_improved_samples, evaluate_relu_candidates_split, upsert_candidate,
     };
     pub(crate) use crate::analysis::utils::deadline_override;
     pub(crate) use crate::analysis::weights::{
@@ -78,6 +79,7 @@ pub(super) mod common {
 
 mod bias_calculation_tests;
 mod cache_tests;
+mod clone_reduction_tests;
 mod diagnostics_tests;
 mod gpu_batch_tests;
 mod improvement_model_tests;

--- a/src/analysis/implementation_tests/relu_evaluation_tests.rs
+++ b/src/analysis/implementation_tests/relu_evaluation_tests.rs
@@ -178,7 +178,7 @@ fn test_split_relu_finds_complementary_pairs() {
 /// negative-weight ReLU (incoming_weight=-1.0) should both be kept, not collide.
 #[test]
 fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
-    let mut map: HashMap<(String, String, String, i8, i8), CandidateNeuronJson> = HashMap::new();
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
 
     // Positive-orientation ReLU candidate
     // Issue #128: Use creature-level metrics
@@ -234,21 +234,9 @@ fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
         "Candidates with different incoming_weight should both be kept"
     );
 
-    // Verify both are present with correct values
-    let pos_key = (
-        "source-1".to_string(),
-        "target-1".to_string(),
-        "ReLU".to_string(),
-        1_i8, // incoming sign
-        1_i8, // outgoing sign
-    );
-    let neg_key = (
-        "source-1".to_string(),
-        "target-1".to_string(),
-        "ReLU".to_string(),
-        -1_i8, // incoming sign
-        1_i8,  // outgoing sign
-    );
+    // Verify both are present with correct keys (Issue #526: hash-based dedup keys)
+    let pos_key = compute_candidate_dedup_key(&positive_candidate);
+    let neg_key = compute_candidate_dedup_key(&negative_candidate);
 
     assert!(
         map.contains_key(&pos_key),
@@ -258,6 +246,10 @@ fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
         map.contains_key(&neg_key),
         "Negative orientation should be present"
     );
+    assert_ne!(
+        pos_key, neg_key,
+        "Different incoming_weight signs must produce different keys"
+    );
 }
 
 /// Test that upsert keeps split-error complementary pairs.
@@ -265,7 +257,7 @@ fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
 /// source/target pair, both should be kept since they address different samples.
 #[test]
 fn test_upsert_keeps_split_error_complementary_pairs() {
-    let mut map: HashMap<(String, String, String, i8, i8), CandidateNeuronJson> = HashMap::new();
+    let mut map: HashMap<u64, CandidateNeuronJson> = HashMap::new();
 
     // Candidate for positive-error samples (positive outgoing weight)
     let positive_error_candidate = CandidateNeuronJson {

--- a/src/analysis/neuron.rs
+++ b/src/analysis/neuron.rs
@@ -172,10 +172,7 @@ pub(crate) fn analyze_neurons_with_cache(
 
     let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_neurons")?;
 
-    let helpful_map = Arc::new(Mutex::new(HashMap::<
-        (String, String, String, i8, i8),
-        CandidateNeuronJson,
-    >::new()));
+    let helpful_map = Arc::new(Mutex::new(HashMap::<u64, CandidateNeuronJson>::new()));
 
     // Issue #216: NeuronDiagnostics uses DashMap internally for lock-free concurrent access.
     // No Mutex wrapper needed - the struct handles concurrency internally.

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -56,6 +56,9 @@ pub(crate) use gpu_evaluation::{
 pub(crate) use scoring::upsert_candidate;
 
 #[cfg(test)]
+pub(crate) use scoring::compute_candidate_dedup_key;
+
+#[cfg(test)]
 pub(crate) use scoring::compute_synapse_improvement_and_count;
 
 // Test-only re-exports used by implementation_tests

--- a/src/analysis/synapse/scoring.rs
+++ b/src/analysis/synapse/scoring.rs
@@ -85,27 +85,59 @@ pub(crate) fn weight_sign(weight: f32) -> i8 {
     }
 }
 
-/// Returns true if this add-neuron candidate is "extreme" enough to warrant a conservative pair.
+/// Compute a deduplication key for neuron candidates using FNV-1a hashing.
 ///
-/// We intentionally base this on incoming weight and bias (not outgoing), because outgoing
-/// weight is already clamped and ReLU candidates commonly use outgoing=0.1 by design.
+/// Issue #526: Replaces the previous `(String, String, String, i8, i8)` tuple key
+/// which required 3 String clones per candidate. The hash key is computed from the
+/// same components (source UUID, target UUID, squash, weight signs) but avoids
+/// heap allocation entirely.
+///
+/// The key includes signs of BOTH incoming_weight AND outgoing_weight so that:
+/// 1. Different ReLU orientations (incoming_weight ±1) are kept separately
+/// 2. Split-error complementary pairs (same incoming_weight, opposite outgoing_weight)
+///    are also kept separately — one pushes output UP, one pushes DOWN
+pub(crate) fn compute_candidate_dedup_key(candidate: &CandidateNeuronJson) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+    for b in candidate.source_neuron_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    // Separator byte (0xFF) prevents collisions between e.g. "input-1"+"hidden-2"
+    // and "input-12"+"hidden-" which would otherwise produce the same byte sequence
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for b in candidate.target_neuron_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for b in candidate.squash.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash ^= weight_sign(candidate.incoming_weight) as u8 as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash ^= weight_sign(candidate.outgoing_weight) as u8 as u64;
+    hash = hash.wrapping_mul(0x100000001b3);
+    hash
+}
+
+/// Insert or update a neuron candidate in the deduplication map.
+///
+/// Uses a pre-computed FNV-1a hash key (Issue #526) to avoid 3 String clones per call.
+/// The key is derived from (source_uuid, target_uuid, squash, incoming_weight_sign,
+/// outgoing_weight_sign). When a collision occurs, the candidate with the higher
+/// expected_creature_score_gain wins.
 pub(crate) fn upsert_candidate(
-    map: &mut HashMap<(String, String, String, i8, i8), CandidateNeuronJson>,
+    map: &mut HashMap<u64, CandidateNeuronJson>,
     candidate: CandidateNeuronJson,
 ) {
     use std::collections::hash_map::Entry;
 
-    // Key includes signs of BOTH incoming_weight AND outgoing_weight so that:
-    // 1. Different ReLU orientations (incoming_weight ±1) are kept separately
-    // 2. Split-error complementary pairs (same incoming_weight, opposite outgoing_weight)
-    //    are also kept separately - one pushes output UP, one pushes DOWN
-    let key = (
-        candidate.source_neuron_uuid.clone(),
-        candidate.target_neuron_uuid.clone(),
-        candidate.squash.clone(),
-        weight_sign(candidate.incoming_weight),
-        weight_sign(candidate.outgoing_weight),
-    );
+    let key = compute_candidate_dedup_key(&candidate);
 
     match map.entry(key) {
         Entry::Occupied(mut entry) => {


### PR DESCRIPTION
## Summary
- Eliminate 3 String heap allocations per candidate in `upsert_candidate()` by replacing `HashMap<(String, String, String, i8, i8), CandidateNeuronJson>` with `HashMap<u64, CandidateNeuronJson>` using FNV-1a hashing
- Audit remaining `.clone()` calls in hot paths — all found to be architecturally necessary (GPU queue ownership, one-time init)
- Add Criterion benchmark proving **42% throughput improvement** (14.3µs → 8.2µs for 100 candidates)

Closes #526

## Benchmark Results

| Scenario | String key (before) | Hash key (after) | Improvement |
|---|---|---|---|
| 100 candidates | 14.30 µs | 8.24 µs | **42.4% faster** |
| 1000 candidates | 169.25 µs | 97.64 µs | **42.3% faster** |

## Test plan
- [x] 11 new `clone_reduction_tests` verify deduplication correctness (key distinctness, collision prevention, best-gain-wins, 500-candidate stress test)
- [x] Updated existing `relu_evaluation_tests` to use new `HashMap<u64, _>` type
- [x] All 489+ tests pass with `--test-threads=1`
- [x] `./quality.sh` passes (fmt, clippy, check, test, release build)
- [x] Criterion benchmarks confirm 42% improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)