### PR TITLE
Add coordinated changeSquash + setBias for error plateau escape (#547)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-547.md
+++ b/docs/pr-summary-547.md
@@ -1,0 +1,28 @@
+## Summary
+
+Enhanced the error stagnation plateau detection module to generate coordinated `changeSquash` + `setBias` structural candidates for escaping local minimums. Previously the module only recommended a squash function change; now it also computes a bias adjustment based on the mean signed error, recentring the output after the activation function change. The `setBias` operation is only included when the adjustment exceeds a minimum threshold to avoid trivial changes. Closes #547.
+
+## Changes
+
+- **`src/analysis/detection/error_plateau.rs`**: Added `current_bias` and `recommended_bias` fields to `ErrorPlateauCandidate`. Added `compute_bias_adjustment()` to calculate bias correction from mean signed error. Updated `error_plateaus_to_coordinated_candidates()` to emit combined `changeSquash` + `setBias` operations when bias adjustment is meaningful.
+- **`tests/issue_547_error_plateau_structural.rs`**: New integration test file with 6 tests covering coordinated squash+bias operations, bias adjustment computation, negligible bias suppression, multiple plateau neurons, healthy network rejection, and positive improvement estimates.
+- **`tests/issue_545_error_plateau.rs`**: Updated issue reference in comment assertion from #545 to #547.
+
+## Evidence
+
+This is a backend detection module with no UI. All verification is via integration tests:
+
+```
+running 7 tests (issue_545_error_plateau) ... ok
+running 6 tests (issue_547_error_plateau_structural) ... ok
+quality.sh: All quality checks passed!
+```
+
+## Test Plan
+
+- `test_coordinated_candidate_has_squash_and_bias_operations` — verifies both `changeSquash` and `setBias` appear in coordinated candidates
+- `test_recommended_bias_adjusts_for_plateau` — verifies bias is computed from mean signed error
+- `test_no_set_bias_when_adjustment_negligible` — verifies `setBias` is omitted when errors are symmetric
+- `test_multiple_plateau_neurons_get_coordinated_pairs` — verifies each plateau neuron gets its own candidate
+- `test_healthy_network_no_candidates` — verifies converged networks produce no false positives
+- `test_estimated_improvement_positive` — verifies positive expected score gain

--- a/src/analysis/detection/error_plateau.rs
+++ b/src/analysis/detection/error_plateau.rs
@@ -15,8 +15,10 @@
 //!
 //! ## Recommended Actions
 //!
-//! For plateau neurons, the module recommends `changeSquash` candidates to
-//! fundamentally alter the error landscape and potentially escape the local minimum.
+//! For plateau neurons, the module recommends coordinated `changeSquash` + `setBias`
+//! candidates to fundamentally alter the error landscape and attempt a structural
+//! jump out of the local minimum (Issue #547). The bias adjustment compensates for
+//! the mean signed error, recentring the output after the squash change.
 
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
 use crate::types::DiscoverRecord;
@@ -30,6 +32,10 @@ const MIN_PLATEAU_ERROR: f32 = 0.05;
 /// a plateau. Low CV means errors are tightly clustered around the mean.
 const MAX_COEFFICIENT_OF_VARIATION: f32 = 0.3;
 
+/// Minimum absolute bias adjustment to include a `setBias` operation.
+/// Below this threshold, the bias change is too small to be worthwhile.
+const MIN_BIAS_ADJUSTMENT: f32 = 0.02;
+
 /// A detected error plateau candidate.
 #[derive(Debug, Clone)]
 pub struct ErrorPlateauCandidate {
@@ -39,6 +45,10 @@ pub struct ErrorPlateauCandidate {
     pub current_squash: String,
     /// Recommended replacement activation function.
     pub recommended_squash: String,
+    /// Current bias value.
+    pub current_bias: f32,
+    /// Recommended bias value to recentre output after squash change.
+    pub recommended_bias: f32,
     /// Mean absolute error across observations.
     pub mean_error: f32,
     /// Standard deviation of errors.
@@ -103,6 +113,25 @@ fn recommend_plateau_escape(current_squash: &str, records: &[DiscoverRecord]) ->
     }
 }
 
+/// Compute a recommended bias adjustment based on mean signed error.
+///
+/// When errors are consistently biased in one direction (e.g., always positive),
+/// the output is systematically off-centre. Adjusting the bias by the negative
+/// of the mean signed error helps recentre the output after a squash change.
+fn compute_bias_adjustment(records: &[DiscoverRecord], current_bias: f32) -> f32 {
+    let n = records.len() as f32;
+    let mean_signed_error: f32 = records
+        .iter()
+        .map(|r| r.errors.first().copied().unwrap_or(0.0))
+        .sum::<f32>()
+        / n;
+
+    // The bias adjustment opposes the mean signed error to recentre output.
+    // error = activation - target, so if error is positive, activation is too high,
+    // meaning we should decrease the bias.
+    current_bias - mean_signed_error
+}
+
 /// Detect error stagnation plateaus in output neurons.
 ///
 /// # Arguments
@@ -117,7 +146,7 @@ pub fn detect_error_plateaus(
 ) -> Vec<ErrorPlateauCandidate> {
     let mut candidates = Vec::new();
 
-    for (uuid, squash, _bias) in output_neurons {
+    for (uuid, squash, bias) in output_neurons {
         let Some((_id, records)) = neuron_records.iter().find(|(u, _)| u == uuid) else {
             continue;
         };
@@ -163,6 +192,9 @@ pub fn detect_error_plateaus(
             continue;
         }
 
+        // Compute recommended bias adjustment (Issue #547)
+        let recommended_bias = compute_bias_adjustment(records, *bias);
+
         // Confidence based on sample size and how tight the plateau is
         let sample_confidence = (records.len() as f32 / 100.0).min(1.0);
         let plateau_tightness = (1.0 - cv / MAX_COEFFICIENT_OF_VARIATION).max(0.0);
@@ -173,17 +205,25 @@ pub fn detect_error_plateaus(
         // Estimated improvement: proportional to plateau error and tightness
         let estimated_improvement = mean_error * plateau_tightness * 0.3;
 
+        let bias_info = if (recommended_bias - bias).abs() >= MIN_BIAS_ADJUSTMENT {
+            format!(" Bias adjustment: {bias:.3} → {recommended_bias:.3}.")
+        } else {
+            String::new()
+        };
+
         candidates.push(ErrorPlateauCandidate {
             neuron_uuid: uuid.clone(),
             current_squash: squash.clone(),
             recommended_squash: recommended.clone(),
+            current_bias: *bias,
+            recommended_bias,
             mean_error,
             error_std_dev: std_dev,
             error_coefficient_of_variation: cv,
             confidence,
             estimated_improvement,
             reason: format!(
-                "Output neuron {uuid} shows error plateau: mean error {mean_error:.3} with CV {cv:.3} (tight clustering around non-zero error indicates local minimum). Recommending {recommended} to escape plateau. (Issue #545)",
+                "Output neuron {uuid} shows error plateau: mean error {mean_error:.3} with CV {cv:.3} (tight clustering around non-zero error indicates local minimum). Recommending {recommended}{bias_info} to escape plateau. (Issue #547)",
             ),
         });
     }
@@ -199,18 +239,34 @@ pub fn detect_error_plateaus(
 }
 
 /// Convert error plateau candidates to coordinated structural candidates.
+///
+/// Generates `changeSquash` + `setBias` operations for a structural jump
+/// to escape the local minimum (Issue #547). The `setBias` operation is only
+/// included when the bias adjustment exceeds `MIN_BIAS_ADJUSTMENT`.
 pub fn error_plateaus_to_coordinated_candidates(
     candidates: &[ErrorPlateauCandidate],
 ) -> Vec<CoordinatedStructuralCandidateJson> {
     candidates
         .iter()
-        .map(|c| CoordinatedStructuralCandidateJson {
-            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+        .map(|c| {
+            let mut operations = vec![CoordinatedStructuralOpJson::ChangeSquash {
                 neuron_uuid: c.neuron_uuid.clone(),
                 squash: c.recommended_squash.clone(),
-            }],
-            expected_creature_score_gain: c.estimated_improvement,
-            comment: Some(c.reason.clone()),
+            }];
+
+            // Only include setBias when the adjustment is meaningful (Issue #547)
+            if (c.recommended_bias - c.current_bias).abs() >= MIN_BIAS_ADJUSTMENT {
+                operations.push(CoordinatedStructuralOpJson::SetBias {
+                    neuron_uuid: c.neuron_uuid.clone(),
+                    bias: c.recommended_bias,
+                });
+            }
+
+            CoordinatedStructuralCandidateJson {
+                operations,
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(c.reason.clone()),
+            }
         })
         .collect()
 }

--- a/tests/issue_545_error_plateau.rs
+++ b/tests/issue_545_error_plateau.rs
@@ -166,8 +166,8 @@ fn test_coordinated_candidate_conversion() {
         "Expected score gain should be positive"
     );
     assert!(
-        coordinated[0].comment.as_ref().unwrap().contains("545"),
-        "Comment should reference issue #545"
+        coordinated[0].comment.as_ref().unwrap().contains("547"),
+        "Comment should reference issue #547"
     );
 
     let ops_json = serde_json::to_string(&coordinated[0].operations).unwrap();

--- a/tests/issue_547_error_plateau_structural.rs
+++ b/tests/issue_547_error_plateau_structural.rs
@@ -1,0 +1,275 @@
+//! Tests for Issue #547: Error stagnation plateau detection — coordinated
+//! `changeSquash` + `setBias` structural escape candidates.
+//!
+//! ## TDD Plan
+//! 1. Test coordinated candidates include both changeSquash and setBias operations
+//! 2. Test recommended bias is computed from mean error to centre the output
+//! 3. Test no setBias generated when bias adjustment is negligible
+//! 4. Test multiple plateau neurons each get their own coordinated pair
+//! 5. Test that healthy networks produce no candidates
+//! 6. Test that the estimated improvement accounts for both squash and bias changes
+
+mod common;
+
+use neat_ai_discovery::analysis::detection::error_plateau::{
+    detect_error_plateaus, error_plateaus_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(uuid: &str, idx: u32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn output_neuron(uuid: &str, squash: &str) -> (String, String, f32) {
+    (uuid.to_string(), squash.to_string(), 0.0)
+}
+
+fn output_neuron_with_bias(uuid: &str, squash: &str, bias: f32) -> (String, String, f32) {
+    (uuid.to_string(), squash.to_string(), bias)
+}
+
+// =============================================================================
+// 1. Coordinated candidates include both changeSquash and setBias
+// =============================================================================
+
+#[test]
+fn test_coordinated_candidate_has_squash_and_bias_operations() {
+    let outputs = vec![output_neuron("output-1", "HARD_TANH")];
+
+    // Plateau: consistently high error (~0.3), tightly clustered
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "output-1".to_string(),
+        (0..60)
+            .map(|i| {
+                let activation = (i as f32 - 30.0) / 40.0;
+                let error = 0.30 + (i as f32 * 0.001).sin() * 0.01;
+                make_record("output-1", i, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(!candidates.is_empty(), "Should detect error plateau");
+
+    let coordinated = error_plateaus_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    let ops_json = serde_json::to_string(&coordinated[0].operations).unwrap();
+
+    // Must contain both changeSquash and setBias for a structural jump
+    assert!(
+        ops_json.contains("changeSquash"),
+        "Coordinated candidate must include changeSquash, got: {ops_json}"
+    );
+    assert!(
+        ops_json.contains("setBias"),
+        "Coordinated candidate must include setBias for structural escape, got: {ops_json}"
+    );
+}
+
+// =============================================================================
+// 2. Recommended bias adjusts towards reducing mean error
+// =============================================================================
+
+#[test]
+fn test_recommended_bias_adjusts_for_plateau() {
+    // Neuron with existing bias of 0.0 and consistent positive error (~0.4)
+    // means the output is consistently too high → bias should be adjusted
+    let outputs = vec![output_neuron_with_bias("output-1", "HARD_TANH", 0.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "output-1".to_string(),
+        (0..60)
+            .map(|i| {
+                let activation = 0.5;
+                // Consistent positive error means activation is above target
+                let error = 0.40 + (i as f32 * 0.001).sin() * 0.01;
+                make_record("output-1", i, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(
+        !candidates.is_empty(),
+        "Should detect error plateau with consistent positive error"
+    );
+
+    // The recommended bias should be different from the current bias
+    let candidate = &candidates[0];
+    assert!(
+        (candidate.recommended_bias - 0.0).abs() > 0.01,
+        "Recommended bias should differ from current bias (0.0), got: {}",
+        candidate.recommended_bias
+    );
+}
+
+// =============================================================================
+// 3. No setBias when bias adjustment is negligible
+// =============================================================================
+
+#[test]
+fn test_no_set_bias_when_adjustment_negligible() {
+    // Errors are symmetric around zero → mean signed error ≈ 0 → no bias shift needed
+    let outputs = vec![output_neuron("output-1", "HARD_TANH")];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "output-1".to_string(),
+        (0..60)
+            .map(|i| {
+                let activation = (i as f32 - 30.0) / 40.0;
+                // Alternating sign errors with same magnitude → mean signed error ≈ 0
+                // but abs error is consistently ~0.3 (plateau)
+                let error = if i % 2 == 0 { 0.30 } else { -0.30 };
+                make_record("output-1", i, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(
+        !candidates.is_empty(),
+        "Should detect error plateau even with symmetric errors"
+    );
+
+    let coordinated = error_plateaus_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    // When bias adjustment is negligible, should only have changeSquash (no setBias)
+    let ops_json = serde_json::to_string(&coordinated[0].operations).unwrap();
+    assert!(
+        ops_json.contains("changeSquash"),
+        "Must include changeSquash"
+    );
+    assert!(
+        !ops_json.contains("setBias"),
+        "Should NOT include setBias when signed mean error is near zero, got: {ops_json}"
+    );
+}
+
+// =============================================================================
+// 4. Multiple plateau neurons each get coordinated pairs
+// =============================================================================
+
+#[test]
+fn test_multiple_plateau_neurons_get_coordinated_pairs() {
+    let outputs = vec![
+        output_neuron("output-a", "HARD_TANH"),
+        output_neuron("output-b", "LOGISTIC"),
+    ];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "output-a".to_string(),
+            (0..60)
+                .map(|i| {
+                    let activation = (i as f32 - 30.0) / 40.0;
+                    let error = 0.35 + (i as f32 * 0.002).sin() * 0.005;
+                    make_record("output-a", i, activation, error)
+                })
+                .collect(),
+        ),
+        (
+            "output-b".to_string(),
+            (0..60)
+                .map(|i| {
+                    let activation = 0.5 + (i as f32 - 30.0) / 100.0;
+                    let error = 0.25 + (i as f32 * 0.001).sin() * 0.008;
+                    make_record("output-b", i, activation, error)
+                })
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(
+        candidates.len() >= 2,
+        "Should detect plateaus for both neurons, got: {}",
+        candidates.len()
+    );
+
+    let coordinated = error_plateaus_to_coordinated_candidates(&candidates);
+    assert!(
+        coordinated.len() >= 2,
+        "Should produce coordinated candidates for each plateau neuron"
+    );
+
+    // Each coordinated candidate should target a different neuron
+    let uuids: Vec<String> = candidates.iter().map(|c| c.neuron_uuid.clone()).collect();
+    assert!(uuids.contains(&"output-a".to_string()));
+    assert!(uuids.contains(&"output-b".to_string()));
+}
+
+// =============================================================================
+// 5. Healthy networks produce no candidates
+// =============================================================================
+
+#[test]
+fn test_healthy_network_no_candidates() {
+    let outputs = vec![output_neuron("output-1", "TANH")];
+
+    // Very low errors = healthy, converged network
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "output-1".to_string(),
+        (0..60)
+            .map(|i| {
+                let activation = (i as f32 - 30.0) / 40.0;
+                let error = 0.001 + (i as f32 * 0.001).sin() * 0.0005;
+                make_record("output-1", i, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(
+        candidates.is_empty(),
+        "Healthy network should produce no plateau candidates"
+    );
+}
+
+// =============================================================================
+// 6. Estimated improvement accounts for both squash and bias changes
+// =============================================================================
+
+#[test]
+fn test_estimated_improvement_positive() {
+    let outputs = vec![output_neuron("output-1", "HARD_TANH")];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "output-1".to_string(),
+        (0..60)
+            .map(|i| {
+                let activation = (i as f32 - 30.0) / 40.0;
+                let error = 0.30 + (i as f32 * 0.001).sin() * 0.01;
+                make_record("output-1", i, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_error_plateaus(&outputs, &records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = error_plateaus_to_coordinated_candidates(&candidates);
+    assert!(!coordinated.is_empty());
+
+    assert!(
+        coordinated[0].expected_creature_score_gain > 0.0,
+        "Expected score gain should be positive for structural escape"
+    );
+}


### PR DESCRIPTION
## Summary

Enhanced the error stagnation plateau detection module to generate coordinated `changeSquash` + `setBias` structural candidates for escaping local minimums. Previously the module only recommended a squash function change; now it also computes a bias adjustment based on the mean signed error, recentring the output after the activation function change. The `setBias` operation is only included when the adjustment exceeds a minimum threshold to avoid trivial changes. Closes #547.

## Changes

- **`src/analysis/detection/error_plateau.rs`**: Added `current_bias` and `recommended_bias` fields to `ErrorPlateauCandidate`. Added `compute_bias_adjustment()` to calculate bias correction from mean signed error. Updated `error_plateaus_to_coordinated_candidates()` to emit combined `changeSquash` + `setBias` operations when bias adjustment is meaningful.
- **`tests/issue_547_error_plateau_structural.rs`**: New integration test file with 6 tests covering coordinated squash+bias operations, bias adjustment computation, negligible bias suppression, multiple plateau neurons, healthy network rejection, and positive improvement estimates.
- **`tests/issue_545_error_plateau.rs`**: Updated issue reference in comment assertion from #545 to #547.

## Evidence

This is a backend detection module with no UI. All verification is via integration tests:

```
running 7 tests (issue_545_error_plateau) ... ok
running 6 tests (issue_547_error_plateau_structural) ... ok
quality.sh: All quality checks passed!
```

## Test Plan

- `test_coordinated_candidate_has_squash_and_bias_operations` — verifies both `changeSquash` and `setBias` appear in coordinated candidates
- `test_recommended_bias_adjusts_for_plateau` — verifies bias is computed from mean signed error
- `test_no_set_bias_when_adjustment_negligible` — verifies `setBias` is omitted when errors are symmetric
- `test_multiple_plateau_neurons_get_coordinated_pairs` — verifies each plateau neuron gets its own candidate
- `test_healthy_network_no_candidates` — verifies converged networks produce no false positives
- `test_estimated_improvement_positive` — verifies positive expected score gain

🤖 Generated with [Claude Code](https://claude.com/claude-code)