### PR TITLE
Filter non-positive gain candidates from all discovery pipelines (#557)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-557.md
+++ b/docs/pr-summary-557.md
@@ -1,0 +1,64 @@
+## Summary
+
+Audit all discovery strategies to ensure only candidates with a positive predicted
+score improvement are returned. Closes #557.
+
+### Problem
+
+Several discovery modules could produce candidates with zero or near-zero
+`expected_creature_score_gain` at boundary conditions:
+
+- **dormant_synapse**: `0.001 * (1.0 - ratio)` equals zero when `mean_abs_contribution`
+  exactly equals `DORMANT_CONTRIBUTION_THRESHOLD`
+- **error_plateau**: `mean_error * plateau_tightness * 0.3` equals zero when
+  `plateau_tightness` is clamped to zero via `.max(0.0)`
+- **correlated_error**: product of factors can be zero if `mean_correlation` or
+  `mean_abs_error` is zero
+- **activation_mismatch**: boundary conditions at detection thresholds
+- **Impact discounting**: any candidate targeting a hidden neuron disconnected from
+  outputs gets multiplied by 0.1, which can reduce already-small gains to effectively
+  zero
+
+Returning these zero-gain candidates wastes evaluation budget since NEAT-AI must
+clone the creature, apply the mutation, and re-score against the full training set
+for each candidate — all for zero predicted benefit.
+
+### Solution
+
+Added positive-gain filtering (`expected_creature_score_gain > 0.0`) at three
+pipeline choke-points, providing defence-in-depth:
+
+1. **`merge_coordinated_structural_replacements`** (mod.rs) — filters all coordinated
+   structural candidates before merging into the synapse result. This catches every
+   discovery module since they all merge through this single function.
+
+2. **Synapse post-processing** (post_processing.rs) — filters helpful, harmful, and
+   coordinated candidates after impact discounting, before sorting and truncation.
+
+3. **Neuron pipeline** (neuron.rs) — filters neuron candidates after impact
+   discounting, before sorting and truncation.
+
+This is a central safety-net approach (DRY) rather than patching each of the 28+
+individual discovery modules, ensuring that future modules also benefit automatically.
+
+## Evidence
+
+This is a backend/pipeline change with no visual output. Evidence is provided by
+the test results from `quality.sh` passing cleanly, including all 502+ unit tests
+and 97+ integration tests.
+
+## Test Plan
+
+- Added `tests/issue_557_audit_discovery_strategies.rs` — integration tests that
+  run the full `analyze_all` pipeline and assert every returned candidate (synapse,
+  neuron, coordinated) has strictly positive `expected_creature_score_gain`, plus
+  metadata consistency checks
+- Added unit tests in `src/analysis/discovery_dispatch_parallel_tests.rs`:
+  - `parallel_dispatch_filters_zero_gain_candidates`
+  - `parallel_dispatch_filters_negative_gain_candidates`
+  - `parallel_dispatch_filters_all_non_positive_returns_empty`
+- Added unit tests in `src/analysis/discovery_dispatch_tests.rs`:
+  - `run_discovery_module_filters_zero_gain_candidates`
+  - `run_discovery_module_filters_negative_gain_candidates`
+- Added unit test in `src/analysis/mod_tests.rs`:
+  - `merge_coordinated_structural_filters_zero_gain_candidates`

--- a/src/analysis/discovery_dispatch_parallel_tests.rs
+++ b/src/analysis/discovery_dispatch_parallel_tests.rs
@@ -243,3 +243,94 @@ fn parallel_dispatch_single_module_matches_sequential_behaviour() {
         syn_sequential.metadata.candidates_returned
     );
 }
+
+// =============================================================================
+// Issue #557: Positive gain filtering tests
+// =============================================================================
+
+#[test]
+fn parallel_dispatch_filters_zero_gain_candidates() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    let modules = vec![make_module(
+        "zero_gain",
+        Some(vec![
+            make_candidate(0.5),
+            make_candidate(0.0), // should be filtered
+            make_candidate(0.3),
+        ]),
+    )];
+
+    run_discovery_modules_parallel(&mut syn, modules, None, false);
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        2,
+        "candidates with zero gain should be filtered out"
+    );
+    for c in &syn.coordinated_structural_candidates {
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "all candidates must have positive gain, got {}",
+            c.expected_creature_score_gain
+        );
+    }
+}
+
+#[test]
+fn parallel_dispatch_filters_negative_gain_candidates() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    let modules = vec![make_module(
+        "negative_gain",
+        Some(vec![
+            make_candidate(1.0),
+            make_candidate(-0.5),   // should be filtered
+            make_candidate(-0.001), // should be filtered
+        ]),
+    )];
+
+    run_discovery_modules_parallel(&mut syn, modules, None, false);
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        1,
+        "candidates with negative gain should be filtered out"
+    );
+    assert!(syn.coordinated_structural_candidates[0].expected_creature_score_gain > 0.0);
+}
+
+#[test]
+fn parallel_dispatch_filters_all_non_positive_returns_empty() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    let modules = vec![make_module(
+        "all_non_positive",
+        Some(vec![make_candidate(0.0), make_candidate(-1.0)]),
+    )];
+
+    run_discovery_modules_parallel(&mut syn, modules, None, false);
+
+    assert!(
+        syn.coordinated_structural_candidates.is_empty(),
+        "all-non-positive module should produce zero candidates"
+    );
+}

--- a/src/analysis/discovery_dispatch_tests.rs
+++ b/src/analysis/discovery_dispatch_tests.rs
@@ -186,3 +186,75 @@ fn run_discovery_module_accumulates_across_multiple_calls() {
     );
     assert_eq!(syn.metadata.candidates_returned, 3);
 }
+
+// =============================================================================
+// Issue #557: Positive gain filtering tests
+// =============================================================================
+
+#[test]
+fn run_discovery_module_filters_zero_gain_candidates() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "zero gain module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 3,
+                candidates: vec![
+                    make_candidate(1.0),
+                    make_candidate(0.0), // should be filtered
+                    make_candidate(0.5),
+                ],
+            })
+        },
+    );
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        2,
+        "zero-gain candidates should be filtered"
+    );
+    for c in &syn.coordinated_structural_candidates {
+        assert!(c.expected_creature_score_gain > 0.0);
+    }
+}
+
+#[test]
+fn run_discovery_module_filters_negative_gain_candidates() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "negative gain module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 2,
+                candidates: vec![make_candidate(-0.1), make_candidate(-0.5)],
+            })
+        },
+    );
+
+    assert!(
+        syn.coordinated_structural_candidates.is_empty(),
+        "all-negative module should produce zero candidates"
+    );
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -289,6 +289,13 @@ fn merge_coordinated_structural_replacements(
         return;
     }
 
+    // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
+    // Only candidates predicted to improve the creature's score should be returned.
+    replacements.retain(|c| c.expected_creature_score_gain > 0.0);
+    if replacements.is_empty() {
+        return;
+    }
+
     synapse
         .coordinated_structural_candidates
         .append(&mut replacements);

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -292,3 +292,62 @@ fn postprocess_updates_neuron_candidates_returned_after_filtering_replacements()
     assert_eq!(neuron.helpful_neurons.len(), 1);
     assert_eq!(neuron.metadata.candidates_returned, 1);
 }
+
+// =============================================================================
+// Issue #557: Positive gain filtering tests
+// =============================================================================
+
+#[test]
+fn merge_coordinated_structural_filters_zero_gain_candidates() {
+    let mut syn = shared::AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: shared::SynapseAnalysisMetadata {
+            candidates_found: 0,
+            candidates_returned: 0,
+            ..Default::default()
+        },
+    };
+
+    let replacements = vec![
+        CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "a".to_string(),
+                to_neuron_uuid: "b".to_string(),
+            }],
+            expected_creature_score_gain: 0.5,
+            comment: Some("positive".to_string()),
+        },
+        CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "c".to_string(),
+                to_neuron_uuid: "d".to_string(),
+            }],
+            expected_creature_score_gain: 0.0, // should be filtered
+            comment: Some("zero".to_string()),
+        },
+        CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "e".to_string(),
+                to_neuron_uuid: "f".to_string(),
+            }],
+            expected_creature_score_gain: -0.1, // should be filtered
+            comment: Some("negative".to_string()),
+        },
+    ];
+
+    merge_coordinated_structural_replacements(&mut syn, replacements, None, false);
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        1,
+        "only positive-gain candidates should be merged"
+    );
+    assert!(syn.coordinated_structural_candidates[0].expected_creature_score_gain > 0.0);
+    assert_eq!(syn.metadata.candidates_returned, 1);
+}

--- a/src/analysis/neuron.rs
+++ b/src/analysis/neuron.rs
@@ -819,6 +819,11 @@ pub(crate) fn analyze_neurons_with_cache(
         }
     }
 
+    // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
+    // After impact discounting, some candidates may have zero or negative gain and
+    // would waste the evaluation budget if returned.
+    helpful_results.retain(|c| c.expected_creature_score_gain > 0.0);
+
     // Sort by expected creature score gain (highest first) - Issue #128
     helpful_results.sort_by(|a, b| {
         b.expected_creature_score_gain

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -212,6 +212,13 @@ pub(crate) fn apply_post_processing(
         apply_impact_to_coordinated(candidate, &impact_scores, &neuron_type_map);
     }
 
+    // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
+    // After impact discounting, some candidates may have zero or negative gain and
+    // would waste the evaluation budget if returned.
+    helpful_results.retain(|c| c.expected_creature_score_gain > 0.0);
+    harmful_results.retain(|c| c.expected_creature_score_gain > 0.0);
+    coordinated_structural_results.retain(|c| c.expected_creature_score_gain > 0.0);
+
     // Sort all candidate lists by expected_creature_score_gain (highest first)
     helpful_results.sort_by(|a, b| {
         b.expected_creature_score_gain

--- a/tests/issue_557_audit_discovery_strategies.rs
+++ b/tests/issue_557_audit_discovery_strategies.rs
@@ -1,0 +1,247 @@
+//! Issue #557: Audit all discovery strategies
+//!
+//! Verifies that all returned candidates have strictly positive
+//! `expected_creature_score_gain`. Candidates that do not predict an
+//! improvement in the creature's score waste evaluation budget and should
+//! never be returned.
+
+mod common;
+
+use common::{hidden, hidden_with_bias, make_creature, neuron, output, record, synapse};
+use neat_ai_discovery::AnalyzeAllInput;
+use neat_ai_discovery::analysis::analyze_all;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use tempfile::tempdir;
+
+/// Create a creature with structure designed to trigger edge-case discovery
+/// modules that may produce zero or near-zero gain candidates.
+fn create_audit_creature() -> neat_ai_discovery::CreatureJson {
+    make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            // Dead neuron: zero activation → removal candidate
+            hidden("hidden-dead", "RELU"),
+            // Saturated neuron: always near +1 → squash change candidate
+            hidden_with_bias("hidden-saturated", "TANH", 5.0),
+            // Active neuron: varies meaningfully
+            hidden("hidden-active", "IDENTITY"),
+            // Dormant synapse source: very small contribution
+            hidden("hidden-dormant-src", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-0", "hidden-dead", 0.0),
+            synapse("input-0", "hidden-saturated", 3.0),
+            synapse("input-0", "hidden-active", 0.5),
+            synapse("input-1", "hidden-active", 0.3),
+            synapse("hidden-dead", "output-0", 0.5),
+            synapse("hidden-saturated", "output-0", 0.8),
+            synapse("hidden-active", "output-0", 0.6),
+            // Dormant synapse: extremely small weight
+            synapse("hidden-dormant-src", "output-0", 0.0001),
+            synapse("input-0", "hidden-dormant-src", 0.0001),
+        ],
+    )
+}
+
+/// Create parquet records that trigger edge-case detection patterns.
+fn create_audit_records() -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    let num_samples = 100u32;
+
+    for i in 0..num_samples {
+        let t = i as f32 / num_samples as f32;
+
+        // Input neurons with varying activations
+        records.push(DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "input-0".to_string(),
+            value: None,
+            activation: (t * std::f32::consts::TAU).sin(),
+            errors: Vec::new(),
+        });
+        records.push(DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "input-1".to_string(),
+            value: None,
+            activation: (t * std::f32::consts::PI).cos(),
+            errors: Vec::new(),
+        });
+
+        // Dead neuron: always zero activation
+        records.push(record("hidden-dead", i, 0.0, Some(0.0)));
+
+        // Saturated neuron: always near +1 (tanh saturation)
+        records.push(record("hidden-saturated", i, 0.999, Some(0.999)));
+
+        // Active neuron: varies meaningfully
+        let activation = 0.3 + 0.4 * (t * std::f32::consts::TAU).sin();
+        records.push(record("hidden-active", i, activation, Some(activation)));
+
+        // Dormant source: extremely small activation
+        let dormant_activation = 0.00001 * t;
+        records.push(record(
+            "hidden-dormant-src",
+            i,
+            dormant_activation,
+            Some(dormant_activation),
+        ));
+
+        // Output neuron with error
+        let error = 0.1 * (t * std::f32::consts::PI).cos();
+        records.push(DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "output-0".to_string(),
+            value: Some(0.5 + 0.2 * t),
+            activation: 0.5 + 0.2 * t,
+            errors: vec![error],
+        });
+    }
+
+    records
+}
+
+/// All returned candidates (synapse and neuron) must have strictly positive
+/// expected_creature_score_gain. This is the core audit requirement from
+/// Issue #557.
+#[test]
+fn all_candidates_have_positive_expected_score_gain() {
+    skip_without_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("audit_records.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+
+    let records = create_audit_records();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let creature = create_audit_creature();
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons,
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+        random_seed: Some(42),
+        previous_neuron_fingerprints: None,
+    };
+
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+
+    // Check synapse results: all candidate types must have positive gain
+    if let Some(syn) = &result.synapse {
+        for (i, c) in syn.coordinated_structural_candidates.iter().enumerate() {
+            assert!(
+                c.expected_creature_score_gain > 0.0,
+                "Coordinated candidate {i} has non-positive gain: {} (comment: {:?})",
+                c.expected_creature_score_gain,
+                c.comment,
+            );
+        }
+
+        for (i, c) in syn.helpful_synapses.iter().enumerate() {
+            assert!(
+                c.expected_creature_score_gain > 0.0,
+                "Helpful synapse {i} has non-positive gain: {} (from {} → {})",
+                c.expected_creature_score_gain,
+                c.from_neuron_uuid,
+                c.to_neuron_uuid,
+            );
+        }
+
+        for (i, c) in syn.harmful_synapses.iter().enumerate() {
+            assert!(
+                c.expected_creature_score_gain > 0.0,
+                "Harmful synapse {i} has non-positive gain: {} (from {} → {})",
+                c.expected_creature_score_gain,
+                c.from_neuron_uuid,
+                c.to_neuron_uuid,
+            );
+        }
+    }
+
+    // Check neuron results: all candidates must have positive gain
+    if let Some(neuron_result) = &result.neuron {
+        for (i, c) in neuron_result.helpful_neurons.iter().enumerate() {
+            assert!(
+                c.expected_creature_score_gain > 0.0,
+                "Neuron candidate {i} has non-positive gain: {} (squash: {}, source: {}, target: {})",
+                c.expected_creature_score_gain,
+                c.squash,
+                c.source_neuron_uuid,
+                c.target_neuron_uuid,
+            );
+        }
+    }
+}
+
+/// Metadata candidates_returned must match actual candidate count after
+/// positive-gain filtering.
+#[test]
+fn metadata_consistent_after_positive_gain_filtering() {
+    skip_without_gpu!();
+
+    let temp_dir = tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("audit_meta_records.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+
+    let records = create_audit_records();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let creature = create_audit_creature();
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons,
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+        random_seed: Some(42),
+        previous_neuron_fingerprints: None,
+    };
+
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+
+    if let Some(syn) = &result.synapse {
+        let actual_count = syn.helpful_synapses.len()
+            + syn.harmful_synapses.len()
+            + syn.coordinated_structural_candidates.len();
+
+        assert_eq!(
+            syn.metadata.candidates_returned, actual_count,
+            "synapse metadata.candidates_returned ({}) must match actual count ({actual_count})",
+            syn.metadata.candidates_returned,
+        );
+    }
+
+    if let Some(neuron_result) = &result.neuron {
+        assert_eq!(
+            neuron_result.metadata.candidates_returned,
+            neuron_result.helpful_neurons.len(),
+            "neuron metadata.candidates_returned ({}) must match actual count ({})",
+            neuron_result.metadata.candidates_returned,
+            neuron_result.helpful_neurons.len(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Audit all discovery strategies to ensure only candidates with a positive predicted
score improvement are returned. Closes #557.

### Problem

Several discovery modules could produce candidates with zero or near-zero
`expected_creature_score_gain` at boundary conditions:

- **dormant_synapse**: `0.001 * (1.0 - ratio)` equals zero when `mean_abs_contribution`
  exactly equals `DORMANT_CONTRIBUTION_THRESHOLD`
- **error_plateau**: `mean_error * plateau_tightness * 0.3` equals zero when
  `plateau_tightness` is clamped to zero via `.max(0.0)`
- **correlated_error**: product of factors can be zero if `mean_correlation` or
  `mean_abs_error` is zero
- **activation_mismatch**: boundary conditions at detection thresholds
- **Impact discounting**: any candidate targeting a hidden neuron disconnected from
  outputs gets multiplied by 0.1, which can reduce already-small gains to effectively
  zero

Returning these zero-gain candidates wastes evaluation budget since NEAT-AI must
clone the creature, apply the mutation, and re-score against the full training set
for each candidate — all for zero predicted benefit.

### Solution

Added positive-gain filtering (`expected_creature_score_gain > 0.0`) at three
pipeline choke-points, providing defence-in-depth:

1. **`merge_coordinated_structural_replacements`** (mod.rs) — filters all coordinated
   structural candidates before merging into the synapse result. This catches every
   discovery module since they all merge through this single function.

2. **Synapse post-processing** (post_processing.rs) — filters helpful, harmful, and
   coordinated candidates after impact discounting, before sorting and truncation.

3. **Neuron pipeline** (neuron.rs) — filters neuron candidates after impact
   discounting, before sorting and truncation.

This is a central safety-net approach (DRY) rather than patching each of the 28+
individual discovery modules, ensuring that future modules also benefit automatically.

## Evidence

This is a backend/pipeline change with no visual output. Evidence is provided by
the test results from `quality.sh` passing cleanly, including all 502+ unit tests
and 97+ integration tests.

## Test Plan

- Added `tests/issue_557_audit_discovery_strategies.rs` — integration tests that
  run the full `analyze_all` pipeline and assert every returned candidate (synapse,
  neuron, coordinated) has strictly positive `expected_creature_score_gain`, plus
  metadata consistency checks
- Added unit tests in `src/analysis/discovery_dispatch_parallel_tests.rs`:
  - `parallel_dispatch_filters_zero_gain_candidates`
  - `parallel_dispatch_filters_negative_gain_candidates`
  - `parallel_dispatch_filters_all_non_positive_returns_empty`
- Added unit tests in `src/analysis/discovery_dispatch_tests.rs`:
  - `run_discovery_module_filters_zero_gain_candidates`
  - `run_discovery_module_filters_negative_gain_candidates`
- Added unit test in `src/analysis/mod_tests.rs`:
  - `merge_coordinated_structural_filters_zero_gain_candidates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)