### PR TITLE
Add hard sample clustering detector (cross-network high-error observations) (#642)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.3"
+version = "0.37.4"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.2"
+version = "0.37.3"
 edition = "2024"
 
 [lib]

--- a/docs/discoveries/hard-sample-cluster.md
+++ b/docs/discoveries/hard-sample-cluster.md
@@ -1,0 +1,93 @@
+# Hard Sample Cluster Detection
+
+[Back to Discovery Index](README.md) | **Source:** [`src/analysis/detection/hard_sample_cluster.rs`](../../src/analysis/detection/hard_sample_cluster.rs) | **Issue:** [#642](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/642)
+
+---
+
+## The Problem
+
+**Hard sample clusters** occur when groups of training observations are consistently
+high-error across all output neurons. This indicates a systematic structural gap — the
+network lacks capacity to handle that region of the input space.
+
+```
+  Per-observation mean error across all outputs:
+
+  obs_index │ Mean error │ Classification
+  ──────────┼────────────┼───────────────
+      0     │   0.02     │  Easy
+      1     │   0.03     │  Easy
+     ...    │   ...      │  ...
+     50     │   0.75     │  HARD
+     51     │   0.82     │  HARD
+     52     │   0.71     │  HARD
+     ...    │   ...      │  ...
+     99     │   0.78     │  HARD
+
+  Observations 50-99 are consistently hard across ALL outputs
+  → systematic structural gap
+```
+
+### Why It Hurts the Creature's Score
+
+- The network cannot represent the input region that produces hard samples
+- All output neurons struggle on the same observations simultaneously
+- Adding capacity per-neuron (as `sample_weighted.rs` does) treats each neuron
+  independently and misses the cross-network pattern
+- The hard region drags down the overall score proportionally to its size
+
+### Difference from `sample_weighted.rs`
+
+The `sample_weighted.rs` module analyses error per neuron independently. This
+module joins error data **across neurons** by `obs_index` to find observations
+that are systematically hard for the entire network.
+
+---
+
+## Detection Method
+
+1. **Aggregate per-observation error**: For each `obs_index`, compute the mean
+   absolute error averaged across all output neurons
+2. **Statistical threshold**: Observations with error above `mean + 1 std dev`
+   are classified as "hard"
+3. **Hard-to-easy ratio check**: Only report clusters where the hard group's
+   mean error is at least 2× the easy group's mean error
+4. **Dominant input identification**: Compare input neuron activations between
+   hard and easy groups to find which inputs discriminate the two
+
+---
+
+## Recommended Actions
+
+When a hard sample cluster is detected:
+
+1. **Add a hidden neuron** (TANH activation) placed before the output layer
+2. **Connect dominant inputs** — inputs whose activations differ most between
+   hard and easy observations — to the new neuron
+3. **Connect to all outputs** — the new neuron feeds all output neurons,
+   adding capacity for the entire hard region
+
+These are emitted as `CoordinatedStructuralCandidateJson` with `AddNeuron`
+and `AddSynapse` operations.
+
+---
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `min_hard_easy_ratio` | 2.0 | Minimum ratio to report a cluster |
+| `min_hard_obs` | 5 | Minimum hard observations required |
+| `min_samples` | 20 | Minimum total observations for analysis |
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Single output neuron | Works as degenerate case — aggregation over one output |
+| Uniform error | No clusters detected (ratio below threshold) |
+| All observations hard | No easy baseline → no meaningful ratio |
+| Insufficient samples | Skipped (below `min_samples`) |
+| Non-finite errors | Treated as 0.0 |

--- a/docs/pr-summary-642.md
+++ b/docs/pr-summary-642.md
@@ -1,0 +1,34 @@
+## Summary
+
+Add a hard sample clustering detector that identifies groups of observations (`obs_index` values) with consistently high error across all output neurons, indicating systematic structural gaps. The module produces targeted `addNeuron` + `addSynapse` candidates connecting dominant inputs to all outputs, increasing network capacity for the hard sample region. Closes #642.
+
+## Changes
+
+- **New detection module**: `src/analysis/detection/hard_sample_cluster.rs`
+  - Aggregates per-observation mean error across all output neurons
+  - Uses statistical threshold (mean + 1 std dev) to classify hard observations
+  - Identifies dominant input neurons whose activations discriminate hard vs easy groups
+  - Produces coordinated structural candidates (addNeuron + addSynapse)
+  - Handles single-output networks as a degenerate case
+- **Wired into dispatch pipeline**: Added to `structural_specs.rs` for parallel execution
+- **Module declarations**: Registered in `detection/mod.rs` and re-exported via `analysis/mod.rs`
+- **Scenario documentation**: `docs/discoveries/hard-sample-cluster.md`
+
+## Evidence
+
+This is a backend detection module with no UI changes. Correctness is verified by the test suite below.
+
+## Test Plan
+
+- `tests/issue_642_hard_sample_cluster_detection.rs` — 10 integration tests:
+  1. Detects hard sample cluster across multiple output neurons
+  2. Single-output network works as degenerate case
+  3. Uniform error produces no clusters
+  4. Insufficient samples do not trigger detection
+  5. Hard clusters produce coordinated structural candidates (addNeuron + addSynapse)
+  6. Empty records produce no clusters
+  7. Dominant inputs are identified correctly
+  8. Estimated improvement is positive for detected clusters
+  9. Multiple error values per record are handled
+  10. Hard-to-easy ratio correctly reflects error disparity
+- All existing tests pass (`./quality.sh` clean)

--- a/src/analysis/detection/hard_sample_cluster.rs
+++ b/src/analysis/detection/hard_sample_cluster.rs
@@ -1,0 +1,431 @@
+//! Hard sample clustering detector (Issue #642).
+//!
+//! Identifies groups of observations (`obs_index` values) that are consistently
+//! high-error across all output neurons, indicating a systematic structural gap.
+//! The network lacks capacity to handle that region of the input space.
+//!
+//! ## Approach
+//!
+//! 1. **Aggregate per-observation error**: For each `obs_index`, compute the mean
+//!    absolute error across all output neurons.
+//! 2. **Identify hard observations**: Observations with mean error above a threshold
+//!    (based on the overall error distribution) are classified as "hard".
+//! 3. **Analyse activation patterns**: Compare input activations between hard and easy
+//!    observations to find which inputs discriminate the two groups.
+//! 4. **Produce structural candidates**: `addNeuron` + `addSynapse` candidates targeting
+//!    the dominant input regions that predict hard samples.
+//!
+//! ## Difference from `sample_weighted.rs`
+//!
+//! `sample_weighted.rs` analyses error per neuron independently. This module joins
+//! error data **across neurons** by `obs_index` to find observations that are
+//! systematically hard for the entire network.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Minimum hard-to-easy error ratio to report a cluster.
+const DEFAULT_MIN_HARD_EASY_RATIO: f32 = 2.0;
+
+/// Minimum number of hard observations to form a cluster.
+const DEFAULT_MIN_HARD_OBS: usize = 5;
+
+/// Minimum absolute difference in mean activation between hard and easy groups
+/// for an input to be considered "dominant".
+const DOMINANT_INPUT_ACTIVATION_DIFF: f32 = 0.1;
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/// Configuration for hard sample cluster detection.
+#[derive(Debug, Clone)]
+pub struct HardSampleClusterConfig {
+    /// Minimum hard-to-easy error ratio to report a cluster.
+    pub min_hard_easy_ratio: f32,
+    /// Minimum number of hard observations required.
+    pub min_hard_obs: usize,
+    /// Minimum total observations for reliable analysis.
+    pub min_samples: usize,
+}
+
+impl Default for HardSampleClusterConfig {
+    fn default() -> Self {
+        Self {
+            min_hard_easy_ratio: DEFAULT_MIN_HARD_EASY_RATIO,
+            min_hard_obs: DEFAULT_MIN_HARD_OBS,
+            min_samples: MIN_DISCOVERY_SAMPLE_COUNT,
+        }
+    }
+}
+
+// =============================================================================
+// Detection Types
+// =============================================================================
+
+/// A cluster of observations that are consistently hard across all outputs.
+#[derive(Debug, Clone)]
+pub struct HardSampleCluster {
+    /// Observation indices in the hard cluster.
+    pub hard_obs_indices: Vec<u32>,
+    /// Mean absolute error across all outputs for hard observations.
+    pub mean_error: f32,
+    /// Mean absolute error for easy observations.
+    pub easy_mean_error: f32,
+    /// Ratio of hard mean error to easy mean error.
+    pub hard_to_easy_ratio: f32,
+    /// Input neuron UUIDs whose activations differ most between hard and easy groups.
+    pub dominant_input_uuids: Vec<String>,
+    /// Number of output neurons analysed.
+    pub output_neuron_count: usize,
+    /// Estimated creature score improvement from addressing this cluster.
+    pub estimated_improvement: f32,
+}
+
+// =============================================================================
+// Core Detection
+// =============================================================================
+
+/// Detect hard sample clusters across all output neurons.
+///
+/// For each `obs_index`, aggregates the mean absolute error across all output neurons.
+/// Observations with error above the median + 1 std dev are classified as "hard".
+/// If the hard-to-easy ratio exceeds the configured threshold, a cluster is reported.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples.
+/// * `config` - Detection configuration.
+///
+/// # Returns
+/// A list of `HardSampleCluster` sorted by estimated improvement (best first).
+pub fn detect_hard_sample_clusters(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    config: &HardSampleClusterConfig,
+) -> Vec<HardSampleCluster> {
+    if neuron_records.is_empty() {
+        return Vec::new();
+    }
+
+    // Identify output neuron UUIDs
+    let output_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Identify input neuron UUIDs
+    let input_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Step 1: Aggregate per-observation mean absolute error across all output neurons
+    let obs_errors = aggregate_obs_errors(&output_uuids, &records_map);
+    if obs_errors.len() < config.min_samples {
+        return Vec::new();
+    }
+
+    // Step 2: Compute threshold for hard observations
+    let errors: Vec<f32> = obs_errors.values().copied().collect();
+    let mean_error = errors.iter().sum::<f32>() / errors.len() as f32;
+    let variance = errors
+        .iter()
+        .map(|&e| (e - mean_error).powi(2))
+        .sum::<f32>()
+        / errors.len() as f32;
+    let std_dev = variance.sqrt();
+
+    // Threshold: observations with error above mean + 1 std dev are "hard"
+    let threshold = mean_error + std_dev;
+
+    // Step 3: Split into hard and easy observations
+    let mut hard_obs: Vec<u32> = Vec::new();
+    let mut easy_obs: Vec<u32> = Vec::new();
+    let mut hard_error_sum = 0.0_f32;
+    let mut easy_error_sum = 0.0_f32;
+
+    for (&obs_idx, &error) in &obs_errors {
+        if error > threshold {
+            hard_obs.push(obs_idx);
+            hard_error_sum += error;
+        } else {
+            easy_obs.push(obs_idx);
+            easy_error_sum += error;
+        }
+    }
+
+    if hard_obs.len() < config.min_hard_obs {
+        return Vec::new();
+    }
+
+    let hard_mean = hard_error_sum / hard_obs.len() as f32;
+    let easy_mean = if easy_obs.is_empty() {
+        0.0
+    } else {
+        easy_error_sum / easy_obs.len() as f32
+    };
+
+    let ratio = if easy_mean > f32::EPSILON {
+        hard_mean / easy_mean
+    } else if hard_mean > f32::EPSILON {
+        hard_mean / f32::EPSILON
+    } else {
+        1.0
+    };
+
+    if ratio < config.min_hard_easy_ratio {
+        return Vec::new();
+    }
+
+    // Step 4: Find dominant input neurons
+    let hard_set: HashSet<u32> = hard_obs.iter().copied().collect();
+    let easy_set: HashSet<u32> = easy_obs.iter().copied().collect();
+    let dominant_inputs = find_dominant_inputs(&input_uuids, &records_map, &hard_set, &easy_set);
+
+    // Sort hard obs for deterministic output
+    hard_obs.sort();
+
+    let output_neuron_count = output_uuids.len();
+
+    // Estimate improvement: proportional to error reduction potential
+    let hard_fraction = hard_obs.len() as f32 / obs_errors.len() as f32;
+    let estimated_improvement =
+        (hard_mean - easy_mean) * hard_fraction * (output_neuron_count as f32).sqrt() * 0.01;
+
+    let cluster = HardSampleCluster {
+        hard_obs_indices: hard_obs,
+        mean_error: hard_mean,
+        easy_mean_error: easy_mean,
+        hard_to_easy_ratio: ratio,
+        dominant_input_uuids: dominant_inputs,
+        output_neuron_count,
+        estimated_improvement: estimated_improvement.max(f32::EPSILON),
+    };
+
+    vec![cluster]
+}
+
+/// Aggregate per-observation mean absolute error across all output neurons.
+///
+/// For each `obs_index`, computes the mean of the mean-absolute-errors from
+/// every output neuron that has a record at that index.
+fn aggregate_obs_errors(
+    output_uuids: &HashSet<&str>,
+    records_map: &HashMap<&str, &Vec<DiscoverRecord>>,
+) -> HashMap<u32, f32> {
+    // obs_index -> (sum_of_mean_abs_error, count_of_neurons)
+    let mut obs_aggregated: HashMap<u32, (f32, u32)> = HashMap::new();
+
+    for &uuid in output_uuids {
+        if let Some(records) = records_map.get(uuid) {
+            for r in records.iter() {
+                let abs_error = if r.errors.is_empty() {
+                    0.0
+                } else {
+                    let mean =
+                        r.errors.iter().map(|e| e.abs()).sum::<f32>() / r.errors.len() as f32;
+                    if mean.is_finite() { mean } else { 0.0 }
+                };
+
+                let entry = obs_aggregated.entry(r.obs_index).or_insert((0.0, 0));
+                entry.0 += abs_error;
+                entry.1 += 1;
+            }
+        }
+    }
+
+    // Convert to mean error per observation
+    obs_aggregated
+        .into_iter()
+        .map(|(obs_idx, (sum, count))| {
+            let mean = if count > 0 { sum / count as f32 } else { 0.0 };
+            (obs_idx, mean)
+        })
+        .collect()
+}
+
+/// Find input neurons whose mean activation differs most between hard and easy groups.
+fn find_dominant_inputs(
+    input_uuids: &HashSet<&str>,
+    records_map: &HashMap<&str, &Vec<DiscoverRecord>>,
+    hard_obs: &HashSet<u32>,
+    easy_obs: &HashSet<u32>,
+) -> Vec<String> {
+    let mut scored_inputs: Vec<(String, f32)> = Vec::new();
+
+    for &input_uuid in input_uuids {
+        let Some(records) = records_map.get(input_uuid) else {
+            continue;
+        };
+
+        let mut hard_sum = 0.0_f32;
+        let mut hard_count = 0_u32;
+        let mut easy_sum = 0.0_f32;
+        let mut easy_count = 0_u32;
+
+        for r in records.iter() {
+            if hard_obs.contains(&r.obs_index) {
+                hard_sum += r.activation;
+                hard_count += 1;
+            } else if easy_obs.contains(&r.obs_index) {
+                easy_sum += r.activation;
+                easy_count += 1;
+            }
+        }
+
+        if hard_count == 0 || easy_count == 0 {
+            continue;
+        }
+
+        let hard_mean = hard_sum / hard_count as f32;
+        let easy_mean = easy_sum / easy_count as f32;
+        let diff = (hard_mean - easy_mean).abs();
+
+        if diff >= DOMINANT_INPUT_ACTIVATION_DIFF {
+            scored_inputs.push((input_uuid.to_string(), diff));
+        }
+    }
+
+    // Sort by activation difference (largest first)
+    scored_inputs.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+    scored_inputs.into_iter().map(|(uuid, _)| uuid).collect()
+}
+
+// =============================================================================
+// Candidate Conversion
+// =============================================================================
+
+/// Generate a deterministic UUID for a hard-sample hidden neuron.
+fn hard_sample_neuron_uuid(cluster_index: usize, hard_obs_count: usize) -> String {
+    let key = format!("hard-sample-cluster|{cluster_index}|{hard_obs_count}");
+    // FNV-1a 64-bit
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("hsc-{hash:016x}")
+}
+
+/// Convert hard sample clusters into coordinated structural candidates.
+///
+/// Each cluster produces a candidate that adds a hidden neuron connecting
+/// dominant inputs to all output neurons, increasing capacity for the
+/// hard sample region.
+pub fn hard_sample_clusters_to_coordinated_candidates(
+    clusters: &[HardSampleCluster],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let first_output_uuid = creature
+        .neurons
+        .iter()
+        .find(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone());
+
+    let output_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    let mut results = Vec::new();
+
+    for (idx, cluster) in clusters.iter().enumerate() {
+        let new_uuid = hard_sample_neuron_uuid(idx, cluster.hard_obs_indices.len());
+
+        let mut operations = Vec::new();
+
+        // Add hidden neuron before first output
+        operations.push(CoordinatedStructuralOpJson::AddNeuron {
+            neuron_uuid: new_uuid.clone(),
+            neuron_type: "hidden".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+            insert_before_neuron_uuid: first_output_uuid.clone(),
+        });
+
+        // Connect dominant inputs to the new neuron
+        let input_sources: &[String] = if cluster.dominant_input_uuids.is_empty() {
+            &[]
+        } else {
+            &cluster.dominant_input_uuids
+        };
+
+        for input_uuid in input_sources {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: input_uuid.clone(),
+                to_neuron_uuid: new_uuid.clone(),
+                weight: 0.5,
+            });
+        }
+
+        // Fallback: if no dominant inputs, connect from first input
+        if input_sources.is_empty()
+            && let Some(first_input) = creature.neurons.iter().find(|n| n.neuron_type == "input")
+        {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: first_input.uuid.clone(),
+                to_neuron_uuid: new_uuid.clone(),
+                weight: 0.5,
+            });
+        }
+
+        // Connect new neuron to all outputs
+        for &output_uuid in &output_uuids {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: new_uuid.clone(),
+                to_neuron_uuid: output_uuid.to_string(),
+                weight: 0.1,
+            });
+        }
+
+        let input_list = if cluster.dominant_input_uuids.is_empty() {
+            "auto-selected".to_string()
+        } else {
+            cluster.dominant_input_uuids.join(", ")
+        };
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: cluster.estimated_improvement,
+            comment: Some(format!(
+                "Hard sample cluster: {} hard observations (mean error {:.3}, easy mean {:.3}, ratio {:.1}x, {} outputs) → add hidden neuron from [{}]",
+                cluster.hard_obs_indices.len(),
+                cluster.mean_error,
+                cluster.easy_mean_error,
+                cluster.hard_to_easy_ratio,
+                cluster.output_neuron_count,
+                input_list,
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -13,6 +13,7 @@ pub mod correlated_error;
 pub mod dead_neuron;
 pub mod dormant_synapse;
 pub mod error_plateau;
+pub mod hard_sample_cluster;
 pub mod input_sensitivity;
 pub mod noise_signal;
 pub mod observation_range;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -67,6 +67,7 @@ pub use detection::correlated_error;
 pub use detection::dead_neuron;
 pub use detection::dormant_synapse;
 pub use detection::error_plateau;
+pub use detection::hard_sample_cluster;
 pub use detection::input_sensitivity;
 pub use detection::noise_signal;
 pub use detection::observation_range;

--- a/src/analysis/module_dispatch_specs/structural_specs.rs
+++ b/src/analysis/module_dispatch_specs/structural_specs.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use super::super::{
-    cache, correlated_error, discovery_dispatch, multi_hop, skip_connection, topology,
-    topology_diversification,
+    cache, correlated_error, discovery_dispatch, hard_sample_cluster, multi_hop, skip_connection,
+    topology, topology_diversification,
 };
 
 /// Append structural discovery module specs to the provided vector.
@@ -153,6 +153,33 @@ pub(crate) fn append_structural_specs(
                 let candidates = skip_connection::skip_connections_to_coordinated_candidates(
                     &detected, &creature,
                 );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #642: Hard sample cluster detection (cross-network high-error observations)
+    {
+        let cache = Arc::clone(shared_cache);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "hard sample cluster detection".to_string(),
+            phase_name: "hard_sample_cluster_detection",
+            detect_fn: Box::new(move || {
+                let records = cache.load_records_for_all_neurons(&creature);
+                let config = hard_sample_cluster::HardSampleClusterConfig::default();
+                let detected =
+                    hard_sample_cluster::detect_hard_sample_clusters(&creature, &records, &config);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    hard_sample_cluster::hard_sample_clusters_to_coordinated_candidates(
+                        &detected, &creature,
+                    );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_642_hard_sample_cluster_detection.rs
+++ b/tests/issue_642_hard_sample_cluster_detection.rs
@@ -1,0 +1,502 @@
+//! Tests for Issue #642: Hard sample clustering detector (cross-network high-error observations).
+//!
+//! When groups of observations (`obs_index` values) are consistently high-error across
+//! all output neurons, it indicates a systematic structural gap — the network lacks capacity
+//! to handle that region of the input space. This module detects those hard sample clusters
+//! and produces targeted structural candidates.
+//!
+//! ## TDD Plan
+//! 1. Create test network with clear easy/hard observation split
+//! 2. Verify detection identifies hard sample clusters by obs_index
+//! 3. Verify targeted structural candidates are produced
+//! 4. Test single-output network (degenerate case)
+//! 5. Test no hard samples (uniform error)
+//! 6. Test insufficient samples
+
+use neat_ai_discovery::analysis::detection::hard_sample_cluster::{
+    HardSampleCluster, HardSampleClusterConfig, detect_hard_sample_clusters,
+    hard_sample_clusters_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Test 1: Clear easy/hard split across multiple output neurons is detected.
+///
+/// Observations 0-49 have low error; observations 50-99 have high error across
+/// all output neurons. The detector should identify obs 50-99 as a hard cluster.
+#[test]
+fn test_detects_hard_sample_cluster_across_outputs() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-2", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-2", "output-2", 0.3),
+        ],
+    );
+
+    let mut all_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Both outputs have high error on observations 50-99
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i >= 50 { 0.8 } else { 0.05 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        all_records.push((output_id.to_string(), records));
+    }
+
+    // Input records for activation pattern analysis
+    for input_id in &["input-1", "input-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let activation = if i >= 50 { 0.9 } else { 0.1 };
+                record(input_id, i, activation, vec![])
+            })
+            .collect();
+        all_records.push((input_id.to_string(), records));
+    }
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(
+        !clusters.is_empty(),
+        "Should detect at least one hard sample cluster"
+    );
+
+    let cluster = &clusters[0];
+    assert!(
+        cluster.hard_obs_indices.len() >= 20,
+        "Hard cluster should contain a significant number of observations, got {}",
+        cluster.hard_obs_indices.len()
+    );
+
+    // Most hard observations should be in the 50-99 range
+    let high_range_count = cluster
+        .hard_obs_indices
+        .iter()
+        .filter(|&&idx| idx >= 50)
+        .count();
+    assert!(
+        high_range_count > cluster.hard_obs_indices.len() / 2,
+        "Most hard observations should be in the high-error range"
+    );
+
+    assert!(
+        cluster.mean_error > 0.1,
+        "Mean error of hard cluster should be significant, got {}",
+        cluster.mean_error
+    );
+}
+
+/// Test 2: Single-output network works as a degenerate case.
+#[test]
+fn test_single_output_network_degenerate_case() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let error = if i >= 70 { 0.9 } else { 0.02 };
+            record("output-1", i, 0.5, vec![error])
+        })
+        .collect();
+
+    let input_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = if i >= 70 { 0.8 } else { 0.2 };
+            record("input-1", i, activation, vec![])
+        })
+        .collect();
+
+    let all_records = vec![
+        ("output-1".to_string(), records),
+        ("input-1".to_string(), input_records),
+    ];
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(
+        !clusters.is_empty(),
+        "Single-output network should still detect hard sample clusters"
+    );
+}
+
+/// Test 3: Uniform error produces no hard clusters.
+#[test]
+fn test_uniform_error_no_clusters() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut all_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| record(output_id, i, 0.5, vec![0.1]))
+            .collect();
+        all_records.push((output_id.to_string(), records));
+    }
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(
+        clusters.is_empty(),
+        "Uniform error should not produce hard sample clusters"
+    );
+}
+
+/// Test 4: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_no_detection() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    // Only 5 samples
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| record("output-1", i, 0.5, vec![0.8]))
+        .collect();
+
+    let all_records = vec![("output-1".to_string(), records)];
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(
+        clusters.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 5: Hard clusters produce coordinated structural candidates with
+/// addNeuron and addSynapse operations.
+#[test]
+fn test_hard_clusters_produce_structural_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-2", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-2", "output-1", 0.3),
+        ],
+    );
+
+    let cluster = HardSampleCluster {
+        hard_obs_indices: (50..100).collect(),
+        mean_error: 0.7,
+        easy_mean_error: 0.05,
+        hard_to_easy_ratio: 14.0,
+        dominant_input_uuids: vec!["input-1".to_string()],
+        output_neuron_count: 1,
+        estimated_improvement: 0.03,
+    };
+
+    let candidates = hard_sample_clusters_to_coordinated_candidates(&[cluster], &creature);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+
+    let c = &candidates[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the recommendation"
+    );
+
+    // Check operations include addNeuron and addSynapse
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("addNeuron"),
+        "Should include addNeuron operation, got: {ops_json}"
+    );
+    assert!(
+        ops_json.contains("addSynapse"),
+        "Should include addSynapse operation, got: {ops_json}"
+    );
+}
+
+/// Test 6: Empty records produce no clusters.
+#[test]
+fn test_empty_records_no_clusters() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![],
+    );
+
+    let config = HardSampleClusterConfig::default();
+    let clusters: Vec<HardSampleCluster> = detect_hard_sample_clusters(&creature, &[], &config);
+
+    assert!(
+        clusters.is_empty(),
+        "Empty records should produce no clusters"
+    );
+}
+
+/// Test 7: Dominant inputs are identified — input neurons whose activations
+/// differ most between hard and easy samples.
+#[test]
+fn test_dominant_inputs_identified() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("input-2", "input", "IDENTITY"),
+            neuron("input-3", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-2", "output-1", 0.3),
+            synapse("input-3", "output-2", 0.4),
+        ],
+    );
+
+    let mut all_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Output neurons: high error on obs 50-99
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i >= 50 { 0.8 } else { 0.02 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        all_records.push((output_id.to_string(), records));
+    }
+
+    // input-1: activation strongly differs between easy/hard regions
+    all_records.push((
+        "input-1".to_string(),
+        (0..100)
+            .map(|i| {
+                let activation = if i >= 50 { 0.95 } else { 0.05 };
+                record("input-1", i, activation, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-2: constant activation — NOT discriminative
+    all_records.push((
+        "input-2".to_string(),
+        (0..100)
+            .map(|i| record("input-2", i, 0.5, vec![]))
+            .collect(),
+    ));
+
+    // input-3: random — not strongly correlated
+    all_records.push((
+        "input-3".to_string(),
+        (0..100)
+            .map(|i| {
+                let activation = ((i as f32) * 0.73).sin() * 0.5 + 0.5;
+                record("input-3", i, activation, vec![])
+            })
+            .collect(),
+    ));
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(!clusters.is_empty(), "Should detect hard sample cluster");
+    let cluster = &clusters[0];
+    assert!(
+        !cluster.dominant_input_uuids.is_empty(),
+        "Should identify dominant inputs"
+    );
+    assert!(
+        cluster
+            .dominant_input_uuids
+            .contains(&"input-1".to_string()),
+        "input-1 should be identified as dominant, got: {:?}",
+        cluster.dominant_input_uuids
+    );
+}
+
+/// Test 8: Estimated improvement is positive for detected clusters.
+#[test]
+fn test_estimated_improvement_positive() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut all_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                let error = if i >= 60 { 0.7 } else { 0.03 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        all_records.push((output_id.to_string(), records));
+    }
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(!clusters.is_empty(), "Should detect hard sample cluster");
+    for cluster in &clusters {
+        assert!(
+            cluster.estimated_improvement > 0.0,
+            "Estimated improvement should be positive, got {}",
+            cluster.estimated_improvement
+        );
+    }
+}
+
+/// Test 9: Multiple error values per record — uses mean absolute error across all outputs.
+#[test]
+fn test_multi_error_values_handled() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let errors = if i >= 60 {
+                vec![0.7, 0.9, 0.6]
+            } else {
+                vec![0.02, 0.01, 0.03]
+            };
+            record("output-1", i, 0.5, errors)
+        })
+        .collect();
+
+    let all_records = vec![("output-1".to_string(), records)];
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(
+        !clusters.is_empty(),
+        "Should handle multiple error values per record"
+    );
+}
+
+/// Test 10: Hard-to-easy ratio correctly reflects the disparity.
+#[test]
+fn test_hard_to_easy_ratio() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+            neuron("output-2", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "output-1", 0.5),
+            synapse("input-1", "output-2", 0.3),
+        ],
+    );
+
+    let mut all_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for output_id in &["output-1", "output-2"] {
+        let records: Vec<DiscoverRecord> = (0..100)
+            .map(|i| {
+                // Hard samples have ~10x the error of easy samples
+                let error = if i >= 50 { 0.5 } else { 0.05 };
+                record(output_id, i, 0.5, vec![error])
+            })
+            .collect();
+        all_records.push((output_id.to_string(), records));
+    }
+
+    let config = HardSampleClusterConfig::default();
+    let clusters = detect_hard_sample_clusters(&creature, &all_records, &config);
+
+    assert!(!clusters.is_empty(), "Should detect hard sample cluster");
+    let cluster = &clusters[0];
+    assert!(
+        cluster.hard_to_easy_ratio > 2.0,
+        "Hard-to-easy ratio should be significant, got {}",
+        cluster.hard_to_easy_ratio
+    );
+}


### PR DESCRIPTION
## Summary

Add a hard sample clustering detector that identifies groups of observations (`obs_index` values) with consistently high error across all output neurons, indicating systematic structural gaps. The module produces targeted `addNeuron` + `addSynapse` candidates connecting dominant inputs to all outputs, increasing network capacity for the hard sample region. Closes #642.

## Changes

- **New detection module**: `src/analysis/detection/hard_sample_cluster.rs`
  - Aggregates per-observation mean error across all output neurons
  - Uses statistical threshold (mean + 1 std dev) to classify hard observations
  - Identifies dominant input neurons whose activations discriminate hard vs easy groups
  - Produces coordinated structural candidates (addNeuron + addSynapse)
  - Handles single-output networks as a degenerate case
- **Wired into dispatch pipeline**: Added to `structural_specs.rs` for parallel execution
- **Module declarations**: Registered in `detection/mod.rs` and re-exported via `analysis/mod.rs`
- **Scenario documentation**: `docs/discoveries/hard-sample-cluster.md`

## Evidence

This is a backend detection module with no UI changes. Correctness is verified by the test suite below.

## Test Plan

- `tests/issue_642_hard_sample_cluster_detection.rs` — 10 integration tests:
  1. Detects hard sample cluster across multiple output neurons
  2. Single-output network works as degenerate case
  3. Uniform error produces no clusters
  4. Insufficient samples do not trigger detection
  5. Hard clusters produce coordinated structural candidates (addNeuron + addSynapse)
  6. Empty records produce no clusters
  7. Dominant inputs are identified correctly
  8. Estimated improvement is positive for detected clusters
  9. Multiple error values per record are handled
  10. Hard-to-easy ratio correctly reflects error disparity
- All existing tests pass (`./quality.sh` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)