### PR TITLE
Add output neuron range compression detector (#645)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.8"
+version = "0.37.9"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.37.9"
+version = "0.37.10"
 edition = "2024"
 
 [lib]

--- a/docs/discoveries/output-range-compression.md
+++ b/docs/discoveries/output-range-compression.md
@@ -1,0 +1,116 @@
+# Output Range Compression
+
+[Back to Discovery Index](README.md) | **Source:** [`src/analysis/detection/output_range_compression.rs`](../../src/analysis/detection/output_range_compression.rs) | **Issue:** [#645](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/645)
+
+---
+
+## The Problem
+
+An **output range compression** occurs when an output neuron uses a bounded
+activation function (e.g., TANH with range [-1, 1]) but its actual activations
+cluster in a narrow sub-range (e.g., [0.3, 0.7]). The neuron is using the
+correct *type* of activation but operating at reduced dynamic resolution.
+
+```
+  TANH output range: [-1.0 ─────────────────────────── +1.0]
+  Actual activations:              [0.3 ──── 0.7]
+                                    ↑ only 20% utilised ↑
+
+  The neuron cannot make fine-grained distinctions in the output
+  because weight adjustments produce tiny activation changes
+  relative to the full range.
+```
+
+### Why It Hurts the Creature's Score
+
+- **Reduced resolution**: Small weight changes produce negligible activation
+  differences within the compressed band, making optimisation sluggish.
+- **Wasted capacity**: The activation function's full range could encode much
+  more information than the narrow operating band allows.
+- **Imprecise predictions**: The network cannot distinguish between target
+  values that differ by less than the compressed range's granularity.
+
+---
+
+## How We Detect It
+
+```
+  ┌────────────────────────────────────────────────────────────────┐
+  │  For each output neuron:                                       │
+  │                                                                │
+  │  Prerequisites:                                                │
+  │  • Bounded squash function (TANH, LOGISTIC, etc.)              │
+  │  • Sufficient samples (>= 20)                                  │
+  │  • Not dead (observed range > 0.01)                            │
+  │  • Not saturated (not near activation bounds)                  │
+  │                                                                │
+  │  Detection:                                                    │
+  │  • range_utilisation = observed_range / theoretical_range      │
+  │  • Flag if range_utilisation < 40%                             │
+  │                                                                │
+  │  Exclusions:                                                   │
+  │  • Hidden neurons (handled by restricted_range module)         │
+  │  • Unbounded activations (IDENTITY, RELU, etc.)                │
+  │  • Saturated neurons (near activation bounds)                  │
+  │  • Dead neurons (near-zero activation range)                   │
+  └────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## How We Fix It
+
+```
+  BEFORE (TANH, compressed [0.3, 0.7])    AFTER (rescaled or changeSquash)
+  ┌─────┐    ┌──────────┐    ┌─────┐     ┌─────┐    ┌──────────┐    ┌─────┐
+  │ H1  │───→│ O1       │    │ tgt │     │ H1  │───→│ O1       │    │ tgt │
+  │     │    │ TANH     │    │     │     │     │    │ LOGISTIC │    │     │
+  │     │    │ [0.3,0.7]│    │     │     │     │    │ [0.1,0.9]│    │     │
+  └─────┘    │ 20%      │    └─────┘     └─────┘    │ 80%      │    └─────┘
+             │ utilised  │                           │ utilised  │
+             └──────────┘                            └──────────┘
+```
+
+| Strategy | Candidate | Operations | Description |
+|----------|-----------|------------|-------------|
+| **Change squash** | Better-fitting activation | `changeSquash` | Switch to activation whose range matches target distribution |
+| **Rescale pathway** | Coordinated adjustment | `setBias` + `setWeight` | Scale incoming weights to expand operating range and recentre bias |
+
+---
+
+## Example
+
+```
+  Output neuron O1: TANH (range [-1, +1]), bias = 0.5
+  Observed activations: [0.3, 0.7] across 50 samples
+  Range utilisation: 0.4 / 2.0 = 20%
+
+  Candidate 1: changeSquash → LOGISTIC
+    LOGISTIC range [0, 1] better matches the positive-only distribution
+    Expected improvement: 0.004
+
+  Candidate 2: setBias + setWeight (coordinated)
+    Scale incoming weights by 4.0× to expand operating range
+    Adjust bias from 0.5 to 0.0 to recentre in activation range
+    Expected improvement: 0.0028
+```
+
+---
+
+## Relationship to Other Modules
+
+| Module | What It Detects | Difference |
+|--------|----------------|------------|
+| **Restricted range** (Issue #399) | Hidden neurons with compressed range | This module targets *output* neurons |
+| **Output squash mismatch** (Issue #546) | Wrong activation function type | That module detects fundamentally wrong functions; this detects correct type but compressed usage |
+| **Squash weight rescale** (Issue #548) | Coordinated squash+weight changes | That module is for hidden neurons; this produces similar candidates for outputs |
+
+---
+
+## References
+
+- **Source module**: [`src/analysis/detection/output_range_compression.rs`](../../src/analysis/detection/output_range_compression.rs)
+- **DISCOVERY_TYPES.md**: [Technical reference](../DISCOVERY_TYPES.md)
+- **Related**: [Restricted Range](restricted-range.md) — hidden neuron version
+- **Related**: [Output Squash Mismatch](output-squash-mismatch.md) — wrong function type
+- **Related**: [Squash Weight Rescale](squash-weight-rescale.md) — coordinated rescaling for hidden neurons

--- a/docs/pr-summary-645.md
+++ b/docs/pr-summary-645.md
@@ -1,0 +1,38 @@
+## Summary
+
+Add output neuron range compression detector that flags output neurons operating in a compressed sub-range of their activation function's theoretical range. For example, a TANH output neuron (range [-1, 1]) whose activations cluster in [0.3, 0.7] is using only 20% of the available range, reducing dynamic resolution and making weight adjustments less precise. Closes #645.
+
+This complements the existing `restricted_range` module (hidden neurons) and `output_squash_mismatch` module (wrong function type) by detecting output neurons using the *correct* type of activation but at compressed utilisation.
+
+### Changes
+
+- **New detection module**: `src/analysis/detection/output_range_compression.rs`
+  - Detects output neurons with <40% range utilisation of their bounded squash function
+  - Excludes dead neurons, saturated neurons, unbounded activations, and hidden neurons
+  - Produces two candidate types:
+    - `changeSquash` to a better-fitting activation function
+    - Coordinated `setBias` + `setWeight` to recentre and rescale the output pathway
+- **Dispatch pipeline**: Wired into `scoring_specs.rs` for automatic execution during analysis
+- **Re-exports**: Added to `detection/mod.rs` and `analysis/mod.rs` for backward compatibility
+- **Scenario doc**: `docs/discoveries/output-range-compression.md`
+
+## Evidence
+
+This is a backend detection module with no UI changes. Correctness verified by 12 unit tests covering all detection criteria, edge cases, and candidate generation.
+
+## Test Plan
+
+- `tests/issue_645_output_range_compression.rs` — 12 tests:
+  1. Compressed TANH output detected (20% utilisation)
+  2. Full-range output NOT flagged (80% utilisation)
+  3. Hidden neurons excluded
+  4. Insufficient samples produce no detections
+  5. Unbounded activations excluded
+  6. Produces valid coordinated candidates (changeSquash + setBias/setWeight)
+  7. LOGISTIC output compression detected
+  8. Multiple outputs — only compressed ones flagged
+  9. Near-saturated outputs excluded
+  10. Dead outputs excluded
+  11. Empty records produce no detections
+  12. Results sorted by utilisation (worst first)
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -22,6 +22,7 @@ pub mod observation_utilisation;
 pub mod operating_point;
 pub mod opposing_synapse;
 pub mod oscillating_neuron;
+pub mod output_range_compression;
 pub mod output_squash_mismatch;
 pub mod redundant_path;
 pub mod restricted_range;

--- a/src/analysis/detection/output_range_compression.rs
+++ b/src/analysis/detection/output_range_compression.rs
@@ -1,0 +1,310 @@
+//! Output neuron range compression detection module (Issue #645).
+//!
+//! Detects output neurons operating in a compressed sub-range of their
+//! activation function's theoretical output domain. For example, a TANH
+//! output neuron (range [-1, 1]) whose activations cluster in [0.3, 0.7]
+//! is using only 20% of the available range, reducing dynamic resolution
+//! and making weight adjustments less precise.
+//!
+//! ## Relationship to Other Detection Modules
+//!
+//! - **Restricted range** (Issue #399): hidden neurons with compressed range.
+//! - **Output squash mismatch** (Issue #546): wrong activation function type
+//!   on output neurons (e.g., LOGISTIC for symmetric targets).
+//! - **This module** (Issue #645): output neurons using the *correct* type of
+//!   activation but operating in a compressed sub-range.
+//!
+//! ## Detection Criteria
+//!
+//! An output neuron has "range compression" if:
+//! 1. It uses a bounded squash function (TANH, LOGISTIC, etc.).
+//! 2. `range_utilisation = (activation_max - activation_min) / theoretical_range`
+//!    is below a configurable threshold (default: 40%).
+//! 3. The neuron is not dead (observed range is not near zero).
+//! 4. The neuron is not saturated (not at the activation bounds).
+//! 5. Sufficient samples are available (≥ 20).
+//!
+//! ## Recommended Actions
+//!
+//! - `changeSquash` — switch to an activation function whose range better
+//!   matches the target distribution.
+//! - `setBias` + `setWeight` — coordinated rescaling to recentre and expand
+//!   the output pathway.
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+
+/// Minimum observed range (activation_max - activation_min) to distinguish
+/// from dead neurons. Below this, the neuron is considered dead, not compressed.
+const MIN_OBSERVED_RANGE: f32 = 0.01;
+
+/// Distance from the theoretical bounds within which a neuron is considered
+/// saturated rather than compressed.
+const SATURATION_MARGIN: f32 = 0.10;
+
+/// Configuration for output range compression detection.
+#[derive(Debug, Clone)]
+pub struct OutputRangeCompressionConfig {
+    /// Maximum range utilisation below which a neuron is flagged (default: 0.40 = 40%).
+    pub utilisation_threshold: f32,
+    /// Minimum samples required for detection.
+    pub min_samples: usize,
+}
+
+impl Default for OutputRangeCompressionConfig {
+    fn default() -> Self {
+        Self {
+            utilisation_threshold: 0.40,
+            min_samples: MIN_SAMPLES,
+        }
+    }
+}
+
+/// Result of detecting an output neuron with compressed range.
+#[derive(Debug, Clone)]
+pub struct OutputRangeCompressionNeuron {
+    /// UUID of the output neuron with the compressed range.
+    pub neuron_uuid: String,
+    /// Current squash (activation) function.
+    pub squash: String,
+    /// Current bias of the neuron.
+    pub bias: f32,
+    /// Minimum observed activation across samples.
+    pub activation_min: f32,
+    /// Maximum observed activation across samples.
+    pub activation_max: f32,
+    /// Theoretical range of the squash function (e.g., 2.0 for TANH).
+    pub theoretical_range: f32,
+    /// Ratio of observed range to theoretical range (0.0 to 1.0).
+    pub range_utilisation: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+}
+
+/// Returns the theoretical output range `(min, max)` for bounded squash functions.
+///
+/// Returns `None` for unbounded activations (IDENTITY, RELU, etc.) since they
+/// have no fixed output bounds and range compression detection does not apply.
+fn theoretical_bounds(squash: &str) -> Option<(f32, f32)> {
+    let upper = squash.to_ascii_uppercase();
+    match upper.as_str() {
+        "TANH" | "HARD_TANH" | "CLIPPED" | "BIPOLAR_SIGMOID" | "SOFTSIGN" | "ISRU" => {
+            Some((-1.0, 1.0))
+        }
+        "LOGISTIC" => Some((0.0, 1.0)),
+        "BIPOLAR" | "STEP" => Some((-1.0, 1.0)),
+        "ARCTAN" => Some((-std::f32::consts::FRAC_PI_2, std::f32::consts::FRAC_PI_2)),
+        "RELU6" => Some((0.0, 6.0)),
+        _ => None,
+    }
+}
+
+/// Detect output neurons with compressed activation ranges.
+///
+/// Analyses output neurons to find those where the observed activation range
+/// is a small fraction of the theoretical range of their squash function.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+/// * `config` - Detection configuration (thresholds).
+///
+/// # Returns
+/// A list of `OutputRangeCompressionNeuron` sorted by range utilisation (lowest first).
+pub fn detect_output_range_compression(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    config: &OutputRangeCompressionConfig,
+) -> Vec<OutputRangeCompressionNeuron> {
+    // Build map from UUID to neuron info (only output neurons)
+    let output_neurons: Vec<(&str, &str, f32)> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| (n.uuid.as_str(), n.squash.as_str(), n.bias))
+        .collect();
+
+    let neuron_map: std::collections::HashMap<&str, (&str, f32)> = output_neurons
+        .iter()
+        .map(|&(uuid, squash, bias)| (uuid, (squash, bias)))
+        .collect();
+
+    let mut results = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        // Only consider output neurons
+        let Some(&(squash, bias)) = neuron_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        // Skip if insufficient samples
+        if records.len() < config.min_samples {
+            continue;
+        }
+
+        // Skip unbounded activations
+        let Some((theoretical_min, theoretical_max)) = theoretical_bounds(squash) else {
+            continue;
+        };
+        let theoretical_range = theoretical_max - theoretical_min;
+
+        // Compute observed activation range
+        let mut act_min = f32::INFINITY;
+        let mut act_max = f32::NEG_INFINITY;
+        for r in records {
+            act_min = act_min.min(r.activation);
+            act_max = act_max.max(r.activation);
+        }
+
+        let observed_range = act_max - act_min;
+
+        // Exclude dead neurons (near-zero range)
+        if observed_range < MIN_OBSERVED_RANGE {
+            continue;
+        }
+
+        // Exclude saturated neurons (at bounds)
+        let near_lower = act_min < (theoretical_min + SATURATION_MARGIN);
+        let near_upper = act_max > (theoretical_max - SATURATION_MARGIN);
+        if near_lower || near_upper {
+            continue;
+        }
+
+        // Compute range utilisation
+        let range_utilisation = observed_range / theoretical_range;
+
+        if range_utilisation >= config.utilisation_threshold {
+            continue;
+        }
+
+        results.push(OutputRangeCompressionNeuron {
+            neuron_uuid: uuid.clone(),
+            squash: squash.to_string(),
+            bias,
+            activation_min: act_min,
+            activation_max: act_max,
+            theoretical_range,
+            range_utilisation,
+            sample_count: records.len(),
+        });
+    }
+
+    // Sort by range utilisation (lowest first — worst offenders first)
+    results.sort_by(|a, b| a.range_utilisation.total_cmp(&b.range_utilisation));
+
+    results
+}
+
+/// Convert output range compression detections into coordinated structural candidates.
+///
+/// Each compressed output neuron may produce multiple candidates:
+/// 1. **changeSquash** — switch to an activation whose range better matches
+///    the observed output distribution (e.g., LOGISTIC for [0, 1] targets).
+/// 2. **setBias + setWeight** — coordinated rescaling to recentre and expand
+///    the output pathway through the activation function.
+pub fn output_range_compression_to_coordinated_candidates(
+    detected: &[OutputRangeCompressionNeuron],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::new();
+
+    for n in detected {
+        let base_improvement = (1.0 - n.range_utilisation) * 0.005;
+
+        // Candidate 1: Change squash to a better-fitting function
+        let recommended_squash = recommend_squash(n);
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: n.neuron_uuid.clone(),
+                squash: recommended_squash.clone(),
+            }],
+            expected_creature_score_gain: base_improvement,
+            comment: Some(format!(
+                "Output range compression on {}: {} using {:.0}% of range [{:.3}, {:.3}] → change to {recommended_squash} (Issue #645)",
+                n.neuron_uuid,
+                n.squash,
+                n.range_utilisation * 100.0,
+                n.activation_min,
+                n.activation_max,
+            )),
+        });
+
+        // Candidate 2: Coordinated setBias + setWeight to recentre and rescale
+        let incoming_synapses: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.to_uuid == n.neuron_uuid)
+            .collect();
+
+        if !incoming_synapses.is_empty() {
+            let observed_centre = (n.activation_min + n.activation_max) / 2.0;
+            let (theoretical_min, theoretical_max) =
+                theoretical_bounds(&n.squash).unwrap_or((-1.0, 1.0));
+            let theoretical_centre = (theoretical_min + theoretical_max) / 2.0;
+            let bias_delta = theoretical_centre - observed_centre;
+            let new_bias = n.bias + bias_delta;
+
+            // Scale factor to expand the observed range toward ~80% utilisation
+            let target_utilisation = 0.80;
+            let scale_factor = target_utilisation / n.range_utilisation.max(0.01);
+
+            let mut ops: Vec<CoordinatedStructuralOpJson> = Vec::new();
+
+            // Rescale incoming weights
+            for s in &incoming_synapses {
+                ops.push(CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: s.from_uuid.clone(),
+                    to_neuron_uuid: s.to_uuid.clone(),
+                    weight: s.weight * scale_factor,
+                });
+            }
+
+            // Adjust bias to recentre
+            ops.push(CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: n.neuron_uuid.clone(),
+                bias: new_bias,
+            });
+
+            results.push(CoordinatedStructuralCandidateJson {
+                operations: ops,
+                expected_creature_score_gain: base_improvement * 0.7,
+                comment: Some(format!(
+                    "Output range compression on {}: {} using {:.0}% → rescale weights by {:.2}× and adjust bias from {:.3} to {:.3} (Issue #645)",
+                    n.neuron_uuid,
+                    n.squash,
+                    n.range_utilisation * 100.0,
+                    scale_factor,
+                    n.bias,
+                    new_bias,
+                )),
+            });
+        }
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}
+
+/// Recommend an alternative squash function based on the observed activation range.
+fn recommend_squash(n: &OutputRangeCompressionNeuron) -> String {
+    let all_positive = n.activation_min >= 0.0;
+    let all_in_unit = n.activation_min >= 0.0 && n.activation_max <= 1.0;
+
+    if all_in_unit {
+        // Activations fit in [0, 1] — LOGISTIC is a natural fit
+        "LOGISTIC".to_string()
+    } else if all_positive {
+        // Activations are positive but extend beyond 1 — LOGISTIC still good
+        "LOGISTIC".to_string()
+    } else {
+        // Activations span both positive and negative — TANH is standard
+        "TANH".to_string()
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -76,6 +76,7 @@ pub use detection::observation_utilisation;
 pub use detection::operating_point;
 pub use detection::opposing_synapse;
 pub use detection::oscillating_neuron;
+pub use detection::output_range_compression;
 pub use detection::output_squash_mismatch;
 pub use detection::redundant_path;
 pub use detection::restricted_range;

--- a/src/analysis/module_dispatch_specs/scoring_specs.rs
+++ b/src/analysis/module_dispatch_specs/scoring_specs.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use super::super::{
     bounded_range, cache, discovery_dispatch, error_plateau, gradient_discovery, input_sensitivity,
-    observation_utilisation, output_bias_drift, output_squash_mismatch, sample_weighted,
-    sentinel_gating,
+    observation_utilisation, output_bias_drift, output_range_compression, output_squash_mismatch,
+    sample_weighted, sentinel_gating,
 };
 
 /// Append scoring and recommendation discovery module specs to the provided vector.
@@ -221,6 +221,37 @@ pub(crate) fn append_scoring_specs(
                     return None;
                 }
                 let candidates = gradient_discovery::gradient_candidates_to_coordinated(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #645: Output range compression detection
+    {
+        let cache = Arc::clone(shared_cache);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "output range compression detection".to_string(),
+            phase_name: "output_range_compression_detection",
+            detect_fn: Box::new(move || {
+                let records = cache.load_records_for_neuron_types(&creature, &["output"]);
+                if records.is_empty() {
+                    return None;
+                }
+                let config = output_range_compression::OutputRangeCompressionConfig::default();
+                let detected = output_range_compression::detect_output_range_compression(
+                    &creature, &records, &config,
+                );
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    output_range_compression::output_range_compression_to_coordinated_candidates(
+                        &detected, &creature,
+                    );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_645_output_range_compression.rs
+++ b/tests/issue_645_output_range_compression.rs
@@ -1,0 +1,496 @@
+//! Tests for Issue #645: Output neuron range compression detector.
+//!
+//! Detects output neurons operating in a compressed sub-range of their
+//! activation function's theoretical range. For example, a TANH neuron
+//! (range [-1, 1]) whose activations only span [0.3, 0.7] is using
+//! only 20% of the available range, reducing dynamic resolution.
+//!
+//! ## TDD Plan
+//! 1. Output neuron using <40% of activation range SHOULD be flagged
+//! 2. Output neuron using >40% of range should NOT be flagged
+//! 3. Hidden neurons are excluded (handled by restricted_range module)
+//! 4. Insufficient samples produce no detections
+//! 5. Unbounded activation functions (IDENTITY, RELU) are excluded
+//! 6. Produces valid coordinated candidates (setBias+setWeight or changeSquash)
+//! 7. Distinguishes from output_squash_mismatch (wrong function type vs compression)
+//! 8. Multiple output neurons — only compressed ones flagged
+//! 9. Near-saturated neurons excluded (saturation detection handles those)
+//! 10. Dead output neurons excluded (near-zero range)
+
+use neat_ai_discovery::analysis::detection::output_range_compression::{
+    OutputRangeCompressionConfig, OutputRangeCompressionNeuron, detect_output_range_compression,
+    output_range_compression_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Test 1: Output neuron using TANH with activations in [0.3, 0.7] — only 20% of [-1, 1].
+/// Should be flagged as compressed.
+#[test]
+fn test_compressed_output_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.5),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.3),
+        ],
+    );
+
+    // Activations confined to [0.3, 0.7] out of TANH's [-1, 1] range = 20% utilisation
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.4;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        !detected.is_empty(),
+        "Output neuron using only 20% of TANH range should be flagged"
+    );
+    assert_eq!(detected[0].neuron_uuid, "output-1");
+    assert!(
+        detected[0].range_utilisation < 0.40,
+        "Range utilisation should be below threshold, got {:.2}",
+        detected[0].range_utilisation
+    );
+}
+
+/// Test 2: Output neuron using most of its range should NOT be flagged.
+#[test]
+fn test_full_range_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![synapse("input-1", "output-1", 1.0)],
+    );
+
+    // Activations span [-0.8, 0.8] out of [-1, 1] = 80% utilisation
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = -0.8 + (i as f32 / 49.0) * 1.6;
+            record("output-1", i, activation, vec![0.05])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Output neuron using 80% of range should not be flagged, got {} detections",
+        detected.len()
+    );
+}
+
+/// Test 3: Hidden neurons should be excluded (restricted_range handles those).
+#[test]
+fn test_hidden_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-1", "output", "IDENTITY", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Compressed hidden neuron — should NOT be flagged by this module
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.1 + (i as f32 / 49.0) * 0.2;
+            record("hidden-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Hidden neurons should not be flagged by output range compression detector"
+    );
+}
+
+/// Test 4: Insufficient samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_no_detection() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "TANH", 0.5),
+        ],
+        vec![synapse("input-1", "output-1", 0.3)],
+    );
+
+    // Only 5 samples (below MIN_SAMPLES threshold)
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 4.0) * 0.4;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Insufficient samples should produce no detections"
+    );
+}
+
+/// Test 5: Unbounded activation functions should be excluded.
+#[test]
+fn test_unbounded_activation_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "IDENTITY", 0.0),
+        ],
+        vec![synapse("input-1", "output-1", 0.3)],
+    );
+
+    // IDENTITY has no bounded range — cannot be "compressed"
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.1;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Unbounded activation functions should not be flagged"
+    );
+}
+
+/// Test 6: Produces valid coordinated candidates (setBias+setWeight or changeSquash).
+#[test]
+fn test_produces_valid_coordinated_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.5),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.3),
+        ],
+    );
+
+    let detected = vec![OutputRangeCompressionNeuron {
+        neuron_uuid: "output-1".to_string(),
+        squash: "TANH".to_string(),
+        bias: 0.5,
+        activation_min: 0.3,
+        activation_max: 0.7,
+        theoretical_range: 2.0,
+        range_utilisation: 0.20,
+        sample_count: 50,
+    }];
+
+    let candidates = output_range_compression_to_coordinated_candidates(&detected, &creature);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+
+    for c in &candidates {
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "Expected improvement should be positive"
+        );
+        assert!(c.comment.is_some(), "Should have a descriptive comment");
+    }
+
+    // Check we get both changeSquash and setBias+setWeight type candidates
+    let ops_json = serde_json::to_string(&candidates).unwrap();
+    let has_change_squash = ops_json.contains("changeSquash");
+    let has_set_bias = ops_json.contains("setBias");
+    let has_set_weight = ops_json.contains("setWeight");
+    assert!(has_change_squash, "Should include changeSquash candidate");
+    assert!(
+        has_set_bias && has_set_weight,
+        "Should include coordinated setBias+setWeight candidate"
+    );
+}
+
+/// Test 7: LOGISTIC output neuron compressed to [0.6, 0.8] — only 20% of [0, 1].
+#[test]
+fn test_logistic_output_compressed() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "LOGISTIC", 1.0),
+        ],
+        vec![synapse("input-1", "output-1", 0.5)],
+    );
+
+    // LOGISTIC range is [0, 1]; activations in [0.6, 0.8] = 20% utilisation
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.6 + (i as f32 / 49.0) * 0.2;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        !detected.is_empty(),
+        "LOGISTIC output compressed to 20% of range should be flagged"
+    );
+    assert_eq!(detected[0].squash, "LOGISTIC");
+}
+
+/// Test 8: Multiple output neurons — only compressed ones flagged.
+#[test]
+fn test_multiple_outputs_only_compressed_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-good", "output", "TANH", 0.0),
+            neuron("output-bad", "output", "TANH", 0.5),
+        ],
+        vec![
+            synapse("input-1", "output-good", 1.0),
+            synapse("input-1", "output-bad", 0.2),
+        ],
+    );
+
+    // output-good: uses 80% of range [-0.8, 0.8]
+    let good_records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = -0.8 + (i as f32 / 49.0) * 1.6;
+            record("output-good", i, activation, vec![0.05])
+        })
+        .collect();
+
+    // output-bad: uses only 15% of range [0.2, 0.5]
+    let bad_records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.2 + (i as f32 / 49.0) * 0.3;
+            record("output-bad", i, activation, vec![0.2])
+        })
+        .collect();
+
+    let neuron_records = vec![
+        ("output-good".to_string(), good_records),
+        ("output-bad".to_string(), bad_records),
+    ];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    let flagged_uuids: Vec<&str> = detected.iter().map(|d| d.neuron_uuid.as_str()).collect();
+    assert!(
+        flagged_uuids.contains(&"output-bad"),
+        "output-bad should be flagged, got: {flagged_uuids:?}"
+    );
+    assert!(
+        !flagged_uuids.contains(&"output-good"),
+        "output-good should NOT be flagged, got: {flagged_uuids:?}"
+    );
+}
+
+/// Test 9: Near-saturated output neuron should be excluded.
+#[test]
+fn test_near_saturated_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![synapse("input-1", "output-1", 1.0)],
+    );
+
+    // Activations near upper bound [0.92, 0.98] — this is saturation, not compression
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.92 + (i as f32 / 49.0) * 0.06;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Near-saturated output should not be flagged as compressed"
+    );
+}
+
+/// Test 10: Dead output neuron (near-zero range) should be excluded.
+#[test]
+fn test_dead_output_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![synapse("input-1", "output-1", 1.0)],
+    );
+
+    // All activations essentially the same value (dead neuron)
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.5 + (i as f32 / 49.0) * 0.005;
+            record("output-1", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![("output-1".to_string(), records)];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(
+        detected.is_empty(),
+        "Dead output neuron (near-zero range) should not be flagged"
+    );
+}
+
+/// Test 11: Empty records produce no detections.
+#[test]
+fn test_empty_records_no_detections() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![synapse("input-1", "output-1", 1.0)],
+    );
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &[], &config);
+
+    assert!(
+        detected.is_empty(),
+        "Empty records should produce no detections"
+    );
+}
+
+/// Test 12: Results sorted by range utilisation (worst first).
+#[test]
+fn test_results_sorted_by_utilisation() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("output-a", "output", "TANH", 0.0),
+            neuron("output-b", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "output-a", 0.5),
+            synapse("input-1", "output-b", 0.5),
+        ],
+    );
+
+    // output-a: 30% utilisation [0.1, 0.7]
+    let records_a: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.1 + (i as f32 / 49.0) * 0.6;
+            record("output-a", i, activation, vec![0.1])
+        })
+        .collect();
+
+    // output-b: 15% utilisation [0.3, 0.6]
+    let records_b: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.3;
+            record("output-b", i, activation, vec![0.1])
+        })
+        .collect();
+
+    let neuron_records = vec![
+        ("output-a".to_string(), records_a),
+        ("output-b".to_string(), records_b),
+    ];
+
+    let config = OutputRangeCompressionConfig::default();
+    let detected = detect_output_range_compression(&creature, &neuron_records, &config);
+
+    assert!(detected.len() >= 2, "Should detect both compressed outputs");
+
+    // Worst utilisation (lowest) should be first
+    assert!(
+        detected[0].range_utilisation <= detected[1].range_utilisation,
+        "Results should be sorted by utilisation (lowest first), got {:.2} then {:.2}",
+        detected[0].range_utilisation,
+        detected[1].range_utilisation
+    );
+}


### PR DESCRIPTION
## Summary

Add output neuron range compression detector that flags output neurons operating in a compressed sub-range of their activation function's theoretical range. For example, a TANH output neuron (range [-1, 1]) whose activations cluster in [0.3, 0.7] is using only 20% of the available range, reducing dynamic resolution and making weight adjustments less precise. Closes #645.

This complements the existing `restricted_range` module (hidden neurons) and `output_squash_mismatch` module (wrong function type) by detecting output neurons using the *correct* type of activation but at compressed utilisation.

### Changes

- **New detection module**: `src/analysis/detection/output_range_compression.rs`
  - Detects output neurons with <40% range utilisation of their bounded squash function
  - Excludes dead neurons, saturated neurons, unbounded activations, and hidden neurons
  - Produces two candidate types:
    - `changeSquash` to a better-fitting activation function
    - Coordinated `setBias` + `setWeight` to recentre and rescale the output pathway
- **Dispatch pipeline**: Wired into `scoring_specs.rs` for automatic execution during analysis
- **Re-exports**: Added to `detection/mod.rs` and `analysis/mod.rs` for backward compatibility
- **Scenario doc**: `docs/discoveries/output-range-compression.md`

## Evidence

This is a backend detection module with no UI changes. Correctness verified by 12 unit tests covering all detection criteria, edge cases, and candidate generation.

## Test Plan

- `tests/issue_645_output_range_compression.rs` — 12 tests:
  1. Compressed TANH output detected (20% utilisation)
  2. Full-range output NOT flagged (80% utilisation)
  3. Hidden neurons excluded
  4. Insufficient samples produce no detections
  5. Unbounded activations excluded
  6. Produces valid coordinated candidates (changeSquash + setBias/setWeight)
  7. LOGISTIC output compression detected
  8. Multiple outputs — only compressed ones flagged
  9. Near-saturated outputs excluded
  10. Dead outputs excluded
  11. Empty records produce no detections
  12. Results sorted by utilisation (worst first)
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)