### PR TITLE
Add bias perturbation detection for activation regime shifts (#551)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.5"
+version = "0.21.6"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.21.4"
+version = "0.21.5"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-551.md
+++ b/docs/pr-summary-551.md
@@ -1,0 +1,45 @@
+## Summary
+
+Add bias perturbation detection for activation regime shifts — a new detection
+module that identifies hidden neurons operating in suboptimal activation regimes
+and generates exploratory `setBias` candidates targeting specific regime shifts.
+Closes #551.
+
+Sub-issue of #545 (Suggestions for getting out of local minimums).
+
+### What it does
+
+A neuron's bias determines its operating regime on the activation function curve.
+When a neuron operates in a saturated tail (e.g., TANH output ~1.0) or flat region,
+small bias changes keep it in the same regime. This module detects such neurons and
+generates a large bias shift that moves the neuron to the centre of the active zone,
+effecting a qualitative regime change to escape the local minimum.
+
+### Detection criteria
+
+1. Hidden neuron uses a bounded squash with a known active zone
+2. Dynamic range utilisation < 25% (operating in a suboptimal regime)
+3. Mean absolute error ≥ 0.05 (non-negligible error — not already converged)
+4. Sufficient samples (≥ 20)
+5. Bias change would be meaningful (≥ 0.1)
+
+### Candidate generation
+
+Each detected neuron produces a coordinated `setBias` candidate targeting the
+centre of the activation function's active zone.
+
+## Evidence
+
+This is a backend detection module with no UI changes. Evidence is provided by
+the integration test suite.
+
+## Test Plan
+
+- `tests/issue_551_bias_perturbation_regime_shift.rs` — 7 integration tests:
+  1. Detects neurons in saturated positive tail regime (TANH with bias=5.0)
+  2. Detects neurons in saturated negative tail regime (LOGISTIC with bias=-6.0)
+  3. `setBias` targets active zone centre (recommended bias closer to 0)
+  4. No false positives for neurons in healthy operating regimes (low error)
+  5. Coordinated candidates have positive gain and reference issue #551
+  6. Multiple suboptimal neurons each produce candidates
+  7. Insufficient samples returns empty

--- a/src/analysis/detection/bias_perturbation.rs
+++ b/src/analysis/detection/bias_perturbation.rs
@@ -1,0 +1,262 @@
+//! Bias perturbation for activation regime shifts (Issue #551).
+//!
+//! A neuron's bias determines its operating regime on the activation function
+//! curve. When a neuron operates in a saturated or flat region, small bias
+//! changes keep it in the same regime. A large bias shift can move the neuron
+//! to a qualitatively different operating regime (e.g., from the saturated tail
+//! of TANH to the linear centre), effectively escaping the local minimum.
+//!
+//! ## Relationship to Other Detection Modules
+//!
+//! - **Operating point** (Issue #401): measures dynamic range utilisation and
+//!   recommends incremental bias/weight adjustments.
+//! - **Saturation** (Issue #342): detects neurons stuck at activation bounds.
+//! - **This module** (Issue #551): identifies neurons in suboptimal activation
+//!   regimes and generates exploratory `setBias` candidates that target
+//!   specific regime shifts rather than incremental improvements.
+//!
+//! ## Detection Criteria
+//!
+//! A hidden neuron is a regime-shift candidate when:
+//! 1. It uses a bounded squash with a known active zone.
+//! 2. Its mean pre-activation falls outside the active zone (saturated tail)
+//!    **or** is confined to a narrow sub-region (linear-only).
+//! 3. It has non-negligible error (mean |error| ≥ `MIN_ERROR_THRESHOLD`).
+//! 4. Sufficient samples are available (≥ `MIN_SAMPLES`).
+//!
+//! ## Recommended Actions
+//!
+//! - `setBias` — shift the operating point to the centre of the active zone
+//!   for a full regime change.
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Minimum mean absolute error before a neuron is considered for regime shift.
+/// Below this threshold, the neuron is performing well enough.
+const MIN_ERROR_THRESHOLD: f32 = 0.05;
+
+/// Maximum fraction of the active zone utilised before a neuron is flagged.
+/// Neurons using less than this fraction of the zone's dynamic range are
+/// operating in a suboptimal regime.
+const MAX_UTILISATION_FOR_REGIME_SHIFT: f32 = 0.25;
+
+/// A detected bias perturbation candidate for activation regime shift.
+#[derive(Debug, Clone)]
+pub struct BiasPerturbationCandidate {
+    /// UUID of the neuron requiring a regime shift.
+    pub neuron_uuid: String,
+    /// Current activation function.
+    pub squash: String,
+    /// Current bias value.
+    pub current_bias: f32,
+    /// Recommended bias value targeting a different operating regime.
+    pub recommended_bias: f32,
+    /// Active zone lower bound for the squash function.
+    pub active_zone_min: f32,
+    /// Active zone upper bound for the squash function.
+    pub active_zone_max: f32,
+    /// Mean pre-activation value across observations.
+    pub mean_pre_activation: f32,
+    /// Fraction of the active zone's dynamic range actually utilised (0.0–1.0).
+    pub dynamic_range_utilisation: f32,
+    /// Mean absolute error across observations.
+    pub mean_error: f32,
+    /// Estimated improvement from the regime shift.
+    pub estimated_improvement: f32,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// Returns the active zone `(min, max)` for a squash function — the
+/// pre-activation range over which the function transitions most of its
+/// output dynamic range.
+///
+/// Returns `None` for unbounded or discrete activations.
+fn active_zone(squash: &str) -> Option<(f32, f32)> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        "TANH" | "HARD_TANH" | "CLIPPED" => Some((-2.0, 2.0)),
+        "LOGISTIC" => Some((-4.0, 4.0)),
+        "SOFTSIGN" => Some((-4.0, 4.0)),
+        "ARCTAN" => Some((-3.0, 3.0)),
+        "RELU6" => Some((0.0, 6.0)),
+        _ => None,
+    }
+}
+
+/// Compute what fraction of a squash function's dynamic range is utilised
+/// by the given pre-activation range.
+fn compute_dynamic_range_utilisation(
+    squash: &str,
+    value_min: f32,
+    value_max: f32,
+    zone_min: f32,
+    zone_max: f32,
+) -> f32 {
+    let activation_fn = match crate::activations::target_simulation_fn(squash) {
+        Some(f) => f,
+        None => return 0.0,
+    };
+
+    let zone_out_min = activation_fn(zone_min);
+    let zone_out_max = activation_fn(zone_max);
+    let theoretical_range = (zone_out_max - zone_out_min).abs();
+
+    if theoretical_range < 1e-9 {
+        return 0.0;
+    }
+
+    let obs_out_min = activation_fn(value_min);
+    let obs_out_max = activation_fn(value_max);
+    let observed_range = (obs_out_max - obs_out_min).abs();
+
+    (observed_range / theoretical_range).clamp(0.0, 1.0)
+}
+
+/// Compute a bias that would shift the neuron's operating point to the
+/// centre of the active zone, effecting a regime change.
+///
+/// The key insight: `pre_activation = weighted_sum + bias`, so
+/// `new_bias = old_bias + (zone_centre - mean_pre_activation)`.
+fn compute_regime_shift_bias(
+    current_bias: f32,
+    mean_pre_activation: f32,
+    zone_min: f32,
+    zone_max: f32,
+) -> f32 {
+    let zone_centre = (zone_min + zone_max) / 2.0;
+    let delta = zone_centre - mean_pre_activation;
+    current_bias + delta
+}
+
+/// Detect hidden neurons in suboptimal activation regimes that would
+/// benefit from bias perturbation to shift to a different operating regime.
+///
+/// # Arguments
+/// * `hidden_neurons` - Slice of `(uuid, squash, bias)` tuples for hidden neurons.
+/// * `neuron_records` - Slice of `(uuid, records)` pairs with observation data.
+///
+/// # Returns
+/// Vector of detected candidates, sorted by estimated improvement (best first).
+pub fn detect_bias_perturbation_candidates(
+    hidden_neurons: &[(String, String, f32)],
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<BiasPerturbationCandidate> {
+    let mut candidates = Vec::new();
+
+    for (uuid, squash, bias) in hidden_neurons {
+        let Some((_id, records)) = neuron_records.iter().find(|(u, _)| u == uuid) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Get the active zone for this squash function
+        let Some((zone_min, zone_max)) = active_zone(squash) else {
+            continue;
+        };
+
+        // Collect pre-activation values
+        let values: Vec<f32> = records
+            .iter()
+            .filter_map(|r| r.value)
+            .filter(|v| v.is_finite())
+            .collect();
+
+        if values.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Compute error statistics
+        let mean_error: f32 = records
+            .iter()
+            .map(|r| r.errors.first().copied().unwrap_or(0.0).abs())
+            .sum::<f32>()
+            / records.len() as f32;
+
+        // Skip neurons with negligible error — they're performing fine
+        if mean_error < MIN_ERROR_THRESHOLD {
+            continue;
+        }
+
+        // Compute pre-activation statistics
+        let n = values.len() as f32;
+        let mean_pre_activation: f32 = values.iter().sum::<f32>() / n;
+        let value_min = values.iter().copied().fold(f32::INFINITY, f32::min);
+        let value_max = values.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+
+        // Compute dynamic range utilisation
+        let utilisation =
+            compute_dynamic_range_utilisation(squash, value_min, value_max, zone_min, zone_max);
+
+        // Skip neurons that are already using a healthy portion of the active zone
+        if utilisation >= MAX_UTILISATION_FOR_REGIME_SHIFT {
+            continue;
+        }
+
+        // Compute the regime-shifting bias
+        let recommended_bias =
+            compute_regime_shift_bias(*bias, mean_pre_activation, zone_min, zone_max);
+
+        // Skip if the bias change would be negligible
+        if (recommended_bias - bias).abs() < 0.1 {
+            continue;
+        }
+
+        // Estimated improvement: proportional to error magnitude and how far
+        // outside the active zone the neuron is operating
+        let regime_severity = 1.0 - utilisation;
+        let estimated_improvement = mean_error * regime_severity * 0.2;
+
+        candidates.push(BiasPerturbationCandidate {
+            neuron_uuid: uuid.clone(),
+            squash: squash.clone(),
+            current_bias: *bias,
+            recommended_bias,
+            active_zone_min: zone_min,
+            active_zone_max: zone_max,
+            mean_pre_activation,
+            dynamic_range_utilisation: utilisation,
+            mean_error,
+            estimated_improvement,
+            reason: format!(
+                "Hidden neuron {uuid} operating in suboptimal regime: {squash} with \
+                 mean pre-activation {mean_pre_activation:.2} using {:.0}% of dynamic \
+                 range (active zone [{zone_min:.1}, {zone_max:.1}]). Bias perturbation \
+                 {bias:.3} → {recommended_bias:.3} targets regime shift to active zone \
+                 centre. (Issue #551)",
+                utilisation * 100.0,
+            ),
+        });
+    }
+
+    // Sort by estimated improvement descending (best first)
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+
+    candidates
+}
+
+/// Convert bias perturbation candidates to coordinated structural candidates.
+///
+/// Each candidate generates a `setBias` operation targeting a specific
+/// activation regime shift. The coordinated format allows NEAT-AI to
+/// evaluate the regime shift as an atomic operation.
+pub fn bias_perturbation_to_coordinated_candidates(
+    candidates: &[BiasPerturbationCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    candidates
+        .iter()
+        .map(|c| CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: c.neuron_uuid.clone(),
+                bias: c.recommended_bias,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(c.reason.clone()),
+        })
+        .collect()
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -5,6 +5,7 @@
 //! and convert them into coordinated structural candidates.
 
 pub mod activation_mismatch;
+pub mod bias_perturbation;
 pub mod bottleneck;
 pub mod bounded_range;
 pub mod correlated_error;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -57,6 +57,7 @@ pub mod scoring;
 
 // Re-export detection modules at analysis level for backward compatibility
 pub use detection::activation_mismatch;
+pub use detection::bias_perturbation;
 pub use detection::bottleneck;
 pub use detection::bounded_range;
 pub use detection::correlated_error;
@@ -1606,6 +1607,33 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                     }
                     let candidates =
                         weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected);
+                    Some(discovery_dispatch::DiscoveryDetectionResult {
+                        detected_count: detected.len(),
+                        candidates,
+                    })
+                }),
+            });
+        }
+
+        // Issue #551: Bias perturbation for activation regime shifts (local minimum escape)
+        {
+            let cache = Arc::clone(&shared_cache);
+            let hidden = Arc::clone(&hidden_neurons);
+            modules.push(discovery_dispatch::DiscoveryModuleSpec {
+                module_name: "bias perturbation regime shift detection".to_string(),
+                phase_name: "bias_perturbation_regime_shift_detection",
+                detect_fn: Box::new(move || {
+                    if hidden.is_empty() {
+                        return None;
+                    }
+                    let records = cache.load_records_for_hidden(&hidden);
+                    let detected =
+                        bias_perturbation::detect_bias_perturbation_candidates(&hidden, &records);
+                    if detected.is_empty() {
+                        return None;
+                    }
+                    let candidates =
+                        bias_perturbation::bias_perturbation_to_coordinated_candidates(&detected);
                     Some(discovery_dispatch::DiscoveryDetectionResult {
                         detected_count: detected.len(),
                         candidates,

--- a/tests/issue_551_bias_perturbation_regime_shift.rs
+++ b/tests/issue_551_bias_perturbation_regime_shift.rs
@@ -1,0 +1,289 @@
+//! Tests for Issue #551: Local minimum escape — bias perturbation for activation
+//! regime shifts.
+//!
+//! ## TDD Plan
+//! 1. Test detection identifies neurons in saturated tail regimes
+//! 2. Test detection identifies neurons in flat/linear-only regimes
+//! 3. Test setBias candidates target specific regime shifts (e.g., tail → centre)
+//! 4. Test no false positives for neurons in healthy operating regimes
+//! 5. Test coordinated candidates include compensating weight adjustments
+//! 6. Test multiple suboptimal neurons each produce candidates
+//! 7. Test insufficient samples returns empty
+
+mod common;
+
+use neat_ai_discovery::analysis::detection::bias_perturbation::{
+    bias_perturbation_to_coordinated_candidates, detect_bias_perturbation_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn hidden_neuron(uuid: &str, squash: &str, bias: f32) -> (String, String, f32) {
+    (uuid.to_string(), squash.to_string(), bias)
+}
+
+// =============================================================================
+// 1. Detects neurons operating in saturated tail regime
+// =============================================================================
+
+#[test]
+fn test_detects_neuron_in_saturated_tail_regime() {
+    // TANH neuron with bias=5.0 — pre-activation values are all far positive,
+    // so the neuron is stuck in the saturated upper tail (~1.0 output).
+    let hidden_neurons = vec![hidden_neuron("h1", "TANH", 5.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                // Pre-activation values all in [4.5, 5.5] — deep in TANH saturation
+                let value = 4.5 + (i as f32) / 60.0;
+                let activation = value.tanh();
+                let error = 0.3; // Consistent error — stuck
+                make_record("h1", i, value, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(
+        !candidates.is_empty(),
+        "Should detect neuron in saturated tail regime"
+    );
+
+    let coordinated = bias_perturbation_to_coordinated_candidates(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    // Must include a setBias operation targeting the active zone
+    let ops_json = serde_json::to_string(&coordinated[0].operations).unwrap();
+    assert!(
+        ops_json.contains("setBias"),
+        "Must include setBias for regime shift, got: {ops_json}"
+    );
+}
+
+// =============================================================================
+// 2. Detects neurons in flat/linear-only regime
+// =============================================================================
+
+#[test]
+fn test_detects_neuron_in_saturated_negative_tail() {
+    // LOGISTIC neuron with large negative bias — stuck near output 0.0
+    // in the saturated lower tail.
+    let hidden_neurons = vec![hidden_neuron("h1", "LOGISTIC", -6.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                // Pre-activation in [-6.5, -5.5] — deep in logistic saturation
+                let value = -6.5 + (i as f32) / 60.0;
+                let activation = 1.0 / (1.0 + (-value).exp());
+                let error = 0.25;
+                make_record("h1", i, value, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(
+        !candidates.is_empty(),
+        "Should detect neuron stuck in saturated negative tail of LOGISTIC"
+    );
+}
+
+// =============================================================================
+// 3. setBias candidates target specific regime shifts
+// =============================================================================
+
+#[test]
+fn test_set_bias_targets_active_zone_centre() {
+    // TANH neuron stuck in the saturated positive tail (bias=6.0).
+    // The new bias should shift the operating point towards the centre
+    // of the active zone (~0.0 for TANH).
+    let hidden_neurons = vec![hidden_neuron("h1", "TANH", 6.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                let value = 5.5 + (i as f32) / 100.0;
+                let activation = value.tanh();
+                let error = 0.2;
+                make_record("h1", i, value, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(!candidates.is_empty());
+
+    // The recommended bias should bring the neuron significantly closer to the
+    // active zone centre
+    let candidate = &candidates[0];
+    assert!(
+        candidate.recommended_bias.abs() < candidate.current_bias.abs(),
+        "Recommended bias ({}) should be closer to active zone centre than current ({})",
+        candidate.recommended_bias,
+        candidate.current_bias
+    );
+}
+
+// =============================================================================
+// 4. No false positives for healthy operating regimes
+// =============================================================================
+
+#[test]
+fn test_no_false_positives_for_healthy_regimes() {
+    // TANH neuron operating well within the active zone [-2, 2] with low error
+    let hidden_neurons = vec![hidden_neuron("h1", "TANH", 0.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                // Pre-activation spans the active zone well
+                let value = -1.5 + (i as f32) * 3.0 / 60.0;
+                let activation = value.tanh();
+                let error = 0.01; // Very low error = healthy
+                make_record("h1", i, value, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(
+        candidates.is_empty(),
+        "Healthy operating regime should produce no candidates"
+    );
+}
+
+// =============================================================================
+// 5. Coordinated candidates include compensating weight adjustments
+// =============================================================================
+
+#[test]
+fn test_coordinated_candidates_include_set_bias_with_positive_gain() {
+    let hidden_neurons = vec![hidden_neuron("h1", "TANH", 5.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                let value = 4.5 + (i as f32) / 60.0;
+                let activation = value.tanh();
+                let error = 0.3;
+                make_record("h1", i, value, activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(!candidates.is_empty());
+
+    let coordinated = bias_perturbation_to_coordinated_candidates(&candidates);
+    assert!(!coordinated.is_empty());
+
+    // Positive expected gain
+    assert!(
+        coordinated[0].expected_creature_score_gain > 0.0,
+        "Expected gain should be positive for regime shift"
+    );
+
+    // Comment should reference issue #551
+    assert!(
+        coordinated[0].comment.as_ref().unwrap().contains("551"),
+        "Comment should reference issue #551, got: {:?}",
+        coordinated[0].comment
+    );
+}
+
+// =============================================================================
+// 6. Multiple suboptimal neurons each produce candidates
+// =============================================================================
+
+#[test]
+fn test_multiple_suboptimal_neurons_produce_candidates() {
+    let hidden_neurons = vec![
+        hidden_neuron("h1", "TANH", 5.0),
+        hidden_neuron("h2", "LOGISTIC", -6.0),
+    ];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = 4.5 + (i as f32) / 60.0;
+                    let activation = value.tanh();
+                    make_record("h1", i, value, activation, 0.25)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..60)
+                .map(|i| {
+                    // Far negative pre-activation — stuck near 0 on logistic
+                    let value = -6.5 + (i as f32) / 60.0;
+                    let activation = 1.0 / (1.0 + (-value).exp());
+                    make_record("h2", i, value, activation, 0.20)
+                })
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(
+        candidates.len() >= 2,
+        "Should detect both suboptimal neurons, got: {}",
+        candidates.len()
+    );
+
+    let uuids: Vec<&str> = candidates.iter().map(|c| c.neuron_uuid.as_str()).collect();
+    assert!(uuids.contains(&"h1"), "Should detect h1");
+    assert!(uuids.contains(&"h2"), "Should detect h2");
+}
+
+// =============================================================================
+// 7. Insufficient samples returns empty
+// =============================================================================
+
+#[test]
+fn test_insufficient_samples_returns_empty() {
+    let hidden_neurons = vec![hidden_neuron("h1", "TANH", 5.0)];
+
+    // Only 5 samples — below MIN_DISCOVERY_SAMPLE_COUNT
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..5)
+            .map(|i| {
+                let value = 4.5 + (i as f32) / 10.0;
+                let activation = value.tanh();
+                make_record("h1", i, value, activation, 0.3)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_bias_perturbation_candidates(&hidden_neurons, &records);
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}


### PR DESCRIPTION
## Summary

Add bias perturbation detection for activation regime shifts — a new detection
module that identifies hidden neurons operating in suboptimal activation regimes
and generates exploratory `setBias` candidates targeting specific regime shifts.
Closes #551.

Sub-issue of #545 (Suggestions for getting out of local minimums).

### What it does

A neuron's bias determines its operating regime on the activation function curve.
When a neuron operates in a saturated tail (e.g., TANH output ~1.0) or flat region,
small bias changes keep it in the same regime. This module detects such neurons and
generates a large bias shift that moves the neuron to the centre of the active zone,
effecting a qualitative regime change to escape the local minimum.

### Detection criteria

1. Hidden neuron uses a bounded squash with a known active zone
2. Dynamic range utilisation < 25% (operating in a suboptimal regime)
3. Mean absolute error ≥ 0.05 (non-negligible error — not already converged)
4. Sufficient samples (≥ 20)
5. Bias change would be meaningful (≥ 0.1)

### Candidate generation

Each detected neuron produces a coordinated `setBias` candidate targeting the
centre of the activation function's active zone.

## Evidence

This is a backend detection module with no UI changes. Evidence is provided by
the integration test suite.

## Test Plan

- `tests/issue_551_bias_perturbation_regime_shift.rs` — 7 integration tests:
  1. Detects neurons in saturated positive tail regime (TANH with bias=5.0)
  2. Detects neurons in saturated negative tail regime (LOGISTIC with bias=-6.0)
  3. `setBias` targets active zone centre (recommended bias closer to 0)
  4. No false positives for neurons in healthy operating regimes (low error)
  5. Coordinated candidates have positive gain and reference issue #551
  6. Multiple suboptimal neurons each produce candidates
  7. Insufficient samples returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)