### PR TITLE
Skip-connection discovery — identify beneficial residual connections across layers (#570)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.28.3"
+version = "0.29.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.28.2"
+version = "0.28.3"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-570.md
+++ b/docs/pr-summary-570.md
@@ -1,0 +1,44 @@
+## Summary
+
+Add skip-connection discovery module that identifies beneficial residual connections
+across layers in deep NEAT networks. The module analyses topological depth from inputs
+and detects gradient attenuation in deep neurons (depth > 2), then suggests addSynapse
+candidates connecting shallow sources (inputs or shallow hidden neurons) directly to
+deep neurons with conservative near-zero weights. Closes #570.
+
+## Changes
+
+- **`src/analysis/detection/skip_connection.rs`** — New detection module implementing:
+  - Forward BFS to compute topological depth of each neuron from inputs
+  - Gradient attenuation detection (deep neurons with mean error < 50% of shallow mean)
+  - Candidate generation prioritising largest depth gaps with conservative weights
+- **`src/analysis/detection/mod.rs`** — Register `skip_connection` module
+- **`src/analysis/mod.rs`** — Re-export `skip_connection` at analysis level
+- **`src/analysis/module_dispatch_specs.rs`** — Add parallel dispatch spec for the new module
+- **`tests/issue_570_skip_connection_discovery.rs`** — 13 integration tests
+
+## Evidence
+
+This is a backend detection module with no UI. All 13 tests pass and `quality.sh` passes cleanly:
+- Deep network with gradient attenuation produces candidates
+- Shallow networks produce no candidates
+- Candidates prioritise largest depth gaps
+- Conservative weights (≤ 0.15) on all candidates
+- Existing skip connections are not duplicated
+- Edge cases: no hidden neurons, insufficient samples, no records, uniform error
+
+## Test Plan
+
+- `test_deep_network_detects_skip_connection_candidates` — verifies detection in deep networks
+- `test_shallow_network_no_candidates` — no false positives for shallow networks
+- `test_candidates_prioritise_largest_depth_gaps` — sorting by depth gap
+- `test_candidates_have_positive_improvement` — all candidates have positive gain
+- `test_coordinated_candidates_use_conservative_weights` — weight ≤ 0.15
+- `test_existing_skip_connection_not_duplicated` — no duplicate suggestions
+- `test_no_hidden_neurons_no_candidates` — edge case: no hidden neurons
+- `test_insufficient_samples_no_candidates` — edge case: too few samples
+- `test_no_records_no_candidates` — edge case: empty records
+- `test_multi_input_deep_network` — multi-input topology
+- `test_source_is_shallow_neuron` — source always shallower than target
+- `test_candidates_sorted_by_improvement` — sorted best-first
+- `test_uniform_error_no_attenuation_no_candidates` — no attenuation = no candidates

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -24,6 +24,7 @@ pub mod redundant_path;
 pub mod restricted_range;
 pub mod saturation;
 pub mod sentinel_gating;
+pub mod skip_connection;
 pub mod squash_weight_rescale;
 pub mod symmetry_breaking;
 pub mod topology;

--- a/src/analysis/detection/skip_connection.rs
+++ b/src/analysis/detection/skip_connection.rs
@@ -1,0 +1,319 @@
+//! Skip-connection discovery module (Issue #570).
+//!
+//! Analyses neuron topological depth and gradient attenuation to identify
+//! beneficial residual (skip) connections across layers. Deep neurons with
+//! attenuated error gradients are connected directly to shallow neurons or
+//! inputs, bridging large depth gaps.
+//!
+//! ## Detection Criteria
+//!
+//! 1. **Layer depth analysis**: Compute topological depth of each neuron from
+//!    inputs using forward BFS.
+//! 2. **Gradient attenuation**: Identify neurons at depth > 2 whose mean
+//!    absolute error is significantly lower than the mean error at shallow
+//!    depths (ratio below `ATTENUATION_THRESHOLD`).
+//! 3. **Candidate generation**: For attenuated neurons, suggest addSynapse
+//!    candidates connecting a shallow source (input or shallow hidden) directly
+//!    to the deep neuron, prioritising the largest depth gaps and using
+//!    conservative initial weights near zero.
+//!
+//! ## Recommended Actions
+//!
+//! - **Attenuated gradient → addSynapse** (skip connection): Connect a shallow
+//!   neuron directly to a deep neuron to restore gradient signal flow.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+/// Minimum topological depth from inputs for a neuron to be considered "deep"
+/// and eligible for skip-connection candidates.
+const MIN_DEEP_DEPTH: usize = 3;
+
+/// Attenuation threshold: a deep neuron's mean absolute error must be below
+/// this fraction of the shallow mean error to be considered gradient-attenuated.
+const ATTENUATION_THRESHOLD: f32 = 0.5;
+
+/// Result of detecting a skip-connection candidate.
+#[derive(Debug, Clone)]
+pub struct SkipConnectionCandidate {
+    /// UUID of the deep neuron that would receive the skip connection.
+    pub target_uuid: String,
+    /// Topological depth of the target neuron from inputs.
+    pub target_depth: usize,
+    /// UUID of the shallow source neuron for the skip connection.
+    pub source_uuid: String,
+    /// Topological depth of the source neuron from inputs.
+    pub source_depth: usize,
+    /// Depth gap bridged by this skip connection.
+    pub depth_gap: usize,
+    /// Mean absolute error of the target neuron.
+    pub target_mean_error: f32,
+    /// Estimated creature score improvement from adding this connection.
+    pub estimated_improvement: f32,
+}
+
+/// Compute topological depth of each neuron from inputs using forward BFS.
+///
+/// Input neurons have depth 0. Each subsequent layer increments by 1.
+/// Returns a map from neuron UUID to its depth.
+fn compute_depths_from_inputs(creature: &CreatureJson) -> HashMap<String, usize> {
+    // Build forward adjacency: from_uuid → [to_uuid, ...]
+    let mut forward_adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    for s in &creature.synapses {
+        forward_adj
+            .entry(s.from_uuid.as_str())
+            .or_default()
+            .push(s.to_uuid.as_str());
+    }
+
+    let mut depths: HashMap<String, usize> = HashMap::new();
+    let mut queue: VecDeque<(&str, usize)> = VecDeque::new();
+
+    // Seed: input neurons at depth 0
+    for n in &creature.neurons {
+        if n.neuron_type == "input" {
+            depths.insert(n.uuid.clone(), 0);
+            queue.push_back((n.uuid.as_str(), 0));
+        }
+    }
+
+    // BFS forward through the graph, taking maximum depth for each neuron
+    // (so depth reflects the longest path from any input, giving true layer depth)
+    while let Some((current, depth)) = queue.pop_front() {
+        if let Some(successors) = forward_adj.get(current) {
+            for &succ in successors {
+                let new_depth = depth + 1;
+                let entry = depths.entry(succ.to_string()).or_insert(0);
+                if new_depth > *entry {
+                    *entry = new_depth;
+                    queue.push_back((succ, new_depth));
+                }
+            }
+        }
+    }
+
+    depths
+}
+
+/// Detect skip-connection candidates based on gradient attenuation in deep neurons.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded data.
+///
+/// # Returns
+/// A list of `SkipConnectionCandidate` sorted by estimated improvement (best first).
+pub fn detect_skip_connection_candidates(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<SkipConnectionCandidate> {
+    let hidden_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if hidden_uuids.is_empty() {
+        return Vec::new();
+    }
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Only consider hidden neurons with sufficient samples
+    let qualified_hidden: Vec<&str> = hidden_uuids
+        .iter()
+        .filter(|&&uuid| {
+            records_map
+                .get(uuid)
+                .map(|r| r.len() >= MIN_DISCOVERY_SAMPLE_COUNT)
+                .unwrap_or(false)
+        })
+        .copied()
+        .collect();
+
+    if qualified_hidden.is_empty() {
+        return Vec::new();
+    }
+
+    // Compute topological depth from inputs
+    let depths = compute_depths_from_inputs(creature);
+
+    // Compute mean absolute error for each qualified hidden neuron
+    let mean_errors: HashMap<&str, f32> = qualified_hidden
+        .iter()
+        .filter_map(|&uuid| {
+            let records = records_map.get(uuid)?;
+            let total_err: f32 = records
+                .iter()
+                .flat_map(|r| r.errors.iter())
+                .map(|e| e.abs())
+                .sum();
+            let count = records.iter().map(|r| r.errors.len()).sum::<usize>() as f32;
+            if count > 0.0 {
+                Some((uuid, total_err / count))
+            } else {
+                Some((uuid, 0.0))
+            }
+        })
+        .collect();
+
+    // Compute shallow mean error (neurons at depth <= 2)
+    let shallow_errors: Vec<f32> = qualified_hidden
+        .iter()
+        .filter(|&&uuid| depths.get(uuid).copied().unwrap_or(0) <= 2)
+        .filter_map(|&uuid| mean_errors.get(uuid).copied())
+        .filter(|&e| e > 0.0)
+        .collect();
+
+    if shallow_errors.is_empty() {
+        return Vec::new();
+    }
+
+    let shallow_mean_error: f32 = shallow_errors.iter().sum::<f32>() / shallow_errors.len() as f32;
+
+    if shallow_mean_error <= 0.0 {
+        return Vec::new();
+    }
+
+    // Find deep neurons with attenuated gradients
+    let deep_attenuated: Vec<(&str, usize, f32)> = qualified_hidden
+        .iter()
+        .filter_map(|&uuid| {
+            let depth = depths.get(uuid).copied()?;
+            if depth < MIN_DEEP_DEPTH {
+                return None;
+            }
+            let mean_err = mean_errors.get(uuid).copied()?;
+            let attenuation_ratio = mean_err / shallow_mean_error;
+            if attenuation_ratio < ATTENUATION_THRESHOLD {
+                Some((uuid, depth, mean_err))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if deep_attenuated.is_empty() {
+        return Vec::new();
+    }
+
+    // Build set of existing synapses for deduplication
+    let existing_synapses: HashSet<(&str, &str)> = creature
+        .synapses
+        .iter()
+        .map(|s| (s.from_uuid.as_str(), s.to_uuid.as_str()))
+        .collect();
+
+    // Collect shallow source neurons (inputs and hidden at depth <= 1)
+    let shallow_sources: Vec<(&str, usize)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input" || n.neuron_type == "hidden")
+        .filter_map(|n| {
+            let depth = depths.get(n.uuid.as_str()).copied().unwrap_or(0);
+            if depth <= 1 {
+                Some((n.uuid.as_str(), depth))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for &(target_uuid, target_depth, target_mean_err) in &deep_attenuated {
+        // Find the best shallow source: prefer largest depth gap, not already connected
+        let mut best_source: Option<(&str, usize)> = None;
+        let mut best_gap: usize = 0;
+
+        for &(source_uuid, source_depth) in &shallow_sources {
+            if existing_synapses.contains(&(source_uuid, target_uuid)) {
+                continue;
+            }
+            let gap = target_depth.saturating_sub(source_depth);
+            if gap > best_gap {
+                best_gap = gap;
+                best_source = Some((source_uuid, source_depth));
+            }
+        }
+
+        if let Some((source_uuid, source_depth)) = best_source {
+            // Estimated improvement: depth gap × attenuation severity × factor
+            let attenuation_severity = 1.0 - (target_mean_err / shallow_mean_error);
+            let estimated_improvement = best_gap as f32 * attenuation_severity * 0.005;
+
+            if estimated_improvement > 0.0 {
+                candidates.push(SkipConnectionCandidate {
+                    target_uuid: target_uuid.to_string(),
+                    target_depth,
+                    source_uuid: source_uuid.to_string(),
+                    source_depth,
+                    depth_gap: best_gap,
+                    target_mean_error: target_mean_err,
+                    estimated_improvement,
+                });
+            }
+        }
+    }
+
+    // Sort by estimated improvement (best first), using depth_gap as tiebreaker
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .total_cmp(&a.estimated_improvement)
+            .then_with(|| b.depth_gap.cmp(&a.depth_gap))
+    });
+
+    candidates
+}
+
+/// Convert skip-connection candidates into coordinated structural candidates.
+///
+/// Each candidate becomes an `addSynapse` operation with a conservative
+/// initial weight near zero to avoid disrupting existing network behaviour.
+pub fn skip_connections_to_coordinated_candidates(
+    candidates: &[SkipConnectionCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let existing_synapses: HashSet<(String, String)> = creature
+        .synapses
+        .iter()
+        .map(|s| (s.from_uuid.clone(), s.to_uuid.clone()))
+        .collect();
+
+    let mut results = Vec::new();
+
+    for c in candidates {
+        // Skip if synapse already exists
+        if existing_synapses.contains(&(c.source_uuid.clone(), c.target_uuid.clone())) {
+            continue;
+        }
+
+        // Conservative weight: small and proportional to attenuation
+        let weight = 0.01 * c.target_mean_error.min(1.0);
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: c.source_uuid.clone(),
+                to_neuron_uuid: c.target_uuid.clone(),
+                weight,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Skip connection: {} (depth {}) → {} (depth {}), gap={}, mean error {:.4}, attenuation detected",
+                c.source_uuid, c.source_depth, c.target_uuid, c.target_depth,
+                c.depth_gap, c.target_mean_error
+            )),
+        });
+    }
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -77,6 +77,7 @@ pub use detection::redundant_path;
 pub use detection::restricted_range;
 pub use detection::saturation;
 pub use detection::sentinel_gating;
+pub use detection::skip_connection;
 pub use detection::squash_weight_rescale;
 pub use detection::symmetry_breaking;
 pub use detection::topology;

--- a/src/analysis/module_dispatch_specs.rs
+++ b/src/analysis/module_dispatch_specs.rs
@@ -12,7 +12,7 @@ use super::{
     gradient_discovery, input_sensitivity, multi_hop, noise_signal, observation_utilisation,
     operating_point, opposing_synapse, oscillating_neuron, output_bias_drift,
     output_squash_mismatch, restricted_range, sample_weighted, saturation, sentinel_gating, shared,
-    squash_weight_rescale, symmetry_breaking, topology, topology_diversification,
+    skip_connection, squash_weight_rescale, symmetry_breaking, topology, topology_diversification,
     unbounded_capping, weight_coherence, weight_magnitude_reset,
 };
 
@@ -956,6 +956,35 @@ pub(crate) fn build_discovery_module_specs(
                 }
                 let candidates =
                     symmetry_breaking::symmetric_neurons_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #570: Skip-connection discovery for beneficial residual connections
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "skip connection discovery".to_string(),
+            phase_name: "skip_connection_discovery",
+            detect_fn: Box::new(move || {
+                if hidden.is_empty() {
+                    return None;
+                }
+                let records = cache.load_records_for_all_neurons(&creature);
+                let detected =
+                    skip_connection::detect_skip_connection_candidates(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = skip_connection::skip_connections_to_coordinated_candidates(
+                    &detected, &creature,
+                );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_570_skip_connection_discovery.rs
+++ b/tests/issue_570_skip_connection_discovery.rs
@@ -1,0 +1,656 @@
+//! Tests for Issue #570: Skip-connection discovery — identify beneficial residual
+//! connections across layers.
+//!
+//! Analyses neuron topological depth and gradient attenuation to recommend
+//! skip connections (addSynapse) that bridge large depth gaps in deep networks.
+//!
+//! ## TDD Plan
+//! 1. Test layer depth computation from inputs
+//! 2. Test gradient attenuation detection in deep networks
+//! 3. Test candidate generation prioritises largest depth gaps
+//! 4. Test shallow networks produce no candidates
+//! 5. Test conservative initial weights (near zero)
+//! 6. Test existing skip connections are not duplicated
+//! 7. Test edge cases (empty network, no hidden neurons, insufficient samples)
+
+mod common;
+
+use neat_ai_discovery::analysis::detection::skip_connection::{
+    detect_skip_connection_candidates, skip_connections_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord with custom errors.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: None,
+        activation,
+        errors,
+    }
+}
+
+/// Build records for a neuron: `count` samples with varying activations and errors.
+fn make_records(uuid: &str, count: u32, activation_scale: f32, error: f32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| {
+            record(
+                uuid,
+                i,
+                (i as f32 * 0.1).sin() * activation_scale,
+                vec![error * (1.0 + (i as f32 * 0.05).sin())],
+            )
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Test network builders
+// ---------------------------------------------------------------------------
+
+/// Deep network: input-0 → h0 → h1 → h2 → h3 → h4 → output-0
+/// h0 is at depth 1 from input, h4 at depth 5. The deep neurons (h2–h4)
+/// have significantly attenuated error gradients compared to shallow ones.
+fn deep_network_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h0".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h1".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h2".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h3".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h4".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".into(),
+                neuron_type: "output".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".into(),
+                to_uuid: "h0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h0".into(),
+                to_uuid: "h1".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h1".into(),
+                to_uuid: "h2".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h2".into(),
+                to_uuid: "h3".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h3".into(),
+                to_uuid: "h4".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h4".into(),
+                to_uuid: "output-0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// Shallow network: input-0 → h0 → output-0, input-1 → h1 → output-0
+/// All neurons at depth <= 1 from input. No gradient attenuation expected.
+fn shallow_network_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-1".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h0".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h1".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".into(),
+                neuron_type: "output".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".into(),
+                to_uuid: "h0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".into(),
+                to_uuid: "h1".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h0".into(),
+                to_uuid: "output-0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h1".into(),
+                to_uuid: "output-0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+/// Deep network with two inputs feeding different depths, creating
+/// gradient attenuation at deeper levels.
+fn multi_input_deep_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-1".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h0".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h1".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h2".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h3".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".into(),
+                neuron_type: "output".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".into(),
+                to_uuid: "h0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".into(),
+                to_uuid: "h1".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h0".into(),
+                to_uuid: "h2".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h1".into(),
+                to_uuid: "h2".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h2".into(),
+                to_uuid: "h3".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h3".into(),
+                to_uuid: "output-0".into(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Test 1: Deep network with gradient attenuation produces skip connection candidates.
+#[test]
+fn test_deep_network_detects_skip_connection_candidates() {
+    let creature = deep_network_creature();
+
+    // Simulate gradient attenuation: shallow neurons have high error,
+    // deep neurons have significantly lower error (attenuated gradients).
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Deep network with gradient attenuation should produce skip-connection candidates"
+    );
+}
+
+/// Test 2: Shallow network produces no skip-connection candidates.
+#[test]
+fn test_shallow_network_no_candidates() {
+    let creature = shallow_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.5, 0.2)),
+        ("h1".into(), make_records("h1", 30, 0.5, 0.2)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Shallow network (depth <= 2) should not produce skip-connection candidates, found {}",
+        candidates.len()
+    );
+}
+
+/// Test 3: Candidates prioritise largest depth gaps.
+#[test]
+fn test_candidates_prioritise_largest_depth_gaps() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    if candidates.len() >= 2 {
+        // First candidate should have a larger depth gap than later ones
+        assert!(
+            candidates[0].depth_gap >= candidates[1].depth_gap,
+            "Candidates should be sorted by depth gap (largest first): {} vs {}",
+            candidates[0].depth_gap,
+            candidates[1].depth_gap
+        );
+    }
+}
+
+/// Test 4: Candidates have positive estimated improvement.
+#[test]
+fn test_candidates_have_positive_improvement() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement > 0.0,
+            "All skip-connection candidates should have positive estimated improvement, got {}",
+            c.estimated_improvement
+        );
+    }
+}
+
+/// Test 5: Conversion to coordinated candidates uses addSynapse with conservative weights.
+#[test]
+fn test_coordinated_candidates_use_conservative_weights() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let detected = detect_skip_connection_candidates(&creature, &neuron_records);
+    assert!(!detected.is_empty(), "Should detect candidates first");
+
+    let coordinated = skip_connections_to_coordinated_candidates(&detected, &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated structural candidates"
+    );
+
+    for c in &coordinated {
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "Coordinated candidate should have positive expected gain"
+        );
+
+        // Verify all operations are addSynapse with conservative weights
+        for op in &c.operations {
+            let json = serde_json::to_string(op).unwrap_or_default();
+            assert!(
+                json.contains("addSynapse"),
+                "Skip-connection candidates should use addSynapse, got: {json}"
+            );
+
+            // Extract weight from the JSON and check it's conservative (near zero)
+            if let Some(w_start) = json.find("\"weight\":") {
+                let weight_str = &json[w_start + 9..];
+                if let Some(end) = weight_str.find([',', '}']) {
+                    let weight: f32 = weight_str[..end].parse().unwrap_or(999.0);
+                    assert!(
+                        weight.abs() <= 0.15,
+                        "Skip-connection weight should be conservative (near zero), got {weight}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Test 6: Existing skip connections are not duplicated.
+#[test]
+fn test_existing_skip_connection_not_duplicated() {
+    // Deep chain with an existing skip: input-0 → h0 directly connected
+    let mut creature = deep_network_creature();
+    // Add an existing skip: input-0 → h4
+    creature.synapses.push(SynapseJson {
+        from_uuid: "input-0".into(),
+        to_uuid: "h4".into(),
+        weight: 0.1,
+        synapse_type: None,
+    });
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let detected = detect_skip_connection_candidates(&creature, &neuron_records);
+    let coordinated = skip_connections_to_coordinated_candidates(&detected, &creature);
+
+    // No candidate should suggest input-0 → h4 since it already exists
+    for c in &coordinated {
+        let json = serde_json::to_string(&c.operations).unwrap_or_default();
+        let duplicates = json.contains("\"fromNeuronUuid\":\"input-0\"")
+            && json.contains("\"toNeuronUuid\":\"h4\"");
+        assert!(
+            !duplicates,
+            "Should not suggest skip connection that already exists (input-0 → h4)"
+        );
+    }
+}
+
+/// Test 7: Empty network (no hidden neurons) produces no candidates.
+#[test]
+fn test_no_hidden_neurons_no_candidates() {
+    let creature = CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".into(),
+                neuron_type: "input".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".into(),
+                neuron_type: "output".into(),
+                squash: "TANH".into(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![SynapseJson {
+            from_uuid: "input-0".into(),
+            to_uuid: "output-0".into(),
+            weight: 0.5,
+            synapse_type: None,
+        }],
+        input: 1,
+        output: 1,
+    };
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Network with no hidden neurons should produce no candidates"
+    );
+}
+
+/// Test 8: Insufficient samples do not trigger detection.
+#[test]
+fn test_insufficient_samples_no_candidates() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 5, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 5, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 5, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 5, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 5, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+/// Test 9: No records at all produces no candidates.
+#[test]
+fn test_no_records_no_candidates() {
+    let creature = deep_network_creature();
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "No records should produce no candidates"
+    );
+}
+
+/// Test 10: Multi-input deep network detects candidates for deep neurons.
+#[test]
+fn test_multi_input_deep_network() {
+    let creature = multi_input_deep_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.7, 0.40)),
+        ("h1".into(), make_records("h1", 30, 0.7, 0.40)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.2, 0.04)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    // Deep neurons (h2, h3) with attenuated gradients should be candidates
+    if !candidates.is_empty() {
+        // All candidates should be for deep neurons (depth > 2)
+        for c in &candidates {
+            assert!(
+                c.target_depth > 2,
+                "Skip-connection candidates should only target deep neurons, got depth {} for {}",
+                c.target_depth,
+                c.target_uuid
+            );
+        }
+    }
+}
+
+/// Test 11: Source neuron is shallow (input or shallow hidden).
+#[test]
+fn test_source_is_shallow_neuron() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    for c in &candidates {
+        assert!(
+            c.source_depth < c.target_depth,
+            "Source should be shallower than target: source depth {} vs target depth {}",
+            c.source_depth,
+            c.target_depth
+        );
+    }
+}
+
+/// Test 12: Candidates are sorted by estimated improvement (best first).
+#[test]
+fn test_candidates_sorted_by_improvement() {
+    let creature = deep_network_creature();
+
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.8, 0.50)),
+        ("h1".into(), make_records("h1", 30, 0.6, 0.35)),
+        ("h2".into(), make_records("h2", 30, 0.4, 0.08)),
+        ("h3".into(), make_records("h3", 30, 0.3, 0.05)),
+        ("h4".into(), make_records("h4", 30, 0.2, 0.03)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    for window in candidates.windows(2) {
+        assert!(
+            window[0].estimated_improvement >= window[1].estimated_improvement,
+            "Candidates should be sorted by estimated improvement (best first)"
+        );
+    }
+}
+
+/// Test 13: Uniform error across depths (no attenuation) produces no candidates.
+#[test]
+fn test_uniform_error_no_attenuation_no_candidates() {
+    let creature = deep_network_creature();
+
+    // All neurons have the same error — no gradient attenuation
+    let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_records("h0", 30, 0.5, 0.20)),
+        ("h1".into(), make_records("h1", 30, 0.5, 0.20)),
+        ("h2".into(), make_records("h2", 30, 0.5, 0.20)),
+        ("h3".into(), make_records("h3", 30, 0.5, 0.20)),
+        ("h4".into(), make_records("h4", 30, 0.5, 0.20)),
+    ];
+
+    let candidates = detect_skip_connection_candidates(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Uniform error (no gradient attenuation) should produce no candidates, found {}",
+        candidates.len()
+    );
+}


### PR DESCRIPTION
## Summary

Add skip-connection discovery module that identifies beneficial residual connections
across layers in deep NEAT networks. The module analyses topological depth from inputs
and detects gradient attenuation in deep neurons (depth > 2), then suggests addSynapse
candidates connecting shallow sources (inputs or shallow hidden neurons) directly to
deep neurons with conservative near-zero weights. Closes #570.

## Changes

- **`src/analysis/detection/skip_connection.rs`** — New detection module implementing:
  - Forward BFS to compute topological depth of each neuron from inputs
  - Gradient attenuation detection (deep neurons with mean error < 50% of shallow mean)
  - Candidate generation prioritising largest depth gaps with conservative weights
- **`src/analysis/detection/mod.rs`** — Register `skip_connection` module
- **`src/analysis/mod.rs`** — Re-export `skip_connection` at analysis level
- **`src/analysis/module_dispatch_specs.rs`** — Add parallel dispatch spec for the new module
- **`tests/issue_570_skip_connection_discovery.rs`** — 13 integration tests

## Evidence

This is a backend detection module with no UI. All 13 tests pass and `quality.sh` passes cleanly:
- Deep network with gradient attenuation produces candidates
- Shallow networks produce no candidates
- Candidates prioritise largest depth gaps
- Conservative weights (≤ 0.15) on all candidates
- Existing skip connections are not duplicated
- Edge cases: no hidden neurons, insufficient samples, no records, uniform error

## Test Plan

- `test_deep_network_detects_skip_connection_candidates` — verifies detection in deep networks
- `test_shallow_network_no_candidates` — no false positives for shallow networks
- `test_candidates_prioritise_largest_depth_gaps` — sorting by depth gap
- `test_candidates_have_positive_improvement` — all candidates have positive gain
- `test_coordinated_candidates_use_conservative_weights` — weight ≤ 0.15
- `test_existing_skip_connection_not_duplicated` — no duplicate suggestions
- `test_no_hidden_neurons_no_candidates` — edge case: no hidden neurons
- `test_insufficient_samples_no_candidates` — edge case: too few samples
- `test_no_records_no_candidates` — edge case: empty records
- `test_multi_input_deep_network` — multi-input topology
- `test_source_is_shallow_neuron` — source always shallower than target
- `test_candidates_sorted_by_improvement` — sorted best-first
- `test_uniform_error_no_attenuation_no_candidates` — no attenuation = no candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)