### PR TITLE
Add per-output error disaggregation detector for hidden neurons (#639)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.39.1"
+version = "0.40.0"
 edition = "2024"
 
 [lib]

--- a/docs/discoveries/output-conflict.md
+++ b/docs/discoveries/output-conflict.md
@@ -1,0 +1,110 @@
+# Output Conflict Detection
+
+[Back to Discovery Index](README.md) | **Source:** [`src/analysis/detection/output_conflict.rs`](../../src/analysis/detection/output_conflict.rs) | **Issue:** [#639](https://github.com/stSoftwareAU/NEAT-AI-Discovery/issues/639)
+
+---
+
+## The Problem
+
+A **per-output error conflict** occurs when a hidden neuron has a positive
+effect on some outputs but actively harms others. The net error may look
+acceptable, but the neuron is creating a cross-output tug-of-war.
+
+```
+  Hidden neuron "h1":
+    output-0 error contribution: -0.5  (helping — reducing error)
+    output-1 error contribution: +0.3  (harming — increasing error)
+                                 ────
+    Net effect:                  -0.2  (looks helpful overall)
+
+  But output-1 is being actively harmed!
+```
+
+### Why It Hurts the Creature's Score
+
+- **Hidden harm**: The net error masks the damage to individual outputs.
+  Summed-error metrics make the neuron appear beneficial when it is not.
+- **Training interference**: Gradient updates that improve one output's
+  contribution through this neuron may worsen another output.
+- **Structural limitation**: A single hidden neuron cannot simultaneously
+  optimise its contribution to outputs that require opposing effects.
+
+---
+
+## How We Detect It
+
+```
+  ┌────────────────────────────────────────────────────────────────┐
+  │  For each hidden neuron:                                       │
+  │                                                                │
+  │  1. Collect errors[0..n] across all observations               │
+  │  2. Compute mean error per output index                        │
+  │  3. Check for sign conflict:                                   │
+  │     - At least one output has mean error < -threshold (helped) │
+  │     - At least one output has mean error > +threshold (harmed) │
+  │  4. Compute conflict severity = max_positive × |min_negative|  │
+  │  5. Filter out weak conflicts (below significance threshold)   │
+  └────────────────────────────────────────────────────────────────┘
+```
+
+### Thresholds
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| Minimum significant error | 0.01 | Ignore noise-level error contributions |
+| Minimum samples | 10 | Ensure statistical reliability |
+| Minimum outputs | 2 | Conflict requires multiple outputs |
+
+---
+
+## What We Recommend
+
+### Strategy 1: Attenuate the harmful connection (SetWeight)
+
+When a direct synapse exists from the conflicting neuron to the harmed
+output, reduce its weight to 30% of the current value.
+
+```
+  Before:  h1 ──(w=0.8)──→ output-1 (harmed)
+  After:   h1 ──(w=0.24)──→ output-1 (reduced harm)
+```
+
+### Strategy 2: Add a compensating gating neuron (AddNeuron + AddSynapse)
+
+When the path to the harmed output is indirect, insert a compensating
+neuron that counteracts the harmful contribution.
+
+```
+  Before:  h1 ──→ ... ──→ output-1 (harmed)
+  After:   h1 ──(-w)──→ [gate] ──(1.0)──→ output-1
+```
+
+All recommendations are emitted as `CoordinatedStructuralCandidateJson`.
+
+---
+
+## Relationship to Other Modules
+
+| Module | Scope | Difference |
+|--------|-------|------------|
+| **Correlated error** | Output-neuron error correlations | Analyses correlations between output neurons, not hidden neuron per-output contributions |
+| **Output conflict** (this) | Hidden neuron per-output disaggregation | Analyses the `errors[0..n]` vector for hidden neurons to find cross-output sign conflicts |
+
+---
+
+## Example Scenario
+
+A creature with 2 outputs and 1 hidden neuron:
+
+```
+  input-1 ──→ hidden-1 ──→ output-0 (speech recognition)
+                        └──→ output-1 (noise classification)
+```
+
+Over 50 training samples, `hidden-1` consistently:
+- Reduces error on output-0 by ~0.5 (mean error = -0.5)
+- Increases error on output-1 by ~0.3 (mean error = +0.3)
+
+The detector flags `hidden-1` with:
+- `conflict_severity = 0.5 × 0.3 = 0.15`
+- Recommends attenuating the synapse to output-1

--- a/docs/pr-summary-639.md
+++ b/docs/pr-summary-639.md
@@ -1,0 +1,31 @@
+## Summary
+
+Add per-output error disaggregation detector for hidden neurons. This new detection module analyses the full `errors[0..n]` vector for each hidden neuron to identify cross-output conflicts — cases where a neuron helps some outputs but actively harms others. Closes #639.
+
+### What changed
+
+- **New detection module** `src/analysis/detection/output_conflict.rs`: Computes per-output mean error for each hidden neuron and flags those with sign conflicts (negative on some outputs, positive on others). Produces `CoordinatedStructuralCandidateJson` candidates recommending either weight attenuation (SetWeight) or compensating gating neurons (AddNeuron + AddSynapse).
+- **Dispatch wiring** in `src/analysis/module_dispatch_specs/structural_specs.rs`: The module runs in parallel with other structural discovery modules, loading hidden neuron records from the shared cache.
+- **Module registration** in `src/analysis/detection/mod.rs` and `src/analysis/mod.rs`: Re-exported at the analysis level for backward compatibility.
+
+## Evidence
+
+This is a backend detection module with no UI. Verified by 11 integration tests covering all acceptance criteria.
+
+## Test Plan
+
+Added `tests/issue_639_output_conflict_detection.rs` with 11 tests:
+
+1. `test_conflicting_hidden_neuron_detected` — hidden neuron helping one output but harming another is flagged
+2. `test_consistently_helpful_not_flagged` — uniformly helpful neuron is not flagged
+3. `test_only_hidden_neurons_analysed` — input/output neurons excluded
+4. `test_insufficient_samples_no_detection` — below minimum sample threshold
+5. `test_single_output_no_detection` — single-output networks produce no detections
+6. `test_produces_valid_coordinated_candidates` — valid structural candidates generated
+7. `test_multiple_conflicting_neurons_all_flagged` — multiple conflicts all detected
+8. `test_weak_conflict_not_flagged` — noise-level conflicts ignored
+9. `test_results_sorted_by_severity` — worst conflicts ranked first
+10. `test_empty_records_no_detections` — empty input handled gracefully
+11. `test_three_output_partial_conflict` — partial conflict in 3-output network detected
+
+All tests pass. `./quality.sh` passes cleanly.

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -22,6 +22,7 @@ pub mod observation_utilisation;
 pub mod operating_point;
 pub mod opposing_synapse;
 pub mod oscillating_neuron;
+pub mod output_conflict;
 pub mod output_range_compression;
 pub mod output_squash_mismatch;
 pub mod redundant_path;

--- a/src/analysis/detection/output_conflict.rs
+++ b/src/analysis/detection/output_conflict.rs
@@ -1,0 +1,337 @@
+//! Per-output error disaggregation detector for hidden neurons (Issue #639).
+//!
+//! Identifies hidden neurons with conflicting per-output error contributions.
+//! A hidden neuron can have a net positive effect when errors are summed, but
+//! actively harm a specific output. For example, a hidden neuron might reduce
+//! error on output-0 by 0.5 but increase error on output-1 by 0.3 — its net
+//! effect looks positive, but it is actively harming output-1.
+//!
+//! ## Detection Method
+//!
+//! 1. For each hidden neuron, compute the mean error per output index across
+//!    all observations using `errors[0..n]`.
+//! 2. Check whether the sign of the mean error differs across outputs
+//!    (some negative = helping, some positive = harming).
+//! 3. Filter out weak conflicts where all per-output mean errors are near zero.
+//! 4. Rank by conflict severity: the product of the largest positive and
+//!    largest negative mean errors (higher magnitude = more severe).
+//!
+//! ## Recommended Actions
+//!
+//! When a conflicting hidden neuron is detected, we recommend:
+//! 1. **Add a gating synapse**: Insert a gating synapse so the neuron's
+//!    contribution to the harmed output is attenuated.
+//! 2. **Split the neuron**: Clone the neuron into output-specific copies,
+//!    each connected only to the outputs it helps.
+//!
+//! These are emitted as `CoordinatedStructuralCandidateJson` candidates.
+
+use std::collections::HashSet;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+
+/// Minimum absolute mean error per output to be considered significant.
+/// Below this, the error contribution is treated as noise.
+const MIN_SIGNIFICANT_ERROR: f32 = 0.01;
+
+/// Result of detecting a hidden neuron with conflicting per-output errors.
+#[derive(Debug, Clone)]
+pub struct OutputConflictNeuron {
+    /// UUID of the conflicting hidden neuron.
+    pub neuron_uuid: String,
+    /// Activation function of this neuron.
+    pub squash: String,
+    /// Bias of this neuron.
+    pub bias: f32,
+    /// Mean error contribution per output index.
+    /// Negative means helping (reducing error), positive means harming.
+    pub per_output_mean_error: Vec<f32>,
+    /// Severity of the conflict: product of max positive and |max negative| mean errors.
+    pub conflict_severity: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Estimated creature score improvement from resolving the conflict.
+    pub estimated_improvement: f32,
+}
+
+/// Detect hidden neurons with conflicting per-output error contributions.
+///
+/// Analyses the full `errors` vector (not just `errors[0]`) for each hidden
+/// neuron to find cases where the neuron helps some outputs but harms others.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples.
+///
+/// # Returns
+/// A list of `OutputConflictNeuron` sorted by conflict severity (worst first).
+pub fn detect_output_conflict_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<OutputConflictNeuron> {
+    // Need at least 2 outputs for cross-output conflict
+    if creature.output < 2 {
+        return Vec::new();
+    }
+
+    // Identify hidden neuron UUIDs
+    let hidden_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if hidden_uuids.is_empty() {
+        return Vec::new();
+    }
+
+    // Build a lookup from UUID to neuron info
+    let neuron_info: std::collections::HashMap<&str, (&str, f32)> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), (n.squash.as_str(), n.bias)))
+        .collect();
+
+    let mut results: Vec<OutputConflictNeuron> = Vec::new();
+
+    for (uuid, records) in neuron_records {
+        // Only analyse hidden neurons
+        if !hidden_uuids.contains(uuid.as_str()) {
+            continue;
+        }
+
+        // Need sufficient samples
+        if records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Determine the number of output error channels from the records.
+        // Use the first record with non-empty errors to determine channel count.
+        let num_outputs = match records.iter().find(|r| !r.errors.is_empty()) {
+            Some(r) => r.errors.len(),
+            None => continue,
+        };
+
+        // Need at least 2 error channels for conflict detection
+        if num_outputs < 2 {
+            continue;
+        }
+
+        // Compute mean error per output index
+        let mut sum_errors = vec![0.0_f32; num_outputs];
+        let mut count = 0_usize;
+
+        for r in records {
+            if r.errors.len() >= num_outputs {
+                for (idx, &err) in r.errors.iter().enumerate().take(num_outputs) {
+                    sum_errors[idx] += err;
+                }
+                count += 1;
+            }
+        }
+
+        if count < MIN_SAMPLES {
+            continue;
+        }
+
+        let mean_errors: Vec<f32> = sum_errors.iter().map(|&s| s / count as f32).collect();
+
+        // Check for sign conflict: at least one negative and one positive mean error
+        let has_negative = mean_errors.iter().any(|&e| e < -MIN_SIGNIFICANT_ERROR);
+        let has_positive = mean_errors.iter().any(|&e| e > MIN_SIGNIFICANT_ERROR);
+
+        if !has_negative || !has_positive {
+            continue;
+        }
+
+        // Compute conflict severity: max positive × |min negative|
+        let max_positive = mean_errors
+            .iter()
+            .copied()
+            .filter(|&e| e > 0.0)
+            .fold(0.0_f32, f32::max);
+        let max_negative_abs = mean_errors
+            .iter()
+            .copied()
+            .filter(|&e| e < 0.0)
+            .map(|e| e.abs())
+            .fold(0.0_f32, f32::max);
+
+        let conflict_severity = max_positive * max_negative_abs;
+
+        // Look up neuron info
+        let (squash, bias) = neuron_info
+            .get(uuid.as_str())
+            .copied()
+            .unwrap_or(("IDENTITY", 0.0));
+
+        // Estimated improvement: addressing the conflict could reduce the harmed output's
+        // error contribution. Use the mean of the positive (harmful) errors as estimate.
+        let harmful_mean: f32 = mean_errors.iter().filter(|&&e| e > 0.0).sum::<f32>()
+            / mean_errors.iter().filter(|&&e| e > 0.0).count().max(1) as f32;
+        let estimated_improvement = harmful_mean * 0.1; // conservative 10% capture
+
+        results.push(OutputConflictNeuron {
+            neuron_uuid: uuid.clone(),
+            squash: squash.to_string(),
+            bias,
+            per_output_mean_error: mean_errors,
+            conflict_severity,
+            sample_count: count,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by conflict severity (worst first)
+    results.sort_by(|a, b| b.conflict_severity.total_cmp(&a.conflict_severity));
+
+    results
+}
+
+/// Generate a deterministic UUID for a split neuron.
+fn split_neuron_uuid(original_uuid: &str, output_index: usize) -> String {
+    let key = format!("output-conflict-split|{original_uuid}|{output_index}");
+    // FNV-1a 64-bit
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in key.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("ocs-{hash:016x}")
+}
+
+/// Convert output conflict detections into coordinated structural candidates.
+///
+/// For each conflicting neuron, produces a candidate that adds a gating synapse
+/// to attenuate the neuron's contribution to the harmed output(s).
+///
+/// # Arguments
+/// * `conflicts` - Detected output conflict neurons.
+/// * `creature` - The creature topology.
+pub fn output_conflicts_to_coordinated_candidates(
+    conflicts: &[OutputConflictNeuron],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    // Find output neuron UUIDs in order
+    let output_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Find the first output neuron UUID for insert_before placement
+    let first_output_uuid = output_uuids.first().map(|s| s.to_string());
+
+    let mut results = Vec::new();
+
+    for conflict in conflicts {
+        // Strategy: add a new gating neuron that routes the original neuron's
+        // output only to the helped outputs, bypassing the harmed ones.
+        // We create a split: a new hidden neuron connected only to the harmed outputs
+        // with a corrective weight.
+
+        let mut operations = Vec::new();
+
+        // Identify which outputs are harmed (positive mean error)
+        let harmed_outputs: Vec<(usize, f32)> = conflict
+            .per_output_mean_error
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| **e > MIN_SIGNIFICANT_ERROR)
+            .map(|(i, &e)| (i, e))
+            .collect();
+
+        // Find which existing synapses connect this neuron to the harmed outputs
+        let existing_synapses: Vec<&crate::SynapseJson> = creature
+            .synapses
+            .iter()
+            .filter(|s| s.from_uuid == conflict.neuron_uuid)
+            .collect();
+
+        // For each harmed output, adjust the synapse weight to reduce the harm
+        for &(output_idx, harm_magnitude) in &harmed_outputs {
+            if output_idx >= output_uuids.len() {
+                continue;
+            }
+            let output_uuid = output_uuids[output_idx];
+
+            // Check if there's a direct synapse from the conflicting neuron to this output
+            if let Some(syn) = existing_synapses.iter().find(|s| s.to_uuid == output_uuid) {
+                // Reduce the weight toward zero to attenuate harm
+                let reduced_weight = syn.weight * 0.3; // reduce to 30%
+                operations.push(CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: conflict.neuron_uuid.clone(),
+                    to_neuron_uuid: output_uuid.to_string(),
+                    weight: reduced_weight,
+                });
+            } else {
+                // No direct synapse — add a compensating neuron between the
+                // conflicting hidden neuron and the harmed output
+                let new_uuid = split_neuron_uuid(&conflict.neuron_uuid, output_idx);
+
+                operations.push(CoordinatedStructuralOpJson::AddNeuron {
+                    neuron_uuid: new_uuid.clone(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                    insert_before_neuron_uuid: first_output_uuid.clone(),
+                });
+
+                // Connect: conflicting neuron → new gating neuron
+                operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: conflict.neuron_uuid.clone(),
+                    to_neuron_uuid: new_uuid.clone(),
+                    weight: -harm_magnitude * 0.5,
+                });
+
+                // Connect: new gating neuron → harmed output
+                operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                    from_neuron_uuid: new_uuid,
+                    to_neuron_uuid: output_uuid.to_string(),
+                    weight: 1.0,
+                });
+            }
+        }
+
+        if operations.is_empty() {
+            continue;
+        }
+
+        let helped_outputs: Vec<usize> = conflict
+            .per_output_mean_error
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| **e < -MIN_SIGNIFICANT_ERROR)
+            .map(|(i, _)| i)
+            .collect();
+
+        let harmed_indices: Vec<usize> = harmed_outputs.iter().map(|&(i, _)| i).collect();
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: conflict.estimated_improvement,
+            comment: Some(format!(
+                "Output conflict on hidden neuron {}: helps output(s) {:?}, harms output(s) {:?} \
+                 (severity {:.3}, {} samples)",
+                conflict.neuron_uuid,
+                helped_outputs,
+                harmed_indices,
+                conflict.conflict_severity,
+                conflict.sample_count,
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -76,6 +76,7 @@ pub use detection::observation_utilisation;
 pub use detection::operating_point;
 pub use detection::opposing_synapse;
 pub use detection::oscillating_neuron;
+pub use detection::output_conflict;
 pub use detection::output_range_compression;
 pub use detection::output_squash_mismatch;
 pub use detection::redundant_path;

--- a/src/analysis/module_dispatch_specs/structural_specs.rs
+++ b/src/analysis/module_dispatch_specs/structural_specs.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use super::super::{
-    cache, correlated_error, discovery_dispatch, hard_sample_cluster, multi_hop, skip_connection,
-    topology, topology_diversification,
+    cache, correlated_error, discovery_dispatch, hard_sample_cluster, multi_hop, output_conflict,
+    skip_connection, topology, topology_diversification,
 };
 
 /// Append structural discovery module specs to the provided vector.
@@ -151,6 +151,42 @@ pub(crate) fn append_structural_specs(
                     return None;
                 }
                 let candidates = skip_connection::skip_connections_to_coordinated_candidates(
+                    &detected, &creature,
+                );
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #639: Per-output error disaggregation for hidden neurons
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "output conflict detection".to_string(),
+            phase_name: "output_conflict_detection",
+            detect_fn: Box::new(move || {
+                if hidden.is_empty() {
+                    return None;
+                }
+                let output_count = creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "output")
+                    .count();
+                if output_count < 2 {
+                    return None;
+                }
+                let records = cache.load_records_for_neuron_types(&creature, &["hidden"]);
+                let detected = output_conflict::detect_output_conflict_neurons(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates = output_conflict::output_conflicts_to_coordinated_candidates(
                     &detected, &creature,
                 );
                 Some(discovery_dispatch::DiscoveryDetectionResult {

--- a/tests/issue_639_output_conflict_detection.rs
+++ b/tests/issue_639_output_conflict_detection.rs
@@ -1,0 +1,419 @@
+//! Tests for Issue #639: Per-output error disaggregation detector for hidden neurons.
+//!
+//! Detects hidden neurons with conflicting per-output error contributions.
+//! A hidden neuron might reduce error on output-0 but increase error on output-1,
+//! meaning its net positive effect masks harm to a specific output.
+//!
+//! ## TDD Plan
+//! 1. Hidden neuron helping one output but harming another SHOULD be flagged
+//! 2. Hidden neuron consistently helpful across all outputs should NOT be flagged
+//! 3. Only hidden neurons are analysed (input/output neurons excluded)
+//! 4. Insufficient samples produce no detections
+//! 5. Single-output networks produce no detections (no conflict possible)
+//! 6. Produces valid coordinated structural candidates
+//! 7. Multiple conflicting hidden neurons — all flagged
+//! 8. Hidden neuron with mixed but weak conflicts should NOT be flagged
+//! 9. Results sorted by conflict severity (worst first)
+//! 10. Empty records produce no detections
+
+use neat_ai_discovery::analysis::detection::output_conflict::{
+    OutputConflictNeuron, detect_output_conflict_neurons,
+    output_conflicts_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a DiscoverRecord with multi-output errors.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Build a two-output creature with one hidden neuron.
+fn two_output_creature() -> CreatureJson {
+    make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-0", 0.8),
+            synapse("hidden-1", "output-1", -0.3),
+        ],
+    )
+}
+
+/// Test 1: Hidden neuron that helps output-0 but harms output-1 should be flagged.
+///
+/// When a hidden neuron is active, error on output-0 decreases (negative error contribution)
+/// but error on output-1 increases (positive error contribution). The sign conflict should
+/// be detected.
+#[test]
+fn test_conflicting_hidden_neuron_detected() {
+    let creature = two_output_creature();
+
+    // hidden-1: when active, reduces error on output-0 but increases error on output-1
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.4;
+            // errors[0] negative (helping), errors[1] positive (harming)
+            record("hidden-1", i, activation, vec![-0.5, 0.3])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        !detected.is_empty(),
+        "Hidden neuron helping output-0 but harming output-1 should be flagged"
+    );
+    assert_eq!(detected[0].neuron_uuid, "hidden-1");
+}
+
+/// Test 2: Hidden neuron consistently helpful across all outputs should NOT be flagged.
+#[test]
+fn test_consistently_helpful_not_flagged() {
+    let creature = two_output_creature();
+
+    // hidden-1: reduces error on both outputs (both negative)
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.4;
+            record("hidden-1", i, activation, vec![-0.3, -0.2])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.is_empty(),
+        "Consistently helpful hidden neuron should NOT be flagged"
+    );
+}
+
+/// Test 3: Only hidden neurons should be analysed.
+#[test]
+fn test_only_hidden_neurons_analysed() {
+    let creature = two_output_creature();
+
+    // Input neuron with conflicting errors — should be ignored
+    let input_records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("input-1", i, 0.5, vec![-0.5, 0.3]))
+        .collect();
+
+    // Output neuron with conflicting errors — should be ignored
+    let output_records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("output-0", i, 0.5, vec![-0.5, 0.3]))
+        .collect();
+
+    let neuron_records = vec![
+        ("input-1".to_string(), input_records),
+        ("output-0".to_string(), output_records),
+    ];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.is_empty(),
+        "Input and output neurons should not be analysed for output conflicts"
+    );
+}
+
+/// Test 4: Insufficient samples produce no detections.
+#[test]
+fn test_insufficient_samples_no_detection() {
+    let creature = two_output_creature();
+
+    // Only 5 samples — below minimum threshold
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| record("hidden-1", i, 0.5, vec![-0.5, 0.3]))
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.is_empty(),
+        "Insufficient samples should produce no detections"
+    );
+}
+
+/// Test 5: Single-output networks produce no detections.
+#[test]
+fn test_single_output_no_detection() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-0", 0.8),
+        ],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-1", i, 0.5, vec![-0.5]))
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.is_empty(),
+        "Single-output network cannot have output conflicts"
+    );
+}
+
+/// Test 6: Produces valid coordinated structural candidates.
+#[test]
+fn test_produces_valid_coordinated_candidates() {
+    let creature = two_output_creature();
+
+    let detected = vec![OutputConflictNeuron {
+        neuron_uuid: "hidden-1".to_string(),
+        squash: "TANH".to_string(),
+        bias: 0.0,
+        per_output_mean_error: vec![-0.5, 0.3],
+        conflict_severity: 0.8,
+        sample_count: 50,
+        estimated_improvement: 0.05,
+    }];
+
+    let candidates = output_conflicts_to_coordinated_candidates(&detected, &creature);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should produce at least one coordinated candidate"
+    );
+
+    for c in &candidates {
+        assert!(
+            c.expected_creature_score_gain > 0.0,
+            "Expected improvement should be positive"
+        );
+        assert!(c.comment.is_some(), "Should have a descriptive comment");
+        assert!(
+            !c.operations.is_empty(),
+            "Should have at least one structural operation"
+        );
+    }
+}
+
+/// Test 7: Multiple conflicting hidden neurons — all flagged.
+#[test]
+fn test_multiple_conflicting_neurons_all_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("hidden-2", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("input-1", "hidden-2", 0.5),
+            synapse("hidden-1", "output-0", 0.8),
+            synapse("hidden-1", "output-1", -0.3),
+            synapse("hidden-2", "output-0", -0.4),
+            synapse("hidden-2", "output-1", 0.6),
+        ],
+    );
+
+    let records_1: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-1", i, 0.5, vec![-0.5, 0.3]))
+        .collect();
+
+    let records_2: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-2", i, 0.4, vec![0.4, -0.6]))
+        .collect();
+
+    let neuron_records = vec![
+        ("hidden-1".to_string(), records_1),
+        ("hidden-2".to_string(), records_2),
+    ];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.len() >= 2,
+        "Both conflicting hidden neurons should be flagged, got {}",
+        detected.len()
+    );
+
+    let uuids: Vec<&str> = detected.iter().map(|d| d.neuron_uuid.as_str()).collect();
+    assert!(uuids.contains(&"hidden-1"), "hidden-1 should be flagged");
+    assert!(uuids.contains(&"hidden-2"), "hidden-2 should be flagged");
+}
+
+/// Test 8: Hidden neuron with mixed but weak conflicts should NOT be flagged.
+///
+/// If the per-output mean errors have opposing signs but are very small,
+/// the conflict is not significant enough to warrant structural changes.
+#[test]
+fn test_weak_conflict_not_flagged() {
+    let creature = two_output_creature();
+
+    // Very small opposing errors — noise, not real conflict
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| {
+            let activation = 0.3 + (i as f32 / 49.0) * 0.4;
+            record("hidden-1", i, activation, vec![-0.001, 0.002])
+        })
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.is_empty(),
+        "Very weak conflicts should not be flagged"
+    );
+}
+
+/// Test 9: Results sorted by conflict severity (worst first).
+#[test]
+fn test_results_sorted_by_severity() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-mild", "hidden", "TANH", 0.0),
+            neuron("hidden-severe", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-mild", 0.5),
+            synapse("input-1", "hidden-severe", 0.5),
+            synapse("hidden-mild", "output-0", 0.5),
+            synapse("hidden-mild", "output-1", -0.2),
+            synapse("hidden-severe", "output-0", 0.8),
+            synapse("hidden-severe", "output-1", -0.8),
+        ],
+    );
+
+    // hidden-mild: mild conflict
+    let records_mild: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-mild", i, 0.5, vec![-0.1, 0.05]))
+        .collect();
+
+    // hidden-severe: severe conflict
+    let records_severe: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-severe", i, 0.5, vec![-0.8, 0.7]))
+        .collect();
+
+    let neuron_records = vec![
+        ("hidden-mild".to_string(), records_mild),
+        ("hidden-severe".to_string(), records_severe),
+    ];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        detected.len() >= 2,
+        "Should detect both conflicting neurons"
+    );
+
+    // Most severe conflict should be first
+    assert!(
+        detected[0].conflict_severity >= detected[1].conflict_severity,
+        "Results should be sorted by severity (highest first), got {:.3} then {:.3}",
+        detected[0].conflict_severity,
+        detected[1].conflict_severity
+    );
+}
+
+/// Test 10: Empty records produce no detections.
+#[test]
+fn test_empty_records_no_detections() {
+    let creature = two_output_creature();
+
+    let detected = detect_output_conflict_neurons(&creature, &[]);
+
+    assert!(
+        detected.is_empty(),
+        "Empty records should produce no detections"
+    );
+}
+
+/// Test 11: Three-output network with conflict on only one output.
+#[test]
+fn test_three_output_partial_conflict() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "TANH", 0.0),
+            neuron("output-1", "output", "TANH", 0.0),
+            neuron("output-2", "output", "TANH", 0.0),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-0", 0.8),
+            synapse("hidden-1", "output-1", 0.5),
+            synapse("hidden-1", "output-2", -0.6),
+        ],
+    );
+
+    // Helps output-0 and output-1, harms output-2
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-1", i, 0.5, vec![-0.3, -0.2, 0.4]))
+        .collect();
+
+    let neuron_records = vec![("hidden-1".to_string(), records)];
+
+    let detected = detect_output_conflict_neurons(&creature, &neuron_records);
+
+    assert!(
+        !detected.is_empty(),
+        "Hidden neuron with sign conflict across 3 outputs should be flagged"
+    );
+    assert_eq!(detected[0].per_output_mean_error.len(), 3);
+}


### PR DESCRIPTION
## Summary

Add per-output error disaggregation detector for hidden neurons. This new detection module analyses the full `errors[0..n]` vector for each hidden neuron to identify cross-output conflicts — cases where a neuron helps some outputs but actively harms others. Closes #639.

### What changed

- **New detection module** `src/analysis/detection/output_conflict.rs`: Computes per-output mean error for each hidden neuron and flags those with sign conflicts (negative on some outputs, positive on others). Produces `CoordinatedStructuralCandidateJson` candidates recommending either weight attenuation (SetWeight) or compensating gating neurons (AddNeuron + AddSynapse).
- **Dispatch wiring** in `src/analysis/module_dispatch_specs/structural_specs.rs`: The module runs in parallel with other structural discovery modules, loading hidden neuron records from the shared cache.
- **Module registration** in `src/analysis/detection/mod.rs` and `src/analysis/mod.rs`: Re-exported at the analysis level for backward compatibility.

## Evidence

This is a backend detection module with no UI. Verified by 11 integration tests covering all acceptance criteria.

## Test Plan

Added `tests/issue_639_output_conflict_detection.rs` with 11 tests:

1. `test_conflicting_hidden_neuron_detected` — hidden neuron helping one output but harming another is flagged
2. `test_consistently_helpful_not_flagged` — uniformly helpful neuron is not flagged
3. `test_only_hidden_neurons_analysed` — input/output neurons excluded
4. `test_insufficient_samples_no_detection` — below minimum sample threshold
5. `test_single_output_no_detection` — single-output networks produce no detections
6. `test_produces_valid_coordinated_candidates` — valid structural candidates generated
7. `test_multiple_conflicting_neurons_all_flagged` — multiple conflicts all detected
8. `test_weak_conflict_not_flagged` — noise-level conflicts ignored
9. `test_results_sorted_by_severity` — worst conflicts ranked first
10. `test_empty_records_no_detections` — empty input handled gracefully
11. `test_three_output_partial_conflict` — partial conflict in 3-output network detected

All tests pass. `./quality.sh` passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)