### PR TITLE
Add activation-error monotonicity detector (#643)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.5"
+version = "0.37.6"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.4"
+version = "0.37.5"
 edition = "2024"
 
 [lib]

--- a/docs/discoveries/monotonicity.md
+++ b/docs/discoveries/monotonicity.md
@@ -1,0 +1,110 @@
+# Activation-Error Monotonicity Detection
+
+[Back to Discovery Index](README.md) | **Source:** [`src/analysis/detection/monotonicity.rs`](../../src/analysis/detection/monotonicity.rs) | **Issue:** [#643](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/643)
+
+---
+
+## The Problem
+
+**Non-monotonic activation-error relationships** occur when a hidden neuron's
+activation is inconsistently related to output error — higher activation sometimes
+correlates with lower error and sometimes with higher error. This contradictory
+behaviour suggests the neuron is trying to encode two or more features and should
+be split or restructured.
+
+```
+  Activation vs Error for a non-monotonic neuron:
+
+  Error │     *           *
+        │    * *       * *
+        │   *   *   *   *
+        │  *     * *     *
+        │ *       *       *
+        │*                 *
+        └──────────────────── Activation
+         low    mid     high
+
+  U-shaped: error high at both extremes → non-monotonic
+  The neuron encodes contradictory information
+```
+
+### Why It Hurts the Creature's Score
+
+- The neuron cannot consistently reduce error by increasing or decreasing activation
+- It encodes multiple features that interfere with each other
+- Downstream neurons receive contradictory signals from the same source
+- The creature's learning process cannot find a stable weight configuration
+
+### Difference from `noise_signal.rs`
+
+The noise-to-signal detector measures **variance ratio** — whether error variance
+dominates activation variance. A neuron can have high noise-to-signal ratio but
+still be monotonic (e.g., noisy but consistently trending). Conversely, a neuron
+can have low noise but be non-monotonic (e.g., a clean U-shaped curve).
+
+The monotonicity detector specifically measures **directional consistency** using
+Spearman's rank correlation.
+
+### Difference from `gradient_discovery.rs`
+
+Gradient discovery analyses existing synapse gradients to suggest weight adjustments.
+It operates on synapse-level data. The monotonicity detector analyses the
+neuron-level activation-error relationship independent of specific synapses.
+
+---
+
+## Detection Method
+
+1. For each hidden neuron, collect all (activation, error) pairs from recorded samples
+2. Compute **Spearman's rank correlation** (rho) between activation and absolute error
+3. If |rho| < 0.3, the relationship is considered non-monotonic
+4. Estimate improvement based on the degree of non-monotonicity and sample count
+
+### Spearman's Rank Correlation
+
+Spearman's rho measures the monotonicity of the relationship between two variables:
+
+| rho value | Interpretation |
+|-----------|----------------|
+| +1.0 | Perfectly monotonically increasing |
+| -1.0 | Perfectly monotonically decreasing |
+| ~0.0 | No monotonic relationship |
+| < 0.3 | Weak/non-monotonic (flagged) |
+
+---
+
+## Recommended Actions
+
+| Candidate Type | When Produced | Rationale |
+|---------------|---------------|-----------|
+| `addNeuron` (coordinated) | Neuron has incoming and outgoing synapses | Split the neuron into two, each handling one direction of the activation-error mapping |
+| `changeSquash` | Neuron lacks full connectivity | Try a different activation function that may better fit the data |
+
+---
+
+## Example Scenario
+
+```
+  Network: input-1 → hidden-1 → output-1
+
+  hidden-1 activation-error relationship:
+    activation 0.1 → error 0.7  (high)
+    activation 0.3 → error 0.2  (low)
+    activation 0.5 → error 0.1  (low)
+    activation 0.7 → error 0.3  (medium)
+    activation 0.9 → error 0.8  (high)
+
+  Spearman's rho ≈ 0.1 (non-monotonic)
+
+  → Recommendation: Add a parallel neuron (split-hidden-1)
+    to handle the high-activation region separately
+```
+
+---
+
+## Thresholds
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `MONOTONICITY_THRESHOLD` | 0.3 | Minimum |rho| to consider a relationship monotonic |
+| `MIN_SAMPLES_FOR_DETECTION` | 20 | Minimum samples for reliable rank correlation |

--- a/docs/pr-summary-643.md
+++ b/docs/pr-summary-643.md
@@ -1,0 +1,44 @@
+## Summary
+
+Add activation-error monotonicity detector that identifies hidden neurons with
+non-monotonic activation-error relationships using Spearman's rank correlation.
+A well-functioning hidden neuron should have a consistent (monotonic) relationship
+between its activation and output error. Neurons where this relationship is
+contradictory (e.g., U-shaped or W-shaped) are encoding multiple features that
+interfere with each other and should be restructured. Closes #643.
+
+## What Changed
+
+- **New detection module** (`src/analysis/detection/monotonicity.rs`):
+  - Computes Spearman's rank correlation (rho) between activation and absolute error
+  - Flags hidden neurons where |rho| < 0.3 (non-monotonic)
+  - Produces `addNeuron` candidates (to split the workload) or `changeSquash`
+    candidates (to try a better-fitting activation function)
+- **Dispatch pipeline wiring** (`src/analysis/module_dispatch_specs/neuron_specs.rs`):
+  - Registered as "monotonicity detection" phase
+- **Module registration** (`src/analysis/detection/mod.rs`, `src/analysis/mod.rs`):
+  - Re-exported at analysis level for backward compatibility
+- **Scenario documentation** (`docs/discoveries/monotonicity.md`):
+  - Explains the problem, detection method, and recommended actions
+  - Clarifies distinction from `noise_signal.rs` (variance-based) and
+    `gradient_discovery.rs` (synapse-level gradients)
+
+## Evidence
+
+This is a backend detection module with no UI changes. Evidence is provided by
+the 10 integration tests listed below.
+
+## Test Plan
+
+Added `tests/issue_643_activation_error_monotonicity.rs` with 10 tests:
+
+1. `test_monotonic_increasing_not_flagged` — monotonic increasing relationship is not flagged
+2. `test_monotonic_decreasing_not_flagged` — monotonic decreasing relationship is not flagged
+3. `test_non_monotonic_u_shape_flagged` — U-shaped activation-error is detected
+4. `test_non_monotonic_inverted_u_flagged` — inverted-U activation-error is detected
+5. `test_input_output_neurons_excluded` — input/output neurons are never flagged
+6. `test_insufficient_samples_no_detection` — fewer than 20 samples produces no detections
+7. `test_produces_valid_structural_candidates` — candidates include addNeuron or changeSquash
+8. `test_multiple_neurons_only_non_monotonic_flagged` — only non-monotonic neurons flagged
+9. `test_estimated_improvement_positive` — estimated improvement is always positive
+10. `test_empty_records_no_detections` — empty records produce no detections

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -15,6 +15,7 @@ pub mod dormant_synapse;
 pub mod error_plateau;
 pub mod hard_sample_cluster;
 pub mod input_sensitivity;
+pub mod monotonicity;
 pub mod noise_signal;
 pub mod observation_range;
 pub mod observation_utilisation;

--- a/src/analysis/detection/monotonicity.rs
+++ b/src/analysis/detection/monotonicity.rs
@@ -1,0 +1,315 @@
+//! Activation-error monotonicity detection module (Issue #643).
+//!
+//! For a well-functioning hidden neuron, the relationship between activation and
+//! output error should be monotonic — higher activation consistently correlates
+//! with either lower or higher error. A non-monotonic relationship (where activation
+//! increases produce **both** error improvements and error worsenings) indicates the
+//! neuron is encoding contradictory information and should be split or restructured.
+//!
+//! ## Detection Method
+//!
+//! For each hidden neuron:
+//! 1. Sort observations by activation value
+//! 2. Compute Spearman's rank correlation between activation rank and error
+//! 3. Flag neurons where |rho| is below the monotonicity threshold
+//!
+//! ## Distinction from Related Modules
+//!
+//! - `noise_signal.rs` — measures variance ratio (noise), not directional consistency
+//! - `gradient_discovery.rs` — analyses gradients for existing synapses, not
+//!   neuron activation-error relationships
+//!
+//! ## Recommended Actions
+//!
+//! - `addNeuron`: Split the non-monotonic neuron so each sub-neuron handles one
+//!   direction of the activation-error mapping
+//! - `changeSquash`: Change the activation function to better fit the data
+
+use std::collections::HashSet;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES_FOR_DETECTION;
+
+/// Minimum |rho| below which a neuron is considered non-monotonic.
+/// Spearman's rho ranges from -1.0 (perfectly decreasing) to +1.0 (perfectly increasing).
+/// Values near zero indicate no monotonic relationship.
+const MONOTONICITY_THRESHOLD: f32 = 0.3;
+
+/// Result of detecting a non-monotonic neuron.
+#[derive(Debug, Clone)]
+pub struct MonotonicityCandidate {
+    /// UUID of the neuron with non-monotonic activation-error relationship.
+    pub neuron_uuid: String,
+    /// Spearman's rank correlation between activation and error.
+    /// Values near zero indicate strong non-monotonicity.
+    pub monotonicity_score: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Estimated creature score improvement from restructuring this neuron.
+    pub estimated_improvement: f32,
+}
+
+/// Compute Spearman's rank correlation coefficient between two slices.
+///
+/// Returns a value in [-1.0, 1.0] where:
+/// - +1.0 = perfectly monotonically increasing
+/// - -1.0 = perfectly monotonically decreasing
+/// - 0.0 = no monotonic relationship
+fn spearman_rank_correlation(x: &[f32], y: &[f32]) -> f32 {
+    let n = x.len();
+    if n < 2 {
+        return 0.0;
+    }
+
+    let rank_x = compute_ranks(x);
+    let rank_y = compute_ranks(y);
+
+    // Pearson correlation on ranks
+    let n_f = n as f32;
+    let mean_rx: f32 = rank_x.iter().sum::<f32>() / n_f;
+    let mean_ry: f32 = rank_y.iter().sum::<f32>() / n_f;
+
+    let mut cov = 0.0f32;
+    let mut var_x = 0.0f32;
+    let mut var_y = 0.0f32;
+
+    for i in 0..n {
+        let dx = rank_x[i] - mean_rx;
+        let dy = rank_y[i] - mean_ry;
+        cov += dx * dy;
+        var_x += dx * dx;
+        var_y += dy * dy;
+    }
+
+    let denom = (var_x * var_y).sqrt();
+    if denom < 1e-12 {
+        return 0.0;
+    }
+
+    cov / denom
+}
+
+/// Compute fractional ranks for a slice of f32 values.
+/// Ties receive the average of their ranks.
+fn compute_ranks(values: &[f32]) -> Vec<f32> {
+    let n = values.len();
+    let mut indexed: Vec<(usize, f32)> = values.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
+
+    let mut ranks = vec![0.0f32; n];
+    let mut i = 0;
+    while i < n {
+        let mut j = i;
+        // Find all ties
+        while j < n && indexed[j].1.total_cmp(&indexed[i].1) == std::cmp::Ordering::Equal {
+            j += 1;
+        }
+        // Average rank for tied values (1-based)
+        let avg_rank = (i + j) as f32 / 2.0 + 0.5;
+        for item in indexed.iter().take(j).skip(i) {
+            ranks[item.0] = avg_rank;
+        }
+        i = j;
+    }
+
+    ranks
+}
+
+/// Detect neurons with non-monotonic activation-error relationships.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded data.
+///
+/// # Returns
+/// A list of `MonotonicityCandidate` for neurons with non-monotonic activation-error
+/// relationships, sorted by estimated improvement (best first).
+pub fn detect_non_monotonic_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<MonotonicityCandidate> {
+    // Only consider hidden neurons
+    let hidden_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        if !hidden_uuids.contains(uuid.as_str()) {
+            continue;
+        }
+
+        if records.len() < MIN_SAMPLES_FOR_DETECTION {
+            continue;
+        }
+
+        // Extract activation and error pairs
+        let activations: Vec<f32> = records.iter().map(|r| r.activation).collect();
+        let errors: Vec<f32> = records
+            .iter()
+            .filter_map(|r| r.errors.first().copied())
+            .collect();
+
+        if errors.len() < MIN_SAMPLES_FOR_DETECTION {
+            continue;
+        }
+
+        // Use the minimum length if activations and errors differ in count
+        let n = activations.len().min(errors.len());
+        let activations = &activations[..n];
+        let errors = &errors[..n];
+
+        // Use absolute error values for monotonicity analysis
+        let abs_errors: Vec<f32> = errors.iter().map(|e| e.abs()).collect();
+
+        let rho = spearman_rank_correlation(activations, &abs_errors);
+
+        // Flag if |rho| is below threshold (non-monotonic)
+        if rho.abs() >= MONOTONICITY_THRESHOLD {
+            continue;
+        }
+
+        // Estimated improvement: lower |rho| and more samples → higher confidence
+        let non_monotonicity = 1.0 - rho.abs();
+        let sample_factor = (n as f32 / 1000.0).min(1.0);
+        let estimated_improvement = 0.001 * (non_monotonicity * 0.7 + sample_factor * 0.3);
+
+        candidates.push(MonotonicityCandidate {
+            neuron_uuid: uuid.clone(),
+            monotonicity_score: rho,
+            sample_count: n,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+
+    candidates
+}
+
+/// Convert non-monotonic neuron candidates into coordinated structural candidates.
+///
+/// Each non-monotonic neuron produces either:
+/// - An `AddNeuron` candidate (to split the neuron so each handles one direction)
+/// - A `ChangeSquash` candidate (to try a different activation function)
+///
+/// Which candidate is produced depends on the creature's topology — if the neuron
+/// has downstream synapses, we prefer adding a neuron to split the workload;
+/// otherwise we suggest changing the activation function.
+pub fn non_monotonic_neurons_to_coordinated_candidates(
+    candidates: &[MonotonicityCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        // Find the neuron's current squash function
+        let current_squash = creature
+            .neurons
+            .iter()
+            .find(|n| n.uuid == c.neuron_uuid)
+            .map(|n| n.squash.as_str())
+            .unwrap_or("LOGISTIC");
+
+        // Find synapses going out of this neuron
+        let outgoing: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.from_uuid == c.neuron_uuid)
+            .collect();
+
+        // Find synapses coming into this neuron
+        let incoming: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.to_uuid == c.neuron_uuid)
+            .collect();
+
+        // Strategy: if the neuron has outgoing connections, add a parallel neuron
+        // to split the workload. Otherwise, try changing the activation function.
+        if !outgoing.is_empty() && !incoming.is_empty() {
+            // AddNeuron: create a new neuron inserted before the target of the
+            // first outgoing synapse, with a complementary activation function
+            let target_uuid = &outgoing[0].to_uuid;
+            let new_uuid = format!("split-{}", c.neuron_uuid);
+            let new_squash = suggest_complementary_squash(current_squash);
+
+            let mut operations = vec![CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: new_uuid.clone(),
+                neuron_type: "hidden".to_string(),
+                squash: new_squash,
+                bias: 0.0,
+                insert_before_neuron_uuid: Some(target_uuid.clone()),
+            }];
+
+            // Connect the first incoming source to the new neuron
+            let source_uuid = &incoming[0].from_uuid;
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: source_uuid.clone(),
+                to_neuron_uuid: new_uuid.clone(),
+                weight: incoming[0].weight * 0.5,
+            });
+
+            // Connect new neuron to the first outgoing target
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: new_uuid,
+                to_neuron_uuid: target_uuid.clone(),
+                weight: outgoing[0].weight * 0.5,
+            });
+
+            results.push(CoordinatedStructuralCandidateJson {
+                operations,
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(format!(
+                    "Non-monotonic neuron {}: rho {:.3}, {} samples → add parallel neuron to split contradictory activation-error mapping",
+                    c.neuron_uuid, c.monotonicity_score, c.sample_count
+                )),
+            });
+        } else {
+            // ChangeSquash: try a different activation function
+            let new_squash = suggest_complementary_squash(current_squash);
+            results.push(CoordinatedStructuralCandidateJson {
+                operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                    neuron_uuid: c.neuron_uuid.clone(),
+                    squash: new_squash,
+                }],
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(format!(
+                    "Non-monotonic neuron {}: rho {:.3}, {} samples → change squash to improve activation-error mapping",
+                    c.neuron_uuid, c.monotonicity_score, c.sample_count
+                )),
+            });
+        }
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}
+
+/// Suggest a complementary activation function for a non-monotonic neuron.
+///
+/// The idea is to try a function with different saturation and linearity
+/// characteristics that may better fit the data.
+fn suggest_complementary_squash(current: &str) -> String {
+    match current {
+        "LOGISTIC" => "TANH".to_string(),
+        "TANH" => "RELU".to_string(),
+        "RELU" => "LOGISTIC".to_string(),
+        "IDENTITY" => "TANH".to_string(),
+        "SOFTSIGN" => "LOGISTIC".to_string(),
+        "SOFTPLUS" => "TANH".to_string(),
+        _ => "TANH".to_string(),
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -69,6 +69,7 @@ pub use detection::dormant_synapse;
 pub use detection::error_plateau;
 pub use detection::hard_sample_cluster;
 pub use detection::input_sensitivity;
+pub use detection::monotonicity;
 pub use detection::noise_signal;
 pub use detection::observation_range;
 pub use detection::observation_utilisation;

--- a/src/analysis/module_dispatch_specs/neuron_specs.rs
+++ b/src/analysis/module_dispatch_specs/neuron_specs.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use super::super::{
     activation_mismatch, activation_recommendation, bias_perturbation, bottleneck, cache,
-    co_adaptation, dead_neuron, discovery_dispatch, noise_signal, operating_point,
+    co_adaptation, dead_neuron, discovery_dispatch, monotonicity, noise_signal, operating_point,
     oscillating_neuron, restricted_range, saturation, squash_weight_rescale, symmetry_breaking,
     unbounded_capping,
 };
@@ -406,6 +406,34 @@ pub(crate) fn append_neuron_specs(
                     squash_weight_rescale::squash_weight_rescale_to_coordinated_candidates(
                         &detected,
                     );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #643: Activation-error monotonicity detection
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "monotonicity detection".to_string(),
+            phase_name: "monotonicity_detection",
+            detect_fn: Box::new(move || {
+                if hidden.is_empty() {
+                    return None;
+                }
+                let records = cache.load_records_for_hidden(&hidden);
+                let detected = monotonicity::detect_non_monotonic_neurons(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = monotonicity::non_monotonic_neurons_to_coordinated_candidates(
+                    &detected, &creature,
+                );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_643_activation_error_monotonicity.rs
+++ b/tests/issue_643_activation_error_monotonicity.rs
@@ -1,0 +1,457 @@
+//! Tests for Issue #643: Activation-error monotonicity detector.
+//!
+//! A well-functioning hidden neuron should have a monotonic relationship between
+//! its activation and the output error — higher activation consistently correlates
+//! with either lower or higher error. A non-monotonic relationship suggests the
+//! neuron is encoding contradictory information and should be restructured.
+//!
+//! ## TDD Plan
+//! 1. Monotonic activation-error relationship should NOT be flagged
+//! 2. Non-monotonic (contradictory) relationship SHOULD be flagged
+//! 3. Input/output neurons are excluded
+//! 4. Insufficient samples produce no detections
+//! 5. Produces valid structural candidates (addNeuron or changeSquash)
+//! 6. Distinguishes from noise-to-signal detection (variance-based)
+//! 7. Multiple neurons — only non-monotonic ones flagged
+
+use neat_ai_discovery::analysis::detection::monotonicity::{
+    MonotonicityCandidate, detect_non_monotonic_neurons,
+    non_monotonic_neurons_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Test 1: Monotonically increasing activation-error (higher activation → higher error)
+/// should NOT be flagged as non-monotonic.
+#[test]
+fn test_monotonic_increasing_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Monotonically increasing: as activation goes up, error goes up
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let error = 0.01 + activation * 0.8;
+            record("hidden-1", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Monotonically increasing activation-error should not be flagged, got {} candidates",
+        candidates.len()
+    );
+}
+
+/// Test 2: Monotonically decreasing activation-error (higher activation → lower error)
+/// should NOT be flagged.
+#[test]
+fn test_monotonic_decreasing_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Monotonically decreasing: as activation goes up, error goes down
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let error = 0.8 - activation * 0.7;
+            record("hidden-1", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Monotonically decreasing activation-error should not be flagged, got {} candidates",
+        candidates.len()
+    );
+}
+
+/// Test 3: Non-monotonic (U-shaped) activation-error SHOULD be flagged.
+/// Low and high activations have high error, mid activations have low error.
+#[test]
+fn test_non_monotonic_u_shape_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // U-shaped: error is high at both extremes, low in the middle
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let mid = 0.5;
+            let error = 0.02 + (activation - mid).powi(2) * 3.0;
+            record("hidden-1", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Non-monotonic (U-shaped) activation-error should be flagged"
+    );
+
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "hidden-1");
+    assert!(
+        c.monotonicity_score.abs() < 0.5,
+        "U-shaped pattern should have low monotonicity score, got {}",
+        c.monotonicity_score
+    );
+}
+
+/// Test 4: Non-monotonic (inverted-U) activation-error SHOULD be flagged.
+/// Mid activations have high error, extremes have low error.
+#[test]
+fn test_non_monotonic_inverted_u_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Inverted-U: error is high in the middle, low at extremes
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let mid = 0.5;
+            let error = 0.8 - (activation - mid).powi(2) * 3.0;
+            let error = error.max(0.01);
+            record("hidden-1", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Non-monotonic (inverted-U) activation-error should be flagged"
+    );
+}
+
+/// Test 5: Input and output neurons should be excluded from detection.
+#[test]
+fn test_input_output_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    // Non-monotonic records for both input and output neurons
+    let make_non_monotonic = |uuid: &str| -> Vec<DiscoverRecord> {
+        (0..100)
+            .map(|i| {
+                let activation = i as f32 / 100.0;
+                let error = 0.02 + (activation - 0.5).powi(2) * 3.0;
+                record(uuid, i, activation, vec![error])
+            })
+            .collect()
+    };
+
+    let neuron_records = vec![
+        ("input-1".to_string(), make_non_monotonic("input-1")),
+        ("output-1".to_string(), make_non_monotonic("output-1")),
+    ];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Input and output neurons should not be flagged"
+    );
+}
+
+/// Test 6: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_no_detection() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Only 5 samples
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| {
+            let activation = i as f32 / 5.0;
+            let error = 0.02 + (activation - 0.5).powi(2) * 3.0;
+            record("hidden-1", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should not produce detections"
+    );
+}
+
+/// Test 7: Produces valid structural candidates (addNeuron to split, or changeSquash).
+#[test]
+fn test_produces_valid_structural_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    let candidate = MonotonicityCandidate {
+        neuron_uuid: "hidden-1".to_string(),
+        monotonicity_score: 0.1,
+        sample_count: 100,
+        estimated_improvement: 0.005,
+    };
+
+    let coordinated = non_monotonic_neurons_to_coordinated_candidates(&[candidate], &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(c.comment.is_some(), "Should have a descriptive comment");
+
+    // Check operations include addNeuron or changeSquash
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    let has_structural_op = ops_json.contains("addNeuron") || ops_json.contains("changeSquash");
+    assert!(
+        has_structural_op,
+        "Should produce addNeuron or changeSquash operation, got: {ops_json}"
+    );
+}
+
+/// Test 8: Multiple neurons — only non-monotonic ones are flagged.
+#[test]
+fn test_multiple_neurons_only_non_monotonic_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-good", "hidden", "LOGISTIC"),
+            neuron("hidden-bad", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-good", 0.5),
+            synapse("input-1", "hidden-bad", 0.5),
+            synapse("hidden-good", "output-1", 0.8),
+            synapse("hidden-bad", "output-1", 0.3),
+        ],
+    );
+
+    // hidden-good: monotonically decreasing (activation up → error down)
+    let good_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let error = 0.8 - activation * 0.7;
+            record("hidden-good", i, activation, vec![error])
+        })
+        .collect();
+
+    // hidden-bad: non-monotonic (U-shaped)
+    let bad_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            let error = 0.02 + (activation - 0.5).powi(2) * 3.0;
+            record("hidden-bad", i, activation, vec![error])
+        })
+        .collect();
+
+    let neuron_records = vec![
+        ("hidden-good".to_string(), good_records),
+        ("hidden-bad".to_string(), bad_records),
+    ];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect at least one non-monotonic neuron"
+    );
+
+    let flagged_uuids: Vec<&str> = candidates.iter().map(|c| c.neuron_uuid.as_str()).collect();
+    assert!(
+        flagged_uuids.contains(&"hidden-bad"),
+        "hidden-bad should be flagged, got: {flagged_uuids:?}"
+    );
+    assert!(
+        !flagged_uuids.contains(&"hidden-good"),
+        "hidden-good should NOT be flagged, got: {flagged_uuids:?}"
+    );
+}
+
+/// Test 9: Estimated improvement is positive for detected non-monotonic neurons.
+#[test]
+fn test_estimated_improvement_positive() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Strongly non-monotonic: W-shaped error pattern relative to activation
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = i as f32 / 100.0;
+            // W-shape — two valleys, no consistent direction
+            let error = if activation < 0.25 {
+                0.7 - activation * 2.0
+            } else if activation < 0.5 {
+                0.2 + (activation - 0.25) * 2.0
+            } else if activation < 0.75 {
+                0.7 - (activation - 0.5) * 2.0
+            } else {
+                0.2 + (activation - 0.75) * 2.0
+            };
+            record("hidden-1", i, activation, vec![error.max(0.01)])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let candidates = detect_non_monotonic_neurons(&creature, &neuron_records);
+
+    assert!(!candidates.is_empty(), "Should detect non-monotonic neuron");
+
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement > 0.0,
+            "Estimated improvement should be positive, got {}",
+            c.estimated_improvement
+        );
+    }
+}
+
+/// Test 10: Empty records produce no detections.
+#[test]
+fn test_empty_records_no_detections() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![],
+    );
+
+    let candidates = detect_non_monotonic_neurons(&creature, &[]);
+
+    assert!(
+        candidates.is_empty(),
+        "Empty records should produce no detections"
+    );
+}


### PR DESCRIPTION
## Summary

Add activation-error monotonicity detector that identifies hidden neurons with
non-monotonic activation-error relationships using Spearman's rank correlation.
A well-functioning hidden neuron should have a consistent (monotonic) relationship
between its activation and output error. Neurons where this relationship is
contradictory (e.g., U-shaped or W-shaped) are encoding multiple features that
interfere with each other and should be restructured. Closes #643.

## What Changed

- **New detection module** (`src/analysis/detection/monotonicity.rs`):
  - Computes Spearman's rank correlation (rho) between activation and absolute error
  - Flags hidden neurons where |rho| < 0.3 (non-monotonic)
  - Produces `addNeuron` candidates (to split the workload) or `changeSquash`
    candidates (to try a better-fitting activation function)
- **Dispatch pipeline wiring** (`src/analysis/module_dispatch_specs/neuron_specs.rs`):
  - Registered as "monotonicity detection" phase
- **Module registration** (`src/analysis/detection/mod.rs`, `src/analysis/mod.rs`):
  - Re-exported at analysis level for backward compatibility
- **Scenario documentation** (`docs/discoveries/monotonicity.md`):
  - Explains the problem, detection method, and recommended actions
  - Clarifies distinction from `noise_signal.rs` (variance-based) and
    `gradient_discovery.rs` (synapse-level gradients)

## Evidence

This is a backend detection module with no UI changes. Evidence is provided by
the 10 integration tests listed below.

## Test Plan

Added `tests/issue_643_activation_error_monotonicity.rs` with 10 tests:

1. `test_monotonic_increasing_not_flagged` — monotonic increasing relationship is not flagged
2. `test_monotonic_decreasing_not_flagged` — monotonic decreasing relationship is not flagged
3. `test_non_monotonic_u_shape_flagged` — U-shaped activation-error is detected
4. `test_non_monotonic_inverted_u_flagged` — inverted-U activation-error is detected
5. `test_input_output_neurons_excluded` — input/output neurons are never flagged
6. `test_insufficient_samples_no_detection` — fewer than 20 samples produces no detections
7. `test_produces_valid_structural_candidates` — candidates include addNeuron or changeSquash
8. `test_multiple_neurons_only_non_monotonic_flagged` — only non-monotonic neurons flagged
9. `test_estimated_improvement_positive` — estimated improvement is always positive
10. `test_empty_records_no_detections` — empty records produce no detections

🤖 Generated with [Claude Code](https://claude.com/claude-code)