### PR TITLE
Candidate confidence calibration — track predicted vs actual improvement accuracy (#605)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.35.2"
+version = "0.35.3"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.35.3"
+version = "0.35.4"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-605.md
+++ b/docs/pr-summary-605.md
@@ -1,0 +1,42 @@
+## Summary
+
+Add calibration tracking to the discovery pipeline so it can self-correct prediction biases over time. The `CalibrationTracker` records predicted vs actual improvement per discovery module and candidate type, then computes calibration metrics (MAE, bias direction, per-module calibration factors). An FFI endpoint (`get_calibration_summary`) exposes the calibration data to NEAT-AI for debugging and logging. Closes #605.
+
+### What changed
+
+- **`src/discovery_history.rs`**: Added `CalibrationTracker` type with `record_prediction()`, `calibration_factor()`, and `calibration_summary()` methods. Integrated into `DiscoveryHistory` with `record_calibration()`, `calibration_factor()`, and `calibration_summary()` delegate methods. Backward-compatible: existing serialised `DiscoveryHistory` JSON deserialises cleanly via `#[serde(default)]`.
+- **`src/ffi_types/requests.rs`**: Added `CalibrationSummaryInput` request type.
+- **`src/ffi_types/responses.rs`**: Added `CalibrationSummaryOutput` response type.
+- **`src/ffi_internal.rs`**: Added `get_calibration_summary_internal()` business logic function.
+- **`src/ffi/utilities.rs`**: Added `get_calibration_summary()` FFI entry point with panic safety.
+- **`tests/issue_605_calibration_tracking.rs`**: 13 integration tests covering all calibration functionality.
+
+## Evidence
+
+This is a backend/library change with no visual UI. Evidence is provided by the 13 passing integration tests covering:
+
+- Recording predictions and computing metrics (MAE, bias, calibration factor)
+- Per-module/candidate-type separation
+- Serialisation roundtrip
+- FFI endpoint returning valid JSON
+- Edge cases (zero predicted, unknown modules, empty history)
+
+## Test Plan
+
+- `tests/issue_605_calibration_tracking.rs` — 13 new integration tests:
+  - `calibration_tracker_records_predictions`
+  - `calibration_tracker_computes_mean_absolute_error`
+  - `calibration_tracker_computes_bias_direction`
+  - `calibration_tracker_negative_bias_for_under_prediction`
+  - `calibration_tracker_per_module_calibration_factor`
+  - `calibration_factor_defaults_to_one_for_unknown_module`
+  - `calibration_tracker_separates_modules_and_candidate_types`
+  - `calibration_tracker_serialisation_roundtrip`
+  - `discovery_history_includes_calibration_tracker`
+  - `calibration_tracker_handles_zero_predicted`
+  - `calibration_summary_sorted_by_sample_count`
+  - `ffi_get_calibration_summary_returns_valid_json`
+  - `ffi_get_calibration_summary_empty_history`
+- All 509 existing unit tests pass
+- All existing integration tests pass
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

--- a/src/discovery_history.rs
+++ b/src/discovery_history.rs
@@ -37,6 +37,178 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+// =============================================================================
+// Calibration Tracking (Issue #605)
+// =============================================================================
+
+/// Build a string key from module name and candidate type for HashMap lookup.
+fn calibration_key(module_name: &str, candidate_type: &str) -> String {
+    format!("{module_name}::{candidate_type}")
+}
+
+/// Parse a calibration key back into (module_name, candidate_type).
+fn parse_calibration_key(key: &str) -> (&str, &str) {
+    key.split_once("::").unwrap_or((key, ""))
+}
+
+/// A single predicted vs actual improvement observation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct CalibrationObservation {
+    predicted: f64,
+    actual: f64,
+}
+
+/// Summary of calibration metrics for a single module/candidate-type combination.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationSummaryEntry {
+    /// Discovery module name (e.g. "saturation", "bottleneck").
+    pub module_name: String,
+    /// Candidate type (e.g. "addSynapse", "addNeuron").
+    pub candidate_type: String,
+    /// Number of recorded predictions.
+    pub sample_count: usize,
+    /// Mean absolute error between predicted and actual improvement.
+    pub mean_absolute_error: f64,
+    /// Bias direction: positive means over-prediction, negative means under-prediction.
+    /// Computed as mean(predicted - actual).
+    pub bias: f64,
+    /// Calibration factor: multiply future predictions by this to correct bias.
+    /// Computed as mean(actual / predicted), clamped to [0.1, 10.0].
+    pub calibration_factor: f64,
+}
+
+/// Tracks predicted vs actual improvement accuracy per discovery module and
+/// candidate type (Issue #605).
+///
+/// Records observations of (predicted improvement, actual improvement) and
+/// computes calibration metrics: mean absolute error, bias direction, and
+/// per-module calibration factors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationTracker {
+    /// Observations keyed by "module_name::candidate_type".
+    observations: HashMap<String, Vec<CalibrationObservation>>,
+}
+
+/// Minimum number of observations before calibration factor is applied.
+const MIN_CALIBRATION_SAMPLES: usize = 1;
+
+/// Clamp range for calibration factors to prevent extreme corrections.
+const CALIBRATION_FACTOR_MIN: f64 = 0.1;
+const CALIBRATION_FACTOR_MAX: f64 = 10.0;
+
+impl CalibrationTracker {
+    /// Creates a new empty calibration tracker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a predicted vs actual improvement observation.
+    ///
+    /// # Arguments
+    ///
+    /// * `module_name` - The discovery module that produced the candidate
+    /// * `candidate_type` - The type of candidate (e.g. "addSynapse", "addNeuron")
+    /// * `predicted` - The predicted improvement (expected creature score gain)
+    /// * `actual` - The actual improvement observed after ablation testing
+    pub fn record_prediction(
+        &mut self,
+        module_name: &str,
+        candidate_type: &str,
+        predicted: f64,
+        actual: f64,
+    ) {
+        let key = calibration_key(module_name, candidate_type);
+        self.observations
+            .entry(key)
+            .or_default()
+            .push(CalibrationObservation { predicted, actual });
+    }
+
+    /// Returns a calibration factor for the given module and candidate type.
+    ///
+    /// Multiply future predictions by this factor to correct for systematic bias.
+    /// Returns 1.0 (no correction) if no observations exist for the combination.
+    pub fn calibration_factor(&self, module_name: &str, candidate_type: &str) -> f64 {
+        let key = calibration_key(module_name, candidate_type);
+
+        let observations = match self.observations.get(&key) {
+            Some(obs) if obs.len() >= MIN_CALIBRATION_SAMPLES => obs,
+            _ => return 1.0,
+        };
+
+        compute_calibration_factor(observations)
+    }
+
+    /// Returns a summary of calibration metrics for all tracked modules.
+    ///
+    /// Results are sorted by sample count (descending) for easy review.
+    pub fn calibration_summary(&self) -> Vec<CalibrationSummaryEntry> {
+        let mut entries: Vec<CalibrationSummaryEntry> = self
+            .observations
+            .iter()
+            .map(|(key, obs)| {
+                let (module_name, candidate_type) = parse_calibration_key(key);
+                let n = obs.len() as f64;
+                let mae: f64 = obs
+                    .iter()
+                    .map(|o| (o.predicted - o.actual).abs())
+                    .sum::<f64>()
+                    / n;
+                let bias: f64 = obs.iter().map(|o| o.predicted - o.actual).sum::<f64>() / n;
+                let factor = compute_calibration_factor(obs);
+
+                CalibrationSummaryEntry {
+                    module_name: module_name.to_string(),
+                    candidate_type: candidate_type.to_string(),
+                    sample_count: obs.len(),
+                    mean_absolute_error: mae,
+                    bias,
+                    calibration_factor: factor,
+                }
+            })
+            .collect();
+
+        entries.sort_by(|a, b| b.sample_count.cmp(&a.sample_count));
+        entries
+    }
+}
+
+/// Compute calibration factor from observations as mean(actual / predicted),
+/// clamped to a reasonable range.
+fn compute_calibration_factor(observations: &[CalibrationObservation]) -> f64 {
+    if observations.is_empty() {
+        return 1.0;
+    }
+
+    // Use ratio-based calibration: mean(actual / predicted)
+    // Skip entries where predicted is near zero to avoid division issues.
+    let epsilon = 1e-10;
+    let mut ratio_sum = 0.0;
+    let mut ratio_count = 0u32;
+
+    for obs in observations {
+        if obs.predicted.abs() > epsilon {
+            ratio_sum += obs.actual / obs.predicted;
+            ratio_count += 1;
+        } else {
+            // Predicted was ~0 but actual may be non-zero.
+            // Treat as a large under-prediction: cap ratio.
+            ratio_sum += CALIBRATION_FACTOR_MAX;
+            ratio_count += 1;
+        }
+    }
+
+    if ratio_count == 0 {
+        return 1.0;
+    }
+
+    let mean_ratio = ratio_sum / ratio_count as f64;
+    mean_ratio.clamp(CALIBRATION_FACTOR_MIN, CALIBRATION_FACTOR_MAX)
+}
+
 /// Tracks discovery history for a single neuron.
 ///
 /// This struct records how many times a neuron has been selected as a focus target
@@ -182,6 +354,9 @@ impl NeuronDiscoveryHistory {
 pub struct DiscoveryHistory {
     /// History entries keyed by neuron UUID
     neurons: HashMap<String, NeuronDiscoveryHistory>,
+    /// Calibration tracker for predicted vs actual improvement (Issue #605)
+    #[serde(default)]
+    calibration: CalibrationTracker,
 }
 
 impl DiscoveryHistory {
@@ -242,6 +417,33 @@ impl DiscoveryHistory {
     /// Clears all history entries.
     pub fn clear(&mut self) {
         self.neurons.clear();
+    }
+
+    /// Records a calibration observation (predicted vs actual improvement).
+    ///
+    /// Delegates to the internal `CalibrationTracker`.
+    pub fn record_calibration(
+        &mut self,
+        module_name: &str,
+        candidate_type: &str,
+        predicted: f64,
+        actual: f64,
+    ) {
+        self.calibration
+            .record_prediction(module_name, candidate_type, predicted, actual);
+    }
+
+    /// Returns the calibration factor for a given module and candidate type.
+    ///
+    /// Returns 1.0 if no calibration data exists for the combination.
+    pub fn calibration_factor(&self, module_name: &str, candidate_type: &str) -> f64 {
+        self.calibration
+            .calibration_factor(module_name, candidate_type)
+    }
+
+    /// Returns a summary of calibration metrics for all tracked modules.
+    pub fn calibration_summary(&self) -> Vec<CalibrationSummaryEntry> {
+        self.calibration.calibration_summary()
     }
 
     /// Removes history for neurons that are no longer in the creature.

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -264,6 +264,106 @@ pub extern "C" fn export_visualisation_snapshot(
 }
 
 // ============================================================================
+// Calibration Summary (Issue #605)
+// ============================================================================
+
+/// FFI export for querying calibration summary from discovery history.
+///
+/// Input JSON:
+/// ```json
+/// {
+///   "discoveryHistory": "<serialised DiscoveryHistory JSON string>"
+/// }
+/// ```
+///
+/// Output JSON:
+/// ```json
+/// {
+///   "success": true,
+///   "calibrationSummary": [
+///     {
+///       "moduleName": "saturation",
+///       "candidateType": "addSynapse",
+///       "sampleCount": 10,
+///       "meanAbsoluteError": 0.02,
+///       "bias": 0.01,
+///       "calibrationFactor": 0.95
+///     }
+///   ]
+/// }
+/// ```
+///
+/// # Safety
+/// The returned pointer must be freed using free_discovery_result
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[unsafe(no_mangle)]
+pub extern "C" fn get_calibration_summary(
+    input_json: *const std::ffi::c_char,
+) -> *mut std::ffi::c_char {
+    use std::ffi::{CStr, CString};
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        log_version_once();
+
+        let input_str = unsafe {
+            if input_json.is_null() {
+                let error = r#"{"success":false,"calibrationSummary":[],"error":"Null input pointer"}"#;
+                return CString::new(error).unwrap().into_raw();
+            }
+            match CStr::from_ptr(input_json).to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    let error = r#"{"success":false,"calibrationSummary":[],"error":"Invalid UTF-8 in input"}"#;
+                    return CString::new(error).unwrap().into_raw();
+                }
+            }
+        };
+
+        let json_result = match crate::get_calibration_summary_internal(input_str) {
+            Ok(json) => json,
+            Err(e) => {
+                let output = crate::ffi_types::CalibrationSummaryOutput {
+                    success: false,
+                    calibration_summary: vec![],
+                    error: Some(e.to_string()),
+                };
+                serde_json::to_string(&output).unwrap_or_else(|_| {
+                    r#"{"success":false,"calibrationSummary":[],"error":"Failed to serialize error message"}"#.to_string()
+                })
+            }
+        };
+
+        match CString::new(json_result) {
+            Ok(c_string) => c_string.into_raw(),
+            Err(_) => {
+                let error = r#"{"success":false,"calibrationSummary":[],"error":"Failed to create output string"}"#;
+                CString::new(error).unwrap().into_raw()
+            }
+        }
+    }))
+    .unwrap_or_else(|panic_info| {
+        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        let error_json = format!(
+            "{{\"success\":false,\"calibrationSummary\":[],\"error\":\"Internal panic caught: {}\"}}",
+            msg.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        CString::new(error_json)
+            .unwrap_or_else(|_| {
+                CString::new(r#"{"success":false,"calibrationSummary":[],"error":"Failed to create panic error string"}"#)
+                    .unwrap()
+            })
+            .into_raw()
+    })
+}
+
+// ============================================================================
 // Library version
 // ============================================================================
 

--- a/src/ffi_internal.rs
+++ b/src/ffi_internal.rs
@@ -432,6 +432,45 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
     }
 }
 
+/// Returns a calibration summary from discovery history (Issue #605).
+///
+/// Takes JSON input containing a serialised `DiscoveryHistory` and returns
+/// calibration metrics (MAE, bias, calibration factor) per module/candidate type.
+pub fn get_calibration_summary_internal(input_json: &str) -> Result<String> {
+    let input: CalibrationSummaryInput = match serde_json::from_str(input_json) {
+        Ok(input) => input,
+        Err(e) => {
+            let output = CalibrationSummaryOutput {
+                success: false,
+                calibration_summary: vec![],
+                error: Some(format!("Failed to parse input JSON: {e}")),
+            };
+            return Ok(serde_json::to_string(&output)?);
+        }
+    };
+
+    let history: crate::discovery_history::DiscoveryHistory =
+        match serde_json::from_str(&input.discovery_history) {
+            Ok(h) => h,
+            Err(e) => {
+                let output = CalibrationSummaryOutput {
+                    success: false,
+                    calibration_summary: vec![],
+                    error: Some(format!("Failed to parse discovery history: {e}")),
+                };
+                return Ok(serde_json::to_string(&output)?);
+            }
+        };
+
+    let summary = history.calibration_summary();
+    let output = CalibrationSummaryOutput {
+        success: true,
+        calibration_summary: summary,
+        error: None,
+    };
+    Ok(serde_json::to_string(&output)?)
+}
+
 /// Read discovery records from Parquet file for a specific neuron
 ///
 /// Takes JSON input and returns JSON output for easy integration with TypeScript/DenoJS

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -179,3 +179,11 @@ pub struct ReadDiscoveryInput {
     pub parquet_file: String,
     pub neuron_uuid: String,
 }
+
+/// JSON input for get_calibration_summary function (Issue #605).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationSummaryInput {
+    /// Serialised `DiscoveryHistory` JSON string containing calibration data.
+    pub discovery_history: String,
+}

--- a/src/ffi_types/responses.rs
+++ b/src/ffi_types/responses.rs
@@ -325,6 +325,21 @@ pub struct DiscoverRecordJson {
 }
 
 // ============================================================================
+// Calibration Summary (Issue #605)
+// ============================================================================
+
+/// JSON output from get_calibration_summary function.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationSummaryOutput {
+    pub success: bool,
+    /// Calibration summary entries, one per module/candidate-type combination.
+    pub calibration_summary: Vec<crate::discovery_history::CalibrationSummaryEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+// ============================================================================
 // Diagnostic types
 // ============================================================================
 

--- a/tests/issue_605_calibration_tracking.rs
+++ b/tests/issue_605_calibration_tracking.rs
@@ -1,0 +1,251 @@
+//! Integration tests for Issue #605: Candidate confidence calibration —
+//! track predicted vs actual improvement accuracy.
+//!
+//! Tests verify that the calibration tracker correctly records predicted
+//! vs actual improvements and computes calibration metrics.
+
+use neat_ai_discovery::discovery_history::{CalibrationTracker, DiscoveryHistory};
+use neat_ai_discovery::get_calibration_summary_internal;
+
+#[test]
+fn calibration_tracker_records_predictions() {
+    let mut tracker = CalibrationTracker::new();
+    tracker.record_prediction("saturation", "addSynapse", 0.05, 0.03);
+    tracker.record_prediction("saturation", "addSynapse", 0.10, 0.08);
+
+    let summary = tracker.calibration_summary();
+    assert_eq!(summary.len(), 1);
+
+    let entry = &summary[0];
+    assert_eq!(entry.module_name, "saturation");
+    assert_eq!(entry.candidate_type, "addSynapse");
+    assert_eq!(entry.sample_count, 2);
+}
+
+#[test]
+fn calibration_tracker_computes_mean_absolute_error() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Predicted 0.10, actual 0.08 => error 0.02
+    tracker.record_prediction("saturation", "addSynapse", 0.10, 0.08);
+    // Predicted 0.05, actual 0.03 => error 0.02
+    tracker.record_prediction("saturation", "addSynapse", 0.05, 0.03);
+
+    let summary = tracker.calibration_summary();
+    let entry = &summary[0];
+
+    // MAE = (0.02 + 0.02) / 2 = 0.02
+    assert!(
+        (entry.mean_absolute_error - 0.02).abs() < 1e-6,
+        "Expected MAE ~0.02, got {}",
+        entry.mean_absolute_error
+    );
+}
+
+#[test]
+fn calibration_tracker_computes_bias_direction() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Over-predictions: predicted > actual
+    tracker.record_prediction("bottleneck", "addNeuron", 0.10, 0.05);
+    tracker.record_prediction("bottleneck", "addNeuron", 0.08, 0.03);
+
+    let summary = tracker.calibration_summary();
+    let entry = &summary[0];
+
+    // Bias = mean(predicted - actual) = mean(0.05, 0.05) = 0.05
+    // Positive bias means over-prediction
+    assert!(
+        entry.bias > 0.0,
+        "Expected positive bias (over-prediction), got {}",
+        entry.bias
+    );
+    assert!(
+        (entry.bias - 0.05).abs() < 1e-6,
+        "Expected bias ~0.05, got {}",
+        entry.bias
+    );
+}
+
+#[test]
+fn calibration_tracker_negative_bias_for_under_prediction() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Under-predictions: predicted < actual
+    tracker.record_prediction("dead_neuron", "removeNeuron", 0.02, 0.06);
+    tracker.record_prediction("dead_neuron", "removeNeuron", 0.03, 0.07);
+
+    let summary = tracker.calibration_summary();
+    let entry = &summary[0];
+
+    // Bias = mean(predicted - actual) = mean(-0.04, -0.04) = -0.04
+    assert!(
+        entry.bias < 0.0,
+        "Expected negative bias (under-prediction), got {}",
+        entry.bias
+    );
+}
+
+#[test]
+fn calibration_tracker_per_module_calibration_factor() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Module that consistently over-predicts by 2x
+    tracker.record_prediction("saturation", "addSynapse", 0.10, 0.05);
+    tracker.record_prediction("saturation", "addSynapse", 0.20, 0.10);
+    tracker.record_prediction("saturation", "addSynapse", 0.06, 0.03);
+
+    let factor = tracker.calibration_factor("saturation", "addSynapse");
+
+    // actual/predicted = 0.5 on average, so calibration factor should be ~0.5
+    assert!(
+        (factor - 0.5).abs() < 0.1,
+        "Expected calibration factor ~0.5, got {factor}"
+    );
+}
+
+#[test]
+fn calibration_factor_defaults_to_one_for_unknown_module() {
+    let tracker = CalibrationTracker::new();
+
+    let factor = tracker.calibration_factor("unknown_module", "addSynapse");
+    assert!(
+        (factor - 1.0).abs() < 1e-6,
+        "Expected default calibration factor of 1.0, got {factor}"
+    );
+}
+
+#[test]
+fn calibration_tracker_separates_modules_and_candidate_types() {
+    let mut tracker = CalibrationTracker::new();
+
+    tracker.record_prediction("saturation", "addSynapse", 0.10, 0.08);
+    tracker.record_prediction("saturation", "setBias", 0.05, 0.04);
+    tracker.record_prediction("bottleneck", "addSynapse", 0.15, 0.12);
+
+    let summary = tracker.calibration_summary();
+    assert_eq!(
+        summary.len(),
+        3,
+        "Should have 3 separate entries for different module/type combinations"
+    );
+}
+
+#[test]
+fn calibration_tracker_serialisation_roundtrip() {
+    let mut tracker = CalibrationTracker::new();
+    tracker.record_prediction("saturation", "addSynapse", 0.10, 0.08);
+    tracker.record_prediction("bottleneck", "addNeuron", 0.05, 0.03);
+
+    let json = serde_json::to_string(&tracker).expect("should serialise");
+    let restored: CalibrationTracker = serde_json::from_str(&json).expect("should deserialise");
+
+    let original_summary = tracker.calibration_summary();
+    let restored_summary = restored.calibration_summary();
+    assert_eq!(original_summary.len(), restored_summary.len());
+}
+
+#[test]
+fn discovery_history_includes_calibration_tracker() {
+    let mut history = DiscoveryHistory::new();
+
+    // Record neuron discovery as before
+    history.record("hidden-1", true, Some(100));
+
+    // Record calibration data
+    history.record_calibration("saturation", "addSynapse", 0.10, 0.08);
+    history.record_calibration("bottleneck", "addNeuron", 0.05, 0.03);
+
+    let summary = history.calibration_summary();
+    assert_eq!(summary.len(), 2);
+
+    let factor = history.calibration_factor("saturation", "addSynapse");
+    assert!(factor > 0.0 && factor <= 2.0);
+}
+
+#[test]
+fn calibration_tracker_handles_zero_predicted() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Edge case: predicted improvement is zero
+    tracker.record_prediction("saturation", "addSynapse", 0.0, 0.05);
+
+    let factor = tracker.calibration_factor("saturation", "addSynapse");
+    // When predicted is zero but actual is non-zero, calibration factor should be clamped
+    assert!(
+        (0.1..=10.0).contains(&factor),
+        "Calibration factor should be clamped to reasonable range, got {factor}"
+    );
+}
+
+#[test]
+fn ffi_get_calibration_summary_returns_valid_json() {
+    let mut history = DiscoveryHistory::new();
+    history.record_calibration("saturation", "addSynapse", 0.10, 0.08);
+    history.record_calibration("saturation", "addSynapse", 0.20, 0.15);
+    history.record_calibration("bottleneck", "addNeuron", 0.05, 0.03);
+
+    let history_json = serde_json::to_string(&history).expect("should serialise history");
+    let input_json = serde_json::json!({
+        "discoveryHistory": history_json
+    })
+    .to_string();
+
+    let output_json = get_calibration_summary_internal(&input_json).expect("should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("should be valid JSON");
+
+    assert_eq!(output["success"], true);
+    let entries = output["calibrationSummary"]
+        .as_array()
+        .expect("should have calibrationSummary array");
+    assert_eq!(entries.len(), 2);
+
+    // Verify fields are present
+    let first = &entries[0];
+    assert!(first["moduleName"].is_string());
+    assert!(first["candidateType"].is_string());
+    assert!(first["sampleCount"].is_number());
+    assert!(first["meanAbsoluteError"].is_number());
+    assert!(first["bias"].is_number());
+    assert!(first["calibrationFactor"].is_number());
+}
+
+#[test]
+fn ffi_get_calibration_summary_empty_history() {
+    let history = DiscoveryHistory::new();
+    let history_json = serde_json::to_string(&history).expect("should serialise");
+    let input_json = serde_json::json!({
+        "discoveryHistory": history_json
+    })
+    .to_string();
+
+    let output_json = get_calibration_summary_internal(&input_json).expect("should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("should be valid JSON");
+
+    assert_eq!(output["success"], true);
+    let entries = output["calibrationSummary"]
+        .as_array()
+        .expect("should have calibrationSummary array");
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn calibration_summary_sorted_by_sample_count() {
+    let mut tracker = CalibrationTracker::new();
+
+    // Module with 1 sample
+    tracker.record_prediction("dead_neuron", "removeNeuron", 0.10, 0.08);
+
+    // Module with 3 samples
+    for _ in 0..3 {
+        tracker.record_prediction("saturation", "addSynapse", 0.10, 0.08);
+    }
+
+    let summary = tracker.calibration_summary();
+    assert!(
+        summary[0].sample_count >= summary[1].sample_count,
+        "Summary should be sorted by sample count descending"
+    );
+}


### PR DESCRIPTION
## Summary

Add calibration tracking to the discovery pipeline so it can self-correct prediction biases over time. The `CalibrationTracker` records predicted vs actual improvement per discovery module and candidate type, then computes calibration metrics (MAE, bias direction, per-module calibration factors). An FFI endpoint (`get_calibration_summary`) exposes the calibration data to NEAT-AI for debugging and logging. Closes #605.

### What changed

- **`src/discovery_history.rs`**: Added `CalibrationTracker` type with `record_prediction()`, `calibration_factor()`, and `calibration_summary()` methods. Integrated into `DiscoveryHistory` with `record_calibration()`, `calibration_factor()`, and `calibration_summary()` delegate methods. Backward-compatible: existing serialised `DiscoveryHistory` JSON deserialises cleanly via `#[serde(default)]`.
- **`src/ffi_types/requests.rs`**: Added `CalibrationSummaryInput` request type.
- **`src/ffi_types/responses.rs`**: Added `CalibrationSummaryOutput` response type.
- **`src/ffi_internal.rs`**: Added `get_calibration_summary_internal()` business logic function.
- **`src/ffi/utilities.rs`**: Added `get_calibration_summary()` FFI entry point with panic safety.
- **`tests/issue_605_calibration_tracking.rs`**: 13 integration tests covering all calibration functionality.

## Evidence

This is a backend/library change with no visual UI. Evidence is provided by the 13 passing integration tests covering:

- Recording predictions and computing metrics (MAE, bias, calibration factor)
- Per-module/candidate-type separation
- Serialisation roundtrip
- FFI endpoint returning valid JSON
- Edge cases (zero predicted, unknown modules, empty history)

## Test Plan

- `tests/issue_605_calibration_tracking.rs` — 13 new integration tests:
  - `calibration_tracker_records_predictions`
  - `calibration_tracker_computes_mean_absolute_error`
  - `calibration_tracker_computes_bias_direction`
  - `calibration_tracker_negative_bias_for_under_prediction`
  - `calibration_tracker_per_module_calibration_factor`
  - `calibration_factor_defaults_to_one_for_unknown_module`
  - `calibration_tracker_separates_modules_and_candidate_types`
  - `calibration_tracker_serialisation_roundtrip`
  - `discovery_history_includes_calibration_tracker`
  - `calibration_tracker_handles_zero_predicted`
  - `calibration_summary_sorted_by_sample_count`
  - `ffi_get_calibration_summary_returns_valid_json`
  - `ffi_get_calibration_summary_empty_history`
- All 509 existing unit tests pass
- All existing integration tests pass
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)