### PR TITLE
Add synapse weight polarity flip candidate to gradient discovery (#644)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.6"
+version = "0.37.7"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.7"
+version = "0.37.8"
 edition = "2024"
 
 [lib]

--- a/docs/discoveries/weight-polarity-flip.md
+++ b/docs/discoveries/weight-polarity-flip.md
@@ -1,0 +1,125 @@
+# Synapse Weight Polarity Flip
+
+[Back to Discovery Index](README.md) | **Source:** [`src/analysis/detection/weight_polarity_flip.rs`](../../src/analysis/detection/weight_polarity_flip.rs) | **Issue:** [#644](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/644)
+
+---
+
+## The Problem
+
+When a synapse has weight +2.0 but the gradient consistently indicates the
+weight should decrease (positive gradient → descent direction is negative),
+many small delta steps are needed to cross zero and reach the optimal value
+(e.g., -2.0). The existing `gradient_discovery` module proposes only small
+delta adjustments, requiring many iterations to traverse through zero.
+
+```
+  Small-delta approach:             Polarity flip (this module):
+  ────────────────────              ────────────────────────────
+
+  weight: +2.0                      weight: +2.0
+  step 1: +1.98                     flip:   -2.0  ← single step
+  step 2: +1.96
+  ...
+  step N: -2.0  ← many steps
+```
+
+### Why It Matters
+
+- **Faster convergence**: A single `setWeight` candidate replaces dozens of
+  incremental gradient steps.
+- **Structural jump**: Crosses the zero boundary directly rather than
+  approaching it asymptotically.
+- **Complementary to gradient discovery**: The polarity flip handles large
+  sign inversions; gradient discovery handles fine-grained adjustments.
+
+---
+
+## Detection Criteria
+
+A synapse is a polarity flip candidate when:
+
+1. **Sign agreement between weight and gradient**: The raw gradient
+   (∂error/∂weight) has the same sign as the current weight. This means
+   gradient descent (which moves in the -gradient direction) would push the
+   weight through zero toward the opposite sign.
+
+2. **High gradient consistency**: The ratio |mean gradient| / std_dev exceeds
+   0.5, ensuring the gradient direction is reliable and not just noise. This
+   threshold is higher than `gradient_discovery` (0.3) because a polarity
+   flip is a larger structural change that requires stronger evidence.
+
+3. **Significant weight magnitude**: The absolute weight exceeds 0.1, so
+   flipping the sign represents a meaningful structural change.
+
+4. **Gradient magnitude relative to weight**: The gradient-to-weight ratio
+   exceeds 0.05, indicating that many small steps would be needed.
+
+---
+
+## Candidate Generation
+
+For each detected synapse, the module produces a single `setWeight` coordinated
+structural candidate with the negated weight value:
+
+| Field | Value |
+|-------|-------|
+| **Operation** | `SetWeight` |
+| **New weight** | `-current_weight` |
+| **Expected improvement** | Proportional to gradient magnitude × weight change × consistency |
+
+The candidate comment includes the gradient value, current weight, consistency
+metric, and sample count for traceability.
+
+---
+
+## Relationship to Other Modules
+
+| Module | Scope | Overlap |
+|--------|-------|---------|
+| `gradient_discovery` | Small delta adjustments in gradient descent direction | No overlap — different weight values proposed |
+| `weight_magnitude_reset` | Stuck synapses with high error plateau | May detect same synapse but uses different criteria (error plateau vs gradient direction) |
+
+The cross-module deduplication pipeline ensures that if both modules propose
+candidates for the same synapse, only the most promising candidate survives.
+
+---
+
+## Example Scenario
+
+```
+Creature topology:
+  input-0 ──[weight: +2.0]──▶ output-0
+
+Observation data (30 samples):
+  input-0 activations: 0.1, 0.2, ..., 3.0 (positive)
+  output-0 errors:     0.05, 0.1, ..., 1.5 (positive)
+
+Gradient computation:
+  gradient ≈ mean(activation × error) = positive
+  Weight is also positive → same sign
+
+Detection:
+  ✓ Weight magnitude |2.0| > 0.1
+  ✓ Gradient consistency |mean|/std > 0.5
+  ✓ Same sign → descent crosses zero
+  ✓ Gradient/weight ratio > 0.05
+
+Candidate:
+  setWeight(input-0, output-0, -2.0)
+```
+
+---
+
+## Tests
+
+See [`tests/issue_644_weight_polarity_flip.rs`](../../tests/issue_644_weight_polarity_flip.rs):
+
+1. Detects positive weight + positive gradient (descent crosses zero)
+2. Detects negative weight + negative gradient (descent crosses zero)
+3. Rejects opposite-sign weight-gradient pairs (no flip needed)
+4. Rejects inconsistent gradients (noisy signal)
+5. Produces `setWeight` with negated weight
+6. Rejects near-zero weights (no meaningful flip)
+7. Handles edge cases (empty records, insufficient samples)
+8. Candidates are distinct from gradient discovery small-delta proposals
+9. Candidates sorted by estimated improvement

--- a/docs/pr-summary-644.md
+++ b/docs/pr-summary-644.md
@@ -1,0 +1,57 @@
+## Summary
+
+Add a weight polarity flip detection module that identifies synapses where
+the gradient sign consistently agrees with the weight sign — meaning gradient
+descent must push the weight through zero to reach the optimal value. Instead
+of many small delta steps, a direct `setWeight` candidate with the negated
+weight skips the traversal entirely. Closes #644.
+
+### Changes
+
+- **New module**: `src/analysis/detection/weight_polarity_flip.rs` — detects
+  gradient-weight sign agreement and proposes negated weight candidates
+- **Dispatch wiring**: Added to `synapse_specs.rs` dispatch pipeline
+- **Module registration**: Added to `detection/mod.rs` and `analysis/mod.rs`
+  re-exports
+- **Scenario doc**: `docs/discoveries/weight-polarity-flip.md`
+
+### Detection criteria
+
+1. Weight and gradient have the same sign (descent crosses zero)
+2. High gradient consistency (|mean|/std > 0.5)
+3. Significant weight magnitude (|weight| > 0.1)
+4. Gradient large relative to weight (ratio > 0.05)
+
+## Evidence
+
+This is a backend detection module with no UI. Evidence is provided via tests:
+
+```
+running 10 tests
+test test_candidate_produces_negated_weight ... ok
+test test_candidates_sorted_by_improvement ... ok
+test test_detects_negative_weight_negative_gradient ... ok
+test test_detects_positive_weight_positive_gradient ... ok
+test test_empty_records_no_candidates ... ok
+test test_flip_is_distinct_from_gradient_delta ... ok
+test test_inconsistent_gradient_not_flagged ... ok
+test test_insufficient_samples_no_candidates ... ok
+test test_near_zero_weight_not_flagged ... ok
+test test_opposite_sign_weight_gradient_not_flagged ... ok
+
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured
+```
+
+## Test Plan
+
+- `tests/issue_644_weight_polarity_flip.rs` — 10 tests covering:
+  - Detection of positive weight + positive gradient polarity mismatch
+  - Detection of negative weight + negative gradient polarity mismatch
+  - Rejection of opposite-sign weight-gradient pairs (no flip needed)
+  - Rejection of inconsistent/noisy gradients
+  - Candidate produces `setWeight` with negated weight
+  - Rejection of near-zero weights
+  - Edge cases: empty records, insufficient samples
+  - Candidates distinct from gradient discovery small-delta proposals
+  - Candidates sorted by estimated improvement
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -35,3 +35,4 @@ pub mod topology_diversification;
 pub mod unbounded_capping;
 pub mod weight_coherence;
 pub mod weight_magnitude_reset;
+pub mod weight_polarity_flip;

--- a/src/analysis/detection/weight_polarity_flip.rs
+++ b/src/analysis/detection/weight_polarity_flip.rs
@@ -1,0 +1,278 @@
+//! Weight polarity flip detection module (Issue #644).
+//!
+//! Detects synapses where the gradient sign is consistently opposite to the
+//! current weight sign. When the gradient magnitude is large relative to the
+//! weight, a direct sign inversion (`setWeight` to the negated value) can skip
+//! the many small delta steps needed to cross zero.
+//!
+//! ## Detection Criteria
+//!
+//! A synapse is a polarity flip candidate when:
+//! 1. **Sign disagreement**: The weight sign is opposite to the gradient descent
+//!    direction (i.e., weight and gradient have the same sign — gradient descent
+//!    would push weight through zero).
+//! 2. **High gradient consistency**: The gradient direction is reliable across
+//!    samples (|mean| / std_dev exceeds threshold).
+//! 3. **Significant weight magnitude**: The weight is far enough from zero that
+//!    flipping the sign represents a meaningful structural change.
+//! 4. **Gradient magnitude relative to weight**: The gradient is large enough
+//!    relative to the weight that many small steps would be needed to cross zero.
+//!
+//! ## Recommended Actions
+//!
+//! For each detected synapse, the module produces a `setWeight` candidate with
+//! the negated weight value. This is distinct from the small-delta adjustments
+//! proposed by `gradient_discovery.rs`.
+
+use std::collections::HashMap;
+
+use crate::analysis::constants::MIN_NEURON_SAMPLE_COUNT as MIN_SAMPLES_FOR_GRADIENT;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum absolute weight to consider for polarity flip.
+/// Weights near zero have no meaningful polarity to invert.
+const MIN_WEIGHT_MAGNITUDE: f32 = 0.1;
+
+/// Minimum gradient consistency (|mean| / std_dev) for reliable direction.
+/// Higher than `gradient_discovery` because a polarity flip is a large change
+/// and requires stronger evidence.
+const MIN_FLIP_CONSISTENCY: f32 = 0.5;
+
+/// Minimum absolute gradient magnitude.
+/// The gradient must be strong enough to indicate a clear directional signal.
+const MIN_GRADIENT_MAGNITUDE: f32 = 0.01;
+
+/// Minimum ratio of gradient magnitude to weight magnitude.
+/// Ensures the gradient is large relative to the weight, meaning many small
+/// steps would be needed to cross zero without a direct flip.
+const MIN_GRADIENT_WEIGHT_RATIO: f32 = 0.05;
+
+/// A detected polarity flip candidate.
+#[derive(Debug, Clone)]
+pub struct PolarityFlipCandidate {
+    /// UUID of the source neuron.
+    pub from_neuron_uuid: String,
+    /// UUID of the target neuron.
+    pub to_neuron_uuid: String,
+    /// Current synapse weight.
+    pub current_weight: f32,
+    /// Mean gradient (∂error/∂weight) across samples.
+    pub mean_gradient: f32,
+    /// Standard deviation of per-sample gradients.
+    pub gradient_std_dev: f32,
+    /// Gradient consistency ratio (|mean| / std_dev).
+    pub gradient_consistency: f32,
+    /// Number of samples used for gradient computation.
+    pub sample_count: usize,
+    /// Estimated improvement from flipping the weight polarity.
+    pub estimated_improvement: f32,
+}
+
+/// Detect synapses where a weight polarity flip would be beneficial.
+///
+/// Scans synapses targeting output neurons, computes per-sample gradients, and
+/// identifies cases where the gradient consistently points opposite to the
+/// current weight sign — indicating that the weight should cross zero.
+///
+/// # Arguments
+/// * `creature` - The creature topology (neurons and synapses).
+/// * `neuron_records` - Slice of `(uuid, records)` pairs with observation data.
+///
+/// # Returns
+/// Vector of polarity flip candidates, sorted by estimated improvement (best first).
+pub fn detect_weight_polarity_flip_candidates(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<PolarityFlipCandidate> {
+    // Build records lookup
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    // Build obs_index → error lookup for each neuron
+    let target_error_map: HashMap<&str, HashMap<u32, f32>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| {
+            let obs_map: HashMap<u32, f32> = records
+                .iter()
+                .filter_map(|r| {
+                    r.errors
+                        .first()
+                        .filter(|e| e.is_finite())
+                        .map(|&e| (r.obs_index, e))
+                })
+                .collect();
+            (uuid.as_str(), obs_map)
+        })
+        .collect();
+
+    // Identify output neuron UUIDs
+    let output_uuids: std::collections::HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for synapse in &creature.synapses {
+        // Only analyse synapses targeting output neurons
+        if !output_uuids.contains(synapse.to_uuid.as_str()) {
+            continue;
+        }
+
+        // Skip near-zero weights — no meaningful polarity to flip
+        if synapse.weight.abs() < MIN_WEIGHT_MAGNITUDE {
+            continue;
+        }
+
+        // Get source neuron records
+        let Some(source_records) = records_map.get(synapse.from_uuid.as_str()) else {
+            continue;
+        };
+
+        if source_records.len() < MIN_SAMPLES_FOR_GRADIENT {
+            continue;
+        }
+
+        // Get target error map
+        let Some(target_obs_map) = target_error_map.get(synapse.to_uuid.as_str()) else {
+            continue;
+        };
+
+        // Compute per-sample gradients
+        let mut gradients: Vec<f32> = Vec::new();
+
+        for source in source_records.iter() {
+            if !source.activation.is_finite() {
+                continue;
+            }
+            if let Some(&error) = target_obs_map.get(&source.obs_index) {
+                gradients.push(source.activation * error);
+            }
+        }
+
+        if gradients.len() < MIN_SAMPLES_FOR_GRADIENT {
+            continue;
+        }
+
+        let n = gradients.len() as f32;
+        let mean_gradient = gradients.iter().sum::<f32>() / n;
+
+        if !mean_gradient.is_finite() || mean_gradient.abs() < MIN_GRADIENT_MAGNITUDE {
+            continue;
+        }
+
+        // Compute standard deviation
+        let variance = gradients
+            .iter()
+            .map(|&g| {
+                let diff = g - mean_gradient;
+                diff * diff
+            })
+            .sum::<f32>()
+            / n;
+        let std_dev = variance.sqrt();
+
+        // Check gradient consistency
+        let consistency = if std_dev > 1e-12 {
+            mean_gradient.abs() / std_dev
+        } else {
+            f32::MAX
+        };
+
+        if consistency < MIN_FLIP_CONSISTENCY {
+            continue;
+        }
+
+        // Check sign disagreement: weight and gradient have the same sign means
+        // gradient descent (which moves in -gradient direction) pushes weight
+        // through zero. This is the polarity flip case.
+        let weight_sign = synapse.weight.signum();
+        let gradient_sign = mean_gradient.signum();
+
+        if weight_sign != gradient_sign {
+            // Weight and gradient have opposite signs — gradient descent pushes
+            // weight further from zero in the same direction. No flip needed.
+            continue;
+        }
+
+        // Check gradient magnitude relative to weight
+        let gradient_weight_ratio = mean_gradient.abs() / synapse.weight.abs();
+        if gradient_weight_ratio < MIN_GRADIENT_WEIGHT_RATIO {
+            continue;
+        }
+
+        // Estimate improvement: proportional to gradient magnitude, weight magnitude,
+        // and consistency. A large gradient on a large weight with high consistency
+        // suggests a strong polarity mismatch.
+        let flipped_weight = -synapse.weight;
+        let weight_change = (flipped_weight - synapse.weight).abs();
+        let estimated_improvement =
+            mean_gradient.abs() * weight_change * consistency.min(3.0) * 0.005;
+
+        if estimated_improvement <= 0.0 {
+            continue;
+        }
+
+        candidates.push(PolarityFlipCandidate {
+            from_neuron_uuid: synapse.from_uuid.clone(),
+            to_neuron_uuid: synapse.to_uuid.clone(),
+            current_weight: synapse.weight,
+            mean_gradient,
+            gradient_std_dev: std_dev,
+            gradient_consistency: consistency,
+            sample_count: gradients.len(),
+            estimated_improvement,
+        });
+    }
+
+    // Sort by estimated improvement (best first)
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+
+    candidates
+}
+
+/// Convert polarity flip candidates into coordinated structural candidates.
+///
+/// Each candidate produces a `SetWeight` operation with the negated weight value.
+pub fn polarity_flip_candidates_to_coordinated(
+    candidates: &[PolarityFlipCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        let negated_weight = -c.current_weight;
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid: c.from_neuron_uuid.clone(),
+                to_neuron_uuid: c.to_neuron_uuid.clone(),
+                weight: negated_weight,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Polarity flip {} \u{2192} {}: gradient {:.4} opposes weight {:.4}, \
+                 consistency {:.2} ({} samples). Flip to {:.4}. (Issue #644)",
+                c.from_neuron_uuid,
+                c.to_neuron_uuid,
+                c.mean_gradient,
+                c.current_weight,
+                c.gradient_consistency,
+                c.sample_count,
+                negated_weight,
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -89,6 +89,7 @@ pub use detection::topology_diversification;
 pub use detection::unbounded_capping;
 pub use detection::weight_coherence;
 pub use detection::weight_magnitude_reset;
+pub use detection::weight_polarity_flip;
 
 // Re-export recommendation modules at analysis level for backward compatibility
 pub use recommendation::activation_recommendation;

--- a/src/analysis/module_dispatch_specs/synapse_specs.rs
+++ b/src/analysis/module_dispatch_specs/synapse_specs.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use super::super::{
     cache, discovery_dispatch, dormant_synapse, noise_signal, opposing_synapse, weight_coherence,
-    weight_magnitude_reset,
+    weight_magnitude_reset, weight_polarity_flip,
 };
 
 /// Append synapse-focused discovery module specs to the provided vector.
@@ -188,6 +188,34 @@ pub(crate) fn append_synapse_specs(
                 }
                 let candidates =
                     weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #644: Weight polarity flip detection (gradient-weight sign disagreement)
+    {
+        let cache = Arc::clone(shared_cache);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "weight polarity flip detection".to_string(),
+            phase_name: "weight_polarity_flip_detection",
+            detect_fn: Box::new(move || {
+                let records = cache.load_records_for_all_neurons(&creature);
+                if records.is_empty() {
+                    return None;
+                }
+                let detected = weight_polarity_flip::detect_weight_polarity_flip_candidates(
+                    &creature, &records,
+                );
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    weight_polarity_flip::polarity_flip_candidates_to_coordinated(&detected);
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_644_weight_polarity_flip.rs
+++ b/tests/issue_644_weight_polarity_flip.rs
@@ -1,0 +1,528 @@
+//! Tests for Issue #644: Synapse weight polarity flip candidate.
+//!
+//! When a synapse weight and raw gradient have the same sign, gradient descent
+//! pushes the weight through zero toward the opposite sign. Many small delta
+//! steps are needed. A direct polarity flip (`setWeight` to the negated value)
+//! can skip that traversal entirely.
+//!
+//! Sign logic:
+//! - gradient > 0 → ∂error/∂weight > 0 → descent direction is negative
+//! - If weight is also positive, descent must cross zero → polarity flip case
+//! - Same-sign weight and gradient = polarity mismatch
+//!
+//! ## TDD Plan
+//! 1. Test detection of positive weight + positive gradient (descent crosses zero)
+//! 2. Test detection of negative weight + negative gradient (descent crosses zero)
+//! 3. Test that opposite-sign weight-gradient pairs are NOT flagged
+//! 4. Test that inconsistent gradients are NOT flagged
+//! 5. Test candidate produces negated weight via `setWeight`
+//! 6. Test that near-zero weights are NOT flagged (no meaningful flip)
+//! 7. Test edge cases: empty records, insufficient samples
+//! 8. Test candidates are distinct from small-delta gradient proposals
+//! 9. Test candidates sorted by improvement
+
+mod common;
+
+use common::{make_creature, neuron, output, synapse};
+use neat_ai_discovery::analysis::detection::weight_polarity_flip::{
+    detect_weight_polarity_flip_candidates, polarity_flip_candidates_to_coordinated,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helper: create records with specified activations and errors
+// =============================================================================
+
+fn make_record(neuron_uuid: &str, obs_index: u32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors: vec![error],
+    }
+}
+
+// =============================================================================
+// Test 1: Detects clear polarity mismatch (positive weight, positive gradient)
+// =============================================================================
+
+/// When a synapse has positive weight and positive gradient (∂error/∂weight > 0),
+/// gradient descent pushes the weight negative through zero.
+#[test]
+fn test_detects_positive_weight_positive_gradient() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)], // Positive weight
+    );
+
+    // Positive activations × positive errors → positive gradient
+    // Descent direction is negative → pushes weight through zero
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = (i as f32 + 1.0) / 10.0 * 0.5;
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect polarity flip for positive weight with positive gradient"
+    );
+
+    let c = &candidates[0];
+    assert_eq!(c.from_neuron_uuid, "input-0");
+    assert_eq!(c.to_neuron_uuid, "output-0");
+    assert!(c.current_weight > 0.0, "Current weight should be positive");
+    assert!(c.mean_gradient > 0.0, "Mean gradient should be positive");
+}
+
+// =============================================================================
+// Test 2: Detects reverse polarity mismatch (negative weight, negative gradient)
+// =============================================================================
+
+/// When a synapse has negative weight and negative gradient (∂error/∂weight < 0),
+/// gradient descent pushes the weight positive through zero.
+#[test]
+fn test_detects_negative_weight_negative_gradient() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", -2.0)], // Negative weight
+    );
+
+    // Positive activations × negative errors → negative gradient
+    // Descent direction is positive → pushes weight through zero
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = -((i as f32 + 1.0) / 10.0 * 0.5);
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect polarity flip for negative weight with negative gradient"
+    );
+
+    let c = &candidates[0];
+    assert!(c.current_weight < 0.0, "Current weight should be negative");
+    assert!(c.mean_gradient < 0.0, "Mean gradient should be negative");
+}
+
+// =============================================================================
+// Test 3: Opposite-sign weight-gradient pairs are NOT flagged
+// =============================================================================
+
+/// When weight is positive and gradient is negative, descent pushes weight MORE
+/// positive (further from zero). No flip is needed.
+#[test]
+fn test_opposite_sign_weight_gradient_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)], // Positive weight
+    );
+
+    // Positive activations × negative errors → negative gradient
+    // Descent direction is positive → weight increases, moves away from zero
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = -((i as f32 + 1.0) / 10.0 * 0.5);
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Opposite-sign weight-gradient should not trigger polarity flip, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 4: Inconsistent gradients are NOT flagged
+// =============================================================================
+
+/// When the gradient direction is noisy (low consistency), no polarity flip
+/// should be proposed even if the mean gradient has the same sign as the weight.
+#[test]
+fn test_inconsistent_gradient_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)],
+    );
+
+    // Alternating error signs → gradient products are noisy
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| make_record("input-0", i, 1.0, 0.0))
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = if i % 2 == 0 { 0.5 } else { -0.4 };
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Inconsistent gradient should not trigger polarity flip, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 5: Candidate produces negated weight via setWeight
+// =============================================================================
+
+/// The coordinated candidate should propose `setWeight` with the negated weight.
+#[test]
+fn test_candidate_produces_negated_weight() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)],
+    );
+
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = (i as f32 + 1.0) / 10.0 * 0.5;
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+    assert!(!candidates.is_empty(), "Should detect candidate");
+
+    let coordinated = polarity_flip_candidates_to_coordinated(&candidates);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    let coord = &coordinated[0];
+    assert_eq!(coord.operations.len(), 1, "Should have one operation");
+    assert!(
+        coord.expected_creature_score_gain > 0.0,
+        "Should have positive expected improvement"
+    );
+
+    use neat_ai_discovery::CoordinatedStructuralOpJson;
+    match &coord.operations[0] {
+        CoordinatedStructuralOpJson::SetWeight {
+            from_neuron_uuid,
+            to_neuron_uuid,
+            weight,
+        } => {
+            assert_eq!(from_neuron_uuid, "input-0");
+            assert_eq!(to_neuron_uuid, "output-0");
+            assert!(
+                (*weight - (-2.0)).abs() < 0.01,
+                "Weight should be negated: expected -2.0, got {weight}"
+            );
+        }
+        other => panic!("Expected SetWeight operation, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// Test 6: Near-zero weights are NOT flagged
+// =============================================================================
+
+/// Weights close to zero have no meaningful polarity to flip.
+#[test]
+fn test_near_zero_weight_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 0.01)],
+    );
+
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = (i as f32 + 1.0) / 10.0 * 0.5;
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Near-zero weight should not trigger polarity flip, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 7: Edge cases — empty records, insufficient samples
+// =============================================================================
+
+/// Empty records should produce no candidates.
+#[test]
+fn test_empty_records_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Empty records should produce no candidates"
+    );
+}
+
+/// Insufficient samples should produce no candidates.
+#[test]
+fn test_insufficient_samples_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)],
+    );
+
+    let input_records: Vec<DiscoverRecord> = (0..3)
+        .map(|i| make_record("input-0", i, 0.8, 0.0))
+        .collect();
+    let output_records: Vec<DiscoverRecord> = (0..3)
+        .map(|i| make_record("output-0", i, 0.0, 0.5))
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+// =============================================================================
+// Test 8: Candidates are distinct from small-delta gradient proposals
+// =============================================================================
+
+/// The polarity flip candidate should propose the full negated weight,
+/// not a small delta adjustment like the gradient discovery module.
+#[test]
+fn test_flip_is_distinct_from_gradient_delta() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![synapse("input-0", "output-0", 2.0)],
+    );
+
+    let input_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = (i as f32 + 1.0) / 10.0 * 0.5;
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    // Get polarity flip candidates
+    let flip_candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+    assert!(!flip_candidates.is_empty(), "Should detect flip candidate");
+
+    // Get regular gradient candidates
+    use neat_ai_discovery::analysis::gradient_discovery::detect_gradient_candidates;
+    let gradient_candidates = detect_gradient_candidates(&creature, &records);
+
+    let flip_coord = polarity_flip_candidates_to_coordinated(&flip_candidates);
+    assert!(!flip_coord.is_empty());
+
+    use neat_ai_discovery::CoordinatedStructuralOpJson;
+    if let CoordinatedStructuralOpJson::SetWeight {
+        weight: flip_weight,
+        ..
+    } = &flip_coord[0].operations[0]
+    {
+        // Flip weight should be -2.0 (negated from +2.0)
+        assert!(
+            (*flip_weight - (-2.0)).abs() < 0.01,
+            "Flip weight should be -2.0, got {flip_weight}"
+        );
+
+        // If gradient also detected this synapse, its proposed weight should be different
+        if let Some(gc) = gradient_candidates
+            .iter()
+            .find(|c| c.from_neuron_uuid == "input-0")
+        {
+            let gradient_new_weight = gc.current_weight + gc.proposed_weight_delta;
+            assert!(
+                (gradient_new_weight - flip_weight).abs() > 0.1,
+                "Flip weight ({flip_weight}) should be distinct from gradient weight ({gradient_new_weight})"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Test 9: Candidates sorted by estimated improvement
+// =============================================================================
+
+/// Candidates should be sorted by estimated improvement (best first).
+#[test]
+fn test_candidates_sorted_by_improvement() {
+    let creature = make_creature(
+        vec![
+            neuron("input-0", "input", "IDENTITY"),
+            neuron("input-1", "input", "IDENTITY"),
+            output("output-0", "HARD_TANH"),
+        ],
+        vec![
+            synapse("input-0", "output-0", 3.0),
+            synapse("input-1", "output-0", 1.5),
+        ],
+    );
+
+    let input0_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-0", i, act, 0.0)
+        })
+        .collect();
+
+    let input1_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let act = (i as f32 + 1.0) / 10.0;
+            make_record("input-1", i, act, 0.0)
+        })
+        .collect();
+
+    let output_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| {
+            let err = (i as f32 + 1.0) / 10.0 * 0.5;
+            make_record("output-0", i, 0.0, err)
+        })
+        .collect();
+
+    let records = vec![
+        ("input-0".to_string(), input0_records),
+        ("input-1".to_string(), input1_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let candidates = detect_weight_polarity_flip_candidates(&creature, &records);
+
+    if candidates.len() >= 2 {
+        for i in 1..candidates.len() {
+            assert!(
+                candidates[i - 1].estimated_improvement >= candidates[i].estimated_improvement,
+                "Candidates should be sorted by improvement (descending)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a weight polarity flip detection module that identifies synapses where
the gradient sign consistently agrees with the weight sign — meaning gradient
descent must push the weight through zero to reach the optimal value. Instead
of many small delta steps, a direct `setWeight` candidate with the negated
weight skips the traversal entirely. Closes #644.

### Changes

- **New module**: `src/analysis/detection/weight_polarity_flip.rs` — detects
  gradient-weight sign agreement and proposes negated weight candidates
- **Dispatch wiring**: Added to `synapse_specs.rs` dispatch pipeline
- **Module registration**: Added to `detection/mod.rs` and `analysis/mod.rs`
  re-exports
- **Scenario doc**: `docs/discoveries/weight-polarity-flip.md`

### Detection criteria

1. Weight and gradient have the same sign (descent crosses zero)
2. High gradient consistency (|mean|/std > 0.5)
3. Significant weight magnitude (|weight| > 0.1)
4. Gradient large relative to weight (ratio > 0.05)

## Evidence

This is a backend detection module with no UI. Evidence is provided via tests:

```
running 10 tests
test test_candidate_produces_negated_weight ... ok
test test_candidates_sorted_by_improvement ... ok
test test_detects_negative_weight_negative_gradient ... ok
test test_detects_positive_weight_positive_gradient ... ok
test test_empty_records_no_candidates ... ok
test test_flip_is_distinct_from_gradient_delta ... ok
test test_inconsistent_gradient_not_flagged ... ok
test test_insufficient_samples_no_candidates ... ok
test test_near_zero_weight_not_flagged ... ok
test test_opposite_sign_weight_gradient_not_flagged ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured
```

## Test Plan

- `tests/issue_644_weight_polarity_flip.rs` — 10 tests covering:
  - Detection of positive weight + positive gradient polarity mismatch
  - Detection of negative weight + negative gradient polarity mismatch
  - Rejection of opposite-sign weight-gradient pairs (no flip needed)
  - Rejection of inconsistent/noisy gradients
  - Candidate produces `setWeight` with negated weight
  - Rejection of near-zero weights
  - Edge cases: empty records, insufficient samples
  - Candidates distinct from gradient discovery small-delta proposals
  - Candidates sorted by estimated improvement
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)