### PR TITLE
Add weight magnitude reset detection for stuck synapses (#550)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-550.md
+++ b/docs/pr-summary-550.md
@@ -1,0 +1,26 @@
+## Summary
+
+Add weight magnitude reset detection for stuck synapses to escape local minima. When a synapse's target neuron shows persistently high error with low variance (a plateau in the error landscape) and the source neuron is actively contributing signal, the module generates multiple exploratory `setWeight` candidates with dramatically different weights — sign flips, zero resets, and scaled magnitudes — to probe beyond the local basin. Closes #550.
+
+This is part of the broader local minimum escape strategy (#545). The approach is analogous to simulated annealing: occasionally making large, seemingly worse moves to escape local minima, relying on NEAT-AI's validation framework to only accept changes that actually improve the score.
+
+## Evidence
+
+This is a backend detection module with no UI component. Evidence is provided through comprehensive test coverage:
+
+- `tests/issue_550_weight_magnitude_reset.rs` — 7 integration tests verifying:
+  - Detection identifies stuck synapses with high error contribution
+  - Generates `setWeight` candidates with exploratory weight values
+  - Weight candidates span a wide range (sign flip, magnitude change)
+  - No candidates for healthy (low-error) synapses
+  - No candidates with insufficient samples
+  - Multiple stuck synapses produce ranked candidates
+  - Comment references Issue #550
+
+All tests pass, and `quality.sh` passes cleanly (fmt, clippy, check, test, release build).
+
+## Test Plan
+
+- Added `tests/issue_550_weight_magnitude_reset.rs` with 7 tests
+- All 502 unit tests + 97 integration test files pass with `--test-threads=1`
+- Full `quality.sh` gate passes

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -28,3 +28,4 @@ pub mod topology;
 pub mod topology_diversification;
 pub mod unbounded_capping;
 pub mod weight_coherence;
+pub mod weight_magnitude_reset;

--- a/src/analysis/detection/weight_magnitude_reset.rs
+++ b/src/analysis/detection/weight_magnitude_reset.rs
@@ -1,0 +1,291 @@
+//! Weight magnitude reset detection module (Issue #550).
+//!
+//! Identifies synapses that are stuck in a local minimum — the current weight
+//! is locally optimal but a dramatically different weight would be globally better.
+//! Incremental weight adjustments cannot cross the error barrier between the local
+//! and global optimum, so we generate exploratory `setWeight` candidates with
+//! large magnitude changes (sign flip, order of magnitude shift) to escape the
+//! local basin.
+//!
+//! ## Detection Criteria
+//!
+//! A synapse is "stuck" when:
+//! 1. The target neuron has persistently high error (mean abs error above threshold)
+//! 2. The error is tightly clustered (low coefficient of variation — plateau-like)
+//! 3. The source neuron has active (non-negligible) activations, meaning the synapse
+//!    contributes meaningfully to the target
+//!
+//! ## Recommended Actions
+//!
+//! For each stuck synapse, the module generates multiple `setWeight` candidates
+//! with exploratory weights — sign flips, zero, and scaled magnitudes — to probe
+//! beyond the local basin. The NEAT-AI validation framework naturally handles
+//! this by only accepting changes that improve the score.
+
+use std::collections::HashMap;
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum mean absolute error on the target neuron to consider a synapse stuck.
+/// Below this, the synapse is performing well enough.
+const MIN_STUCK_ERROR: f32 = 0.1;
+
+/// Maximum coefficient of variation (std_dev / mean) for the target error.
+/// Low CV means the error is tightly clustered — a plateau in the error landscape.
+const MAX_ERROR_CV: f32 = 0.4;
+
+/// Minimum mean absolute activation of the source neuron.
+/// The source must be actively contributing signal for the synapse to matter.
+const MIN_SOURCE_ACTIVATION: f32 = 0.01;
+
+/// A detected stuck synapse candidate.
+#[derive(Debug, Clone)]
+pub struct StuckSynapseCandidate {
+    /// UUID of the source neuron.
+    pub from_neuron_uuid: String,
+    /// UUID of the target neuron.
+    pub to_neuron_uuid: String,
+    /// Current synapse weight.
+    pub current_weight: f32,
+    /// Mean absolute error of the target neuron.
+    pub target_mean_error: f32,
+    /// Coefficient of variation of the target error.
+    pub target_error_cv: f32,
+    /// Mean absolute activation of the source neuron.
+    pub source_mean_activation: f32,
+    /// Estimated improvement from resetting the weight.
+    pub estimated_improvement: f32,
+    /// Exploratory weight values to try.
+    pub exploratory_weights: Vec<f32>,
+}
+
+/// Generate exploratory weight candidates for a stuck synapse.
+///
+/// Produces weights that are dramatically different from the current weight:
+/// - Sign flip (negative of current weight)
+/// - Zero (remove the synapse's contribution entirely)
+/// - Scaled magnitudes (2×, 0.5×, 0.1× the current weight)
+/// - Fixed exploratory values (-1.0, 1.0)
+fn generate_exploratory_weights(current_weight: f32) -> Vec<f32> {
+    let mut weights = Vec::new();
+
+    // Sign flip — reverse the synapse's direction
+    let flipped = -current_weight;
+    if flipped.is_finite() && flipped.abs() > 1e-6 {
+        weights.push(flipped);
+    }
+
+    // Zero — completely silence this synapse
+    weights.push(0.0);
+
+    // Doubled magnitude
+    let doubled = current_weight * 2.0;
+    if doubled.is_finite() {
+        weights.push(doubled);
+    }
+
+    // Half magnitude
+    let halved = current_weight * 0.5;
+    if halved.is_finite() {
+        weights.push(halved);
+    }
+
+    // Tenth magnitude (order of magnitude reduction)
+    let tenth = current_weight * 0.1;
+    if tenth.is_finite() {
+        weights.push(tenth);
+    }
+
+    // Fixed exploratory values if they differ meaningfully from current
+    for &fixed in &[-1.0_f32, 1.0] {
+        if (fixed - current_weight).abs() > 0.2 {
+            weights.push(fixed);
+        }
+    }
+
+    // Deduplicate: remove weights that are too close to each other
+    weights.sort_by(|a, b| a.total_cmp(b));
+    weights.dedup_by(|a, b| (*a - *b).abs() < 1e-4);
+
+    // Remove the current weight if it accidentally ended up in the list
+    weights.retain(|w| (w - current_weight).abs() > 1e-4);
+
+    weights
+}
+
+/// Detect synapses stuck in a local minimum that would benefit from a weight
+/// magnitude reset.
+///
+/// # Arguments
+/// * `creature` - The creature topology (neurons and synapses).
+/// * `neuron_records` - Slice of `(uuid, records)` pairs with observation data.
+///
+/// # Returns
+/// Vector of stuck synapse candidates, sorted by estimated improvement (best first).
+pub fn detect_stuck_synapse_weight_resets(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<StuckSynapseCandidate> {
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for syn in &creature.synapses {
+        // Get source neuron records
+        let Some(source_records) = records_map.get(syn.from_uuid.as_str()) else {
+            continue;
+        };
+
+        if source_records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Get target neuron records
+        let Some(target_records) = records_map.get(syn.to_uuid.as_str()) else {
+            continue;
+        };
+
+        if target_records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Check source activation — must be actively contributing
+        let source_mean_abs_activation: f32 = source_records
+            .iter()
+            .map(|r| r.activation.abs())
+            .sum::<f32>()
+            / source_records.len() as f32;
+
+        if source_mean_abs_activation < MIN_SOURCE_ACTIVATION {
+            continue;
+        }
+
+        // Compute target error statistics
+        let target_errors: Vec<f32> = target_records
+            .iter()
+            .map(|r| r.errors.first().copied().unwrap_or(0.0).abs())
+            .collect();
+
+        let n = target_errors.len() as f32;
+        let mean_error: f32 = target_errors.iter().sum::<f32>() / n;
+
+        // Skip if error is already low (converged)
+        if mean_error < MIN_STUCK_ERROR {
+            continue;
+        }
+
+        // Compute coefficient of variation
+        let variance: f32 = target_errors
+            .iter()
+            .map(|e| (e - mean_error).powi(2))
+            .sum::<f32>()
+            / n;
+        let std_dev = variance.sqrt();
+        let cv = if mean_error > 1e-6 {
+            std_dev / mean_error
+        } else {
+            f32::INFINITY
+        };
+
+        // Stuck = high error + low variance (plateau in error landscape)
+        if cv > MAX_ERROR_CV {
+            continue;
+        }
+
+        // Compute sensitivity: how much the synapse contributes to the target
+        // sensitivity ≈ mean(|source_activation × weight|)
+        let sensitivity = source_mean_abs_activation * syn.weight.abs();
+
+        // Generate exploratory weights
+        let exploratory_weights = generate_exploratory_weights(syn.weight);
+        if exploratory_weights.is_empty() {
+            continue;
+        }
+
+        // Estimated improvement: proportional to error magnitude, plateau tightness,
+        // and synapse sensitivity
+        let plateau_tightness = (1.0 - cv / MAX_ERROR_CV).max(0.0);
+        let sensitivity_factor = sensitivity.min(1.0);
+        let estimated_improvement = mean_error * plateau_tightness * sensitivity_factor * 0.15;
+
+        if estimated_improvement <= 0.0 {
+            continue;
+        }
+
+        candidates.push(StuckSynapseCandidate {
+            from_neuron_uuid: syn.from_uuid.clone(),
+            to_neuron_uuid: syn.to_uuid.clone(),
+            current_weight: syn.weight,
+            target_mean_error: mean_error,
+            target_error_cv: cv,
+            source_mean_activation: source_mean_abs_activation,
+            estimated_improvement,
+            exploratory_weights,
+        });
+    }
+
+    // Sort by estimated improvement descending
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    candidates
+}
+
+/// Convert stuck synapse candidates to coordinated structural candidates.
+///
+/// Each stuck synapse produces multiple `setWeight` candidates — one per
+/// exploratory weight value — so the NEAT-AI validation framework can test
+/// which dramatic weight change (if any) escapes the local minimum.
+pub fn stuck_synapses_to_coordinated_candidates(
+    candidates: &[StuckSynapseCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::new();
+
+    for c in candidates {
+        for &new_weight in &c.exploratory_weights {
+            let direction = if (new_weight - c.current_weight).abs() < 1e-6 {
+                "unchanged".to_string()
+            } else if new_weight.signum() != c.current_weight.signum()
+                && c.current_weight.abs() > 1e-6
+            {
+                "sign flip".to_string()
+            } else if new_weight.abs() < 1e-6 {
+                "zero reset".to_string()
+            } else {
+                let ratio = new_weight / c.current_weight;
+                format!("{ratio:.1}× scale")
+            };
+
+            results.push(CoordinatedStructuralCandidateJson {
+                operations: vec![CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: c.from_neuron_uuid.clone(),
+                    to_neuron_uuid: c.to_neuron_uuid.clone(),
+                    weight: new_weight,
+                }],
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(format!(
+                    "Stuck synapse {} → {}: weight {:.3} → {:.3} ({direction}). \
+                     Target mean error: {:.3}, CV: {:.3}. \
+                     Exploratory reset to escape local minimum. (Issue #550)",
+                    c.from_neuron_uuid,
+                    c.to_neuron_uuid,
+                    c.current_weight,
+                    new_weight,
+                    c.target_mean_error,
+                    c.target_error_cv,
+                )),
+            });
+        }
+    }
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -80,6 +80,7 @@ pub use detection::topology;
 pub use detection::topology_diversification;
 pub use detection::unbounded_capping;
 pub use detection::weight_coherence;
+pub use detection::weight_magnitude_reset;
 
 // Re-export recommendation modules at analysis level for backward compatibility
 pub use recommendation::activation_recommendation;
@@ -1577,6 +1578,34 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     }
                     let candidates =
                         error_plateau::error_plateaus_to_coordinated_candidates(&detected);
+                    Some(discovery_dispatch::DiscoveryDetectionResult {
+                        detected_count: detected.len(),
+                        candidates,
+                    })
+                }),
+            });
+        }
+
+        // Issue #550: Weight magnitude reset for stuck synapses (local minimum escape)
+        {
+            let cache = Arc::clone(&shared_cache);
+            let creature = Arc::clone(&creature);
+            modules.push(discovery_dispatch::DiscoveryModuleSpec {
+                module_name: "weight magnitude reset detection".to_string(),
+                phase_name: "weight_magnitude_reset_detection",
+                detect_fn: Box::new(move || {
+                    let records = cache.load_records_for_all_neurons(&creature);
+                    if records.is_empty() {
+                        return None;
+                    }
+                    let detected = weight_magnitude_reset::detect_stuck_synapse_weight_resets(
+                        &creature, &records,
+                    );
+                    if detected.is_empty() {
+                        return None;
+                    }
+                    let candidates =
+                        weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected);
                     Some(discovery_dispatch::DiscoveryDetectionResult {
                         detected_count: detected.len(),
                         candidates,

--- a/tests/issue_550_weight_magnitude_reset.rs
+++ b/tests/issue_550_weight_magnitude_reset.rs
@@ -1,0 +1,425 @@
+//! Tests for Issue #550: Local minimum escape — weight magnitude reset for stuck
+//! synapses.
+//!
+//! ## TDD Plan
+//! 1. Test detection identifies stuck synapses with high error contribution
+//! 2. Test generates `setWeight` candidates with exploratory weight values
+//! 3. Test weight candidates span a wide range of values (sign flip, magnitude change)
+//! 4. Test no candidates when synapses are not stuck (low error, varying weights)
+//! 5. Test insufficient samples produce no candidates
+//! 6. Test multiple stuck synapses produce ranked candidates
+//! 7. Test comment references issue number
+
+mod common;
+
+use neat_ai_discovery::analysis::detection::weight_magnitude_reset::{
+    detect_stuck_synapse_weight_resets, stuck_synapses_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 2,
+        output: 1,
+    }
+}
+
+fn input_neuron(uuid: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "input".to_string(),
+        squash: "IDENTITY".to_string(),
+        bias: 0.0,
+    }
+}
+
+fn hidden_neuron(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn output_neuron(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "output".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Create records simulating a stuck synapse pattern:
+/// - Source neuron has active (non-zero) activations
+/// - Target neuron has persistently high error
+/// - Weight is stable (low variance across observations)
+fn make_stuck_synapse_records(
+    source_uuid: &str,
+    target_uuid: &str,
+    sample_count: usize,
+) -> Vec<(String, Vec<DiscoverRecord>)> {
+    let source_records: Vec<DiscoverRecord> = (0..sample_count)
+        .map(|i| {
+            // Stable non-zero activations — the source is contributing signal
+            let activation = 0.5 + (i as f32 * 0.01).sin() * 0.05;
+            make_record(source_uuid, i as u32, activation, activation, 0.0)
+        })
+        .collect();
+
+    let target_records: Vec<DiscoverRecord> = (0..sample_count)
+        .map(|i| {
+            // Persistently high error with low variance — stuck in local minimum
+            let error = 0.4 + (i as f32 * 0.01).sin() * 0.02;
+            let activation = 0.3;
+            make_record(target_uuid, i as u32, 0.3, activation, error)
+        })
+        .collect();
+
+    vec![
+        (source_uuid.to_string(), source_records),
+        (target_uuid.to_string(), target_records),
+    ]
+}
+
+// =============================================================================
+// 1. Detection identifies stuck synapses with high error contribution
+// =============================================================================
+
+#[test]
+fn test_detects_stuck_synapse_with_high_error() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            input_neuron("input-2"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.2),
+            synapse("input-2", "hidden-1", 0.8),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    let neuron_records = make_stuck_synapse_records("hidden-1", "output-1", 40);
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(
+        !candidates.is_empty(),
+        "Should detect stuck synapse with persistently high error"
+    );
+
+    // The candidate should target the synapse from hidden-1 to output-1
+    let found = candidates
+        .iter()
+        .any(|c| c.from_neuron_uuid == "hidden-1" && c.to_neuron_uuid == "output-1");
+    assert!(
+        found,
+        "Should identify the stuck synapse hidden-1 → output-1"
+    );
+}
+
+// =============================================================================
+// 2. Generates setWeight candidates with exploratory weight values
+// =============================================================================
+
+#[test]
+fn test_generates_set_weight_candidates() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            input_neuron("input-2"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.2),
+            synapse("input-2", "hidden-1", 0.8),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    let neuron_records = make_stuck_synapse_records("hidden-1", "output-1", 40);
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = stuck_synapses_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    // Each candidate should contain a setWeight operation
+    for cc in &coordinated {
+        let ops_json = serde_json::to_string(&cc.operations).unwrap();
+        assert!(
+            ops_json.contains("setWeight"),
+            "Candidate must contain setWeight operation, got: {ops_json}"
+        );
+    }
+}
+
+// =============================================================================
+// 3. Weight candidates span a wide range of values
+// =============================================================================
+
+#[test]
+fn test_weight_candidates_span_wide_range() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    let neuron_records = make_stuck_synapse_records("hidden-1", "output-1", 40);
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = stuck_synapses_to_coordinated_candidates(&candidates);
+    assert!(
+        coordinated.len() >= 2,
+        "Should produce multiple exploratory weight candidates, got: {}",
+        coordinated.len()
+    );
+
+    // Extract the proposed weights from all candidates
+    let mut weights: Vec<f32> = Vec::new();
+    for cc in &coordinated {
+        for op in &cc.operations {
+            let json = serde_json::to_string(op).unwrap();
+            if json.contains("setWeight") {
+                // Extract weight from JSON
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json)
+                    && let Some(w) = val.get("weight").and_then(|v| v.as_f64())
+                {
+                    weights.push(w as f32);
+                }
+            }
+        }
+    }
+
+    assert!(
+        !weights.is_empty(),
+        "Should have extracted weights from candidates"
+    );
+
+    // Verify the weights span a wide range: should include both positive and negative,
+    // or significantly different magnitudes
+    let has_sign_variation = weights.iter().any(|w| *w < 0.0) && weights.iter().any(|w| *w > 0.0);
+    let min_w = weights.iter().cloned().fold(f32::INFINITY, f32::min);
+    let max_w = weights.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let has_magnitude_variation = (max_w - min_w).abs() > 0.5;
+
+    assert!(
+        has_sign_variation || has_magnitude_variation,
+        "Weight candidates should span a wide range (sign flip or magnitude change). Weights: {weights:?}"
+    );
+}
+
+// =============================================================================
+// 4. No candidates when synapses are not stuck
+// =============================================================================
+
+#[test]
+fn test_no_candidates_for_healthy_synapses() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    // Low, varying error — the synapse is healthy and converging
+    let source_records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| {
+            let activation = 0.5 + (i as f32 * 0.1).sin() * 0.3;
+            make_record("hidden-1", i, activation, activation, 0.0)
+        })
+        .collect();
+    let target_records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| {
+            // Low error — network is performing well
+            let error = 0.005 + (i as f32 * 0.05).sin() * 0.003;
+            make_record("output-1", i, 0.3, 0.3, error)
+        })
+        .collect();
+
+    let neuron_records = vec![
+        ("hidden-1".to_string(), source_records),
+        ("output-1".to_string(), target_records),
+    ];
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(
+        candidates.is_empty(),
+        "Healthy synapses should produce no candidates, got: {}",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// 5. Insufficient samples produce no candidates
+// =============================================================================
+
+#[test]
+fn test_insufficient_samples_no_candidates() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    // Only 5 samples — far below the minimum threshold
+    let neuron_records = make_stuck_synapse_records("hidden-1", "output-1", 5);
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+// =============================================================================
+// 6. Multiple stuck synapses produce ranked candidates
+// =============================================================================
+
+#[test]
+fn test_multiple_stuck_synapses_ranked() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            input_neuron("input-2"),
+            hidden_neuron("hidden-1", "TANH"),
+            hidden_neuron("hidden-2", "RELU"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("input-2", "hidden-2", 0.8),
+            synapse("hidden-1", "output-1", 0.5),
+            synapse("hidden-2", "output-1", 0.3),
+        ],
+    );
+
+    // Both hidden→output synapses are stuck, but hidden-1→output-1 has higher error
+    let source1_records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| {
+            let activation = 0.6 + (i as f32 * 0.01).sin() * 0.04;
+            make_record("hidden-1", i, activation, activation, 0.0)
+        })
+        .collect();
+    let source2_records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| {
+            let activation = 0.4 + (i as f32 * 0.01).sin() * 0.03;
+            make_record("hidden-2", i, activation, activation, 0.0)
+        })
+        .collect();
+    let target_records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| {
+            // High persistent error
+            let error = 0.5 + (i as f32 * 0.01).sin() * 0.02;
+            make_record("output-1", i, 0.3, 0.3, error)
+        })
+        .collect();
+
+    let neuron_records = vec![
+        ("hidden-1".to_string(), source1_records),
+        ("hidden-2".to_string(), source2_records),
+        ("output-1".to_string(), target_records),
+    ];
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(
+        candidates.len() >= 2,
+        "Should detect multiple stuck synapses, got: {}",
+        candidates.len()
+    );
+
+    // Candidates should be sorted by estimated improvement (descending)
+    for window in candidates.windows(2) {
+        assert!(
+            window[0].estimated_improvement >= window[1].estimated_improvement,
+            "Candidates should be sorted by estimated improvement (descending)"
+        );
+    }
+}
+
+// =============================================================================
+// 7. Comment references issue number
+// =============================================================================
+
+#[test]
+fn test_comment_references_issue_number() {
+    let creature = make_creature(
+        vec![
+            input_neuron("input-1"),
+            hidden_neuron("hidden-1", "TANH"),
+            output_neuron("output-1", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 1.0),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    let neuron_records = make_stuck_synapse_records("hidden-1", "output-1", 40);
+
+    let candidates = detect_stuck_synapse_weight_resets(&creature, &neuron_records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = stuck_synapses_to_coordinated_candidates(&candidates);
+    assert!(!coordinated.is_empty());
+
+    let comment = coordinated[0].comment.as_deref().unwrap_or("");
+    assert!(
+        comment.contains("Issue #550"),
+        "Comment should reference Issue #550, got: {comment}"
+    );
+}


### PR DESCRIPTION
## Summary

Add weight magnitude reset detection for stuck synapses to escape local minima. When a synapse's target neuron shows persistently high error with low variance (a plateau in the error landscape) and the source neuron is actively contributing signal, the module generates multiple exploratory `setWeight` candidates with dramatically different weights — sign flips, zero resets, and scaled magnitudes — to probe beyond the local basin. Closes #550.

This is part of the broader local minimum escape strategy (#545). The approach is analogous to simulated annealing: occasionally making large, seemingly worse moves to escape local minima, relying on NEAT-AI's validation framework to only accept changes that actually improve the score.

## Evidence

This is a backend detection module with no UI component. Evidence is provided through comprehensive test coverage:

- `tests/issue_550_weight_magnitude_reset.rs` — 7 integration tests verifying:
  - Detection identifies stuck synapses with high error contribution
  - Generates `setWeight` candidates with exploratory weight values
  - Weight candidates span a wide range (sign flip, magnitude change)
  - No candidates for healthy (low-error) synapses
  - No candidates with insufficient samples
  - Multiple stuck synapses produce ranked candidates
  - Comment references Issue #550

All tests pass, and `quality.sh` passes cleanly (fmt, clippy, check, test, release build).

## Test Plan

- Added `tests/issue_550_weight_magnitude_reset.rs` with 7 tests
- All 502 unit tests + 97 integration test files pass with `--test-threads=1`
- Full `quality.sh` gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)