### PR TITLE
Add fan-in weight polarity conflict detector (#641)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.40.2"
+version = "0.40.3"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.40.3"
+version = "0.41.0"
 edition = "2024"
 
 [lib]

--- a/docs/pr-summary-641.md
+++ b/docs/pr-summary-641.md
@@ -1,0 +1,35 @@
+## Summary
+
+Add a fan-in weight polarity conflict detector that identifies hidden neurons
+whose incoming synapses have sharply conflicting polarities — strongly positive
+weights fighting strongly negative weights of similar magnitude. When this
+occurs, most of the input signal cancels out, wasting representational capacity.
+
+The detector produces coordinated structural candidates (`addNeuron` +
+`addSynapse` + `removeSynapse`) to split the minority-polarity pathway into a
+separate neuron, eliminating the internal cancellation.
+
+This is distinct from:
+- `opposing_synapse.rs` — detects same-source opposing pairs (narrow case)
+- `weight_coherence.rs` — checks ratio consistency and correlated-source cancellation
+
+Closes #641.
+
+## Evidence
+
+This is a backend detection module with no UI component. Correctness is verified
+by the integration test suite below.
+
+## Test Plan
+
+- Added `tests/issue_641_fanin_polarity_conflict.rs` with 8 tests:
+  1. Detects clear polarity conflict (balanced positive/negative fan-in)
+  2. Healthy same-sign fan-in produces no candidates
+  3. Tiny opposing weight is not flagged (below threshold)
+  4. Candidate proposes `addNeuron` to split positive/negative pathways
+  5. Insufficient samples produce no candidates
+  6. Empty records produce no candidates
+  7. Only hidden neurons are flagged (input/output excluded)
+  8. Candidates sorted by conflict score (worst first)
+- All existing tests continue to pass
+- `./quality.sh` passes cleanly

--- a/src/analysis/detection/fanin_polarity_conflict.rs
+++ b/src/analysis/detection/fanin_polarity_conflict.rs
@@ -1,0 +1,301 @@
+//! Fan-in weight polarity conflict detector (Issue #641).
+//!
+//! Identifies hidden neurons whose incoming synapses have sharply conflicting
+//! polarities — strongly positive weights fighting strongly negative weights.
+//! When this happens, most of the input signal cancels out, wasting
+//! representational capacity.
+//!
+//! ## How it differs from related modules
+//!
+//! - `opposing_synapse.rs` detects two synapses from the *same source* to the
+//!   *same target* with opposing signs — a narrow, per-synapse case.
+//! - `weight_coherence.rs` checks incoming/outgoing weight *ratio* consistency
+//!   and symmetric cancellation of *correlated* sources.
+//! - This module detects the general case: the entire fan-in is in fundamental
+//!   polarity tension regardless of source identity or correlation.
+//!
+//! ## Detection
+//!
+//! For each hidden neuron:
+//! 1. Partition incoming synapse weights by sign.
+//! 2. Compute `conflict_score = min(|positive_sum|, |negative_sum|) / max(…)`.
+//!    A score of 1.0 means perfect cancellation; 0.0 means no conflict.
+//! 3. Flag neurons where the conflict score exceeds a threshold and both groups
+//!    have meaningful total magnitude.
+//!
+//! ## Recommended action
+//!
+//! Produce a `coordinatedStructural` candidate with `addNeuron` to split the
+//! positive and negative pathways into separate neurons, plus `addSynapse` ops
+//! to wire the new neuron into the network.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+/// Minimum conflict score to flag a neuron (ratio of minority to majority group).
+/// 0.4 means the smaller-magnitude group is at least 40% of the larger group.
+const MIN_CONFLICT_SCORE: f32 = 0.4;
+
+/// Minimum total absolute weight across all incoming synapses to consider
+/// meaningful. Very small weights are not worth flagging.
+const MIN_TOTAL_WEIGHT_MAGNITUDE: f32 = 1.0;
+
+/// Minimum number of incoming synapses required for conflict analysis.
+/// A neuron with fewer than 2 incoming synapses cannot have polarity conflict.
+const MIN_INCOMING_SYNAPSES: usize = 2;
+
+// =============================================================================
+// Candidate type
+// =============================================================================
+
+/// A hidden neuron whose incoming synapses exhibit polarity conflict.
+#[derive(Debug, Clone)]
+pub struct FaninPolarityConflictCandidate {
+    /// UUID of the conflicted hidden neuron.
+    pub neuron_uuid: String,
+    /// Sum of positive incoming weights.
+    pub positive_weight_sum: f32,
+    /// Sum of absolute negative incoming weights.
+    pub negative_weight_sum: f32,
+    /// Number of positive incoming synapses.
+    pub positive_count: usize,
+    /// Number of negative incoming synapses.
+    pub negative_count: usize,
+    /// Conflict score: min(pos_sum, neg_sum) / max(pos_sum, neg_sum).
+    pub conflict_score: f32,
+    /// Number of samples available for this neuron.
+    pub sample_count: usize,
+    /// Estimated improvement from reorganising the fan-in.
+    pub estimated_improvement: f32,
+}
+
+// =============================================================================
+// Detection
+// =============================================================================
+
+/// Detect hidden neurons with sharply conflicting incoming synapse polarities.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology.
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded data.
+///
+/// # Returns
+/// A list of `FaninPolarityConflictCandidate` sorted by conflict score (worst first).
+pub fn detect_fanin_polarity_conflicts(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<FaninPolarityConflictCandidate> {
+    // Identify hidden neuron UUIDs
+    let hidden_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "hidden")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if hidden_uuids.is_empty() {
+        return Vec::new();
+    }
+
+    // Build records lookup for sample count validation
+    let records_map: HashMap<&str, usize> = neuron_records
+        .iter()
+        .map(|(uuid, recs)| (uuid.as_str(), recs.len()))
+        .collect();
+
+    // Group incoming synapses by target neuron
+    let mut incoming_by_target: HashMap<&str, Vec<f32>> = HashMap::new();
+    for synapse in &creature.synapses {
+        if hidden_uuids.contains(synapse.to_uuid.as_str()) {
+            incoming_by_target
+                .entry(synapse.to_uuid.as_str())
+                .or_default()
+                .push(synapse.weight);
+        }
+    }
+
+    let mut candidates = Vec::new();
+
+    for (neuron_uuid, weights) in &incoming_by_target {
+        // Need at least MIN_INCOMING_SYNAPSES incoming connections
+        if weights.len() < MIN_INCOMING_SYNAPSES {
+            continue;
+        }
+
+        // Need sufficient recorded samples
+        let sample_count = records_map.get(neuron_uuid).copied().unwrap_or(0);
+        if sample_count < MIN_DISCOVERY_SAMPLE_COUNT {
+            continue;
+        }
+
+        // Partition by sign
+        let positive_sum: f32 = weights.iter().filter(|w| **w > 0.0).sum();
+        let negative_sum: f32 = weights.iter().filter(|w| **w < 0.0).map(|w| w.abs()).sum();
+
+        // Both groups must have meaningful magnitude
+        let total_magnitude = positive_sum + negative_sum;
+        if total_magnitude < MIN_TOTAL_WEIGHT_MAGNITUDE {
+            continue;
+        }
+
+        // Skip if either group is empty (no conflict)
+        if positive_sum <= 0.0 || negative_sum <= 0.0 {
+            continue;
+        }
+
+        let positive_count = weights.iter().filter(|w| **w > 0.0).count();
+        let negative_count = weights.iter().filter(|w| **w < 0.0).count();
+
+        // Conflict score: ratio of minority to majority group
+        let conflict_score = positive_sum.min(negative_sum) / positive_sum.max(negative_sum);
+
+        if conflict_score < MIN_CONFLICT_SCORE {
+            continue;
+        }
+
+        // Estimated improvement scales with conflict severity and total magnitude
+        let estimated_improvement = 0.01 * conflict_score * (total_magnitude / 10.0).min(1.0);
+
+        candidates.push(FaninPolarityConflictCandidate {
+            neuron_uuid: neuron_uuid.to_string(),
+            positive_weight_sum: positive_sum,
+            negative_weight_sum: negative_sum,
+            positive_count,
+            negative_count,
+            conflict_score,
+            sample_count,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by conflict score descending (worst conflicts first)
+    candidates.sort_by(|a, b| b.conflict_score.total_cmp(&a.conflict_score));
+
+    candidates
+}
+
+// =============================================================================
+// Candidate conversion
+// =============================================================================
+
+/// Convert fan-in polarity conflict candidates to coordinated structural candidates.
+///
+/// Each candidate proposes splitting the conflicting fan-in by adding a new hidden
+/// neuron to handle the negative-polarity pathway, rewiring the negative incoming
+/// synapses to the new neuron, and connecting the new neuron to the original target.
+pub fn fanin_polarity_conflicts_to_coordinated_candidates(
+    candidates: &[FaninPolarityConflictCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    // Build incoming synapses lookup: target_uuid -> Vec<(from_uuid, weight)>
+    let mut incoming_synapses: HashMap<&str, Vec<(&str, f32)>> = HashMap::new();
+    for synapse in &creature.synapses {
+        incoming_synapses
+            .entry(synapse.to_uuid.as_str())
+            .or_default()
+            .push((synapse.from_uuid.as_str(), synapse.weight));
+    }
+
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        // Determine which group is the minority (to be split off)
+        let split_negative = c.negative_weight_sum <= c.positive_weight_sum;
+
+        // Get the synapses that will be rewired to the new neuron
+        let synapses_for_neuron = incoming_synapses
+            .get(c.neuron_uuid.as_str())
+            .cloned()
+            .unwrap_or_default();
+
+        let synapses_to_move: Vec<(&str, f32)> = if split_negative {
+            synapses_for_neuron
+                .iter()
+                .filter(|(_, w)| *w < 0.0)
+                .copied()
+                .collect()
+        } else {
+            synapses_for_neuron
+                .iter()
+                .filter(|(_, w)| *w > 0.0)
+                .copied()
+                .collect()
+        };
+
+        if synapses_to_move.is_empty() {
+            continue;
+        }
+
+        // Determine the activation function from the original neuron
+        let squash = creature
+            .neurons
+            .iter()
+            .find(|n| n.uuid == c.neuron_uuid)
+            .map(|n| n.squash.clone())
+            .unwrap_or_else(|| "TANH".to_string());
+
+        // Generate a deterministic UUID for the new neuron
+        let new_neuron_uuid = format!("fanin-split-{}", c.neuron_uuid);
+
+        let mut operations = Vec::new();
+
+        // 1. Add the new neuron (placed before the conflicted neuron)
+        operations.push(CoordinatedStructuralOpJson::AddNeuron {
+            neuron_uuid: new_neuron_uuid.clone(),
+            neuron_type: "hidden".to_string(),
+            squash,
+            bias: 0.0,
+            insert_before_neuron_uuid: Some(c.neuron_uuid.clone()),
+        });
+
+        // 2. Add synapses from the moved sources to the new neuron
+        for (from_uuid, weight) in &synapses_to_move {
+            operations.push(CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: from_uuid.to_string(),
+                to_neuron_uuid: new_neuron_uuid.clone(),
+                weight: *weight,
+            });
+        }
+
+        // 3. Connect the new neuron to the original target
+        operations.push(CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: new_neuron_uuid.clone(),
+            to_neuron_uuid: c.neuron_uuid.clone(),
+            weight: 1.0,
+        });
+
+        // 4. Remove the conflicting synapses from the original neuron
+        for (from_uuid, _) in &synapses_to_move {
+            operations.push(CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: from_uuid.to_string(),
+                to_neuron_uuid: c.neuron_uuid.clone(),
+            });
+        }
+
+        results.push(CoordinatedStructuralCandidateJson {
+            operations,
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Fan-in polarity conflict at {}: {} positive synapses (sum={:.2}) vs {} negative synapses (sum={:.2}), conflict score {:.3} — split minority pathway into separate neuron",
+                c.neuron_uuid,
+                c.positive_count,
+                c.positive_weight_sum,
+                c.negative_count,
+                c.negative_weight_sum,
+                c.conflict_score
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -14,6 +14,7 @@ pub mod correlated_error;
 pub mod dead_neuron;
 pub mod dormant_synapse;
 pub mod error_plateau;
+pub mod fanin_polarity_conflict;
 pub mod hard_sample_cluster;
 pub mod input_sensitivity;
 pub mod monotonicity;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -68,6 +68,7 @@ pub use detection::correlated_error;
 pub use detection::dead_neuron;
 pub use detection::dormant_synapse;
 pub use detection::error_plateau;
+pub use detection::fanin_polarity_conflict;
 pub use detection::hard_sample_cluster;
 pub use detection::input_sensitivity;
 pub use detection::monotonicity;

--- a/src/analysis/module_dispatch_specs/synapse_specs.rs
+++ b/src/analysis/module_dispatch_specs/synapse_specs.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use super::super::{
-    cache, discovery_dispatch, dormant_synapse, noise_signal, opposing_synapse, weight_coherence,
-    weight_magnitude_reset, weight_polarity_flip,
+    cache, discovery_dispatch, dormant_synapse, fanin_polarity_conflict, noise_signal,
+    opposing_synapse, weight_coherence, weight_magnitude_reset, weight_polarity_flip,
 };
 
 /// Append synapse-focused discovery module specs to the provided vector.
@@ -188,6 +188,36 @@ pub(crate) fn append_synapse_specs(
                 }
                 let candidates =
                     weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected);
+                Some(discovery_dispatch::DiscoveryDetectionResult {
+                    detected_count: detected.len(),
+                    candidates,
+                })
+            }),
+        });
+    }
+
+    // Issue #641: Fan-in weight polarity conflict detection
+    {
+        let cache = Arc::clone(shared_cache);
+        let hidden = Arc::clone(hidden_neurons);
+        let creature = Arc::clone(creature);
+        modules.push(discovery_dispatch::DiscoveryModuleSpec {
+            module_name: "fan-in polarity conflict detection".to_string(),
+            phase_name: "fanin_polarity_conflict_detection",
+            detect_fn: Box::new(move || {
+                if hidden.is_empty() {
+                    return None;
+                }
+                let records = cache.load_records_for_all_neurons(&creature);
+                let detected =
+                    fanin_polarity_conflict::detect_fanin_polarity_conflicts(&creature, &records);
+                if detected.is_empty() {
+                    return None;
+                }
+                let candidates =
+                    fanin_polarity_conflict::fanin_polarity_conflicts_to_coordinated_candidates(
+                        &detected, &creature,
+                    );
                 Some(discovery_dispatch::DiscoveryDetectionResult {
                     detected_count: detected.len(),
                     candidates,

--- a/tests/issue_641_fanin_polarity_conflict.rs
+++ b/tests/issue_641_fanin_polarity_conflict.rs
@@ -1,0 +1,414 @@
+//! Tests for Issue #641: Fan-in weight polarity conflict detector.
+//!
+//! When a hidden neuron receives incoming synapses with strongly positive weights
+//! and strongly negative weights of similar magnitude, the inputs fight each other.
+//! Most of the input signal cancels out, wasting representational capacity.
+//!
+//! This module detects the general case of "this neuron's incoming weights are in
+//! fundamental tension" — distinct from opposing_synapse (same-source pairs) and
+//! weight_coherence (ratio consistency).
+//!
+//! ## TDD Plan
+//! 1. Test detection of clear polarity conflict (balanced positive/negative fan-in)
+//! 2. Test healthy fan-in (same sign) produces no candidates
+//! 3. Test single-sign fan-in with one tiny opposing weight is not flagged
+//! 4. Test candidate proposes addNeuron to split positive/negative pathways
+//! 5. Test insufficient samples produce no candidates
+//! 6. Test empty records produce no candidates
+//! 7. Test input/output neurons are excluded (hidden only)
+//! 8. Test candidates sorted by conflict score
+
+mod common;
+
+use common::{hidden, make_creature, neuron, output, synapse};
+use neat_ai_discovery::analysis::detection::fanin_polarity_conflict::{
+    detect_fanin_polarity_conflicts, fanin_polarity_conflicts_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helper: create records with specified activations and errors
+// =============================================================================
+
+fn make_record(neuron_uuid: &str, obs_index: u32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn make_records(neuron_uuid: &str, count: u32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| make_record(neuron_uuid, i, (i as f32 + 1.0) / 10.0, 0.01))
+        .collect()
+}
+
+// =============================================================================
+// Test 1: Detects clear polarity conflict (balanced positive/negative fan-in)
+// =============================================================================
+
+/// A hidden neuron with five +2.0 synapses and three -2.0 synapses has strong
+/// internal cancellation. The conflict score should exceed the threshold.
+#[test]
+fn test_detects_clear_polarity_conflict() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("in-3", "input", "IDENTITY"),
+            neuron("in-4", "input", "IDENTITY"),
+            neuron("in-5", "input", "IDENTITY"),
+            neuron("in-6", "input", "IDENTITY"),
+            neuron("in-7", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            // Five positive incoming synapses
+            synapse("in-0", "h-0", 2.0),
+            synapse("in-1", "h-0", 2.0),
+            synapse("in-2", "h-0", 2.0),
+            synapse("in-3", "h-0", 2.0),
+            synapse("in-4", "h-0", 2.0),
+            // Three negative incoming synapses of similar magnitude
+            synapse("in-5", "h-0", -2.0),
+            synapse("in-6", "h-0", -2.0),
+            synapse("in-7", "h-0", -2.0),
+            // Outgoing synapse
+            synapse("h-0", "out-0", 1.0),
+        ],
+    );
+
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for i in 0..8 {
+        records.push((format!("in-{i}"), make_records(&format!("in-{i}"), 30)));
+    }
+    records.push(("h-0".to_string(), make_records("h-0", 30)));
+    records.push(("out-0".to_string(), make_records("out-0", 30)));
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect polarity conflict for hidden neuron with balanced opposing weights"
+    );
+
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "h-0");
+    assert!(
+        c.conflict_score > 0.0,
+        "Conflict score should be positive: got {}",
+        c.conflict_score
+    );
+    assert!(
+        c.positive_weight_sum > 0.0,
+        "Positive weight sum should be > 0"
+    );
+    assert!(
+        c.negative_weight_sum > 0.0,
+        "Negative weight sum (absolute) should be > 0"
+    );
+}
+
+// =============================================================================
+// Test 2: Healthy fan-in (same sign) produces no candidates
+// =============================================================================
+
+/// A hidden neuron with all positive incoming weights has no polarity conflict.
+#[test]
+fn test_healthy_fanin_no_conflict() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-0", "h-0", 2.0),
+            synapse("in-1", "h-0", 1.5),
+            synapse("in-2", "h-0", 3.0),
+            synapse("h-0", "out-0", 1.0),
+        ],
+    );
+
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for i in 0..3 {
+        records.push((format!("in-{i}"), make_records(&format!("in-{i}"), 30)));
+    }
+    records.push(("h-0".to_string(), make_records("h-0", 30)));
+    records.push(("out-0".to_string(), make_records("out-0", 30)));
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Healthy same-sign fan-in should produce no conflict candidates, got {}",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 3: One tiny opposing weight is not flagged
+// =============================================================================
+
+/// A fan-in with many positive weights and one small negative weight should
+/// not be flagged, because the conflict score is too low.
+#[test]
+fn test_tiny_opposing_weight_not_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("in-3", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-0", "h-0", 2.0),
+            synapse("in-1", "h-0", 2.0),
+            synapse("in-2", "h-0", 2.0),
+            synapse("in-3", "h-0", -0.1), // Tiny opposing weight
+            synapse("h-0", "out-0", 1.0),
+        ],
+    );
+
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for i in 0..4 {
+        records.push((format!("in-{i}"), make_records(&format!("in-{i}"), 30)));
+    }
+    records.push(("h-0".to_string(), make_records("h-0", 30)));
+    records.push(("out-0".to_string(), make_records("out-0", 30)));
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Tiny opposing weight should not trigger conflict, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 4: Candidate proposes addNeuron to split positive/negative pathways
+// =============================================================================
+
+/// The coordinated candidate should propose an addNeuron operation to split
+/// the conflicting pathways into separate neurons.
+#[test]
+fn test_candidate_proposes_add_neuron_split() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("in-3", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-0", "h-0", 2.0),
+            synapse("in-1", "h-0", 2.0),
+            synapse("in-2", "h-0", -2.0),
+            synapse("in-3", "h-0", -2.0),
+            synapse("h-0", "out-0", 1.0),
+        ],
+    );
+
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for i in 0..4 {
+        records.push((format!("in-{i}"), make_records(&format!("in-{i}"), 30)));
+    }
+    records.push(("h-0".to_string(), make_records("h-0", 30)));
+    records.push(("out-0".to_string(), make_records("out-0", 30)));
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+    assert!(!candidates.is_empty(), "Should detect conflict");
+
+    let coordinated = fanin_polarity_conflicts_to_coordinated_candidates(&candidates, &creature);
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    let coord = &coordinated[0];
+    assert!(
+        coord.expected_creature_score_gain > 0.0,
+        "Should have positive expected improvement"
+    );
+
+    // Should contain an AddNeuron operation
+    use neat_ai_discovery::CoordinatedStructuralOpJson;
+    let has_add_neuron = coord
+        .operations
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::AddNeuron { .. }));
+    assert!(
+        has_add_neuron,
+        "Coordinated candidate should include an addNeuron operation to split pathways"
+    );
+}
+
+// =============================================================================
+// Test 5: Insufficient samples produce no candidates
+// =============================================================================
+
+#[test]
+fn test_insufficient_samples_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-0", "h-0", 2.0),
+            synapse("in-1", "h-0", -2.0),
+            synapse("h-0", "out-0", 1.0),
+        ],
+    );
+
+    // Only 3 samples — below minimum
+    let records = vec![
+        ("in-0".to_string(), make_records("in-0", 3)),
+        ("in-1".to_string(), make_records("in-1", 3)),
+        ("h-0".to_string(), make_records("h-0", 3)),
+        ("out-0".to_string(), make_records("out-0", 3)),
+    ];
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+// =============================================================================
+// Test 6: Empty records produce no candidates
+// =============================================================================
+
+#[test]
+fn test_empty_records_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            hidden("h-0", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![synapse("in-0", "h-0", 2.0), synapse("h-0", "out-0", 1.0)],
+    );
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Empty records should produce no candidates"
+    );
+}
+
+// =============================================================================
+// Test 7: Input/output neurons are excluded (hidden only)
+// =============================================================================
+
+/// Polarity conflict detection only applies to hidden neurons.
+/// Output neurons with conflicting fan-in are not flagged.
+#[test]
+fn test_only_hidden_neurons_flagged() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            // Output neuron with conflicting fan-in
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-0", "out-0", 2.0),
+            synapse("in-1", "out-0", -2.0),
+        ],
+    );
+
+    let records = vec![
+        ("in-0".to_string(), make_records("in-0", 30)),
+        ("in-1".to_string(), make_records("in-1", 30)),
+        ("out-0".to_string(), make_records("out-0", 30)),
+    ];
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Output neurons should not be flagged for polarity conflict, got {} candidate(s)",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Test 8: Candidates sorted by conflict score
+// =============================================================================
+
+#[test]
+fn test_candidates_sorted_by_conflict_score() {
+    let creature = make_creature(
+        vec![
+            neuron("in-0", "input", "IDENTITY"),
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("in-3", "input", "IDENTITY"),
+            // h-0: severe conflict (equal magnitude both sides)
+            hidden("h-0", "TANH"),
+            // h-1: moderate conflict (less balanced)
+            hidden("h-1", "TANH"),
+            output("out-0", "IDENTITY"),
+        ],
+        vec![
+            // h-0: 2 × +3.0 and 2 × -3.0 = perfect balance = max conflict
+            synapse("in-0", "h-0", 3.0),
+            synapse("in-1", "h-0", 3.0),
+            synapse("in-2", "h-0", -3.0),
+            synapse("in-3", "h-0", -3.0),
+            // h-1: 2 × +3.0 and 2 × -1.5 = less balanced
+            synapse("in-0", "h-1", 3.0),
+            synapse("in-1", "h-1", 3.0),
+            synapse("in-2", "h-1", -1.5),
+            synapse("in-3", "h-1", -1.5),
+            // Outgoing
+            synapse("h-0", "out-0", 1.0),
+            synapse("h-1", "out-0", 1.0),
+        ],
+    );
+
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for i in 0..4 {
+        records.push((format!("in-{i}"), make_records(&format!("in-{i}"), 30)));
+    }
+    records.push(("h-0".to_string(), make_records("h-0", 30)));
+    records.push(("h-1".to_string(), make_records("h-1", 30)));
+    records.push(("out-0".to_string(), make_records("out-0", 30)));
+
+    let candidates = detect_fanin_polarity_conflicts(&creature, &records);
+
+    if candidates.len() >= 2 {
+        for i in 1..candidates.len() {
+            assert!(
+                candidates[i - 1].conflict_score >= candidates[i].conflict_score,
+                "Candidates should be sorted by conflict score (descending): {} < {}",
+                candidates[i - 1].conflict_score,
+                candidates[i].conflict_score
+            );
+        }
+        // h-0 (perfect balance) should have higher conflict than h-1
+        assert_eq!(
+            candidates[0].neuron_uuid, "h-0",
+            "Perfectly balanced conflict should rank first"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add a fan-in weight polarity conflict detector that identifies hidden neurons
whose incoming synapses have sharply conflicting polarities — strongly positive
weights fighting strongly negative weights of similar magnitude. When this
occurs, most of the input signal cancels out, wasting representational capacity.

The detector produces coordinated structural candidates (`addNeuron` +
`addSynapse` + `removeSynapse`) to split the minority-polarity pathway into a
separate neuron, eliminating the internal cancellation.

This is distinct from:
- `opposing_synapse.rs` — detects same-source opposing pairs (narrow case)
- `weight_coherence.rs` — checks ratio consistency and correlated-source cancellation

Closes #641.

## Evidence

This is a backend detection module with no UI component. Correctness is verified
by the integration test suite below.

## Test Plan

- Added `tests/issue_641_fanin_polarity_conflict.rs` with 8 tests:
  1. Detects clear polarity conflict (balanced positive/negative fan-in)
  2. Healthy same-sign fan-in produces no candidates
  3. Tiny opposing weight is not flagged (below threshold)
  4. Candidate proposes `addNeuron` to split positive/negative pathways
  5. Insufficient samples produce no candidates
  6. Empty records produce no candidates
  7. Only hidden neurons are flagged (input/output excluded)
  8. Candidates sorted by conflict score (worst first)
- All existing tests continue to pass
- `./quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #641: **Add fan-in weight polarity conflict detector**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #641