### PR TITLE
Add structured error classification and retry strategy (#651)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.38.2"
+version = "0.38.3"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.38.3"
+version = "0.39.0"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-651.md
+++ b/docs/pr-summary-651.md
@@ -1,0 +1,41 @@
+## Summary
+
+Add structured error classification and retry strategy for transient failures. Closes #651.
+
+All FFI error responses now include two new optional fields:
+- `errorKind` — classifies the error (e.g., `gpu_transient`, `data_validation`, `timeout`, `memory_exhausted`, `io_error`, `gpu_permanent`, `internal_panic`, `unknown`)
+- `retryable` — boolean indicating whether the controller should retry the operation
+
+These fields are additive and backward-compatible: existing callers that do not read them are unaffected, while new callers can use them to make informed retry decisions.
+
+### Error classification categories
+
+| Kind | Retryable | Examples |
+|------|-----------|----------|
+| `gpu_transient` | Yes | Device lost, driver unresponsive, command buffer overflow |
+| `gpu_permanent` | No | No GPU available, unsupported hardware |
+| `data_validation` | No | Invalid JSON, null input, missing fields |
+| `timeout` | Yes | Deadline exceeded, operation timed out |
+| `memory_exhausted` | Yes | Out of memory, allocation failed |
+| `io_error` | Yes | Parquet read failure, file not found |
+| `internal_panic` | No | Caught panic at FFI boundary |
+| `unknown` | No | Unclassified errors |
+
+## Evidence
+
+This is a backend/FFI change with no visual output. Correctness is verified through 26 integration tests and all existing unit tests in the `error_classification` module.
+
+## Test Plan
+
+- Added `tests/issue_651_error_classification.rs` — 26 integration tests covering:
+  - All 8 error kind classifications
+  - Retryable/non-retryable correctness for each kind
+  - `error_fields()` and `no_error_fields()` helper functions
+  - JSON serialisation of error kinds (snake_case format)
+  - FFI response shape verification (error fields present on failure, absent on success)
+  - Backward compatibility (existing `success` and `error` fields preserved)
+  - Case-insensitive error message classification
+- Added unit tests in `src/ffi_types/error_classification.rs`
+- Updated `tests/issue_337_candidate_type_contract.rs` to include new fields
+- All existing tests continue to pass
+- `./quality.sh` passes cleanly

--- a/src/ffi/analysis.rs
+++ b/src/ffi/analysis.rs
@@ -35,6 +35,8 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
         let json_result = match crate::rank_focus_neurons_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = RankFocusNeuronsOutput {
                     success: false,
                     neurons: None,
@@ -44,7 +46,9 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
                     processed_neurons: None,
                     total_neurons: None,
                     duration_ms: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
@@ -116,6 +120,8 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
+                let err_msg = format!("Failed to serialize output: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = AnalyzeParallelOutput {
                     success: false,
                     helpful_synapses: None,
@@ -133,7 +139,9 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     neuron_fingerprints: None,
                     fingerprint_cache_hits: None,
                     fingerprint_cache_misses: None,
-                    error: Some(format!("Failed to serialize output: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     // Fallback if serialization fails (shouldn't happen)

--- a/src/ffi/gpu.rs
+++ b/src/ffi/gpu.rs
@@ -17,11 +17,15 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
+                let err_msg = format!("Failed to probe GPU: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = CheckGpuOutput {
                     success: false,
                     gpu_available: false,
                     reason: None,
-                    error: Some(format!("Failed to probe GPU: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     // Fallback if serialization fails (shouldn't happen)

--- a/src/ffi/recording.rs
+++ b/src/ffi/recording.rs
@@ -45,11 +45,15 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = RecordDiscoveryOutput {
                     success: false,
                     temp_dir: None,
                     file: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     // Fallback if serialization fails (shouldn't happen)
@@ -153,10 +157,14 @@ pub extern "C" fn start_discovery_session(
         let input: StartSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
+                let err_msg = format!("Failed to parse input JSON: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = StartSessionOutput {
                     success: false,
                     session_id: None,
-                    error: Some(format!("Failed to parse input JSON: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -164,16 +172,27 @@ pub extern "C" fn start_discovery_session(
         };
 
         let output = match streaming::start_session(input.creature, input.temp_dir) {
-            Ok(session_id) => StartSessionOutput {
-                success: true,
-                session_id: Some(session_id),
-                error: None,
-            },
-            Err(e) => StartSessionOutput {
-                success: false,
-                session_id: None,
-                error: Some(e.to_string()),
-            },
+            Ok(session_id) => {
+                let (error_kind, retryable) = no_error_fields();
+                StartSessionOutput {
+                    success: true,
+                    session_id: Some(session_id),
+                    error: None,
+                    error_kind,
+                    retryable,
+                }
+            }
+            Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
+                StartSessionOutput {
+                    success: false,
+                    session_id: None,
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
+                }
+            }
         };
 
         let json = serde_json::to_string(&output).unwrap();
@@ -249,10 +268,14 @@ pub extern "C" fn append_discovery_records(
         let input: AppendRecordsInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
+                let err_msg = format!("Failed to parse input JSON: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = AppendRecordsOutput {
                     success: false,
                     records_written: None,
-                    error: Some(format!("Failed to parse input JSON: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -267,16 +290,27 @@ pub extern "C" fn append_discovery_records(
             .collect();
 
         let output = match streaming::append_records(&input.session_id, batches) {
-            Ok(records_written) => AppendRecordsOutput {
-                success: true,
-                records_written: Some(records_written),
-                error: None,
-            },
-            Err(e) => AppendRecordsOutput {
-                success: false,
-                records_written: None,
-                error: Some(e.to_string()),
-            },
+            Ok(records_written) => {
+                let (error_kind, retryable) = no_error_fields();
+                AppendRecordsOutput {
+                    success: true,
+                    records_written: Some(records_written),
+                    error: None,
+                    error_kind,
+                    retryable,
+                }
+            }
+            Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
+                AppendRecordsOutput {
+                    success: false,
+                    records_written: None,
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
+                }
+            }
         };
 
         let json = serde_json::to_string(&output).unwrap();
@@ -347,12 +381,16 @@ pub extern "C" fn finish_discovery_session(
         let input: FinishSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
+                let err_msg = format!("Failed to parse input JSON: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = FinishSessionOutput {
                     success: false,
                     temp_dir: None,
                     file: None,
                     total_records: None,
-                    error: Some(format!("Failed to parse input JSON: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -360,20 +398,31 @@ pub extern "C" fn finish_discovery_session(
         };
 
         let output = match streaming::finish_session(&input.session_id) {
-            Ok((temp_dir, file, total_records)) => FinishSessionOutput {
-                success: true,
-                temp_dir: Some(temp_dir),
-                file: Some(file),
-                total_records: Some(total_records),
-                error: None,
-            },
-            Err(e) => FinishSessionOutput {
-                success: false,
-                temp_dir: None,
-                file: None,
-                total_records: None,
-                error: Some(e.to_string()),
-            },
+            Ok((temp_dir, file, total_records)) => {
+                let (error_kind, retryable) = no_error_fields();
+                FinishSessionOutput {
+                    success: true,
+                    temp_dir: Some(temp_dir),
+                    file: Some(file),
+                    total_records: Some(total_records),
+                    error: None,
+                    error_kind,
+                    retryable,
+                }
+            }
+            Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
+                FinishSessionOutput {
+                    success: false,
+                    temp_dir: None,
+                    file: None,
+                    total_records: None,
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
+                }
+            }
         };
 
         let json = serde_json::to_string(&output).unwrap();
@@ -443,9 +492,13 @@ pub extern "C" fn cancel_discovery_session(
         let input: CancelSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
+                let err_msg = format!("Failed to parse input JSON: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = CancelSessionOutput {
                     success: false,
-                    error: Some(format!("Failed to parse input JSON: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -453,14 +506,25 @@ pub extern "C" fn cancel_discovery_session(
         };
 
         let output = match streaming::cancel_session(&input.session_id) {
-            Ok(()) => CancelSessionOutput {
-                success: true,
-                error: None,
-            },
-            Err(e) => CancelSessionOutput {
-                success: false,
-                error: Some(e.to_string()),
-            },
+            Ok(()) => {
+                let (error_kind, retryable) = no_error_fields();
+                CancelSessionOutput {
+                    success: true,
+                    error: None,
+                    error_kind,
+                    retryable,
+                }
+            }
+            Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
+                CancelSessionOutput {
+                    success: false,
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
+                }
+            }
         };
 
         let json = serde_json::to_string(&output).unwrap();

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -37,10 +37,14 @@ pub extern "C" fn merge_discovery_parquet(
         let json_result = match crate::merge_discovery_parquet_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = MergeParquetOutput {
                     success: false,
                     output_file: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
@@ -123,10 +127,14 @@ pub extern "C" fn read_discovery_records_ffi(
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = ReadDiscoveryOutput {
                     success: false,
                     records: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     // Fallback if serialization fails (shouldn't happen)
@@ -222,11 +230,15 @@ pub extern "C" fn export_visualisation_snapshot(
         let json_result = match crate::export_visualisation_snapshot_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = ExportVisualisationSnapshotOutput {
                     success: false,
                     out_file: None,
                     stats: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
@@ -323,10 +335,14 @@ pub extern "C" fn get_calibration_summary(
         let json_result = match crate::get_calibration_summary_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = crate::ffi_types::CalibrationSummaryOutput {
                     success: false,
                     calibration_summary: vec![],
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     r#"{"success":false,"calibrationSummary":[],"error":"Failed to serialize error message"}"#.to_string()
@@ -388,10 +404,14 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
             Ok(json) => json,
             Err(e) => {
                 // Properly serialize error message to avoid JSON injection issues
+                let err_msg = format!("Failed to get version: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = GetVersionOutput {
                     success: false,
                     version: String::new(),
-                    error: Some(format!("Failed to get version: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
                     // Fallback if serialization fails (shouldn't happen)

--- a/src/ffi_internal.rs
+++ b/src/ffi_internal.rs
@@ -19,11 +19,15 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     let input: RecordDiscoveryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = RecordDiscoveryOutput {
                 success: false,
                 temp_dir: None,
                 file: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -33,22 +37,29 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     let result = match record::record_discovery_data(&input) {
         Ok(result) => result,
         Err(e) => {
+            let err_msg = e.to_string();
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = RecordDiscoveryOutput {
                 success: false,
                 temp_dir: None,
                 file: None,
-                error: Some(e.to_string()),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
     };
 
     // Success case
+    let (error_kind, retryable) = no_error_fields();
     let output = RecordDiscoveryOutput {
         success: true,
         temp_dir: Some(result.temp_dir),
         file: Some(result.file),
         error: None,
+        error_kind,
+        retryable,
     };
 
     Ok(serde_json::to_string(&output)?)
@@ -58,38 +69,53 @@ pub fn merge_discovery_parquet_internal(input_json: &str) -> Result<String> {
     let input: MergeParquetInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = MergeParquetOutput {
                 success: false,
                 output_file: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
     };
 
     if input.input_files.is_empty() {
+        let err_msg = "No discovery parquet files provided for merge".to_string();
+        let (error_kind, retryable) = error_fields(&err_msg);
         let output = MergeParquetOutput {
             success: false,
             output_file: None,
-            error: Some("No discovery parquet files provided for merge".to_string()),
+            error: Some(err_msg),
+            error_kind,
+            retryable,
         };
         return Ok(serde_json::to_string(&output)?);
     }
 
     match parquet_format::merge_parquet_files(&input.output_file, &input.input_files) {
         Ok(()) => {
+            let (error_kind, retryable) = no_error_fields();
             let output = MergeParquetOutput {
                 success: true,
                 output_file: Some(input.output_file),
                 error: None,
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
+            let err_msg = e.to_string();
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = MergeParquetOutput {
                 success: false,
                 output_file: None,
-                error: Some(e.to_string()),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
@@ -101,6 +127,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
     {
         Ok(value) => value,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = AnalyzeParallelOutput {
                 success: false,
                 helpful_synapses: None,
@@ -118,7 +146,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_fingerprints: None,
                 fingerprint_cache_hits: None,
                 fingerprint_cache_misses: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -205,10 +235,14 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     None
                 },
                 error: None,
+                error_kind: None,
+                retryable: None,
             };
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
+            let err_msg = e.to_string();
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = AnalyzeParallelOutput {
                 success: false,
                 helpful_synapses: None,
@@ -226,7 +260,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_fingerprints: None,
                 fingerprint_cache_hits: None,
                 fingerprint_cache_misses: None,
-                error: Some(e.to_string()),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
@@ -256,28 +292,38 @@ pub fn check_gpu_available_internal() -> Result<String> {
     // On macOS, missing GPU is an error (Metal should always work).
     // On Linux, missing GPU gracefully disables discovery (common on headless servers).
     let output = if result.is_error {
+        let err_msg = "GPU required but not available".to_string();
+        let (error_kind, retryable) = error_fields(&err_msg);
         CheckGpuOutput {
             success: false,
             gpu_available: false,
             reason: result.reason,
-            error: Some("GPU required but not available".to_string()),
+            error: Some(err_msg),
+            error_kind,
+            retryable,
         }
     } else {
+        let (error_kind, retryable) = no_error_fields();
         CheckGpuOutput {
             success: true,
             gpu_available: result.available,
             reason: result.reason,
             error: None,
+            error_kind,
+            retryable,
         }
     };
     Ok(serde_json::to_string(&output)?)
 }
 
 pub fn get_library_version_internal() -> Result<String> {
+    let (error_kind, retryable) = no_error_fields();
     let output = GetVersionOutput {
         success: true,
         version: crate::LIB_VERSION.to_string(),
         error: None,
+        error_kind,
+        retryable,
     };
     Ok(serde_json::to_string(&output)?)
 }
@@ -286,6 +332,8 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
     let input: RankFocusNeuronsInput = match serde_json::from_str(input_json) {
         Ok(value) => value,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = RankFocusNeuronsOutput {
                 success: false,
                 neurons: None,
@@ -295,7 +343,9 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 processed_neurons: None,
                 total_neurons: None,
                 duration_ms: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -335,6 +385,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                     reason: c.reason,
                 })
                 .collect();
+            let (error_kind, retryable) = no_error_fields();
             let output = RankFocusNeuronsOutput {
                 success: true,
                 neurons: Some(neurons),
@@ -354,10 +405,14 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 total_neurons: Some(stats.total_neurons),
                 duration_ms: Some(stats.duration_ms.min(u64::MAX as u128) as u64),
                 error: None,
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
+            let err_msg = e.to_string();
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = RankFocusNeuronsOutput {
                 success: false,
                 neurons: None,
@@ -367,7 +422,9 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 processed_neurons: None,
                 total_neurons: None,
                 duration_ms: None,
-                error: Some(e.to_string()),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
@@ -383,11 +440,15 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
     let input: ExportVisualisationSnapshotInput = match serde_json::from_str(input_json) {
         Ok(value) => value,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = ExportVisualisationSnapshotOutput {
                 success: false,
                 out_file: None,
                 stats: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -407,6 +468,7 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
         &options,
     ) {
         Ok(stats) => {
+            let (error_kind, retryable) = no_error_fields();
             let output = ExportVisualisationSnapshotOutput {
                 success: true,
                 out_file: Some(input.out_file),
@@ -417,15 +479,21 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
                     output_count: stats.output_count,
                 }),
                 error: None,
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
+            let err_msg = e.to_string();
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = ExportVisualisationSnapshotOutput {
                 success: false,
                 out_file: None,
                 stats: None,
-                error: Some(e.to_string()),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             Ok(serde_json::to_string(&output)?)
         }
@@ -440,10 +508,14 @@ pub fn get_calibration_summary_internal(input_json: &str) -> Result<String> {
     let input: CalibrationSummaryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = CalibrationSummaryOutput {
                 success: false,
                 calibration_summary: vec![],
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -453,20 +525,27 @@ pub fn get_calibration_summary_internal(input_json: &str) -> Result<String> {
         match serde_json::from_str(&input.discovery_history) {
             Ok(h) => h,
             Err(e) => {
+                let err_msg = format!("Failed to parse discovery history: {e}");
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = CalibrationSummaryOutput {
                     success: false,
                     calibration_summary: vec![],
-                    error: Some(format!("Failed to parse discovery history: {e}")),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 return Ok(serde_json::to_string(&output)?);
             }
         };
 
     let summary = history.calibration_summary();
+    let (error_kind, retryable) = no_error_fields();
     let output = CalibrationSummaryOutput {
         success: true,
         calibration_summary: summary,
         error: None,
+        error_kind,
+        retryable,
     };
     Ok(serde_json::to_string(&output)?)
 }
@@ -482,10 +561,14 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
     let input: ReadDiscoveryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
+            let err_msg = format!("Failed to parse input JSON: {e}");
+            let (error_kind, retryable) = error_fields(&err_msg);
             let output = ReadDiscoveryOutput {
                 success: false,
                 records: None,
-                error: Some(format!("Failed to parse input JSON: {e}")),
+                error: Some(err_msg),
+                error_kind,
+                retryable,
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -496,10 +579,14 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
         match read_records_from_parquet(&input.parquet_file, &input.neuron_uuid) {
             Ok(records) => records,
             Err(e) => {
+                let err_msg = e.to_string();
+                let (error_kind, retryable) = error_fields(&err_msg);
                 let output = ReadDiscoveryOutput {
                     success: false,
                     records: None,
-                    error: Some(e.to_string()),
+                    error: Some(err_msg),
+                    error_kind,
+                    retryable,
                 };
                 return Ok(serde_json::to_string(&output)?);
             }
@@ -517,10 +604,13 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
         })
         .collect();
 
+    let (error_kind, retryable) = no_error_fields();
     let output = ReadDiscoveryOutput {
         success: true,
         records: Some(json_records),
         error: None,
+        error_kind,
+        retryable,
     };
 
     let json_string = serde_json::to_string(&output)?;
@@ -598,11 +688,14 @@ mod tests {
 
         for error_msg in error_messages {
             // Test RecordDiscoveryOutput
+            let (error_kind, retryable) = error_fields(error_msg);
             let output = RecordDiscoveryOutput {
                 success: false,
                 temp_dir: None,
                 file: None,
                 error: Some(error_msg.to_string()),
+                error_kind,
+                retryable,
             };
             let json = serde_json::to_string(&output).unwrap();
             // Verify JSON is valid and can be parsed back
@@ -611,10 +704,13 @@ mod tests {
             assert_eq!(parsed["error"].as_str(), Some(error_msg));
 
             // Test ReadDiscoveryOutput
+            let (error_kind, retryable) = error_fields(error_msg);
             let read_output = ReadDiscoveryOutput {
                 success: false,
                 records: None,
                 error: Some(error_msg.to_string()),
+                error_kind,
+                retryable,
             };
             let read_json = serde_json::to_string(&read_output).unwrap();
             // Verify JSON is valid and can be parsed back

--- a/src/ffi_types/error_classification.rs
+++ b/src/ffi_types/error_classification.rs
@@ -1,0 +1,320 @@
+//! Structured error classification for FFI responses (Issue #651).
+//!
+//! Classifies `anyhow::Error` messages into categories so the NEAT-AI controller
+//! can make informed retry decisions — retrying transient GPU errors but not
+//! retrying data validation failures.
+
+use serde::Serialize;
+
+/// Classification of discovery errors for retry decision-making.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoveryErrorKind {
+    /// Transient GPU error (device lost, driver reset) — retryable.
+    GpuTransient,
+    /// Permanent GPU error (no GPU available, unsupported hardware) — not retryable.
+    GpuPermanent,
+    /// Data validation error (malformed input, missing fields) — not retryable.
+    DataValidation,
+    /// Deadline/timeout exceeded — retryable with a longer deadline.
+    Timeout,
+    /// Memory exhaustion — retryable after freeing resources.
+    MemoryExhausted,
+    /// File I/O error (parquet read/write failure) — may be retryable.
+    IoError,
+    /// Internal panic caught at the FFI boundary — not retryable.
+    InternalPanic,
+    /// Unclassified error — check the error message for details.
+    Unknown,
+}
+
+impl DiscoveryErrorKind {
+    /// Whether errors of this kind are typically worth retrying.
+    pub fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            Self::GpuTransient | Self::Timeout | Self::MemoryExhausted | Self::IoError
+        )
+    }
+}
+
+/// Classify an error message into a `DiscoveryErrorKind`.
+///
+/// Inspects the error string for known patterns from GPU (wgpu), parquet I/O,
+/// deadline, and memory subsystems.
+pub fn classify_error(error_msg: &str) -> DiscoveryErrorKind {
+    let lower = error_msg.to_lowercase();
+
+    // GPU transient errors (device lost, driver issues)
+    if is_gpu_transient_pattern(&lower) {
+        return DiscoveryErrorKind::GpuTransient;
+    }
+
+    // GPU permanent errors (no GPU, unsupported)
+    if is_gpu_permanent_pattern(&lower) {
+        return DiscoveryErrorKind::GpuPermanent;
+    }
+
+    // Timeout / deadline exceeded
+    if is_timeout_pattern(&lower) {
+        return DiscoveryErrorKind::Timeout;
+    }
+
+    // Memory exhaustion
+    if is_memory_pattern(&lower) {
+        return DiscoveryErrorKind::MemoryExhausted;
+    }
+
+    // Data validation errors
+    if is_data_validation_pattern(&lower) {
+        return DiscoveryErrorKind::DataValidation;
+    }
+
+    // I/O errors (parquet, file system)
+    if is_io_pattern(&lower) {
+        return DiscoveryErrorKind::IoError;
+    }
+
+    DiscoveryErrorKind::Unknown
+}
+
+fn is_gpu_transient_pattern(lower: &str) -> bool {
+    lower.contains("device is lost")
+        || lower.contains("device lost")
+        || lower.contains("device was lost")
+        || lower.contains("gpu device poll error")
+        || lower.contains("command buffer")
+        || lower.contains("too many command buffers")
+        || lower.contains("gpu driver")
+        || lower.contains("driver may be unresponsive")
+        || lower.contains("device creation failed")
+        || lower.contains("internal error in gpu")
+}
+
+fn is_gpu_permanent_pattern(lower: &str) -> bool {
+    lower.contains("no gpu")
+        || lower.contains("gpu unavailable")
+        || lower.contains("gpu is required")
+        || lower.contains("no compatible gpu")
+        || lower.contains("unsupported gpu")
+        || lower.contains("metal should always be available")
+}
+
+fn is_timeout_pattern(lower: &str) -> bool {
+    lower.contains("deadline")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("time limit")
+        || lower.contains("exceeded time")
+        || lower.contains("aborted after")
+}
+
+fn is_memory_pattern(lower: &str) -> bool {
+    lower.contains("out of memory")
+        || lower.contains("memory exhausted")
+        || lower.contains("allocation failed")
+        || lower.contains("insufficient memory")
+        || lower.contains("memory pressure")
+}
+
+fn is_data_validation_pattern(lower: &str) -> bool {
+    lower.contains("invalid input")
+        || lower.contains("failed to parse")
+        || lower.contains("missing field")
+        || lower.contains("invalid utf-8")
+        || lower.contains("null input")
+        || lower.contains("invalid json")
+        || lower.contains("deserialization")
+        || lower.contains("deserialisation")
+        || lower.contains("validation failed")
+        || lower.contains("expected ") && (lower.contains("found") || lower.contains("but got"))
+}
+
+fn is_io_pattern(lower: &str) -> bool {
+    lower.contains("parquet")
+        || lower.contains("file not found")
+        || lower.contains("permission denied")
+        || lower.contains("no such file")
+        || lower.contains("i/o error")
+        || lower.contains("io error")
+        || lower.contains("broken pipe")
+        || lower.contains("disk full")
+}
+
+/// Classify a panic message as `InternalPanic`.
+pub fn classify_panic() -> DiscoveryErrorKind {
+    DiscoveryErrorKind::InternalPanic
+}
+
+/// Classify an error and return `(error_kind, retryable)` fields ready for
+/// inclusion in an FFI response struct.
+pub fn error_fields(error_msg: &str) -> (Option<DiscoveryErrorKind>, Option<bool>) {
+    let kind = classify_error(error_msg);
+    (Some(kind), Some(kind.is_retryable()))
+}
+
+/// Return `(error_kind, retryable)` fields for a caught panic.
+pub fn panic_error_fields() -> (Option<DiscoveryErrorKind>, Option<bool>) {
+    let kind = classify_panic();
+    (Some(kind), Some(kind.is_retryable()))
+}
+
+/// Return `(None, None)` — no error classification for success responses.
+pub fn no_error_fields() -> (Option<DiscoveryErrorKind>, Option<bool>) {
+    (None, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gpu_transient_device_lost() {
+        assert_eq!(
+            classify_error("Device is lost"),
+            DiscoveryErrorKind::GpuTransient
+        );
+        assert!(classify_error("Device is lost").is_retryable());
+    }
+
+    #[test]
+    fn test_gpu_transient_device_poll() {
+        assert_eq!(
+            classify_error("GPU device poll error (warm-up): device was lost"),
+            DiscoveryErrorKind::GpuTransient
+        );
+    }
+
+    #[test]
+    fn test_gpu_permanent_no_gpu() {
+        assert_eq!(
+            classify_error("No GPU available on this system"),
+            DiscoveryErrorKind::GpuPermanent
+        );
+        assert!(!classify_error("No GPU available on this system").is_retryable());
+    }
+
+    #[test]
+    fn test_data_validation_parse_error() {
+        assert_eq!(
+            classify_error("Failed to parse input JSON: expected value"),
+            DiscoveryErrorKind::DataValidation
+        );
+        assert!(!classify_error("Failed to parse input JSON").is_retryable());
+    }
+
+    #[test]
+    fn test_data_validation_null_input() {
+        assert_eq!(
+            classify_error("Null input pointer"),
+            DiscoveryErrorKind::DataValidation
+        );
+    }
+
+    #[test]
+    fn test_timeout_deadline() {
+        assert_eq!(
+            classify_error("Analysis deadline exceeded"),
+            DiscoveryErrorKind::Timeout
+        );
+        assert!(classify_error("Analysis deadline exceeded").is_retryable());
+    }
+
+    #[test]
+    fn test_timeout_timed_out() {
+        assert_eq!(
+            classify_error("Operation timed out after 30s"),
+            DiscoveryErrorKind::Timeout
+        );
+    }
+
+    #[test]
+    fn test_memory_exhausted() {
+        assert_eq!(
+            classify_error("Out of memory allocating GPU buffer"),
+            DiscoveryErrorKind::MemoryExhausted
+        );
+        assert!(classify_error("Out of memory").is_retryable());
+    }
+
+    #[test]
+    fn test_io_parquet() {
+        assert_eq!(
+            classify_error("Failed to read parquet file"),
+            DiscoveryErrorKind::IoError
+        );
+        assert!(classify_error("parquet error").is_retryable());
+    }
+
+    #[test]
+    fn test_io_file_not_found() {
+        assert_eq!(
+            classify_error("File not found: /tmp/data.parquet"),
+            DiscoveryErrorKind::IoError
+        );
+    }
+
+    #[test]
+    fn test_internal_panic() {
+        let kind = classify_panic();
+        assert_eq!(kind, DiscoveryErrorKind::InternalPanic);
+        assert!(!kind.is_retryable());
+    }
+
+    #[test]
+    fn test_unknown_error() {
+        assert_eq!(
+            classify_error("Something completely unexpected"),
+            DiscoveryErrorKind::Unknown
+        );
+        assert!(!classify_error("Unknown situation").is_retryable());
+    }
+
+    #[test]
+    fn test_case_insensitive_classification() {
+        assert_eq!(
+            classify_error("DEVICE IS LOST"),
+            DiscoveryErrorKind::GpuTransient
+        );
+        assert_eq!(
+            classify_error("OUT OF MEMORY"),
+            DiscoveryErrorKind::MemoryExhausted
+        );
+    }
+
+    #[test]
+    fn test_invalid_utf8_is_data_validation() {
+        assert_eq!(
+            classify_error("Invalid UTF-8 in input"),
+            DiscoveryErrorKind::DataValidation
+        );
+    }
+
+    #[test]
+    fn test_gpu_transient_command_buffer() {
+        assert_eq!(
+            classify_error("Too many command buffers in flight"),
+            DiscoveryErrorKind::GpuTransient
+        );
+    }
+
+    #[test]
+    fn test_gpu_transient_driver_unresponsive() {
+        assert_eq!(
+            classify_error("GPU driver may be unresponsive"),
+            DiscoveryErrorKind::GpuTransient
+        );
+    }
+
+    #[test]
+    fn test_serialise_error_kind_snake_case() {
+        let json = serde_json::to_string(&DiscoveryErrorKind::GpuTransient).unwrap();
+        assert_eq!(json, "\"gpu_transient\"");
+
+        let json = serde_json::to_string(&DiscoveryErrorKind::DataValidation).unwrap();
+        assert_eq!(json, "\"data_validation\"");
+
+        let json = serde_json::to_string(&DiscoveryErrorKind::MemoryExhausted).unwrap();
+        assert_eq!(json, "\"memory_exhausted\"");
+    }
+}

--- a/src/ffi_types/mod.rs
+++ b/src/ffi_types/mod.rs
@@ -4,12 +4,14 @@
 //! FFI boundary between this Rust library and the TypeScript/Deno controller.
 
 mod candidates;
+mod error_classification;
 mod requests;
 mod responses;
 mod session;
 
 // Re-export all sub-module types to preserve the existing public API.
 pub use candidates::*;
+pub use error_classification::*;
 pub use requests::*;
 pub use responses::*;
 pub use session::*;

--- a/src/ffi_types/responses.rs
+++ b/src/ffi_types/responses.rs
@@ -5,6 +5,7 @@
 
 use serde::Serialize;
 
+use super::DiscoveryErrorKind;
 use crate::analysis;
 
 use super::{
@@ -22,6 +23,12 @@ pub struct RecordDiscoveryOutput {
     pub file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -75,6 +82,12 @@ pub struct AnalyzeParallelOutput {
     pub fingerprint_cache_misses: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 // Coordinated structural candidates are now produced inside synapse analysis and surfaced via
@@ -223,6 +236,12 @@ pub struct CheckGpuOutput {
     pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -232,6 +251,12 @@ pub struct GetVersionOutput {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -261,6 +286,12 @@ pub struct RankFocusNeuronsOutput {
     pub duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -271,6 +302,12 @@ pub struct MergeParquetOutput {
     pub output_file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 // ============================================================================
@@ -288,6 +325,12 @@ pub struct ExportVisualisationSnapshotOutput {
     pub stats: Option<ExportVisualisationStats>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 /// Statistics from the export operation
@@ -312,6 +355,12 @@ pub struct ReadDiscoveryOutput {
     pub records: Option<Vec<DiscoverRecordJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 /// JSON representation of DiscoverRecord for serialization
@@ -337,6 +386,12 @@ pub struct CalibrationSummaryOutput {
     pub calibration_summary: Vec<crate::discovery_history::CalibrationSummaryEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 // ============================================================================

--- a/src/ffi_types/session.rs
+++ b/src/ffi_types/session.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{CreatureJson, NeuronData};
+use super::{CreatureJson, DiscoveryErrorKind, NeuronData};
 
 /// JSON input for start_discovery_session function
 #[derive(Debug, Deserialize)]
@@ -24,6 +24,12 @@ pub struct StartSessionOutput {
     pub session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 /// A single observation to append to a streaming session
@@ -52,6 +58,12 @@ pub struct AppendRecordsOutput {
     pub records_written: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 /// JSON input for finish_discovery_session function
@@ -74,6 +86,12 @@ pub struct FinishSessionOutput {
     pub total_records: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }
 
 /// JSON input for cancel_discovery_session function
@@ -90,4 +108,10 @@ pub struct CancelSessionOutput {
     pub success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Structured error classification for retry decisions (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<DiscoveryErrorKind>,
+    /// Whether this error is typically worth retrying (Issue #651).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
 }

--- a/tests/issue_337_candidate_type_contract.rs
+++ b/tests/issue_337_candidate_type_contract.rs
@@ -315,6 +315,8 @@ fn analyze_parallel_output_contains_all_candidate_fields() {
         fingerprint_cache_hits: None,
         fingerprint_cache_misses: None,
         error: None,
+        error_kind: None,
+        retryable: None,
     };
 
     let json: serde_json::Value =
@@ -362,6 +364,8 @@ fn rank_focus_neurons_output_contains_removal_candidate_fields() {
         total_neurons: Some(10),
         duration_ms: Some(100),
         error: None,
+        error_kind: None,
+        retryable: None,
     };
 
     let json: serde_json::Value =

--- a/tests/issue_651_error_classification.rs
+++ b/tests/issue_651_error_classification.rs
@@ -1,0 +1,334 @@
+//! Integration tests for structured error classification (Issue #651).
+//!
+//! Verifies that FFI error responses include `error_kind` and `retryable` fields
+//! with correct classification for different error scenarios.
+
+use neat_ai_discovery::ffi_types::{
+    DiscoveryErrorKind, classify_error, classify_panic, error_fields, no_error_fields,
+};
+
+// ============================================================================
+// classify_error — GPU transient errors
+// ============================================================================
+
+#[test]
+fn gpu_device_lost_is_classified_as_gpu_transient() {
+    let kind = classify_error("Device is lost");
+    assert_eq!(kind, DiscoveryErrorKind::GpuTransient);
+    assert!(
+        kind.is_retryable(),
+        "GPU transient errors should be retryable"
+    );
+}
+
+#[test]
+fn gpu_device_poll_error_is_classified_as_gpu_transient() {
+    let kind = classify_error("GPU device poll error (warm-up): device was lost");
+    assert_eq!(kind, DiscoveryErrorKind::GpuTransient);
+}
+
+#[test]
+fn gpu_command_buffer_overflow_is_classified_as_gpu_transient() {
+    let kind = classify_error("Too many command buffers in flight");
+    assert_eq!(kind, DiscoveryErrorKind::GpuTransient);
+}
+
+#[test]
+fn gpu_driver_unresponsive_is_classified_as_gpu_transient() {
+    let kind = classify_error("GPU driver may be unresponsive");
+    assert_eq!(kind, DiscoveryErrorKind::GpuTransient);
+}
+
+// ============================================================================
+// classify_error — GPU permanent errors
+// ============================================================================
+
+#[test]
+fn no_gpu_available_is_classified_as_gpu_permanent() {
+    let kind = classify_error("No GPU available");
+    assert_eq!(kind, DiscoveryErrorKind::GpuPermanent);
+    assert!(
+        !kind.is_retryable(),
+        "GPU permanent errors should not be retryable"
+    );
+}
+
+#[test]
+fn gpu_required_but_unavailable_is_classified_as_gpu_permanent() {
+    let kind = classify_error("GPU is required but not available on this machine");
+    assert_eq!(kind, DiscoveryErrorKind::GpuPermanent);
+}
+
+// ============================================================================
+// classify_error — Data validation errors
+// ============================================================================
+
+#[test]
+fn parse_failure_is_classified_as_data_validation() {
+    let kind = classify_error("Failed to parse input JSON: expected value at line 1");
+    assert_eq!(kind, DiscoveryErrorKind::DataValidation);
+    assert!(
+        !kind.is_retryable(),
+        "Data validation errors should not be retryable"
+    );
+}
+
+#[test]
+fn null_input_is_classified_as_data_validation() {
+    let kind = classify_error("Null input pointer");
+    assert_eq!(kind, DiscoveryErrorKind::DataValidation);
+}
+
+#[test]
+fn invalid_utf8_is_classified_as_data_validation() {
+    let kind = classify_error("Invalid UTF-8 in input");
+    assert_eq!(kind, DiscoveryErrorKind::DataValidation);
+}
+
+// ============================================================================
+// classify_error — Timeout errors
+// ============================================================================
+
+#[test]
+fn deadline_exceeded_is_classified_as_timeout() {
+    let kind = classify_error("Analysis deadline exceeded after 30000ms");
+    assert_eq!(kind, DiscoveryErrorKind::Timeout);
+    assert!(kind.is_retryable(), "Timeout errors should be retryable");
+}
+
+#[test]
+fn timed_out_is_classified_as_timeout() {
+    let kind = classify_error("Operation timed out");
+    assert_eq!(kind, DiscoveryErrorKind::Timeout);
+}
+
+// ============================================================================
+// classify_error — Memory exhaustion
+// ============================================================================
+
+#[test]
+fn out_of_memory_is_classified_as_memory_exhausted() {
+    let kind = classify_error("Out of memory allocating GPU buffer");
+    assert_eq!(kind, DiscoveryErrorKind::MemoryExhausted);
+    assert!(kind.is_retryable(), "Memory exhaustion should be retryable");
+}
+
+#[test]
+fn allocation_failed_is_classified_as_memory_exhausted() {
+    let kind = classify_error("allocation failed: not enough memory");
+    assert_eq!(kind, DiscoveryErrorKind::MemoryExhausted);
+}
+
+// ============================================================================
+// classify_error — I/O errors
+// ============================================================================
+
+#[test]
+fn parquet_error_is_classified_as_io() {
+    let kind = classify_error("Failed to read parquet file: corrupted footer");
+    assert_eq!(kind, DiscoveryErrorKind::IoError);
+    assert!(kind.is_retryable(), "I/O errors should be retryable");
+}
+
+#[test]
+fn file_not_found_is_classified_as_io() {
+    let kind = classify_error("File not found: /tmp/records.parquet");
+    assert_eq!(kind, DiscoveryErrorKind::IoError);
+}
+
+// ============================================================================
+// classify_error — Internal panic
+// ============================================================================
+
+#[test]
+fn panic_classification_returns_internal_panic() {
+    let kind = classify_panic();
+    assert_eq!(kind, DiscoveryErrorKind::InternalPanic);
+    assert!(
+        !kind.is_retryable(),
+        "Internal panics should not be retryable"
+    );
+}
+
+// ============================================================================
+// classify_error — Unknown errors
+// ============================================================================
+
+#[test]
+fn unrecognised_error_is_classified_as_unknown() {
+    let kind = classify_error("Something completely unexpected happened");
+    assert_eq!(kind, DiscoveryErrorKind::Unknown);
+    assert!(
+        !kind.is_retryable(),
+        "Unknown errors should not be retryable by default"
+    );
+}
+
+// ============================================================================
+// error_fields and no_error_fields helpers
+// ============================================================================
+
+#[test]
+fn error_fields_returns_classified_kind_and_retryable() {
+    let (kind, retryable) = error_fields("Device is lost");
+    assert_eq!(kind, Some(DiscoveryErrorKind::GpuTransient));
+    assert_eq!(retryable, Some(true));
+}
+
+#[test]
+fn error_fields_returns_non_retryable_for_validation() {
+    let (kind, retryable) = error_fields("Failed to parse input JSON: unexpected token");
+    assert_eq!(kind, Some(DiscoveryErrorKind::DataValidation));
+    assert_eq!(retryable, Some(false));
+}
+
+#[test]
+fn no_error_fields_returns_none_for_both() {
+    let (kind, retryable) = no_error_fields();
+    assert_eq!(kind, None);
+    assert_eq!(retryable, None);
+}
+
+// ============================================================================
+// JSON serialisation of error kind
+// ============================================================================
+
+#[test]
+fn error_kind_serialises_as_snake_case_json() {
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::GpuTransient).unwrap(),
+        "\"gpu_transient\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::GpuPermanent).unwrap(),
+        "\"gpu_permanent\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::DataValidation).unwrap(),
+        "\"data_validation\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::Timeout).unwrap(),
+        "\"timeout\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::MemoryExhausted).unwrap(),
+        "\"memory_exhausted\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::IoError).unwrap(),
+        "\"io_error\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::InternalPanic).unwrap(),
+        "\"internal_panic\""
+    );
+    assert_eq!(
+        serde_json::to_string(&DiscoveryErrorKind::Unknown).unwrap(),
+        "\"unknown\""
+    );
+}
+
+// ============================================================================
+// FFI response shape — verify error fields appear in JSON output
+// ============================================================================
+
+#[test]
+fn analyze_parallel_error_response_includes_error_classification() {
+    // Call analyze_parallel_internal with invalid JSON to trigger an error
+    let result = neat_ai_discovery::analyze_parallel_internal("not valid json");
+    let json_str = result.expect("Should return Ok with error JSON, not Err");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(value["success"], false);
+    assert!(value["error"].is_string(), "error field should be present");
+    assert_eq!(
+        value["errorKind"], "data_validation",
+        "Parse errors should be classified as data_validation"
+    );
+    assert_eq!(
+        value["retryable"], false,
+        "Data validation errors should not be retryable"
+    );
+}
+
+#[test]
+fn success_response_omits_error_classification_fields() {
+    // Use get_library_version_internal which always succeeds — verifies that
+    // success responses do not include error_kind or retryable fields.
+    let result = neat_ai_discovery::get_library_version_internal();
+    let json_str = result.expect("Version query should succeed");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(value["success"], true);
+    // Success: error_kind and retryable should be absent (skip_serializing_if = None)
+    assert!(
+        value.get("errorKind").is_none() || value["errorKind"].is_null(),
+        "Success response should not include errorKind"
+    );
+    assert!(
+        value.get("retryable").is_none() || value["retryable"].is_null(),
+        "Success response should not include retryable"
+    );
+}
+
+#[test]
+fn rank_focus_neurons_error_response_includes_error_classification() {
+    let result = neat_ai_discovery::rank_focus_neurons_internal("{invalid}");
+    let json_str = result.expect("Should return Ok with error JSON");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(value["success"], false);
+    assert_eq!(
+        value["errorKind"], "data_validation",
+        "Parse errors should be classified as data_validation"
+    );
+    assert_eq!(value["retryable"], false);
+}
+
+#[test]
+fn case_insensitive_error_classification() {
+    // Verify classification works regardless of case
+    assert_eq!(
+        classify_error("DEVICE IS LOST"),
+        DiscoveryErrorKind::GpuTransient
+    );
+    assert_eq!(
+        classify_error("OUT OF MEMORY"),
+        DiscoveryErrorKind::MemoryExhausted
+    );
+    assert_eq!(classify_error("TIMED OUT"), DiscoveryErrorKind::Timeout);
+}
+
+// ============================================================================
+// Backward compatibility — existing fields are preserved
+// ============================================================================
+
+#[test]
+fn existing_ffi_contract_preserved_with_additive_fields() {
+    // Verify that the error response still has the existing fields (success, error)
+    // and the new fields are additive.
+    let result = neat_ai_discovery::analyze_parallel_internal("{}");
+    let json_str = result.expect("Should return Ok with error JSON");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    // Existing contract fields must still be present
+    assert!(
+        value.get("success").is_some(),
+        "success field must be present"
+    );
+    assert!(
+        value.get("error").is_some(),
+        "error field must be present on failure"
+    );
+
+    // New fields are additive
+    assert!(
+        value.get("errorKind").is_some(),
+        "errorKind field should be present on failure"
+    );
+    assert!(
+        value.get("retryable").is_some(),
+        "retryable field should be present on failure"
+    );
+}


### PR DESCRIPTION
## Summary

Add structured error classification and retry strategy for transient failures. Closes #651.

All FFI error responses now include two new optional fields:
- `errorKind` — classifies the error (e.g., `gpu_transient`, `data_validation`, `timeout`, `memory_exhausted`, `io_error`, `gpu_permanent`, `internal_panic`, `unknown`)
- `retryable` — boolean indicating whether the controller should retry the operation

These fields are additive and backward-compatible: existing callers that do not read them are unaffected, while new callers can use them to make informed retry decisions.

### Error classification categories

| Kind | Retryable | Examples |
|------|-----------|----------|
| `gpu_transient` | Yes | Device lost, driver unresponsive, command buffer overflow |
| `gpu_permanent` | No | No GPU available, unsupported hardware |
| `data_validation` | No | Invalid JSON, null input, missing fields |
| `timeout` | Yes | Deadline exceeded, operation timed out |
| `memory_exhausted` | Yes | Out of memory, allocation failed |
| `io_error` | Yes | Parquet read failure, file not found |
| `internal_panic` | No | Caught panic at FFI boundary |
| `unknown` | No | Unclassified errors |

## Evidence

This is a backend/FFI change with no visual output. Correctness is verified through 26 integration tests and all existing unit tests in the `error_classification` module.

## Test plan

- Added `tests/issue_651_error_classification.rs` — 26 integration tests covering:
  - All 8 error kind classifications
  - Retryable/non-retryable correctness for each kind
  - `error_fields()` and `no_error_fields()` helper functions
  - JSON serialisation of error kinds (snake_case format)
  - FFI response shape verification (error fields present on failure, absent on success)
  - Backward compatibility (existing `success` and `error` fields preserved)
  - Case-insensitive error message classification
- Added unit tests in `src/ffi_types/error_classification.rs`
- Updated `tests/issue_337_candidate_type_contract.rs` to include new fields
- All existing tests continue to pass
- `./quality.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)