### PR TITLE
Activation co-adaptation detection — identify redundant neuron pairs (#571)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.29.1"
+version = "0.30.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-571.md
+++ b/docs/pr-summary-571.md
@@ -1,0 +1,35 @@
+## Summary
+
+Activation co-adaptation detection — identify redundant neuron pairs whose activations are highly correlated (or anti-correlated), wasting network capacity. Closes #571.
+
+New detection module `src/analysis/detection/co_adaptation.rs` computes pairwise Pearson correlation between hidden neuron activations from recorded sample data. Pairs with |correlation| > 0.9 are flagged as co-adapted. For each pair, two candidate strategies are generated:
+1. **RemoveNeuron** — remove the lower-impact neuron to eliminate redundancy
+2. **SetWeight** — perturb one neuron's incoming weights to break the co-adaptation
+
+Unlike the existing symmetry-breaking detection (Issue #569) which compares weight configurations, co-adaptation detection analyses the *recorded activations* — two neurons may have completely different weights and activation functions but still produce correlated outputs.
+
+## Evidence
+
+This is a backend detection module with no UI component. Evidence is provided by the integration test suite.
+
+All 7 integration tests pass, covering:
+- Correlated pair detection
+- Anti-correlated pair detection
+- Independent neuron exclusion
+- Candidate generation (RemoveNeuron + SetWeight)
+- Insufficient sample filtering
+- Single hidden neuron edge case
+- Input/output neuron exclusion
+
+`quality.sh` passes cleanly (fmt, clippy, check, all tests, release build).
+
+## Test Plan
+
+- `tests/issue_571_co_adaptation_detection.rs` — 7 integration tests:
+  - `test_correlated_pair_detected` — verifies highly correlated hidden neurons are flagged
+  - `test_anti_correlated_pair_detected` — verifies anti-correlated neurons are also detected
+  - `test_independent_neurons_ignored` — verifies uncorrelated neurons are not flagged
+  - `test_candidates_generated_for_co_adapted_pair` — verifies coordinated candidates are produced with correct operations and comments
+  - `test_insufficient_samples_skipped` — verifies minimum sample count is enforced
+  - `test_single_hidden_neuron_no_candidates` — edge case: single neuron cannot form a pair
+  - `test_only_hidden_neurons_paired` — verifies input/output neurons are excluded

--- a/src/analysis/detection/co_adaptation.rs
+++ b/src/analysis/detection/co_adaptation.rs
@@ -1,0 +1,284 @@
+//! Activation co-adaptation detection module (Issue #571).
+//!
+//! Identifies pairs of hidden neurons whose activations are highly correlated
+//! (or anti-correlated), meaning they effectively encode the same information.
+//! This wastes network capacity and makes the network fragile.
+//!
+//! Unlike symmetry detection (Issue #569) which compares weight configurations,
+//! co-adaptation detection analyses the *recorded activations* — two neurons may
+//! have completely different weights and activation functions but still produce
+//! correlated outputs due to receiving similar input patterns.
+//!
+//! ## Detection Criteria
+//!
+//! A pair of hidden neurons is "co-adapted" if:
+//! 1. |Pearson correlation| of their activations across samples exceeds a
+//!    threshold (default 0.9)
+//! 2. Both neurons have sufficient recorded samples
+//!
+//! ## Recommended Actions
+//!
+//! For each co-adapted pair:
+//! - `RemoveNeuron` — remove the lower-impact neuron (reuse `remove-low-impact`)
+//! - `SetWeight` — perturb one neuron's incoming weights to break the co-adaptation
+
+use std::collections::HashMap;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+/// Minimum |correlation| to consider a pair co-adapted.
+const CO_ADAPTATION_THRESHOLD: f32 = 0.9;
+
+/// Weight perturbation factor applied to break co-adaptation.
+const PERTURBATION_SCALE: f32 = 0.6;
+
+/// Base estimated improvement for removing a redundant neuron.
+const BASE_IMPROVEMENT: f32 = 0.003;
+
+/// Candidate representing a detected co-adapted neuron pair.
+#[derive(Debug, Clone)]
+pub struct CoAdaptedPairCandidate {
+    /// UUID of the first neuron in the pair.
+    pub neuron_a_uuid: String,
+    /// UUID of the second neuron in the pair.
+    pub neuron_b_uuid: String,
+    /// Pearson correlation coefficient between their activations.
+    pub correlation: f32,
+    /// Number of samples used to compute correlation.
+    pub sample_count: usize,
+    /// Mean absolute activation of neuron A.
+    pub mean_abs_activation_a: f32,
+    /// Mean absolute activation of neuron B.
+    pub mean_abs_activation_b: f32,
+    /// Estimated improvement from resolving the co-adaptation.
+    pub estimated_improvement: f32,
+}
+
+/// Detect co-adapted neuron pairs from recorded activations.
+///
+/// Computes pairwise Pearson correlation between hidden neurons' activations
+/// and flags pairs where |correlation| exceeds the threshold.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+///
+/// # Returns
+/// A list of `CoAdaptedPairCandidate` sorted by |correlation| (highest first).
+pub fn detect_co_adapted_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<CoAdaptedPairCandidate> {
+    // Identify hidden neuron UUIDs
+    let hidden_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if hidden_uuids.len() < 2 {
+        return Vec::new();
+    }
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Filter to hidden neurons with sufficient samples
+    let eligible: Vec<&str> = hidden_uuids
+        .iter()
+        .filter(|&&uuid| {
+            records_map
+                .get(uuid)
+                .is_some_and(|r| r.len() >= MIN_DISCOVERY_SAMPLE_COUNT)
+        })
+        .copied()
+        .collect();
+
+    if eligible.len() < 2 {
+        return Vec::new();
+    }
+
+    // Pre-compute per-neuron activation vectors indexed by obs_index
+    // for consistent pairing across samples.
+    let activation_maps: HashMap<&str, HashMap<u32, f32>> = eligible
+        .iter()
+        .map(|&uuid| {
+            let recs = records_map[uuid];
+            let map: HashMap<u32, f32> = recs.iter().map(|r| (r.obs_index, r.activation)).collect();
+            (uuid, map)
+        })
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    // Compare all pairs of eligible hidden neurons
+    for i in 0..eligible.len() {
+        for j in (i + 1)..eligible.len() {
+            let uuid_a = eligible[i];
+            let uuid_b = eligible[j];
+
+            let map_a = &activation_maps[uuid_a];
+            let map_b = &activation_maps[uuid_b];
+
+            // Find shared observation indices
+            let shared: Vec<(f32, f32)> = map_a
+                .iter()
+                .filter_map(|(&obs, &act_a)| map_b.get(&obs).map(|&act_b| (act_a, act_b)))
+                .collect();
+
+            if shared.len() < MIN_DISCOVERY_SAMPLE_COUNT {
+                continue;
+            }
+
+            let correlation = pearson_correlation(&shared);
+
+            if correlation.abs() < CO_ADAPTATION_THRESHOLD {
+                continue;
+            }
+
+            // Compute mean absolute activations for impact estimation
+            let mean_abs_a = shared.iter().map(|(a, _)| a.abs()).sum::<f32>() / shared.len() as f32;
+            let mean_abs_b = shared.iter().map(|(_, b)| b.abs()).sum::<f32>() / shared.len() as f32;
+
+            // Higher |correlation| → more redundancy → higher improvement
+            let severity =
+                (correlation.abs() - CO_ADAPTATION_THRESHOLD) / (1.0 - CO_ADAPTATION_THRESHOLD);
+            let estimated_improvement = BASE_IMPROVEMENT * (0.5 + 0.5 * severity);
+
+            candidates.push(CoAdaptedPairCandidate {
+                neuron_a_uuid: uuid_a.to_string(),
+                neuron_b_uuid: uuid_b.to_string(),
+                correlation,
+                sample_count: shared.len(),
+                mean_abs_activation_a: mean_abs_a,
+                mean_abs_activation_b: mean_abs_b,
+                estimated_improvement,
+            });
+        }
+    }
+
+    // Sort by |correlation| descending (most co-adapted first)
+    candidates.sort_by(|a, b| b.correlation.abs().total_cmp(&a.correlation.abs()));
+
+    candidates
+}
+
+/// Compute Pearson correlation coefficient for paired activation values.
+///
+/// Returns 0.0 if either variable has zero variance (avoids division by zero).
+fn pearson_correlation(pairs: &[(f32, f32)]) -> f32 {
+    let n = pairs.len() as f32;
+    if n < 2.0 {
+        return 0.0;
+    }
+
+    let sum_a: f32 = pairs.iter().map(|(a, _)| a).sum();
+    let sum_b: f32 = pairs.iter().map(|(_, b)| b).sum();
+    let mean_a = sum_a / n;
+    let mean_b = sum_b / n;
+
+    let mut cov = 0.0_f32;
+    let mut var_a = 0.0_f32;
+    let mut var_b = 0.0_f32;
+
+    for &(a, b) in pairs {
+        let da = a - mean_a;
+        let db = b - mean_b;
+        cov += da * db;
+        var_a += da * da;
+        var_b += db * db;
+    }
+
+    let denom = (var_a * var_b).sqrt();
+    if denom < f32::EPSILON {
+        return 0.0;
+    }
+
+    (cov / denom).clamp(-1.0, 1.0)
+}
+
+/// Convert co-adapted pair candidates into coordinated structural candidates.
+///
+/// For each pair, generates two candidate strategies:
+/// 1. **Remove** the lower-impact neuron (`RemoveNeuron`)
+/// 2. **Perturb** one neuron's incoming weights (`SetWeight`) to break co-adaptation
+///
+/// The NEAT-AI controller validates each candidate through ablation testing.
+pub fn co_adapted_pairs_to_coordinated_candidates(
+    candidates: &[CoAdaptedPairCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len() * 2);
+
+    // Build incoming synapse lookup for weight perturbation
+    let mut incoming_synapses: HashMap<&str, Vec<(&str, f32)>> = HashMap::new();
+    for syn in &creature.synapses {
+        incoming_synapses
+            .entry(syn.to_uuid.as_str())
+            .or_default()
+            .push((syn.from_uuid.as_str(), syn.weight));
+    }
+
+    for c in candidates {
+        // Strategy 1: Remove the lower-impact neuron
+        let remove_uuid = if c.mean_abs_activation_a <= c.mean_abs_activation_b {
+            &c.neuron_a_uuid
+        } else {
+            &c.neuron_b_uuid
+        };
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: remove_uuid.clone(),
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "[#571] Co-adaptation: neurons {} and {} have correlation {:.3} ({} samples) \
+                 — removing lower-impact neuron {}",
+                c.neuron_a_uuid, c.neuron_b_uuid, c.correlation, c.sample_count, remove_uuid
+            )),
+        });
+
+        // Strategy 2: Perturb one neuron's incoming weights to break co-adaptation
+        let perturb_uuid = remove_uuid; // Perturb the same (lower-impact) neuron
+        if let Some(synapses) = incoming_synapses.get(perturb_uuid.as_str()) {
+            let ops: Vec<CoordinatedStructuralOpJson> = synapses
+                .iter()
+                .map(
+                    |(from_uuid, weight)| CoordinatedStructuralOpJson::SetWeight {
+                        from_neuron_uuid: from_uuid.to_string(),
+                        to_neuron_uuid: perturb_uuid.clone(),
+                        weight: weight * PERTURBATION_SCALE,
+                    },
+                )
+                .collect();
+
+            if !ops.is_empty() {
+                results.push(CoordinatedStructuralCandidateJson {
+                    operations: ops,
+                    expected_creature_score_gain: c.estimated_improvement * 0.8,
+                    comment: Some(format!(
+                        "[#571] Co-adaptation: neurons {} and {} have correlation {:.3} \
+                         — perturbing {} incoming weights to break co-adaptation",
+                        c.neuron_a_uuid, c.neuron_b_uuid, c.correlation, perturb_uuid
+                    )),
+                });
+            }
+        }
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -8,6 +8,7 @@ pub mod activation_mismatch;
 pub mod bias_perturbation;
 pub mod bottleneck;
 pub mod bounded_range;
+pub mod co_adaptation;
 pub mod correlated_error;
 pub mod dead_neuron;
 pub mod dormant_synapse;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -61,6 +61,7 @@ pub use detection::activation_mismatch;
 pub use detection::bias_perturbation;
 pub use detection::bottleneck;
 pub use detection::bounded_range;
+pub use detection::co_adaptation;
 pub use detection::correlated_error;
 pub use detection::dead_neuron;
 pub use detection::dormant_synapse;

--- a/src/analysis/module_dispatch_specs.rs
+++ b/src/analysis/module_dispatch_specs.rs
@@ -8,12 +8,12 @@ use std::sync::Arc;
 
 use super::{
     activation_mismatch, activation_recommendation, bias_perturbation, bottleneck, bounded_range,
-    cache, correlated_error, dead_neuron, discovery_dispatch, dormant_synapse, error_plateau,
-    gradient_discovery, input_sensitivity, multi_hop, noise_signal, observation_utilisation,
-    operating_point, opposing_synapse, oscillating_neuron, output_bias_drift,
-    output_squash_mismatch, restricted_range, sample_weighted, saturation, sentinel_gating, shared,
-    skip_connection, squash_weight_rescale, symmetry_breaking, topology, topology_diversification,
-    unbounded_capping, weight_coherence, weight_magnitude_reset,
+    cache, co_adaptation, correlated_error, dead_neuron, discovery_dispatch, dormant_synapse,
+    error_plateau, gradient_discovery, input_sensitivity, multi_hop, noise_signal,
+    observation_utilisation, operating_point, opposing_synapse, oscillating_neuron,
+    output_bias_drift, output_squash_mismatch, restricted_range, sample_weighted, saturation,
+    sentinel_gating, shared, skip_connection, squash_weight_rescale, symmetry_breaking, topology,
+    topology_diversification, unbounded_capping, weight_coherence, weight_magnitude_reset,
 };
 
 /// Build all discovery module specs for parallel dispatch.
@@ -985,6 +985,33 @@ pub(crate) fn build_discovery_module_specs(
                 let candidates = skip_connection::skip_connections_to_coordinated_candidates(
                     &detected, &creature,
                 );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #571: Activation co-adaptation detection for redundant neuron pairs
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "co-adaptation detection".to_string(),
+            phase_name: "co_adaptation_detection",
+            detect_fn: Box::new(move || {
+                if hidden.len() < 2 {
+                    return None;
+                }
+                let records = cache.load_records_for_hidden(&hidden);
+                let detected = co_adaptation::detect_co_adapted_neurons(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    co_adaptation::co_adapted_pairs_to_coordinated_candidates(&detected, &creature);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_571_co_adaptation_detection.rs
+++ b/tests/issue_571_co_adaptation_detection.rs
@@ -1,0 +1,300 @@
+//! Tests for Issue #571: Activation co-adaptation detection — identify redundant
+//! neuron pairs.
+//!
+//! Analyses pairwise activation correlation between hidden neurons to detect
+//! co-adapted pairs whose outputs are highly correlated (or anti-correlated),
+//! wasting network capacity.
+//!
+//! ## TDD Plan
+//! 1. Test correlated neuron pairs are detected
+//! 2. Test anti-correlated neuron pairs are detected
+//! 3. Test independent neurons are ignored
+//! 4. Test candidates are generated for detected pairs (RemoveNeuron + SetWeight)
+//! 5. Test insufficient samples are skipped
+//! 6. Test single hidden neuron produces no candidates
+//! 7. Test output/input neurons are excluded from pairing
+
+mod common;
+
+use common::{hidden, make_creature, neuron, output, record, synapse};
+use neat_ai_discovery::analysis::detection::co_adaptation::{
+    co_adapted_pairs_to_coordinated_candidates, detect_co_adapted_neurons,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper: build N records for a neuron with activations following a pattern.
+fn make_correlated_records(uuid: &str, count: u32, scale: f32, offset: f32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| {
+            let base = (i as f32 * 0.1).sin();
+            record(uuid, i, base * scale + offset, None)
+        })
+        .collect()
+}
+
+/// Helper: build N records with independent (pseudo-random) activations.
+fn make_independent_records(uuid: &str, count: u32, seed: f32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| {
+            // Use different frequency/phase so correlation is low
+            let activation = (i as f32 * seed + 1.7).sin() * 0.5 + (i as f32 * seed * 2.3).cos();
+            record(uuid, i, activation, None)
+        })
+        .collect()
+}
+
+/// Two hidden neurons that produce highly similar activations (same signal
+/// shape, same scale) should be detected as co-adapted.
+#[test]
+fn test_correlated_pair_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            hidden("h1", "LOGISTIC"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-0", "h1", 0.8),
+            synapse("h0", "out-0", 1.0),
+            synapse("h1", "out-0", 0.5),
+        ],
+    );
+
+    let count = 50_u32;
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_correlated_records("h0", count, 1.0, 0.0)),
+        ("h1".into(), make_correlated_records("h1", count, 1.0, 0.0)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(
+        !detected.is_empty(),
+        "Should detect co-adapted pair for highly correlated neurons"
+    );
+    // The pair should involve h0 and h1
+    let pair = &detected[0];
+    let uuids = [pair.neuron_a_uuid.as_str(), pair.neuron_b_uuid.as_str()];
+    assert!(uuids.contains(&"h0"), "Pair should contain h0");
+    assert!(uuids.contains(&"h1"), "Pair should contain h1");
+    assert!(
+        pair.correlation.abs() > 0.9,
+        "Correlation should be > 0.9, got {}",
+        pair.correlation
+    );
+}
+
+/// Two neurons with anti-correlated activations (one goes up when the other
+/// goes down) should also be detected — they encode the same information
+/// with opposite signs.
+#[test]
+fn test_anti_correlated_pair_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            hidden("h1", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-0", "h1", -1.0),
+            synapse("h0", "out-0", 1.0),
+            synapse("h1", "out-0", -0.5),
+        ],
+    );
+
+    let count = 50_u32;
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_correlated_records("h0", count, 1.0, 0.0)),
+        ("h1".into(), make_correlated_records("h1", count, -1.0, 0.0)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(!detected.is_empty(), "Should detect anti-correlated pair");
+    let pair = &detected[0];
+    assert!(
+        pair.correlation < -0.9,
+        "Anti-correlated pair should have correlation < -0.9, got {}",
+        pair.correlation
+    );
+}
+
+/// Two neurons with independent (uncorrelated) activation patterns should
+/// NOT be flagged as co-adapted.
+#[test]
+fn test_independent_neurons_ignored() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            hidden("h1", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-0", "h1", 1.0),
+            synapse("h0", "out-0", 1.0),
+            synapse("h1", "out-0", 0.5),
+        ],
+    );
+
+    let count = 50_u32;
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_independent_records("h0", count, 0.7)),
+        ("h1".into(), make_independent_records("h1", count, 3.1)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(
+        detected.is_empty(),
+        "Independent neurons should not be detected as co-adapted, got {} pairs",
+        detected.len()
+    );
+}
+
+/// Detected co-adapted pairs should produce coordinated structural candidates:
+/// - RemoveNeuron for the lower-impact neuron
+/// - SetWeight perturbation as an alternative
+#[test]
+fn test_candidates_generated_for_co_adapted_pair() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            hidden("h1", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-0", "h1", 0.9),
+            synapse("h0", "out-0", 1.0),
+            synapse("h1", "out-0", 0.5),
+        ],
+    );
+
+    let count = 50_u32;
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_correlated_records("h0", count, 1.0, 0.0)),
+        ("h1".into(), make_correlated_records("h1", count, 1.0, 0.0)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+    assert!(!detected.is_empty());
+
+    let candidates = co_adapted_pairs_to_coordinated_candidates(&detected, &creature);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should produce coordinated candidates for co-adapted pairs"
+    );
+
+    // Each candidate should have operations and a positive expected gain
+    for c in &candidates {
+        assert!(
+            !c.operations.is_empty(),
+            "Candidate should have at least one operation"
+        );
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "Expected gain should be positive"
+        );
+        assert!(c.comment.is_some(), "Candidate should have a comment");
+        let comment = c.comment.as_ref().unwrap();
+        assert!(
+            comment.contains("#571"),
+            "Comment should reference issue #571"
+        );
+    }
+}
+
+/// Neurons with fewer samples than the minimum threshold should be skipped.
+#[test]
+fn test_insufficient_samples_skipped() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            hidden("h1", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-0", "h1", 1.0),
+            synapse("h0", "out-0", 1.0),
+            synapse("h1", "out-0", 0.5),
+        ],
+    );
+
+    // Only 3 samples — below minimum
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("h0".into(), make_correlated_records("h0", 3, 1.0, 0.0)),
+        ("h1".into(), make_correlated_records("h1", 3, 1.0, 0.0)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(
+        detected.is_empty(),
+        "Should not detect pairs when samples are insufficient"
+    );
+}
+
+/// A network with only one hidden neuron cannot have co-adapted pairs.
+#[test]
+fn test_single_hidden_neuron_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![synapse("in-0", "h0", 1.0), synapse("h0", "out-0", 1.0)],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> =
+        vec![("h0".into(), make_correlated_records("h0", 50, 1.0, 0.0))];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(
+        detected.is_empty(),
+        "Single hidden neuron should produce no co-adapted pairs"
+    );
+}
+
+/// Input and output neurons should not be included in co-adaptation pairing.
+#[test]
+fn test_only_hidden_neurons_paired() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            hidden("h0", "TANH"),
+            output("out-0", "TANH"),
+        ],
+        vec![
+            synapse("in-0", "h0", 1.0),
+            synapse("in-1", "h0", 1.0),
+            synapse("h0", "out-0", 1.0),
+        ],
+    );
+
+    // Even though in-0 and in-1 have correlated records, they shouldn't be paired
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        ("in-0".into(), make_correlated_records("in-0", 50, 1.0, 0.0)),
+        ("in-1".into(), make_correlated_records("in-1", 50, 1.0, 0.0)),
+        ("h0".into(), make_correlated_records("h0", 50, 1.0, 0.0)),
+    ];
+
+    let detected = detect_co_adapted_neurons(&creature, &records);
+
+    assert!(
+        detected.is_empty(),
+        "Input/output neurons should not be in co-adapted pairs, only hidden neurons"
+    );
+}


### PR DESCRIPTION
## Summary

Activation co-adaptation detection — identify redundant neuron pairs whose activations are highly correlated (or anti-correlated), wasting network capacity. Closes #571.

New detection module `src/analysis/detection/co_adaptation.rs` computes pairwise Pearson correlation between hidden neuron activations from recorded sample data. Pairs with |correlation| > 0.9 are flagged as co-adapted. For each pair, two candidate strategies are generated:
1. **RemoveNeuron** — remove the lower-impact neuron to eliminate redundancy
2. **SetWeight** — perturb one neuron's incoming weights to break the co-adaptation

Unlike the existing symmetry-breaking detection (Issue #569) which compares weight configurations, co-adaptation detection analyses the *recorded activations* — two neurons may have completely different weights and activation functions but still produce correlated outputs.

## Evidence

This is a backend detection module with no UI component. Evidence is provided by the integration test suite.

All 7 integration tests pass, covering:
- Correlated pair detection
- Anti-correlated pair detection
- Independent neuron exclusion
- Candidate generation (RemoveNeuron + SetWeight)
- Insufficient sample filtering
- Single hidden neuron edge case
- Input/output neuron exclusion

`quality.sh` passes cleanly (fmt, clippy, check, all tests, release build).

## Test Plan

- `tests/issue_571_co_adaptation_detection.rs` — 7 integration tests:
  - `test_correlated_pair_detected` — verifies highly correlated hidden neurons are flagged
  - `test_anti_correlated_pair_detected` — verifies anti-correlated neurons are also detected
  - `test_independent_neurons_ignored` — verifies uncorrelated neurons are not flagged
  - `test_candidates_generated_for_co_adapted_pair` — verifies coordinated candidates are produced with correct operations and comments
  - `test_insufficient_samples_skipped` — verifies minimum sample count is enforced
  - `test_single_hidden_neuron_no_candidates` — edge case: single neuron cannot form a pair
  - `test_only_hidden_neurons_paired` — verifies input/output neurons are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)