### PR TITLE
Candidate diversity enforcement — penalise structurally similar candidates (#610)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.1"
+version = "0.37.2"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-610.md
+++ b/docs/pr-summary-610.md
@@ -1,0 +1,42 @@
+## Summary
+
+Candidate diversity enforcement — penalise structurally similar candidates. Closes #610.
+
+When the discovery pipeline returns multiple candidates that are structurally similar
+(e.g., removing adjacent synapses to the same target), they waste evaluation budget by
+exploring the same region of mutation space. This PR adds diversity-aware reranking that
+penalises lower-ranked candidates that are structurally similar to higher-ranked ones,
+promoting exploration of diverse mutation regions.
+
+### Changes
+
+- **New module `src/analysis/candidate_diversity.rs`**: Implements structural similarity
+  metric (Jaccard similarity of affected neurons + operation types) and diversity-aware
+  reranking with configurable penalty strength.
+- **Integration in `orchestration.rs`**: Diversity reranking runs after ensemble scoring
+  and before candidate clustering, fitting naturally into the existing pipeline.
+- **Configurable penalty**: `DiversityConfig::penalty_strength` (default 0.5) controls
+  the trade-off between exploitation (keeping similar high-scoring candidates) and
+  exploration (promoting diverse alternatives).
+
+### How it works
+
+1. Candidates are sorted by `expected_creature_score_gain` (best first).
+2. For each candidate from position 1 onward, the maximum structural similarity to any
+   higher-ranked candidate is computed.
+3. The candidate's effective score is penalised: `effective = score × (1 - penalty × similarity)`.
+4. Candidates are re-sorted by effective score.
+5. All candidates are preserved (none removed), only the ranking changes.
+
+## Evidence
+
+This is a backend-only change with no visual output. Evidence is provided by the 13
+integration tests that verify correctness of the similarity metric and reranking behaviour.
+
+## Test Plan
+
+- Added `tests/issue_610_candidate_diversity_enforcement.rs` with 13 tests:
+  - Structural similarity: same target (high), identical (1.0), different (low), same neuron different ops (moderate), multi-op, symmetric
+  - Reranking: demotes similar, preserves diverse ordering, empty/single passthrough, configurable penalty, zero penalty preserves order, preserves all candidates
+- All existing tests pass unchanged
+- `cargo clippy` and `./quality.sh` pass cleanly

--- a/src/analysis/candidate_diversity.rs
+++ b/src/analysis/candidate_diversity.rs
@@ -1,0 +1,215 @@
+//! Candidate diversity enforcement (Issue #610).
+//!
+//! Penalises structurally similar candidates so the evaluation budget is spread
+//! across different regions of mutation space. When multiple candidates propose
+//! similar structural changes (e.g., removing adjacent synapses to the same
+//! target), diversity-aware reranking demotes lower-ranked similar candidates
+//! in favour of structurally distinct alternatives.
+//!
+//! ## Algorithm
+//!
+//! 1. Sort candidates by `expected_creature_score_gain` (best first).
+//! 2. For each candidate from position 1 onward, compute the maximum structural
+//!    similarity to any already-accepted candidate.
+//! 3. Penalise the candidate's effective score: `effective = score × (1 - penalty × similarity)`.
+//! 4. Re-sort by effective score to produce the final ranking.
+//!
+//! ## Structural Similarity
+//!
+//! Two candidates are similar when they affect the same neurons/synapses with
+//! the same operation types. The similarity metric considers:
+//! - **Operation type overlap** — same op types score higher.
+//! - **Affected neuron overlap** — targeting/sourcing the same neurons scores higher.
+//! - Both factors are combined into a single [0.0, 1.0] score.
+
+use std::collections::HashSet;
+
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Configuration for diversity-aware reranking.
+#[derive(Debug, Clone)]
+pub struct DiversityConfig {
+    /// Strength of the diversity penalty (0.0 = no penalty, 1.0 = maximum penalty).
+    ///
+    /// At `penalty_strength = 1.0`, a candidate identical to a higher-ranked one
+    /// has its effective score reduced to zero. At `0.5`, the effective score is
+    /// halved for identical candidates.
+    pub penalty_strength: f32,
+}
+
+impl Default for DiversityConfig {
+    fn default() -> Self {
+        Self {
+            penalty_strength: 0.5,
+        }
+    }
+}
+
+/// Compute the structural similarity between two coordinated candidates.
+///
+/// Returns a value in [0.0, 1.0] where:
+/// - 1.0 means identical structure (same operations, same neurons)
+/// - 0.0 means completely unrelated structure
+///
+/// The metric combines:
+/// - **Operation type overlap**: Jaccard similarity of op-type multisets.
+/// - **Affected neuron overlap**: Jaccard similarity of affected neuron UUID sets.
+pub fn compute_structural_similarity(
+    a: &CoordinatedStructuralCandidateJson,
+    b: &CoordinatedStructuralCandidateJson,
+) -> f32 {
+    let types_a = op_type_set(&a.operations);
+    let types_b = op_type_set(&b.operations);
+    let type_similarity = jaccard_similarity(&types_a, &types_b);
+
+    let neurons_a = affected_neurons(&a.operations);
+    let neurons_b = affected_neurons(&b.operations);
+    let neuron_similarity = jaccard_similarity_str(&neurons_a, &neurons_b);
+
+    // Weighted combination: neuron overlap is more important than op-type overlap
+    // because two RemoveSynapse candidates targeting different parts of the network
+    // are genuinely diverse despite sharing the same op type.
+    const NEURON_WEIGHT: f32 = 0.7;
+    const TYPE_WEIGHT: f32 = 0.3;
+
+    NEURON_WEIGHT * neuron_similarity + TYPE_WEIGHT * type_similarity
+}
+
+/// Rerank candidates with a diversity penalty.
+///
+/// Candidates already sorted by `expected_creature_score_gain` are penalised
+/// when structurally similar to higher-ranked candidates. The penalty reduces
+/// each candidate's effective score proportional to its maximum similarity
+/// to any already-accepted candidate.
+///
+/// All candidates are preserved (none are removed), but their order may change.
+pub fn rerank_with_diversity(
+    mut candidates: Vec<CoordinatedStructuralCandidateJson>,
+    config: &DiversityConfig,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    if candidates.len() <= 1 || config.penalty_strength <= 0.0 {
+        return candidates;
+    }
+
+    // Sort by original score (best first)
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    // Compute effective scores with diversity penalty.
+    // For each candidate, find max similarity to any higher-ranked candidate.
+    let n = candidates.len();
+    let mut effective_scores: Vec<f32> = Vec::with_capacity(n);
+
+    // First candidate always keeps its original score
+    effective_scores.push(candidates[0].expected_creature_score_gain);
+
+    for i in 1..n {
+        let mut max_similarity: f32 = 0.0;
+        for j in 0..i {
+            let sim = compute_structural_similarity(&candidates[i], &candidates[j]);
+            max_similarity = max_similarity.max(sim);
+        }
+
+        let original_score = candidates[i].expected_creature_score_gain;
+        let penalty = config.penalty_strength * max_similarity;
+        let effective = original_score * (1.0 - penalty);
+        effective_scores.push(effective);
+    }
+
+    // Create index-score pairs and sort by effective score (best first)
+    let mut indexed: Vec<(usize, f32)> = effective_scores.into_iter().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+    // Reorder candidates by effective score
+    let mut reranked: Vec<CoordinatedStructuralCandidateJson> = Vec::with_capacity(n);
+    // Use a placeholder swap approach to avoid double-borrow issues
+    let mut slots: Vec<Option<CoordinatedStructuralCandidateJson>> =
+        candidates.into_iter().map(Some).collect();
+
+    for (idx, _score) in indexed {
+        if let Some(candidate) = slots[idx].take() {
+            reranked.push(candidate);
+        }
+    }
+
+    reranked
+}
+
+/// Extract operation type tags from a list of operations.
+fn op_type_set(ops: &[CoordinatedStructuralOpJson]) -> HashSet<&'static str> {
+    ops.iter().map(op_type_tag).collect()
+}
+
+/// Get a tag string for an operation type.
+fn op_type_tag(op: &CoordinatedStructuralOpJson) -> &'static str {
+    match op {
+        CoordinatedStructuralOpJson::RemoveSynapse { .. } => "RemoveSynapse",
+        CoordinatedStructuralOpJson::AddSynapse { .. } => "AddSynapse",
+        CoordinatedStructuralOpJson::AddNeuron { .. } => "AddNeuron",
+        CoordinatedStructuralOpJson::RemoveNeuron { .. } => "RemoveNeuron",
+        CoordinatedStructuralOpJson::ChangeSquash { .. } => "ChangeSquash",
+        CoordinatedStructuralOpJson::SetBias { .. } => "SetBias",
+        CoordinatedStructuralOpJson::SetWeight { .. } => "SetWeight",
+    }
+}
+
+/// Collect the set of neuron UUIDs affected by a list of operations.
+fn affected_neurons(ops: &[CoordinatedStructuralOpJson]) -> HashSet<String> {
+    let mut neurons = HashSet::new();
+    for op in ops {
+        match op {
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+            }
+            | CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                ..
+            }
+            | CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                ..
+            } => {
+                neurons.insert(from_neuron_uuid.clone());
+                neurons.insert(to_neuron_uuid.clone());
+            }
+            CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. }
+            | CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid }
+            | CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. }
+            | CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. } => {
+                neurons.insert(neuron_uuid.clone());
+            }
+        }
+    }
+    neurons
+}
+
+/// Jaccard similarity for `HashSet<&str>`.
+fn jaccard_similarity(a: &HashSet<&str>, b: &HashSet<&str>) -> f32 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let intersection = a.intersection(b).count() as f32;
+    let union = a.union(b).count() as f32;
+    if union == 0.0 {
+        return 0.0;
+    }
+    intersection / union
+}
+
+/// Jaccard similarity for `HashSet<String>`.
+fn jaccard_similarity_str(a: &HashSet<String>, b: &HashSet<String>) -> f32 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let intersection = a.intersection(b).count() as f32;
+    let union = a.union(b).count() as f32;
+    if union == 0.0 {
+        return 0.0;
+    }
+    intersection / union
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -35,6 +35,7 @@ pub mod activation;
 pub mod cache;
 pub mod candidate_cache;
 pub mod candidate_clustering;
+pub mod candidate_diversity;
 pub mod constants;
 pub mod diagnostics;
 pub mod discovery_dispatch;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -18,7 +18,7 @@ mod synapse_specs;
 use std::sync::Arc;
 
 use super::{
-    cache, candidate_clustering, discovery_dispatch, ensemble_scoring,
+    cache, candidate_clustering, candidate_diversity, discovery_dispatch, ensemble_scoring,
     module_weights::ModuleOutcomeTracker, shared, utils,
 };
 
@@ -151,6 +151,49 @@ pub(crate) fn cluster_synapse_candidates(
     syn.candidate_clusters = clusters;
 
     crate::watchdog::beat("analysis::analyze_all → candidate clustering finished");
+}
+
+/// Apply diversity-aware reranking to coordinated structural candidates (Issue #610).
+///
+/// Penalises candidates that are structurally similar to higher-ranked candidates,
+/// promoting diverse mutation exploration over redundant clusters.
+pub(crate) fn apply_diversity_reranking(syn: &mut shared::AnalyzeSynapsesResult) {
+    use crate::observability::PhaseTimer;
+
+    if syn.coordinated_structural_candidates.len() <= 1 {
+        return;
+    }
+
+    crate::watchdog::beat("analysis::analyze_all → diversity reranking starting");
+    let _timer = PhaseTimer::new("diversity_reranking");
+
+    let before_order: Vec<f32> = syn
+        .coordinated_structural_candidates
+        .iter()
+        .map(|c| c.expected_creature_score_gain)
+        .collect();
+
+    let config = candidate_diversity::DiversityConfig::default();
+    syn.coordinated_structural_candidates = candidate_diversity::rerank_with_diversity(
+        std::mem::take(&mut syn.coordinated_structural_candidates),
+        &config,
+    );
+
+    if utils::verbose_enabled() {
+        let after_order: Vec<f32> = syn
+            .coordinated_structural_candidates
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        let reordered = before_order != after_order;
+        tracing::debug!(
+            candidates = syn.coordinated_structural_candidates.len(),
+            reordered,
+            "Diversity reranking: applied structural diversity penalty"
+        );
+    }
+
+    crate::watchdog::beat("analysis::analyze_all → diversity reranking finished");
 }
 
 /// Apply ensemble scoring to combine predictions across discovery modules (Issue #572).

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -333,6 +333,11 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         module_dispatch_specs::apply_ensemble_scoring(syn);
     }
 
+    // Issue #610: Diversity-aware reranking — penalise structurally similar candidates.
+    if let Some(syn) = synapse_result.as_mut() {
+        module_dispatch_specs::apply_diversity_reranking(syn);
+    }
+
     // Issue #224: Candidate clustering to reduce redundant ablation tests.
     if let Some(syn) = synapse_result.as_mut() {
         module_dispatch_specs::cluster_synapse_candidates(syn, &input.creature);

--- a/tests/issue_610_candidate_diversity_enforcement.rs
+++ b/tests/issue_610_candidate_diversity_enforcement.rs
@@ -1,0 +1,373 @@
+//! Tests for Issue #610: Candidate diversity enforcement — penalise structurally similar candidates.
+//!
+//! When the discovery pipeline returns multiple candidates that are structurally similar
+//! (e.g., removing adjacent synapses to the same target, or adding neurons at similar
+//! positions), diversity-aware reranking penalises similar candidates so the evaluation
+//! budget is spread across different mutation regions.
+//!
+//! ## TDD Plan
+//! 1. Structural similarity metric correctly identifies similar candidates
+//! 2. Identical candidates have similarity = 1.0
+//! 3. Completely different candidates have similarity = 0.0
+//! 4. Diversity reranking demotes similar lower-ranked candidates
+//! 5. Diverse candidates remain unaffected by reranking
+//! 6. Configurable diversity penalty changes reranking strength
+//! 7. Empty or single-candidate input passes through unchanged
+//! 8. Integration with existing candidate clustering
+
+use neat_ai_discovery::analysis::candidate_diversity::{
+    DiversityConfig, compute_structural_similarity, rerank_with_diversity,
+};
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Helper: create a RemoveSynapse coordinated candidate.
+fn remove_synapse_candidate(from: &str, to: &str, gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: from.to_string(),
+            to_neuron_uuid: to.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: None,
+    }
+}
+
+/// Helper: create an AddSynapse coordinated candidate.
+fn add_synapse_candidate(
+    from: &str,
+    to: &str,
+    weight: f32,
+    gain: f32,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: from.to_string(),
+            to_neuron_uuid: to.to_string(),
+            weight,
+        }],
+        expected_creature_score_gain: gain,
+        comment: None,
+    }
+}
+
+/// Helper: create a ChangeSquash coordinated candidate.
+fn change_squash_candidate(
+    neuron: &str,
+    squash: &str,
+    gain: f32,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+            neuron_uuid: neuron.to_string(),
+            squash: squash.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: None,
+    }
+}
+
+// =============================================================================
+// Structural Similarity Metric Tests
+// =============================================================================
+
+/// Test 1: Two candidates removing synapses to the same target have high similarity.
+#[test]
+fn test_same_target_remove_synapse_high_similarity() {
+    let a = remove_synapse_candidate("input-1", "output-0", 0.10);
+    let b = remove_synapse_candidate("input-2", "output-0", 0.08);
+
+    let sim = compute_structural_similarity(&a, &b);
+    assert!(
+        sim >= 0.5,
+        "Candidates removing synapses to the same target should have high similarity, got {sim}"
+    );
+}
+
+/// Test 2: Identical candidates have similarity = 1.0.
+#[test]
+fn test_identical_candidates_similarity_one() {
+    let a = remove_synapse_candidate("input-1", "output-0", 0.10);
+    let b = remove_synapse_candidate("input-1", "output-0", 0.10);
+
+    let sim = compute_structural_similarity(&a, &b);
+    assert!(
+        (sim - 1.0).abs() < f32::EPSILON,
+        "Identical candidates should have similarity = 1.0, got {sim}"
+    );
+}
+
+/// Test 3: Completely different candidates have similarity = 0.0.
+#[test]
+fn test_different_candidates_low_similarity() {
+    let a = remove_synapse_candidate("input-1", "output-0", 0.10);
+    let b = change_squash_candidate("hidden-5", "RELU", 0.05);
+
+    let sim = compute_structural_similarity(&a, &b);
+    assert!(
+        sim < 0.3,
+        "Completely different candidates should have low similarity, got {sim}"
+    );
+}
+
+/// Test 4: Different operation types on the same neuron have moderate similarity.
+#[test]
+fn test_same_neuron_different_ops_moderate_similarity() {
+    let a = change_squash_candidate("hidden-5", "RELU", 0.10);
+    let b = CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: "hidden-5".to_string(),
+            bias: 0.5,
+        }],
+        expected_creature_score_gain: 0.08,
+        comment: None,
+    };
+
+    let sim = compute_structural_similarity(&a, &b);
+    assert!(
+        sim > 0.0 && sim < 1.0,
+        "Same neuron, different ops should have moderate similarity, got {sim}"
+    );
+}
+
+// =============================================================================
+// Diversity Reranking Tests
+// =============================================================================
+
+/// Test 5: Diversity reranking demotes similar lower-ranked candidates.
+#[test]
+fn test_reranking_demotes_similar_candidates() {
+    // Three candidates all targeting the same output-0, two from adjacent inputs
+    let candidates = vec![
+        remove_synapse_candidate("input-1", "output-0", 0.10), // best
+        remove_synapse_candidate("input-2", "output-0", 0.09), // similar to best
+        add_synapse_candidate("input-50", "hidden-5", 0.5, 0.08), // different structure
+    ];
+
+    let config = DiversityConfig::default();
+    let reranked = rerank_with_diversity(candidates, &config);
+
+    assert_eq!(reranked.len(), 3);
+    // The best candidate stays at the top
+    assert_eq!(reranked[0].expected_creature_score_gain, 0.10);
+    // The diverse candidate (add synapse to hidden-5) should be promoted relative to
+    // the similar remove-synapse candidate
+    let diverse_idx = reranked
+        .iter()
+        .position(|c| {
+            c.operations.iter().any(|op| {
+                matches!(op,
+                CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. }
+                if to_neuron_uuid == "hidden-5")
+            })
+        })
+        .expect("diverse candidate should be present");
+    let similar_idx = reranked
+        .iter()
+        .position(|c| {
+            c.operations.iter().any(|op| {
+                matches!(op,
+                CoordinatedStructuralOpJson::RemoveSynapse { from_neuron_uuid, .. }
+                if from_neuron_uuid == "input-2")
+            })
+        })
+        .expect("similar candidate should be present");
+
+    assert!(
+        diverse_idx < similar_idx,
+        "Diverse candidate should be ranked above similar candidate after reranking"
+    );
+}
+
+/// Test 6: Diverse candidates remain unaffected by reranking.
+#[test]
+fn test_diverse_candidates_unaffected() {
+    // Three completely different candidates — ordering should stay by score
+    let candidates = vec![
+        remove_synapse_candidate("input-1", "output-0", 0.10),
+        change_squash_candidate("hidden-5", "RELU", 0.09),
+        add_synapse_candidate("input-50", "hidden-10", 0.5, 0.08),
+    ];
+
+    let config = DiversityConfig::default();
+    let reranked = rerank_with_diversity(candidates, &config);
+
+    // All candidates are diverse, so ordering should be by original score
+    assert_eq!(reranked[0].expected_creature_score_gain, 0.10);
+    assert_eq!(reranked[1].expected_creature_score_gain, 0.09);
+    assert_eq!(reranked[2].expected_creature_score_gain, 0.08);
+}
+
+/// Test 7: Empty input passes through unchanged.
+#[test]
+fn test_empty_candidates_passthrough() {
+    let config = DiversityConfig::default();
+    let reranked = rerank_with_diversity(Vec::new(), &config);
+    assert!(reranked.is_empty());
+}
+
+/// Test 8: Single candidate passes through unchanged.
+#[test]
+fn test_single_candidate_passthrough() {
+    let candidates = vec![remove_synapse_candidate("input-1", "output-0", 0.10)];
+
+    let config = DiversityConfig::default();
+    let reranked = rerank_with_diversity(candidates, &config);
+
+    assert_eq!(reranked.len(), 1);
+    assert_eq!(reranked[0].expected_creature_score_gain, 0.10);
+}
+
+/// Test 9: Higher diversity penalty increases demotion of similar candidates.
+#[test]
+fn test_higher_penalty_stronger_demotion() {
+    let make_candidates = || {
+        vec![
+            remove_synapse_candidate("input-1", "output-0", 0.10),
+            remove_synapse_candidate("input-2", "output-0", 0.095),
+            remove_synapse_candidate("input-3", "output-0", 0.090),
+            add_synapse_candidate("input-50", "hidden-5", 0.5, 0.085),
+        ]
+    };
+
+    let low_penalty = DiversityConfig {
+        penalty_strength: 0.1,
+    };
+    let high_penalty = DiversityConfig {
+        penalty_strength: 0.9,
+    };
+
+    let reranked_low = rerank_with_diversity(make_candidates(), &low_penalty);
+    let reranked_high = rerank_with_diversity(make_candidates(), &high_penalty);
+
+    // With high penalty, the diverse candidate should rank higher than with low penalty
+    let diverse_rank_low = reranked_low
+        .iter()
+        .position(|c| {
+            c.operations.iter().any(|op| {
+                matches!(op,
+                CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. }
+                if to_neuron_uuid == "hidden-5")
+            })
+        })
+        .unwrap();
+    let diverse_rank_high = reranked_high
+        .iter()
+        .position(|c| {
+            c.operations.iter().any(|op| {
+                matches!(op,
+                CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. }
+                if to_neuron_uuid == "hidden-5")
+            })
+        })
+        .unwrap();
+
+    assert!(
+        diverse_rank_high <= diverse_rank_low,
+        "Higher penalty should promote diverse candidates more (high rank: {diverse_rank_high}, low rank: {diverse_rank_low})"
+    );
+}
+
+/// Test 10: Zero penalty strength preserves original ordering.
+#[test]
+fn test_zero_penalty_preserves_ordering() {
+    let candidates = vec![
+        remove_synapse_candidate("input-1", "output-0", 0.10),
+        remove_synapse_candidate("input-2", "output-0", 0.09),
+        remove_synapse_candidate("input-3", "output-0", 0.08),
+    ];
+
+    let config = DiversityConfig {
+        penalty_strength: 0.0,
+    };
+    let reranked = rerank_with_diversity(candidates, &config);
+
+    assert_eq!(reranked[0].expected_creature_score_gain, 0.10);
+    assert_eq!(reranked[1].expected_creature_score_gain, 0.09);
+    assert_eq!(reranked[2].expected_creature_score_gain, 0.08);
+}
+
+/// Test 11: Candidates with multi-operation groups are compared correctly.
+#[test]
+fn test_multi_operation_similarity() {
+    // Two coordinated candidates that both remove a synapse and add a neuron at similar positions
+    let a = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-1".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: "new-1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "LOGISTIC".to_string(),
+                bias: 0.0,
+                insert_before_neuron_uuid: Some("output-0".to_string()),
+            },
+        ],
+        expected_creature_score_gain: 0.10,
+        comment: None,
+    };
+
+    let b = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-2".to_string(),
+                to_neuron_uuid: "output-0".to_string(),
+            },
+            CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: "new-2".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "LOGISTIC".to_string(),
+                bias: 0.0,
+                insert_before_neuron_uuid: Some("output-0".to_string()),
+            },
+        ],
+        expected_creature_score_gain: 0.08,
+        comment: None,
+    };
+
+    let sim = compute_structural_similarity(&a, &b);
+    // These candidates share op types (RemoveSynapse + AddNeuron) and the target neuron
+    // (output-0), but have different generated neuron UUIDs and source neurons, so
+    // similarity is moderate rather than high.
+    assert!(
+        sim >= 0.3,
+        "Similar multi-op candidates should have moderate-to-high similarity, got {sim}"
+    );
+}
+
+/// Test 12: Similarity is symmetric.
+#[test]
+fn test_similarity_is_symmetric() {
+    let a = remove_synapse_candidate("input-1", "output-0", 0.10);
+    let b = add_synapse_candidate("input-50", "hidden-5", 0.5, 0.08);
+
+    let sim_ab = compute_structural_similarity(&a, &b);
+    let sim_ba = compute_structural_similarity(&b, &a);
+
+    assert!(
+        (sim_ab - sim_ba).abs() < f32::EPSILON,
+        "Similarity should be symmetric: {sim_ab} vs {sim_ba}"
+    );
+}
+
+/// Test 13: Reranking preserves all candidates (no filtering).
+#[test]
+fn test_reranking_preserves_all_candidates() {
+    let candidates = vec![
+        remove_synapse_candidate("input-1", "output-0", 0.10),
+        remove_synapse_candidate("input-2", "output-0", 0.09),
+        remove_synapse_candidate("input-3", "output-0", 0.08),
+        add_synapse_candidate("input-50", "hidden-5", 0.5, 0.07),
+        change_squash_candidate("hidden-5", "RELU", 0.06),
+    ];
+
+    let config = DiversityConfig::default();
+    let reranked = rerank_with_diversity(candidates, &config);
+
+    assert_eq!(
+        reranked.len(),
+        5,
+        "Reranking should preserve all candidates"
+    );
+}


### PR DESCRIPTION
## Summary

Candidate diversity enforcement — penalise structurally similar candidates. Closes #610.

When the discovery pipeline returns multiple candidates that are structurally similar
(e.g., removing adjacent synapses to the same target), they waste evaluation budget by
exploring the same region of mutation space. This PR adds diversity-aware reranking that
penalises lower-ranked candidates that are structurally similar to higher-ranked ones,
promoting exploration of diverse mutation regions.

### Changes

- **New module `src/analysis/candidate_diversity.rs`**: Implements structural similarity
  metric (Jaccard similarity of affected neurons + operation types) and diversity-aware
  reranking with configurable penalty strength.
- **Integration in `orchestration.rs`**: Diversity reranking runs after ensemble scoring
  and before candidate clustering, fitting naturally into the existing pipeline.
- **Configurable penalty**: `DiversityConfig::penalty_strength` (default 0.5) controls
  the trade-off between exploitation (keeping similar high-scoring candidates) and
  exploration (promoting diverse alternatives).

### How it works

1. Candidates are sorted by `expected_creature_score_gain` (best first).
2. For each candidate from position 1 onward, the maximum structural similarity to any
   higher-ranked candidate is computed.
3. The candidate's effective score is penalised: `effective = score × (1 - penalty × similarity)`.
4. Candidates are re-sorted by effective score.
5. All candidates are preserved (none removed), only the ranking changes.

## Evidence

This is a backend-only change with no visual output. Evidence is provided by the 13
integration tests that verify correctness of the similarity metric and reranking behaviour.

## Test Plan

- Added `tests/issue_610_candidate_diversity_enforcement.rs` with 13 tests:
  - Structural similarity: same target (high), identical (1.0), different (low), same neuron different ops (moderate), multi-op, symmetric
  - Reranking: demotes similar, preserves diverse ordering, empty/single passthrough, configurable penalty, zero penalty preserves order, preserves all candidates
- All existing tests pass unchanged
- `cargo clippy` and `./quality.sh` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)