### PR TITLE
chore: add upgrade-dependencies workflow (PR only)

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,0 +1,55 @@
+# Upgrades Cargo.toml dependency version constraints on pull requests.
+# Runs only on PR; commits and pushes updates to the PR branch (default branch is locked).
+name: Upgrade Cargo Dependencies
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  upgrade:
+    name: Upgrade and push to PR branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+
+      - name: Upgrade dependencies
+        run: |
+          cargo upgrade --dry-run 2>&1 | tee upgrade-dry-run.txt || true
+          cargo upgrade 2>&1 | tee upgrade.log || true
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet -- 'Cargo.toml' '**/Cargo.toml' 'Cargo.lock'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Cargo.toml / Cargo.lock dependency changes."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- 'Cargo.toml' '**/Cargo.toml' 'Cargo.lock'
+          fi
+
+      - name: Update Cargo.lock
+        if: steps.changes.outputs.changed == 'true'
+        run: cargo update
+
+      - name: Commit and push to PR branch
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: upgrade Cargo.toml dependencies to latest compatible versions"
+          git push origin HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ crate-type = ["cdylib", "rlib"]  # cdylib for .so/.dylib, rlib for Rust integrat
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-parquet = "57.0"  # Apache Parquet format (viewable with standard tools)
-arrow = { version = "57.0", default-features = false }  # Arrow arrays for Parquet
+parquet = "57.3"  # Apache Parquet format (viewable with standard tools)
+arrow = { version = "57.3", default-features = false }  # Arrow arrays for Parquet
 wgpu = "28"
 pollster = "0.4"
-bytemuck = { version = "1.14", features = ["derive"] }
-rayon = "1.8"
+bytemuck = { version = "1.25", features = ["derive"] }
+rayon = "1.11"
 rand = "0.8"
-once_cell = "1.19"
-uuid = { version = "1.6", features = ["v4"] }  # Session ID generation for streaming API
+once_cell = "1.21"
+uuid = { version = "1.21", features = ["v4"] }  # Session ID generation for streaming API
 
 crossbeam-channel = "0.5"  # Efficient multi-producer work queues for GPU thread
 lz4_flex = "0.11"  # Pure Rust LZ4 compression for memory-constrained cache (Issue #420)
@@ -30,10 +30,10 @@ tracing = "0.1"  # Structured logging framework (Issue #575)
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }  # Subscriber with EnvFilter (Issue #575)
 
 [dev-dependencies]
-tempfile = "3.8"
-serial_test = "3.0"
+tempfile = "3.25"
+serial_test = "3.3"
 criterion = { version = "0.5", default-features = false, features = ["rayon", "cargo_bench_support"] }
-proptest = "1.6"  # Property-based testing for mathematical functions (Issue #573)
+proptest = "1.10"  # Property-based testing for mathematical functions (Issue #573)
 
 [[bench]]
 name = "synapse_counts"

--- a/upgrade-dry-run.txt
+++ b/upgrade-dry-run.txt
@@ -14,4 +14,3 @@ note: Re-run with `--incompatible` to upgrade incompatible version requirements
 note: Re-run with `--verbose` to show more dependencies
   incompatible: 5 packages
   latest: 9 packages
-warning: aborting upgrade due to dry run

--- a/upgrade-dry-run.txt
+++ b/upgrade-dry-run.txt
@@ -1,0 +1,17 @@
+    Checking neat_ai_discovery's dependencies
+name        old req compatible latest new req
+====        ======= ========== ====== =======
+parquet     57.0    57.3.0     57.3.0 57.3   
+arrow       57.0    57.3.0     57.3.0 57.3   
+bytemuck    1.14    1.25.0     1.25.0 1.25   
+rayon       1.8     1.11.0     1.11.0 1.11   
+once_cell   1.19    1.21.3     1.21.3 1.21   
+uuid        1.6     1.21.0     1.21.0 1.21   
+tempfile    3.8     3.25.0     3.25.0 3.25   
+serial_test 3.0     3.3.1      3.3.1  3.3    
+proptest    1.6     1.10.0     1.10.0 1.10   
+note: Re-run with `--incompatible` to upgrade incompatible version requirements
+note: Re-run with `--verbose` to show more dependencies
+  incompatible: 5 packages
+  latest: 9 packages
+warning: aborting upgrade due to dry run

--- a/upgrade.log
+++ b/upgrade.log
@@ -1,0 +1,19 @@
+    Checking neat_ai_discovery's dependencies
+name        old req compatible latest new req
+====        ======= ========== ====== =======
+parquet     57.0    57.3.0     57.3.0 57.3   
+arrow       57.0    57.3.0     57.3.0 57.3   
+bytemuck    1.14    1.25.0     1.25.0 1.25   
+rayon       1.8     1.11.0     1.11.0 1.11   
+once_cell   1.19    1.21.3     1.21.3 1.21   
+uuid        1.6     1.21.0     1.21.0 1.21   
+tempfile    3.8     3.25.0     3.25.0 3.25   
+serial_test 3.0     3.3.1      3.3.1  3.3    
+proptest    1.6     1.10.0     1.10.0 1.10   
+   Upgrading recursive dependencies
+[1m[92m     Locking[0m 0 packages to latest Rust 1.93.1 compatible versions
+[1m[92mnote[0m: pass `--verbose` to see 2 unchanged dependencies behind latest
+note: Re-run with `--incompatible` to upgrade incompatible version requirements
+note: Re-run with `--verbose` to show more dependencies
+  incompatible: 5 packages
+  latest: 9 packages


### PR DESCRIPTION
Adds a workflow that runs only on pull_request: upgrades Cargo.toml dependency version constraints via `cargo upgrade` and pushes changes to the PR branch. Default branch is locked; no schedule. Ref: GRQ-Actual .github/workflows/upgrade-dependencies.yml

Made with [Cursor](https://cursor.com)