### PR TITLE
Update wgpu from 0.19 to 28.0.0 (#566)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ serde_json = "1.0"
 anyhow = "1.0"
 parquet = "57.0"  # Apache Parquet format (viewable with standard tools)
 arrow = { version = "57.0", default-features = false }  # Arrow arrays for Parquet
-wgpu = "0.19"
-pollster = "0.3"
+wgpu = "28"
+pollster = "0.4"
 bytemuck = { version = "1.14", features = ["derive"] }
 rayon = "1.8"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-566.md
+++ b/docs/pr-summary-566.md
@@ -1,0 +1,41 @@
+## Summary
+
+Update wgpu from 0.19 to 28.0.0 (latest stable release) and pollster from 0.3 to 0.4. Closes #566.
+
+This is a major version jump (0.19 → 28) that brings improved Metal backend performance, better shader compilation, reduced GPU resource allocation overhead, and improved error messages. The wgpu project renumbered from 0.x to integer versions at 22.0.
+
+### Breaking API changes addressed
+
+| Change | Files affected |
+|--------|---------------|
+| `Instance::new()` takes `&InstanceDescriptor` (reference) | `device.rs` |
+| `InstanceDescriptor` fields `dx12_shader_compiler` and `gles_minor_version` removed | `device.rs` |
+| `Maintain::Poll` renamed to `PollType::Poll` | `device.rs` |
+| `device.poll()` returns `Result<PollStatus, PollError>` instead of `MaintainResult` | `device.rs` |
+| `request_adapter()` returns `Result<Adapter, RequestAdapterError>` instead of `Option<Adapter>` | `analyzer.rs`, `device.rs` |
+| `DeviceDescriptor` gained `experimental_features`, `memory_hints`, `trace` fields | `analyzer.rs` |
+| `request_device()` no longer takes a second `trace_path` argument | `analyzer.rs` |
+| `PipelineLayoutDescriptor::push_constant_ranges` replaced by `immediate_size` | All evaluation files |
+| `ComputePipelineDescriptor::entry_point` is now `Option<&str>` | All evaluation files |
+| `ComputePipelineDescriptor` gained `compilation_options` and `cache` fields | All evaluation files |
+| `AdapterInfo` gained `device_pci_bus_id`, `subgroup_min_size`, `subgroup_max_size`, `transient_saves_memory` fields | Tests |
+| `Backend::Empty` renamed to `Backend::Noop` | Tests |
+
+### WGSL shaders
+
+All 8 WGSL compute shaders use standard WGSL syntax and required no changes.
+
+## Evidence
+
+This is a backend dependency update with no UI changes. Evidence of correctness:
+
+- `quality.sh` passes (fmt, clippy, check, test, release build)
+- All existing tests pass (`cargo test --lib --tests --all-features -- --test-threads=1`)
+- All WGSL shaders compile and validate correctly with the new wgpu version
+- No benchmark comparison included as this is a dependency update, not a performance optimisation — the issue notes "still proceed if the update is clean" regardless of performance
+
+## Test Plan
+
+- No new tests added — this is a dependency update with no behaviour changes
+- All existing GPU tests pass unchanged (except `AdapterInfo` construction which gained new struct fields)
+- `test_adapter_info()` helper introduced to reduce test boilerplate for `AdapterInfo` construction

--- a/src/analysis/gpu/activation_evaluation.rs
+++ b/src/analysis/gpu/activation_evaluation.rs
@@ -72,14 +72,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -283,18 +283,17 @@ impl GpuAnalyzer {
             force_fallback_adapter: false,
         }));
 
-        let Some(adapter) = adapter else {
-            return no_gpu_result("No GPU adapter found");
+        let adapter = match adapter {
+            Ok(adapter) => adapter,
+            Err(_) => return no_gpu_result("No GPU adapter found"),
         };
 
-        let device_result = pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
-                label: Some("NEAT-AI Discovery GPU probe device"),
-                required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::default(),
-            },
-            None,
-        ));
+        let device_result = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("NEAT-AI Discovery GPU probe device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::default(),
+            ..Default::default()
+        }));
 
         match device_result {
             Ok(_) => GpuAvailabilityResult {
@@ -370,8 +369,8 @@ impl GpuAnalyzer {
         }));
 
         let adapter = match adapter {
-            Some(adapter) => adapter,
-            None => {
+            Ok(adapter) => adapter,
+            Err(_) => {
                 // GPU is required - return an error instead of a CPU-only analyzer.
                 // TypeScript calls check_gpu_available() before discovery, but the GPU
                 // could become unavailable due to race conditions or resource exhaustion.
@@ -392,26 +391,25 @@ impl GpuAnalyzer {
         // Log GPU info once per process (helps diagnose performance issues)
         log_gpu_info_once(&adapter_info, gpu_tier, batch_size);
 
-        let (device, queue) = match pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
+        let (device, queue) =
+            match pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
                 label: Some("NEAT-AI Discovery GPU device"),
                 required_features: wgpu::Features::empty(),
                 required_limits: wgpu::Limits::default(),
-            },
-            None,
-        )) {
-            Ok(result) => result,
-            Err(e) => {
-                // GPU is required - return an error instead of a CPU-only analyzer.
-                // TypeScript calls check_gpu_available() before discovery, but the GPU
-                // could become unavailable due to race conditions or resource exhaustion.
-                // Returning an error here prevents panics in GPU methods that .expect() on device.
-                anyhow::bail!(
-                    "GPU device creation failed: {e}. Discovery requires GPU acceleration. \
+                ..Default::default()
+            })) {
+                Ok(result) => result,
+                Err(e) => {
+                    // GPU is required - return an error instead of a CPU-only analyzer.
+                    // TypeScript calls check_gpu_available() before discovery, but the GPU
+                    // could become unavailable due to race conditions or resource exhaustion.
+                    // Returning an error here prevents panics in GPU methods that .expect() on device.
+                    anyhow::bail!(
+                        "GPU device creation failed: {e}. Discovery requires GPU acceleration. \
                      This may indicate a transient GPU resource issue - consider retrying."
-                );
-            }
-        };
+                    );
+                }
+            };
 
         let (helpful_layout, helpful_pipeline) =
             Self::build_helpful_pipeline(&device, "helpful-synapse-pipeline");

--- a/src/analysis/gpu/bias_evaluation.rs
+++ b/src/analysis/gpu/bias_evaluation.rs
@@ -83,14 +83,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)

--- a/src/analysis/gpu/device.rs
+++ b/src/analysis/gpu/device.rs
@@ -195,11 +195,10 @@ pub fn create_wgpu_instance_safely() -> Option<wgpu::Instance> {
 
     // Wrap in catch_unwind to handle any remaining panics from backend probing
     let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        wgpu::Instance::new(wgpu::InstanceDescriptor {
+        wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends,
             flags: wgpu::InstanceFlags::default(),
-            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
-            gles_minor_version: wgpu::Gles3MinorVersion::default(),
+            ..Default::default()
         })
     }));
 
@@ -261,9 +260,10 @@ pub fn poll_device_until_idle(device: &wgpu::Device, timeout: Duration, label: &
     use std::time::Instant;
     let start = Instant::now();
     loop {
-        let result = device.poll(wgpu::Maintain::Poll);
-        if result.is_queue_empty() {
-            return Ok(());
+        match device.poll(wgpu::PollType::Poll) {
+            Ok(status) if status.is_queue_empty() => return Ok(()),
+            Ok(_) => {} // Queue not empty yet; keep polling.
+            Err(e) => return Err(anyhow!("GPU device poll error ({label}): {e}")),
         }
         if start.elapsed() > timeout {
             return Err(anyhow!(
@@ -302,8 +302,11 @@ pub fn wait_for_buffer_map(
             }
         }
 
-        let result = device.poll(wgpu::Maintain::Poll);
-        if result.is_queue_empty() && start.elapsed() > Duration::from_millis(250) {
+        let queue_empty = matches!(
+            device.poll(wgpu::PollType::Poll),
+            Ok(status) if status.is_queue_empty()
+        );
+        if queue_empty && start.elapsed() > Duration::from_millis(250) {
             // If the queue is empty but the callback hasn't fired, something is off.
             // Keep trying until timeout, but this is a strong signal of driver trouble.
         }
@@ -364,7 +367,7 @@ pub fn wait_for_buffer_maps_batch(
             return Ok(());
         }
 
-        device.poll(wgpu::Maintain::Poll);
+        let _ = device.poll(wgpu::PollType::Poll);
 
         if start.elapsed() > timeout {
             return Err(anyhow!(
@@ -434,7 +437,8 @@ pub fn get_adapter_info_internal() -> Option<wgpu::AdapterInfo> {
         power_preference: wgpu::PowerPreference::HighPerformance,
         compatible_surface: None,
         force_fallback_adapter: false,
-    }))?;
+    }))
+    .ok()?;
 
     Some(adapter.get_info())
 }
@@ -446,6 +450,28 @@ pub fn get_adapter_info_internal() -> Option<wgpu::AdapterInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Helper to construct `wgpu::AdapterInfo` for tests.
+    /// Fills in sensible defaults for fields not relevant to the test.
+    fn test_adapter_info(
+        name: &str,
+        device_type: wgpu::DeviceType,
+        backend: wgpu::Backend,
+    ) -> wgpu::AdapterInfo {
+        wgpu::AdapterInfo {
+            name: name.to_string(),
+            vendor: 0,
+            device: 0,
+            device_type,
+            device_pci_bus_id: String::new(),
+            driver: String::new(),
+            driver_info: String::new(),
+            backend,
+            subgroup_min_size: 0,
+            subgroup_max_size: 0,
+            transient_saves_memory: false,
+        }
+    }
 
     #[test]
     fn test_gpu_performance_tier_variants() {
@@ -480,138 +506,94 @@ mod tests {
     #[test]
     fn test_detect_unified_memory_apple() {
         // Test Apple Silicon detection
-        let apple_info = wgpu::AdapterInfo {
-            name: "Apple M1".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
+        let apple_info = test_adapter_info(
+            "Apple M1",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Metal,
+        );
         assert!(detect_unified_memory(&apple_info));
 
-        let apple_m4_info = wgpu::AdapterInfo {
-            name: "Apple M4 Pro".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
+        let apple_m4_info = test_adapter_info(
+            "Apple M4 Pro",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Metal,
+        );
         assert!(detect_unified_memory(&apple_m4_info));
     }
 
     #[test]
     fn test_detect_unified_memory_non_apple() {
         // Test non-Apple GPU detection (should return false)
-        let nvidia_info = wgpu::AdapterInfo {
-            name: "NVIDIA GeForce RTX 4090".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::DiscreteGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
+        let nvidia_info = test_adapter_info(
+            "NVIDIA GeForce RTX 4090",
+            wgpu::DeviceType::DiscreteGpu,
+            wgpu::Backend::Vulkan,
+        );
         assert!(!detect_unified_memory(&nvidia_info));
 
-        let intel_info = wgpu::AdapterInfo {
-            name: "Intel UHD Graphics 630".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
+        let intel_info = test_adapter_info(
+            "Intel UHD Graphics 630",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Vulkan,
+        );
         // Conservative: non-Apple integrated GPUs return false
         assert!(!detect_unified_memory(&intel_info));
     }
 
     #[test]
     fn test_detect_gpu_tier_m4() {
-        let m4_info = wgpu::AdapterInfo {
-            name: "Apple M4".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
-        assert_eq!(detect_gpu_tier(&m4_info), GpuPerformanceTier::High);
+        let info = test_adapter_info(
+            "Apple M4",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Metal,
+        );
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::High);
     }
 
     #[test]
     fn test_detect_gpu_tier_m3_pro() {
-        let m3_pro_info = wgpu::AdapterInfo {
-            name: "Apple M3 Pro".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
-        assert_eq!(detect_gpu_tier(&m3_pro_info), GpuPerformanceTier::High);
+        let info = test_adapter_info(
+            "Apple M3 Pro",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Metal,
+        );
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::High);
     }
 
     #[test]
     fn test_detect_gpu_tier_m1_base() {
-        let m1_info = wgpu::AdapterInfo {
-            name: "Apple M1".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
-        assert_eq!(detect_gpu_tier(&m1_info), GpuPerformanceTier::Standard);
+        let info = test_adapter_info(
+            "Apple M1",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Metal,
+        );
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::Standard);
     }
 
     #[test]
     fn test_detect_gpu_tier_discrete() {
-        let nvidia_info = wgpu::AdapterInfo {
-            name: "NVIDIA GeForce RTX 4090".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::DiscreteGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
-        assert_eq!(detect_gpu_tier(&nvidia_info), GpuPerformanceTier::High);
+        let info = test_adapter_info(
+            "NVIDIA GeForce RTX 4090",
+            wgpu::DeviceType::DiscreteGpu,
+            wgpu::Backend::Vulkan,
+        );
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::High);
     }
 
     #[test]
     fn test_detect_gpu_tier_integrated() {
-        let intel_info = wgpu::AdapterInfo {
-            name: "Intel UHD Graphics".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
-        assert_eq!(detect_gpu_tier(&intel_info), GpuPerformanceTier::Standard);
+        let info = test_adapter_info(
+            "Intel UHD Graphics",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Vulkan,
+        );
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::Standard);
     }
 
     #[test]
     fn test_detect_gpu_tier_unknown() {
-        let unknown_info = wgpu::AdapterInfo {
-            name: "Unknown GPU".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::Other,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Empty,
-        };
-        assert_eq!(detect_gpu_tier(&unknown_info), GpuPerformanceTier::Unknown);
+        let info = test_adapter_info("Unknown GPU", wgpu::DeviceType::Other, wgpu::Backend::Noop);
+        assert_eq!(detect_gpu_tier(&info), GpuPerformanceTier::Unknown);
     }
 
     #[test]

--- a/src/analysis/gpu/harmful_evaluation.rs
+++ b/src/analysis/gpu/harmful_evaluation.rs
@@ -77,14 +77,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)
@@ -145,14 +147,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)

--- a/src/analysis/gpu/helpful_evaluation.rs
+++ b/src/analysis/gpu/helpful_evaluation.rs
@@ -77,14 +77,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)
@@ -145,14 +147,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)

--- a/src/analysis/gpu/relu_evaluation.rs
+++ b/src/analysis/gpu/relu_evaluation.rs
@@ -71,14 +71,16 @@ impl GpuAnalyzer {
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some(label),
             bind_group_layouts: &[&layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
             label: Some(label),
             layout: Some(&pipeline_layout),
             module: &shader,
-            entry_point: "main",
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
         });
 
         (layout, pipeline)

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -25,6 +25,27 @@
     #[cfg(target_os = "linux")]
     use crate::analysis::utils::memory::parse_meminfo_line;
 
+    /// Helper to construct `wgpu::AdapterInfo` for tests.
+    fn test_adapter_info(
+        name: &str,
+        device_type: wgpu::DeviceType,
+        backend: wgpu::Backend,
+    ) -> wgpu::AdapterInfo {
+        wgpu::AdapterInfo {
+            name: name.to_string(),
+            vendor: 0,
+            device: 0,
+            device_type,
+            device_pci_bus_id: String::new(),
+            driver: String::new(),
+            driver_info: String::new(),
+            backend,
+            subgroup_min_size: 0,
+            subgroup_max_size: 0,
+            transient_saves_memory: false,
+        }
+    }
+
     // ==================== GPU Tier Detection Tests ====================
 
     #[test]
@@ -128,15 +149,8 @@
     /// Test that M4 is detected as high-performance tier.
     #[test]
     fn gpu_tier_detects_m4_as_high_performance() {
-        let info = wgpu::AdapterInfo {
-            name: "Apple M4".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Metal,
-        };
+        let info =
+            test_adapter_info("Apple M4", wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Metal);
         assert_eq!(
             detect_gpu_tier(&info),
             GpuPerformanceTier::High,
@@ -148,15 +162,8 @@
     #[test]
     fn gpu_tier_detects_m4_pro_max_as_high_performance() {
         for name in ["Apple M4 Pro", "Apple M4 Max", "Apple M4 Ultra"] {
-            let info = wgpu::AdapterInfo {
-                name: name.to_string(),
-                vendor: 0,
-                device: 0,
-                device_type: wgpu::DeviceType::IntegratedGpu,
-                driver: String::new(),
-                driver_info: String::new(),
-                backend: wgpu::Backend::Metal,
-            };
+            let info =
+                test_adapter_info(name, wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Metal);
             assert_eq!(
                 detect_gpu_tier(&info),
                 GpuPerformanceTier::High,
@@ -169,15 +176,8 @@
     #[test]
     fn gpu_tier_detects_m3_pro_max_as_high_performance() {
         for name in ["Apple M3 Pro", "Apple M3 Max"] {
-            let info = wgpu::AdapterInfo {
-                name: name.to_string(),
-                vendor: 0,
-                device: 0,
-                device_type: wgpu::DeviceType::IntegratedGpu,
-                driver: String::new(),
-                driver_info: String::new(),
-                backend: wgpu::Backend::Metal,
-            };
+            let info =
+                test_adapter_info(name, wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Metal);
             assert_eq!(
                 detect_gpu_tier(&info),
                 GpuPerformanceTier::High,
@@ -190,15 +190,8 @@
     #[test]
     fn gpu_tier_detects_base_m_series_as_standard() {
         for name in ["Apple M1", "Apple M2", "Apple M3"] {
-            let info = wgpu::AdapterInfo {
-                name: name.to_string(),
-                vendor: 0,
-                device: 0,
-                device_type: wgpu::DeviceType::IntegratedGpu,
-                driver: String::new(),
-                driver_info: String::new(),
-                backend: wgpu::Backend::Metal,
-            };
+            let info =
+                test_adapter_info(name, wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Metal);
             assert_eq!(
                 detect_gpu_tier(&info),
                 GpuPerformanceTier::Standard,
@@ -210,15 +203,11 @@
     /// Test that discrete GPUs are detected as high-performance.
     #[test]
     fn gpu_tier_detects_discrete_gpu_as_high_performance() {
-        let info = wgpu::AdapterInfo {
-            name: "NVIDIA GeForce RTX 4090".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::DiscreteGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
+        let info = test_adapter_info(
+            "NVIDIA GeForce RTX 4090",
+            wgpu::DeviceType::DiscreteGpu,
+            wgpu::Backend::Vulkan,
+        );
         assert_eq!(
             detect_gpu_tier(&info),
             GpuPerformanceTier::High,
@@ -229,15 +218,11 @@
     /// Test that unknown integrated GPUs are detected as standard.
     #[test]
     fn gpu_tier_detects_unknown_integrated_as_standard() {
-        let info = wgpu::AdapterInfo {
-            name: "Intel UHD Graphics 630".to_string(),
-            vendor: 0,
-            device: 0,
-            device_type: wgpu::DeviceType::IntegratedGpu,
-            driver: String::new(),
-            driver_info: String::new(),
-            backend: wgpu::Backend::Vulkan,
-        };
+        let info = test_adapter_info(
+            "Intel UHD Graphics 630",
+            wgpu::DeviceType::IntegratedGpu,
+            wgpu::Backend::Vulkan,
+        );
         assert_eq!(
             detect_gpu_tier(&info),
             GpuPerformanceTier::Standard,


### PR DESCRIPTION
## Summary

Update wgpu from 0.19 to 28.0.0 (latest stable release) and pollster from 0.3 to 0.4. Closes #566.

This is a major version jump (0.19 → 28) that brings improved Metal backend performance, better shader compilation, reduced GPU resource allocation overhead, and improved error messages. The wgpu project renumbered from 0.x to integer versions at 22.0.

### Breaking API changes addressed

| Change | Files affected |
|--------|---------------|
| `Instance::new()` takes `&InstanceDescriptor` (reference) | `device.rs` |
| `InstanceDescriptor` fields `dx12_shader_compiler` and `gles_minor_version` removed | `device.rs` |
| `Maintain::Poll` renamed to `PollType::Poll` | `device.rs` |
| `device.poll()` returns `Result<PollStatus, PollError>` instead of `MaintainResult` | `device.rs` |
| `request_adapter()` returns `Result<Adapter, RequestAdapterError>` instead of `Option<Adapter>` | `analyzer.rs`, `device.rs` |
| `DeviceDescriptor` gained `experimental_features`, `memory_hints`, `trace` fields | `analyzer.rs` |
| `request_device()` no longer takes a second `trace_path` argument | `analyzer.rs` |
| `PipelineLayoutDescriptor::push_constant_ranges` replaced by `immediate_size` | All evaluation files |
| `ComputePipelineDescriptor::entry_point` is now `Option<&str>` | All evaluation files |
| `ComputePipelineDescriptor` gained `compilation_options` and `cache` fields | All evaluation files |
| `AdapterInfo` gained `device_pci_bus_id`, `subgroup_min_size`, `subgroup_max_size`, `transient_saves_memory` fields | Tests |
| `Backend::Empty` renamed to `Backend::Noop` | Tests |

### WGSL shaders

All 8 WGSL compute shaders use standard WGSL syntax and required no changes.

## Evidence

This is a backend dependency update with no UI changes. Evidence of correctness:

- `quality.sh` passes (fmt, clippy, check, test, release build)
- All existing tests pass (`cargo test --lib --tests --all-features -- --test-threads=1`)
- All WGSL shaders compile and validate correctly with the new wgpu version
- No benchmark comparison included as this is a dependency update, not a performance optimisation — the issue notes "still proceed if the update is clean" regardless of performance

## Test Plan

- No new tests added — this is a dependency update with no behaviour changes
- All existing GPU tests pass unchanged (except `AdapterInfo` construction which gained new struct fields)
- `test_adapter_info()` helper introduced to reduce test boilerplate for `AdapterInfo` construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)