### PR TITLE
Adaptive discovery module timeout — allocate time budget based on historical yield (#603)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.34.3"
+version = "0.35.0"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.34.2"
+version = "0.34.3"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-603.md
+++ b/docs/pr-summary-603.md
@@ -1,0 +1,41 @@
+## Summary
+
+Adaptive discovery module timeout — allocate time budget based on historical yield. Closes #603.
+
+Adds an `allocate_time_budgets()` function to `module_weights.rs` that distributes a total
+time budget across discovery modules proportionally to their historical acceptance rates
+(Bayesian success rate from `ModuleOutcomeTracker`). Also adds an `apply_decay()` method
+to `ModuleOutcomeTracker` so historical data can be gradually reduced, preventing permanent
+bias from old outcomes.
+
+### Key behaviours:
+- **Adaptive allocation**: Modules with higher historical acceptance rates receive more time
+- **Starvation prevention**: Minimum weight floor of 0.5 ensures no module is starved
+- **Decay factor**: Blends between equal allocation (decay=0.0) and fully history-driven (decay=1.0)
+- **Sparse history fallback**: Modules with fewer than `MIN_BOOST_SAMPLES` attempts receive neutral (equal) allocation
+- **Budget conservation**: Allocated budgets sum to the total available time
+
+## Evidence
+
+This is a backend/library change with no visual output. Evidence is provided by the 14
+integration tests that verify all allocation behaviours.
+
+## Test Plan
+
+- Added `tests/issue_603_adaptive_module_timeout.rs` with 14 tests:
+  - `test_equal_history_gives_equal_budgets` — equal success rates → equal budgets
+  - `test_high_yield_module_gets_more_time` — high-yield modules get more time
+  - `test_zero_success_module_still_gets_minimum_budget` — no starvation
+  - `test_sparse_history_falls_back_to_proportional` — insufficient history → equal
+  - `test_unknown_modules_get_proportional_allocation` — unknown modules get neutral
+  - `test_empty_tracker_gives_equal_budgets` — no history → equal
+  - `test_decay_factor_reduces_historical_influence` — decay reduces bias
+  - `test_partial_decay_is_intermediate` — partial decay blends correctly
+  - `test_single_module_gets_full_budget` — single module gets all time
+  - `test_empty_module_list_returns_empty_budgets` — edge case
+  - `test_budgets_sum_to_total` — budget conservation
+  - `test_apply_decay_reduces_counts` — decay halves counts
+  - `test_apply_decay_zero_clears_history` — full reset
+  - `test_apply_decay_one_preserves_history` — no-op decay
+- All existing tests pass
+- `cargo clippy` and `./quality.sh` pass cleanly

--- a/src/analysis/module_weights.rs
+++ b/src/analysis/module_weights.rs
@@ -117,6 +117,31 @@ impl ModuleOutcomeTracker {
         &self.modules
     }
 
+    /// Applies a decay factor to all module statistics (Issue #603).
+    ///
+    /// Multiplies `attempts` and `successes` by the given `factor` (clamped to [0.0, 1.0]),
+    /// rounding down. This prevents historical data from permanently biasing allocation
+    /// by gradually reducing the weight of old outcomes.
+    ///
+    /// - `factor = 1.0` — no change (preserve all history)
+    /// - `factor = 0.5` — halve all counts (moderate decay)
+    /// - `factor = 0.0` — clear all counts (full reset)
+    ///
+    /// The success rate is approximately preserved because both numerator and denominator
+    /// are scaled by the same factor.
+    pub fn apply_decay(&mut self, factor: f64) {
+        let factor = factor.clamp(0.0, 1.0);
+        for stats in self.modules.values_mut() {
+            stats.attempts = (stats.attempts as f64 * factor).round() as u32;
+            stats.successes = (stats.successes as f64 * factor).round() as u32;
+            stats.candidates_produced = (stats.candidates_produced as f64 * factor).round() as u32;
+            // Ensure successes never exceeds attempts after rounding.
+            if stats.successes > stats.attempts {
+                stats.successes = stats.attempts;
+            }
+        }
+    }
+
     /// Returns a scoring boost factor for candidates from the given module.
     ///
     /// The boost is based on the Bayesian success rate. Modules with higher
@@ -139,6 +164,88 @@ impl ModuleOutcomeTracker {
         let rate = stats.success_rate();
         (2.0 * rate).clamp(0.5, 2.0)
     }
+}
+
+/// Allocate time budgets to discovery modules based on historical yield (Issue #603).
+///
+/// Returns a map from module name to allocated time in milliseconds. The allocation
+/// strategy is:
+///
+/// 1. **Sufficient history**: Modules with >= [`MIN_BOOST_SAMPLES`] attempts get time
+///    proportional to their Bayesian success rate, with a minimum floor of 0.5 to
+///    prevent starvation.
+/// 2. **Sparse history**: Modules with fewer attempts get a neutral weight (1.0),
+///    equivalent to proportional allocation.
+/// 3. **Decay factor**: The `decay_factor` parameter (0.0–1.0) blends between equal
+///    allocation (0.0) and fully history-driven allocation (1.0). This prevents
+///    historical data from permanently biasing the allocation.
+///
+/// # Arguments
+///
+/// * `module_names` — The names of modules to allocate time for.
+/// * `tracker` — Historical outcome tracker with per-module success/failure data.
+/// * `total_ms` — Total time budget to distribute across all modules.
+/// * `decay_factor` — How much historical data influences allocation (0.0 = equal, 1.0 = full).
+pub fn allocate_time_budgets(
+    module_names: &[String],
+    tracker: &ModuleOutcomeTracker,
+    total_ms: u64,
+    decay_factor: f64,
+) -> HashMap<String, u64> {
+    let mut budgets = HashMap::new();
+    if module_names.is_empty() || total_ms == 0 {
+        return budgets;
+    }
+
+    let decay_factor = decay_factor.clamp(0.0, 1.0);
+
+    // Compute a weight for each module based on historical yield.
+    // Modules with sufficient data get a weight derived from their Bayesian success rate.
+    // Modules without sufficient data get a neutral weight (1.0).
+    let equal_weight = 1.0;
+    let min_adaptive_weight = 0.5;
+
+    let weights: Vec<f64> = module_names
+        .iter()
+        .map(|name| {
+            let stats = tracker.stats(name);
+            let adaptive_weight = if (stats.attempts as usize) >= MIN_BOOST_SAMPLES {
+                // Use success rate as the weight, with a floor to prevent starvation.
+                stats.success_rate().max(min_adaptive_weight)
+            } else {
+                // Insufficient data — neutral weight.
+                equal_weight
+            };
+            // Blend between equal and adaptive based on decay factor.
+            equal_weight * (1.0 - decay_factor) + adaptive_weight * decay_factor
+        })
+        .collect();
+
+    let total_weight: f64 = weights.iter().sum();
+    if total_weight <= 0.0 {
+        // Safety: shouldn't happen with the floor, but fall back to equal.
+        let per_module = total_ms / module_names.len() as u64;
+        for name in module_names {
+            budgets.insert(name.clone(), per_module);
+        }
+        return budgets;
+    }
+
+    // Distribute time proportionally, handling rounding.
+    let mut allocated: u64 = 0;
+    for (i, name) in module_names.iter().enumerate() {
+        let share = if i == module_names.len() - 1 {
+            // Last module gets the remainder to avoid rounding loss.
+            total_ms - allocated
+        } else {
+            let fraction = weights[i] / total_weight;
+            (total_ms as f64 * fraction).round() as u64
+        };
+        budgets.insert(name.clone(), share);
+        allocated += share;
+    }
+
+    budgets
 }
 
 /// Per-module statistics for JSON metadata output.

--- a/tests/issue_603_adaptive_module_timeout.rs
+++ b/tests/issue_603_adaptive_module_timeout.rs
@@ -1,0 +1,366 @@
+//! Integration tests for adaptive discovery module timeout allocation (Issue #603).
+//!
+//! Tests that time budgets are allocated to discovery modules based on their
+//! historical acceptance rates, with decay and fallback behaviour.
+
+use neat_ai_discovery::analysis::module_weights::ModuleOutcomeTracker;
+
+/// Helper to create a tracker with known module history.
+fn tracker_with_history(entries: &[(&str, u32, u32)]) -> ModuleOutcomeTracker {
+    let mut tracker = ModuleOutcomeTracker::new();
+    for &(name, attempts, successes) in entries {
+        for i in 0..attempts {
+            tracker.record(name, i < successes);
+        }
+    }
+    tracker
+}
+
+// =============================================================================
+// Proportional allocation tests
+// =============================================================================
+
+#[test]
+fn test_equal_history_gives_equal_budgets() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 10),
+        ("dead_neuron", 20, 10),
+        ("bottleneck", 20, 10),
+    ]);
+
+    let module_names = vec![
+        "saturation".to_string(),
+        "dead_neuron".to_string(),
+        "bottleneck".to_string(),
+    ];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 3000, 1.0);
+
+    // With equal success rates, budgets should be approximately equal.
+    // Each should get roughly 1000ms (3000 / 3).
+    assert_eq!(budgets.len(), 3);
+    let total: u64 = budgets.values().sum();
+    assert!(total <= 3000, "total budget should not exceed total_ms");
+
+    for budget in budgets.values() {
+        // Allow some tolerance for rounding.
+        assert!(
+            *budget >= 900 && *budget <= 1100,
+            "expected ~1000ms, got {budget}ms"
+        );
+    }
+}
+
+#[test]
+fn test_high_yield_module_gets_more_time() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18), // 90% success rate
+        ("dead_neuron", 20, 2), // 10% success rate
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+
+    assert_eq!(budgets.len(), 2);
+
+    let sat_budget = budgets["saturation"];
+    let dead_budget = budgets["dead_neuron"];
+
+    // The high-yield module should receive more time than the low-yield module.
+    assert!(
+        sat_budget > dead_budget,
+        "saturation ({sat_budget}ms) should get more time than dead_neuron ({dead_budget}ms)"
+    );
+}
+
+#[test]
+fn test_zero_success_module_still_gets_minimum_budget() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 20), // 100% success
+        ("dead_neuron", 20, 0), // 0% success
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+
+    let dead_budget = budgets["dead_neuron"];
+
+    // Even a zero-success module should get a minimum allocation (not zero).
+    assert!(
+        dead_budget > 0,
+        "zero-success module should still get a non-zero budget, got {dead_budget}ms"
+    );
+}
+
+// =============================================================================
+// Fallback to proportional allocation
+// =============================================================================
+
+#[test]
+fn test_sparse_history_falls_back_to_proportional() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    // Fewer than MIN_BOOST_SAMPLES attempts — should fall back to equal allocation.
+    let tracker = tracker_with_history(&[
+        ("saturation", 3, 3),  // too few attempts
+        ("dead_neuron", 3, 0), // too few attempts
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+
+    assert_eq!(budgets.len(), 2);
+
+    let sat_budget = budgets["saturation"];
+    let dead_budget = budgets["dead_neuron"];
+
+    // With insufficient history, should be approximately equal.
+    let diff = (sat_budget as i64 - dead_budget as i64).unsigned_abs();
+    assert!(
+        diff <= 100,
+        "expected roughly equal budgets with sparse history, got saturation={sat_budget}ms dead_neuron={dead_budget}ms"
+    );
+}
+
+#[test]
+fn test_unknown_modules_get_proportional_allocation() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18), // known high-yield
+    ]);
+
+    let module_names = vec![
+        "saturation".to_string(),
+        "unknown_module".to_string(), // not in tracker
+    ];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+
+    assert_eq!(budgets.len(), 2);
+
+    // Unknown module should get a neutral allocation (not zero).
+    let unknown_budget = budgets["unknown_module"];
+    assert!(
+        unknown_budget > 0,
+        "unknown module should get a non-zero budget, got {unknown_budget}ms"
+    );
+}
+
+#[test]
+fn test_empty_tracker_gives_equal_budgets() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = ModuleOutcomeTracker::new();
+
+    let module_names = vec![
+        "saturation".to_string(),
+        "dead_neuron".to_string(),
+        "bottleneck".to_string(),
+    ];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 3000, 1.0);
+
+    assert_eq!(budgets.len(), 3);
+
+    for budget in budgets.values() {
+        assert!(
+            *budget >= 900 && *budget <= 1100,
+            "expected ~1000ms with empty tracker, got {budget}ms"
+        );
+    }
+}
+
+// =============================================================================
+// Decay factor tests
+// =============================================================================
+
+#[test]
+fn test_decay_factor_reduces_historical_influence() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18), // 90% success
+        ("dead_neuron", 20, 2), // 10% success
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+
+    // With full decay (factor = 0.0), history has no influence — equal budgets.
+    let budgets_no_decay = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+    let budgets_full_decay = allocate_time_budgets(&module_names, &tracker, 2000, 0.0);
+
+    let sat_no_decay = budgets_no_decay["saturation"];
+    let dead_no_decay = budgets_no_decay["dead_neuron"];
+    let sat_full_decay = budgets_full_decay["saturation"];
+    let dead_full_decay = budgets_full_decay["dead_neuron"];
+
+    // With no decay, difference should be large.
+    let diff_no_decay = (sat_no_decay as i64 - dead_no_decay as i64).unsigned_abs();
+    // With full decay, difference should be small (equal allocation).
+    let diff_full_decay = (sat_full_decay as i64 - dead_full_decay as i64).unsigned_abs();
+
+    assert!(
+        diff_no_decay > diff_full_decay,
+        "decay should reduce the difference: no_decay_diff={diff_no_decay}, full_decay_diff={diff_full_decay}"
+    );
+}
+
+#[test]
+fn test_partial_decay_is_intermediate() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18), // 90% success
+        ("dead_neuron", 20, 2), // 10% success
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+
+    let budgets_full = allocate_time_budgets(&module_names, &tracker, 2000, 1.0);
+    let budgets_half = allocate_time_budgets(&module_names, &tracker, 2000, 0.5);
+    let budgets_none = allocate_time_budgets(&module_names, &tracker, 2000, 0.0);
+
+    let diff_full =
+        (budgets_full["saturation"] as i64 - budgets_full["dead_neuron"] as i64).unsigned_abs();
+    let diff_half =
+        (budgets_half["saturation"] as i64 - budgets_half["dead_neuron"] as i64).unsigned_abs();
+    let diff_none =
+        (budgets_none["saturation"] as i64 - budgets_none["dead_neuron"] as i64).unsigned_abs();
+
+    // Full influence > half influence > no influence (equal)
+    assert!(
+        diff_full >= diff_half,
+        "full influence diff ({diff_full}) should be >= half influence diff ({diff_half})"
+    );
+    assert!(
+        diff_half >= diff_none,
+        "half influence diff ({diff_half}) should be >= no influence diff ({diff_none})"
+    );
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_single_module_gets_full_budget() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[("saturation", 20, 10)]);
+
+    let module_names = vec!["saturation".to_string()];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 5000, 1.0);
+
+    assert_eq!(budgets.len(), 1);
+    assert_eq!(budgets["saturation"], 5000);
+}
+
+#[test]
+fn test_empty_module_list_returns_empty_budgets() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = ModuleOutcomeTracker::new();
+    let module_names: Vec<String> = vec![];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 5000, 1.0);
+
+    assert!(budgets.is_empty());
+}
+
+#[test]
+fn test_budgets_sum_to_total() {
+    use neat_ai_discovery::analysis::module_weights::allocate_time_budgets;
+
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18),
+        ("dead_neuron", 20, 2),
+        ("bottleneck", 20, 10),
+        ("oscillation", 20, 15),
+    ]);
+
+    let module_names = vec![
+        "saturation".to_string(),
+        "dead_neuron".to_string(),
+        "bottleneck".to_string(),
+        "oscillation".to_string(),
+    ];
+
+    let budgets = allocate_time_budgets(&module_names, &tracker, 10000, 1.0);
+
+    let total: u64 = budgets.values().sum();
+    assert!(
+        total <= 10000,
+        "total budget ({total}ms) should not exceed 10000ms"
+    );
+    // Should use most of the budget (allow small rounding loss).
+    assert!(
+        total >= 9900,
+        "total budget ({total}ms) should use most of the available time"
+    );
+}
+
+// =============================================================================
+// ModuleOutcomeTracker decay method tests
+// =============================================================================
+
+#[test]
+fn test_apply_decay_reduces_counts() {
+    let mut tracker = tracker_with_history(&[("saturation", 20, 10), ("dead_neuron", 40, 20)]);
+
+    tracker.apply_decay(0.5);
+
+    let sat_stats = tracker.stats("saturation");
+    let dead_stats = tracker.stats("dead_neuron");
+
+    // After 0.5 decay: attempts should be halved (rounded).
+    assert!(
+        sat_stats.attempts <= 11,
+        "expected ~10 attempts after decay, got {}",
+        sat_stats.attempts
+    );
+    assert!(
+        dead_stats.attempts <= 21,
+        "expected ~20 attempts after decay, got {}",
+        dead_stats.attempts
+    );
+
+    // Success rate should remain approximately the same.
+    let sat_rate = sat_stats.success_rate();
+    assert!(
+        (sat_rate - 0.5).abs() < 0.1,
+        "success rate should be preserved after decay, got {sat_rate}"
+    );
+}
+
+#[test]
+fn test_apply_decay_zero_clears_history() {
+    let mut tracker = tracker_with_history(&[("saturation", 20, 10)]);
+
+    tracker.apply_decay(0.0);
+
+    let stats = tracker.stats("saturation");
+    assert_eq!(stats.attempts, 0, "zero decay should clear all counts");
+    assert_eq!(stats.successes, 0, "zero decay should clear all counts");
+}
+
+#[test]
+fn test_apply_decay_one_preserves_history() {
+    let mut tracker = tracker_with_history(&[("saturation", 20, 10)]);
+
+    tracker.apply_decay(1.0);
+
+    let stats = tracker.stats("saturation");
+    assert_eq!(stats.attempts, 20, "decay=1.0 should preserve all counts");
+    assert_eq!(stats.successes, 10, "decay=1.0 should preserve all counts");
+}


### PR DESCRIPTION
## Summary

Adaptive discovery module timeout — allocate time budget based on historical yield. Closes #603.

Adds an `allocate_time_budgets()` function to `module_weights.rs` that distributes a total
time budget across discovery modules proportionally to their historical acceptance rates
(Bayesian success rate from `ModuleOutcomeTracker`). Also adds an `apply_decay()` method
to `ModuleOutcomeTracker` so historical data can be gradually reduced, preventing permanent
bias from old outcomes.

### Key behaviours:
- **Adaptive allocation**: Modules with higher historical acceptance rates receive more time
- **Starvation prevention**: Minimum weight floor of 0.5 ensures no module is starved
- **Decay factor**: Blends between equal allocation (decay=0.0) and fully history-driven (decay=1.0)
- **Sparse history fallback**: Modules with fewer than `MIN_BOOST_SAMPLES` attempts receive neutral (equal) allocation
- **Budget conservation**: Allocated budgets sum to the total available time

## Evidence

This is a backend/library change with no visual output. Evidence is provided by the 14
integration tests that verify all allocation behaviours.

## Test Plan

- Added `tests/issue_603_adaptive_module_timeout.rs` with 14 tests:
  - `test_equal_history_gives_equal_budgets` — equal success rates → equal budgets
  - `test_high_yield_module_gets_more_time` — high-yield modules get more time
  - `test_zero_success_module_still_gets_minimum_budget` — no starvation
  - `test_sparse_history_falls_back_to_proportional` — insufficient history → equal
  - `test_unknown_modules_get_proportional_allocation` — unknown modules get neutral
  - `test_empty_tracker_gives_equal_budgets` — no history → equal
  - `test_decay_factor_reduces_historical_influence` — decay reduces bias
  - `test_partial_decay_is_intermediate` — partial decay blends correctly
  - `test_single_module_gets_full_budget` — single module gets all time
  - `test_empty_module_list_returns_empty_budgets` — edge case
  - `test_budgets_sum_to_total` — budget conservation
  - `test_apply_decay_reduces_counts` — decay halves counts
  - `test_apply_decay_zero_clears_history` — full reset
  - `test_apply_decay_one_preserves_history` — no-op decay
- All existing tests pass
- `cargo clippy` and `./quality.sh` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)