### PR TITLE
Add symmetry-breaking detection for converged duplicate neurons (#569)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-569.md
+++ b/docs/pr-summary-569.md
@@ -1,0 +1,35 @@
+## Summary
+
+Add symmetry-breaking detection module that identifies pairs of hidden neurons whose
+weight configurations, bias values, and activation functions have converged to
+near-identical states. When detected, the module recommends perturbation of one
+neuron (bias shift + incoming weight scaling) to break the symmetry and unlock
+latent representational capacity. Closes #569.
+
+## Changes
+
+- **New file**: `src/analysis/detection/symmetry_breaking.rs` — detection module implementing:
+  - `detect_symmetric_neurons()` — identifies symmetric pairs using cosine similarity of incoming weight vectors (threshold 0.95), bias tolerance (0.5), and activation function equality
+  - `symmetric_neurons_to_coordinated_candidates()` — converts detections into `SetBias` + `SetWeight` coordinated candidates
+- **Modified**: `src/analysis/detection/mod.rs` — added `symmetry_breaking` module declaration
+- **Modified**: `src/analysis/mod.rs` — added re-export for backward compatibility
+- **Modified**: `src/analysis/module_dispatch_specs.rs` — added dispatch spec for parallel execution
+
+## Evidence
+
+This is a backend detection module with no visual output. All changes verified through:
+- 9 integration tests covering detection, edge cases, and candidate generation
+- Full `quality.sh` pass (fmt, clippy, check, test, release build)
+
+## Test Plan
+
+- `tests/issue_569_symmetry_breaking.rs` — 9 tests:
+  1. `test_detects_identical_symmetric_neurons` — verifies identical neurons are detected with cosine similarity > 0.95
+  2. `test_ignores_dissimilar_neurons` — verifies neurons with different incoming weights are not flagged
+  3. `test_different_squash_prevents_detection` — verifies different activation functions prevent detection
+  4. `test_single_hidden_neuron_no_candidates` — edge case: single neuron cannot form a pair
+  5. `test_no_hidden_neurons_no_candidates` — edge case: no hidden neurons
+  6. `test_coordinated_candidates_include_perturbations` — verifies candidates include SetBias/SetWeight operations
+  7. `test_insufficient_samples_returns_empty` — verifies minimum sample count is enforced
+  8. `test_multiple_symmetric_pairs` — verifies multiple distinct pairs are each detected
+  9. `test_large_bias_difference_prevents_detection` — verifies bias tolerance is enforced

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -25,6 +25,7 @@ pub mod restricted_range;
 pub mod saturation;
 pub mod sentinel_gating;
 pub mod squash_weight_rescale;
+pub mod symmetry_breaking;
 pub mod topology;
 pub mod topology_diversification;
 pub mod unbounded_capping;

--- a/src/analysis/detection/symmetry_breaking.rs
+++ b/src/analysis/detection/symmetry_breaking.rs
@@ -1,0 +1,268 @@
+//! Symmetry-breaking detection module (Issue #569).
+//!
+//! Identifies pairs of hidden neurons whose weight configurations and activation
+//! functions have converged to near-identical states, effectively reducing the
+//! network's representational capacity. Two neurons computing the same function
+//! waste a network slot.
+//!
+//! ## Detection Criteria
+//!
+//! A pair of hidden neurons is "symmetric" if:
+//! 1. **Cosine similarity** of incoming weight vectors exceeds a threshold (0.95)
+//! 2. **Bias values** are within a tolerance
+//! 3. **Activation functions** are identical
+//!
+//! ## Recommended Actions
+//!
+//! For each detected symmetric pair, we recommend perturbation of one neuron:
+//! - `SetBias` — shift one neuron's bias to break symmetry
+//! - `SetWeight` — scale one neuron's incoming synapse weights
+//! - `ChangeSquash` — change one neuron's activation function (if suitable)
+
+use std::collections::HashMap;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+/// Minimum cosine similarity to consider two weight vectors as symmetric.
+const COSINE_SIMILARITY_THRESHOLD: f32 = 0.95;
+
+/// Maximum absolute bias difference to consider two neurons as symmetric.
+const BIAS_TOLERANCE: f32 = 0.5;
+
+/// Weight scaling factor applied to one neuron to break symmetry.
+const PERTURBATION_WEIGHT_SCALE: f32 = 0.7;
+
+/// Bias perturbation applied to one neuron to break symmetry.
+const PERTURBATION_BIAS_DELTA: f32 = 0.3;
+
+/// Base estimated improvement for breaking a symmetric pair.
+const BASE_IMPROVEMENT: f32 = 0.005;
+
+/// Candidate representing a detected symmetric neuron pair.
+#[derive(Debug, Clone)]
+pub struct SymmetricPairCandidate {
+    /// UUID of the first neuron in the pair.
+    pub neuron_a_uuid: String,
+    /// UUID of the second neuron in the pair (the one to perturb).
+    pub neuron_b_uuid: String,
+    /// Current activation function (shared by both).
+    pub squash: String,
+    /// Bias of neuron B (the one to perturb).
+    pub neuron_b_bias: f32,
+    /// Cosine similarity of incoming weight vectors.
+    pub cosine_similarity: f32,
+    /// Absolute bias difference between the two neurons.
+    pub bias_difference: f32,
+    /// Incoming synapse weights for neuron B: (from_uuid, weight).
+    pub neuron_b_incoming_weights: Vec<(String, f32)>,
+    /// Estimated improvement from breaking this symmetry.
+    pub estimated_improvement: f32,
+}
+
+/// Detect symmetric neuron pairs in the creature's hidden layer.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `SymmetricPairCandidate` for detected symmetric pairs,
+/// sorted by cosine similarity (most symmetric first).
+pub fn detect_symmetric_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<SymmetricPairCandidate> {
+    // Collect hidden neurons
+    let hidden_neurons: Vec<&crate::NeuronJson> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .collect();
+
+    if hidden_neurons.len() < 2 {
+        return Vec::new();
+    }
+
+    // Build records lookup for minimum sample count filtering
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Filter to neurons with sufficient samples
+    let eligible_neurons: Vec<&&crate::NeuronJson> = hidden_neurons
+        .iter()
+        .filter(|n| {
+            records_map
+                .get(n.uuid.as_str())
+                .is_some_and(|r| r.len() >= MIN_DISCOVERY_SAMPLE_COUNT)
+        })
+        .collect();
+
+    if eligible_neurons.len() < 2 {
+        return Vec::new();
+    }
+
+    // Build incoming weight vectors for each hidden neuron
+    let mut incoming_weights: HashMap<&str, Vec<(&str, f32)>> = HashMap::new();
+    for synapse in &creature.synapses {
+        if hidden_neurons.iter().any(|n| n.uuid == synapse.to_uuid) {
+            incoming_weights
+                .entry(synapse.to_uuid.as_str())
+                .or_default()
+                .push((synapse.from_uuid.as_str(), synapse.weight));
+        }
+    }
+
+    // Collect all unique source UUIDs across all hidden neurons for consistent ordering
+    let mut all_sources: Vec<&str> = incoming_weights
+        .values()
+        .flat_map(|weights| weights.iter().map(|(src, _)| *src))
+        .collect();
+    all_sources.sort();
+    all_sources.dedup();
+
+    let mut candidates = Vec::new();
+
+    // Compare all pairs of eligible hidden neurons
+    for i in 0..eligible_neurons.len() {
+        for j in (i + 1)..eligible_neurons.len() {
+            let neuron_a = eligible_neurons[i];
+            let neuron_b = eligible_neurons[j];
+
+            // Criterion 3: Activation functions must be identical
+            if neuron_a.squash != neuron_b.squash {
+                continue;
+            }
+
+            // Criterion 2: Bias values within tolerance
+            let bias_diff = (neuron_a.bias - neuron_b.bias).abs();
+            if bias_diff > BIAS_TOLERANCE {
+                continue;
+            }
+
+            // Criterion 1: Cosine similarity of incoming weight vectors
+            let weights_a = build_weight_vector(&neuron_a.uuid, &incoming_weights, &all_sources);
+            let weights_b = build_weight_vector(&neuron_b.uuid, &incoming_weights, &all_sources);
+
+            let similarity = cosine_similarity(&weights_a, &weights_b);
+            if similarity < COSINE_SIMILARITY_THRESHOLD {
+                continue;
+            }
+
+            // Compute estimated improvement — higher similarity = more wasted capacity
+            let severity =
+                (similarity - COSINE_SIMILARITY_THRESHOLD) / (1.0 - COSINE_SIMILARITY_THRESHOLD);
+            let estimated_improvement = BASE_IMPROVEMENT * (0.5 + 0.5 * severity);
+
+            // Collect incoming weights for neuron B (the one we will perturb)
+            let b_incoming = incoming_weights
+                .get(neuron_b.uuid.as_str())
+                .map(|ws| ws.iter().map(|(src, w)| (src.to_string(), *w)).collect())
+                .unwrap_or_default();
+
+            candidates.push(SymmetricPairCandidate {
+                neuron_a_uuid: neuron_a.uuid.clone(),
+                neuron_b_uuid: neuron_b.uuid.clone(),
+                squash: neuron_a.squash.clone(),
+                neuron_b_bias: neuron_b.bias,
+                cosine_similarity: similarity,
+                bias_difference: bias_diff,
+                neuron_b_incoming_weights: b_incoming,
+                estimated_improvement,
+            });
+        }
+    }
+
+    // Sort by cosine similarity (most symmetric first — highest improvement potential)
+    candidates.sort_by(|a, b| b.cosine_similarity.total_cmp(&a.cosine_similarity));
+
+    candidates
+}
+
+/// Build a weight vector for a neuron, ordered by `all_sources`.
+///
+/// Missing sources get weight 0.0 so both vectors have the same dimensionality.
+fn build_weight_vector(
+    neuron_uuid: &str,
+    incoming_weights: &HashMap<&str, Vec<(&str, f32)>>,
+    all_sources: &[&str],
+) -> Vec<f32> {
+    let weights = incoming_weights.get(neuron_uuid);
+    all_sources
+        .iter()
+        .map(|src| {
+            weights
+                .and_then(|ws| ws.iter().find(|(s, _)| s == src).map(|(_, w)| *w))
+                .unwrap_or(0.0)
+        })
+        .collect()
+}
+
+/// Compute cosine similarity between two vectors.
+///
+/// Returns 0.0 if either vector has zero magnitude (avoids division by zero).
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let mag_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let mag_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if mag_a < f32::EPSILON || mag_b < f32::EPSILON {
+        return 0.0;
+    }
+
+    (dot / (mag_a * mag_b)).clamp(-1.0, 1.0)
+}
+
+/// Convert symmetric pair candidates into coordinated structural candidates.
+///
+/// For each symmetric pair, we perturb neuron B with:
+/// 1. A bias shift (`SetBias`) to move its operating point
+/// 2. Weight scaling (`SetWeight`) on incoming synapses to differentiate computation
+///
+/// The NEAT-AI controller validates each candidate through ablation testing.
+pub fn symmetric_neurons_to_coordinated_candidates(
+    candidates: &[SymmetricPairCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        let mut operations = Vec::new();
+
+        // Perturb neuron B's bias
+        let new_bias = c.neuron_b_bias + PERTURBATION_BIAS_DELTA;
+        operations.push(CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: c.neuron_b_uuid.clone(),
+            bias: new_bias,
+        });
+
+        // Scale neuron B's incoming weights
+        for (from_uuid, weight) in &c.neuron_b_incoming_weights {
+            operations.push(CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid: from_uuid.clone(),
+                to_neuron_uuid: c.neuron_b_uuid.clone(),
+                weight: weight * PERTURBATION_WEIGHT_SCALE,
+            });
+        }
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "[#569] Symmetry-breaking: neurons {} and {} have cosine similarity {:.3}, bias diff {:.3} — perturbing {} to unlock latent capacity",
+                c.neuron_a_uuid, c.neuron_b_uuid, c.cosine_similarity, c.bias_difference, c.neuron_b_uuid
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -77,6 +77,7 @@ pub use detection::restricted_range;
 pub use detection::saturation;
 pub use detection::sentinel_gating;
 pub use detection::squash_weight_rescale;
+pub use detection::symmetry_breaking;
 pub use detection::topology;
 pub use detection::topology_diversification;
 pub use detection::unbounded_capping;

--- a/src/analysis/module_dispatch_specs.rs
+++ b/src/analysis/module_dispatch_specs.rs
@@ -12,8 +12,8 @@ use super::{
     gradient_discovery, input_sensitivity, multi_hop, noise_signal, observation_utilisation,
     operating_point, opposing_synapse, oscillating_neuron, output_bias_drift,
     output_squash_mismatch, restricted_range, sample_weighted, saturation, sentinel_gating, shared,
-    squash_weight_rescale, topology, topology_diversification, unbounded_capping, weight_coherence,
-    weight_magnitude_reset,
+    squash_weight_rescale, symmetry_breaking, topology, topology_diversification,
+    unbounded_capping, weight_coherence, weight_magnitude_reset,
 };
 
 /// Build all discovery module specs for parallel dispatch.
@@ -929,6 +929,33 @@ pub(crate) fn build_discovery_module_specs(
                 }
                 let candidates =
                     bias_perturbation::bias_perturbation_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #569: Symmetry-breaking detection for converged duplicate neurons
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "symmetry breaking detection".to_string(),
+            phase_name: "symmetry_breaking_detection",
+            detect_fn: Box::new(move || {
+                if hidden.len() < 2 {
+                    return None;
+                }
+                let records = cache.load_records_for_hidden(&hidden);
+                let detected = symmetry_breaking::detect_symmetric_neurons(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    symmetry_breaking::symmetric_neurons_to_coordinated_candidates(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_569_symmetry_breaking.rs
+++ b/tests/issue_569_symmetry_breaking.rs
@@ -1,0 +1,508 @@
+//! Tests for Issue #569: Symmetry-breaking discovery — detect and perturb
+//! converged duplicate neurons.
+//!
+//! ## TDD Plan
+//! 1. Test detection identifies identical hidden neurons (same squash, close bias, similar weights)
+//! 2. Test detection ignores dissimilar neurons (different squash, different bias, different weights)
+//! 3. Test edge case: single hidden neuron produces no candidates
+//! 4. Test edge case: no hidden neurons produces no candidates
+//! 5. Test coordinated candidates include setBias and/or setWeight perturbations
+//! 6. Test insufficient samples returns empty
+//! 7. Test multiple symmetric pairs each produce candidates
+
+mod common;
+
+use common::{hidden_with_bias, make_creature, neuron, output, synapse};
+
+use neat_ai_discovery::analysis::detection::symmetry_breaking::{
+    detect_symmetric_neurons, symmetric_neurons_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+/// Build a creature with two symmetric hidden neurons.
+///
+/// Network topology:
+///   input-0 --w=1.0--> h1 --w=0.5--> output-0
+///   input-1 --w=0.8--> h1
+///   input-0 --w=1.0--> h2 --w=0.5--> output-0
+///   input-1 --w=0.8--> h2
+///
+/// h1 and h2 have identical squash (TANH), similar bias, and identical incoming weights.
+fn symmetric_creature() -> neat_ai_discovery::CreatureJson {
+    make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            hidden_with_bias("h2", "TANH", 0.5),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            synapse("input-0", "h1", 1.0),
+            synapse("input-1", "h1", 0.8),
+            synapse("h1", "output-0", 0.5),
+            synapse("input-0", "h2", 1.0),
+            synapse("input-1", "h2", 0.8),
+            synapse("h2", "output-0", 0.5),
+        ],
+    )
+}
+
+/// Build records for two neurons with very similar activations (symmetric behaviour).
+fn symmetric_records() -> Vec<(String, Vec<DiscoverRecord>)> {
+    let sample_count = 60;
+    vec![
+        (
+            "h1".to_string(),
+            (0..sample_count)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / sample_count as f32;
+                    let activation = value.tanh();
+                    make_record("h1", i, value, activation, 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..sample_count)
+                .map(|i| {
+                    // Near-identical activations (symmetric)
+                    let value = -1.0 + (i as f32) * 2.0 / sample_count as f32;
+                    let activation = value.tanh();
+                    make_record("h2", i, value, activation, 0.1)
+                })
+                .collect(),
+        ),
+    ]
+}
+
+// =============================================================================
+// 1. Detects identical hidden neurons
+// =============================================================================
+
+#[test]
+fn test_detects_identical_symmetric_neurons() {
+    let creature = symmetric_creature();
+    let records = symmetric_records();
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        !detected.is_empty(),
+        "Should detect symmetric pair h1/h2 with identical weights, squash, and bias"
+    );
+
+    // Verify the pair involves h1 and h2
+    let pair = &detected[0];
+    let uuids = [pair.neuron_a_uuid.as_str(), pair.neuron_b_uuid.as_str()];
+    assert!(uuids.contains(&"h1"), "Pair should include h1");
+    assert!(uuids.contains(&"h2"), "Pair should include h2");
+    assert!(
+        pair.cosine_similarity > 0.95,
+        "Cosine similarity should be > 0.95, got {}",
+        pair.cosine_similarity
+    );
+}
+
+// =============================================================================
+// 2. Ignores dissimilar neurons
+// =============================================================================
+
+#[test]
+fn test_ignores_dissimilar_neurons() {
+    // h1 and h2 have very different incoming weights
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            hidden_with_bias("h2", "TANH", 0.5),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            synapse("input-0", "h1", 1.0),
+            synapse("input-1", "h1", 0.8),
+            synapse("h1", "output-0", 0.5),
+            // Very different weights for h2
+            synapse("input-0", "h2", -0.3),
+            synapse("input-1", "h2", 2.0),
+            synapse("h2", "output-0", 0.5),
+        ],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h1", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..60)
+                .map(|i| {
+                    // Different activation pattern due to different weights
+                    let value = 1.5 - (i as f32) * 3.0 / 60.0;
+                    make_record("h2", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+    ];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "Should not detect symmetric pair when incoming weights are very different"
+    );
+}
+
+// =============================================================================
+// 3. Different activation functions prevent detection
+// =============================================================================
+
+#[test]
+fn test_different_squash_prevents_detection() {
+    // Same weights but different squash functions
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            hidden_with_bias("h2", "LOGISTIC", 0.5),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            synapse("input-0", "h1", 1.0),
+            synapse("input-1", "h1", 0.8),
+            synapse("h1", "output-0", 0.5),
+            synapse("input-0", "h2", 1.0),
+            synapse("input-1", "h2", 0.8),
+            synapse("h2", "output-0", 0.5),
+        ],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h1", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    let activation = 1.0 / (1.0 + (-value).exp());
+                    make_record("h2", i, value, activation, 0.1)
+                })
+                .collect(),
+        ),
+    ];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "Different squash functions should prevent symmetric detection"
+    );
+}
+
+// =============================================================================
+// 4. Single hidden neuron produces no candidates
+// =============================================================================
+
+#[test]
+fn test_single_hidden_neuron_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            synapse("input-0", "h1", 1.0),
+            synapse("h1", "output-0", 0.5),
+        ],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "h1".to_string(),
+        (0..60)
+            .map(|i| {
+                let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                make_record("h1", i, value, value.tanh(), 0.1)
+            })
+            .collect(),
+    )];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "Single hidden neuron cannot form a symmetric pair"
+    );
+}
+
+// =============================================================================
+// 5. No hidden neurons produces no candidates
+// =============================================================================
+
+#[test]
+fn test_no_hidden_neurons_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![synapse("input-0", "output-0", 1.0)],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "No hidden neurons should produce no candidates"
+    );
+}
+
+// =============================================================================
+// 6. Coordinated candidates include perturbation operations
+// =============================================================================
+
+#[test]
+fn test_coordinated_candidates_include_perturbations() {
+    let creature = symmetric_creature();
+    let records = symmetric_records();
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(!detected.is_empty());
+
+    let coordinated = symmetric_neurons_to_coordinated_candidates(&detected);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates for symmetric pair"
+    );
+
+    // Verify positive expected gain
+    assert!(
+        coordinated[0].expected_creature_score_gain > 0.0,
+        "Expected gain should be positive"
+    );
+
+    // Verify comment references issue #569
+    assert!(
+        coordinated[0].comment.as_ref().unwrap().contains("569"),
+        "Comment should reference issue #569, got: {:?}",
+        coordinated[0].comment
+    );
+
+    // Verify the candidate includes at least a setBias or setWeight operation
+    let ops_json = serde_json::to_string(&coordinated[0].operations).unwrap();
+    let has_perturbation = ops_json.contains("setBias")
+        || ops_json.contains("setWeight")
+        || ops_json.contains("changeSquash");
+    assert!(
+        has_perturbation,
+        "Candidate must include a perturbation operation (setBias, setWeight, or changeSquash), got: {ops_json}"
+    );
+}
+
+// =============================================================================
+// 7. Insufficient samples returns empty
+// =============================================================================
+
+#[test]
+fn test_insufficient_samples_returns_empty() {
+    let creature = symmetric_creature();
+
+    // Only 5 samples — below MIN_DISCOVERY_SAMPLE_COUNT
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..5)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 5.0;
+                    make_record("h1", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..5)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 5.0;
+                    make_record("h2", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+    ];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+// =============================================================================
+// 8. Multiple symmetric pairs each produce candidates
+// =============================================================================
+
+#[test]
+fn test_multiple_symmetric_pairs() {
+    // Two distinct pairs: (h1, h2) and (h3, h4)
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            hidden_with_bias("h2", "TANH", 0.5),
+            hidden_with_bias("h3", "LOGISTIC", 1.0),
+            hidden_with_bias("h4", "LOGISTIC", 1.0),
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            // Pair 1: h1/h2 with identical weights
+            synapse("input-0", "h1", 1.0),
+            synapse("input-1", "h1", 0.8),
+            synapse("h1", "output-0", 0.5),
+            synapse("input-0", "h2", 1.0),
+            synapse("input-1", "h2", 0.8),
+            synapse("h2", "output-0", 0.5),
+            // Pair 2: h3/h4 with identical weights (different from pair 1)
+            synapse("input-0", "h3", 0.3),
+            synapse("input-1", "h3", -0.7),
+            synapse("h3", "output-0", 0.9),
+            synapse("input-0", "h4", 0.3),
+            synapse("input-1", "h4", -0.7),
+            synapse("h4", "output-0", 0.9),
+        ],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h1", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h2", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h3".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = 0.5 + (i as f32) * 1.0 / 60.0;
+                    let activation = 1.0 / (1.0 + (-value).exp());
+                    make_record("h3", i, value, activation, 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h4".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = 0.5 + (i as f32) * 1.0 / 60.0;
+                    let activation = 1.0 / (1.0 + (-value).exp());
+                    make_record("h4", i, value, activation, 0.1)
+                })
+                .collect(),
+        ),
+    ];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.len() >= 2,
+        "Should detect at least 2 symmetric pairs, got: {}",
+        detected.len()
+    );
+
+    let coordinated = symmetric_neurons_to_coordinated_candidates(&detected);
+    assert!(
+        coordinated.len() >= 2,
+        "Should produce at least 2 coordinated candidates, got: {}",
+        coordinated.len()
+    );
+}
+
+// =============================================================================
+// 9. Bias difference beyond tolerance prevents detection
+// =============================================================================
+
+#[test]
+fn test_large_bias_difference_prevents_detection() {
+    // Same weights but very different bias values
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            hidden_with_bias("h1", "TANH", 0.5),
+            hidden_with_bias("h2", "TANH", 5.0), // Very different bias
+            output("output-0", "LOGISTIC"),
+        ],
+        vec![
+            synapse("input-0", "h1", 1.0),
+            synapse("input-1", "h1", 0.8),
+            synapse("h1", "output-0", 0.5),
+            synapse("input-0", "h2", 1.0),
+            synapse("input-1", "h2", 0.8),
+            synapse("h2", "output-0", 0.5),
+        ],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h1".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = -1.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h1", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+        (
+            "h2".to_string(),
+            (0..60)
+                .map(|i| {
+                    let value = 4.0 + (i as f32) * 2.0 / 60.0;
+                    make_record("h2", i, value, value.tanh(), 0.1)
+                })
+                .collect(),
+        ),
+    ];
+
+    let detected = detect_symmetric_neurons(&creature, &records);
+    assert!(
+        detected.is_empty(),
+        "Large bias difference should prevent symmetric detection"
+    );
+}


### PR DESCRIPTION
## Summary

Add symmetry-breaking detection module that identifies pairs of hidden neurons whose
weight configurations, bias values, and activation functions have converged to
near-identical states. When detected, the module recommends perturbation of one
neuron (bias shift + incoming weight scaling) to break the symmetry and unlock
latent representational capacity. Closes #569.

## Changes

- **New file**: `src/analysis/detection/symmetry_breaking.rs` — detection module implementing:
  - `detect_symmetric_neurons()` — identifies symmetric pairs using cosine similarity of incoming weight vectors (threshold 0.95), bias tolerance (0.5), and activation function equality
  - `symmetric_neurons_to_coordinated_candidates()` — converts detections into `SetBias` + `SetWeight` coordinated candidates
- **Modified**: `src/analysis/detection/mod.rs` — added `symmetry_breaking` module declaration
- **Modified**: `src/analysis/mod.rs` — added re-export for backward compatibility
- **Modified**: `src/analysis/module_dispatch_specs.rs` — added dispatch spec for parallel execution

## Evidence

This is a backend detection module with no visual output. All changes verified through:
- 9 integration tests covering detection, edge cases, and candidate generation
- Full `quality.sh` pass (fmt, clippy, check, test, release build)

## Test Plan

- `tests/issue_569_symmetry_breaking.rs` — 9 tests:
  1. `test_detects_identical_symmetric_neurons` — verifies identical neurons are detected with cosine similarity > 0.95
  2. `test_ignores_dissimilar_neurons` — verifies neurons with different incoming weights are not flagged
  3. `test_different_squash_prevents_detection` — verifies different activation functions prevent detection
  4. `test_single_hidden_neuron_no_candidates` — edge case: single neuron cannot form a pair
  5. `test_no_hidden_neurons_no_candidates` — edge case: no hidden neurons
  6. `test_coordinated_candidates_include_perturbations` — verifies candidates include SetBias/SetWeight operations
  7. `test_insufficient_samples_returns_empty` — verifies minimum sample count is enforced
  8. `test_multiple_symmetric_pairs` — verifies multiple distinct pairs are each detected
  9. `test_large_bias_difference_prevents_detection` — verifies bias tolerance is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)