### PR TITLE
Introduce typed error enums for domain errors (#677)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.5"
+version = "0.42.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]  # cdylib for .so/.dylib, rlib for Rust integrat
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
+thiserror = "2"  # Typed domain error enums (Issue #677)
 parquet = "57.3"  # Apache Parquet format (viewable with standard tools)
 arrow = { version = "57.3", default-features = false }  # Arrow arrays for Parquet
 wgpu = "28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.4"
+version = "0.42.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-677.md
+++ b/docs/pr-summary-677.md
@@ -1,0 +1,46 @@
+## Summary
+
+Introduce typed error enums using `thiserror` for domain errors instead of relying
+solely on string matching for error classification. Closes #677.
+
+### What changed
+
+- Added `thiserror` dependency to `Cargo.toml`
+- Defined `DiscoveryError` enum in `src/ffi_types/error_classification.rs` with
+  typed variants: `GpuUnavailable`, `GpuDeviceLost`, `InvalidInput`, `Timeout`,
+  `MemoryExhausted`, and `Io`
+- Each variant maps to its `DiscoveryErrorKind` via pattern matching (`error_kind()`)
+- Added `classify_anyhow_error()` which attempts downcast to `DiscoveryError`
+  before falling back to string-based classification
+- Added `error_fields_from_anyhow()` convenience function for FFI error handling
+- Updated all FFI internal functions (`ffi_internal/`) and FFI boundary functions
+  (`ffi/`) to use typed errors for known categories (e.g., JSON parse errors use
+  `DiscoveryError::InvalidInput`) and `error_fields_from_anyhow` for `anyhow::Error`
+- String-based `classify_error()` and `error_fields()` remain available as
+  backward-compatible fallback for third-party errors
+
+### Backward compatibility
+
+The external JSON error response format is unchanged — `errorKind` and `retryable`
+fields are serialised identically. The `classify_error()` string-based function
+is preserved for errors from third-party crates (wgpu, parquet, etc.).
+
+## Evidence
+
+This is a backend/library change with no visual output. Evidence is provided by
+the test suite:
+
+- All 13 new integration tests pass (`tests/issue_677_typed_error_enums.rs`)
+- All existing error classification tests pass (`tests/issue_651_error_classification.rs`)
+- Full quality gate (`./quality.sh`) passes cleanly
+
+## Test Plan
+
+- Added `tests/issue_677_typed_error_enums.rs` with 13 tests covering:
+  - Each `DiscoveryError` variant maps to correct `DiscoveryErrorKind`
+  - `classify_anyhow_error` downcasts typed errors before string fallback
+  - `classify_anyhow_error` falls back to string matching for non-typed errors
+  - `DiscoveryError::Display` messages are human-readable
+  - String-based `classify_error` backward compatibility preserved
+  - Typed errors produce same JSON classification as string-matched errors
+  - FFI response shape unchanged for existing error scenarios

--- a/src/ffi/analysis.rs
+++ b/src/ffi/analysis.rs
@@ -35,8 +35,7 @@ pub extern "C" fn rank_focus_neurons(input_json: *const std::ffi::c_char) -> *mu
         let json_result = match crate::rank_focus_neurons_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = RankFocusNeuronsOutput {
                     success: false,
                     neurons: None,
@@ -119,9 +118,7 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
         let json_result = match crate::analyze_parallel_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                // Properly serialize error message to avoid JSON injection issues
-                let err_msg = format!("Failed to serialize output: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = AnalyzeParallelOutput {
                     success: false,
                     helpful_synapses: None,
@@ -144,7 +141,6 @@ pub extern "C" fn analyze_parallel(input_json: *const std::ffi::c_char) -> *mut 
                     retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
-                    // Fallback if serialization fails (shouldn't happen)
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }

--- a/src/ffi/gpu.rs
+++ b/src/ffi/gpu.rs
@@ -16,9 +16,7 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
         let json_result = match crate::check_gpu_available_internal() {
             Ok(json) => json,
             Err(e) => {
-                // Properly serialize error message to avoid JSON injection issues
-                let err_msg = format!("Failed to probe GPU: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = CheckGpuOutput {
                     success: false,
                     gpu_available: false,
@@ -28,7 +26,6 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
                     retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
-                    // Fallback if serialization fails (shouldn't happen)
                     r#"{"success":false,"gpuAvailable":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }

--- a/src/ffi/recording.rs
+++ b/src/ffi/recording.rs
@@ -44,9 +44,7 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
         let json_result = match crate::record_discovery_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                // Properly serialize error message to avoid JSON injection issues
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = RecordDiscoveryOutput {
                     success: false,
                     temp_dir: None,
@@ -56,7 +54,6 @@ pub extern "C" fn record_discovery(input_json: *const std::ffi::c_char) -> *mut 
                     retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
-                    // Fallback if serialization fails (shouldn't happen)
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
@@ -157,14 +154,16 @@ pub extern "C" fn start_discovery_session(
         let input: StartSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
-                let err_msg = format!("Failed to parse input JSON: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let typed = DiscoveryError::InvalidInput {
+                    detail: format!("Failed to parse input JSON: {e}"),
+                };
+                let kind = typed.error_kind();
                 let output = StartSessionOutput {
                     success: false,
                     session_id: None,
-                    error: Some(err_msg),
-                    error_kind,
-                    retryable,
+                    error: Some(typed.to_string()),
+                    error_kind: Some(kind),
+                    retryable: Some(kind.is_retryable()),
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -183,8 +182,7 @@ pub extern "C" fn start_discovery_session(
                 }
             }
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 StartSessionOutput {
                     success: false,
                     session_id: None,
@@ -268,14 +266,16 @@ pub extern "C" fn append_discovery_records(
         let input: AppendRecordsInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
-                let err_msg = format!("Failed to parse input JSON: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let typed = DiscoveryError::InvalidInput {
+                    detail: format!("Failed to parse input JSON: {e}"),
+                };
+                let kind = typed.error_kind();
                 let output = AppendRecordsOutput {
                     success: false,
                     records_written: None,
-                    error: Some(err_msg),
-                    error_kind,
-                    retryable,
+                    error: Some(typed.to_string()),
+                    error_kind: Some(kind),
+                    retryable: Some(kind.is_retryable()),
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -301,8 +301,7 @@ pub extern "C" fn append_discovery_records(
                 }
             }
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 AppendRecordsOutput {
                     success: false,
                     records_written: None,
@@ -381,16 +380,18 @@ pub extern "C" fn finish_discovery_session(
         let input: FinishSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
-                let err_msg = format!("Failed to parse input JSON: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let typed = DiscoveryError::InvalidInput {
+                    detail: format!("Failed to parse input JSON: {e}"),
+                };
+                let kind = typed.error_kind();
                 let output = FinishSessionOutput {
                     success: false,
                     temp_dir: None,
                     file: None,
                     total_records: None,
-                    error: Some(err_msg),
-                    error_kind,
-                    retryable,
+                    error: Some(typed.to_string()),
+                    error_kind: Some(kind),
+                    retryable: Some(kind.is_retryable()),
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -411,8 +412,7 @@ pub extern "C" fn finish_discovery_session(
                 }
             }
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 FinishSessionOutput {
                     success: false,
                     temp_dir: None,
@@ -492,13 +492,15 @@ pub extern "C" fn cancel_discovery_session(
         let input: CancelSessionInput = match serde_json::from_str(input_str) {
             Ok(input) => input,
             Err(e) => {
-                let err_msg = format!("Failed to parse input JSON: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let typed = DiscoveryError::InvalidInput {
+                    detail: format!("Failed to parse input JSON: {e}"),
+                };
+                let kind = typed.error_kind();
                 let output = CancelSessionOutput {
                     success: false,
-                    error: Some(err_msg),
-                    error_kind,
-                    retryable,
+                    error: Some(typed.to_string()),
+                    error_kind: Some(kind),
+                    retryable: Some(kind.is_retryable()),
                 };
                 let json = serde_json::to_string(&output).unwrap();
                 return CString::new(json).unwrap().into_raw();
@@ -516,8 +518,7 @@ pub extern "C" fn cancel_discovery_session(
                 }
             }
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 CancelSessionOutput {
                     success: false,
                     error: Some(err_msg),

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -37,8 +37,7 @@ pub extern "C" fn merge_discovery_parquet(
         let json_result = match crate::merge_discovery_parquet_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = MergeParquetOutput {
                     success: false,
                     output_file: None,
@@ -126,9 +125,7 @@ pub extern "C" fn read_discovery_records_ffi(
         let json_result = match crate::read_discovery_records(input_str) {
             Ok(json) => json,
             Err(e) => {
-                // Properly serialize error message to avoid JSON injection issues
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = ReadDiscoveryOutput {
                     success: false,
                     records: None,
@@ -137,7 +134,6 @@ pub extern "C" fn read_discovery_records_ffi(
                     retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
-                    // Fallback if serialization fails (shouldn't happen)
                     r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
                 })
             }
@@ -230,8 +226,7 @@ pub extern "C" fn export_visualisation_snapshot(
         let json_result = match crate::export_visualisation_snapshot_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = ExportVisualisationSnapshotOutput {
                     success: false,
                     out_file: None,
@@ -335,8 +330,7 @@ pub extern "C" fn get_calibration_summary(
         let json_result = match crate::get_calibration_summary_internal(input_str) {
             Ok(json) => json,
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = crate::ffi_types::CalibrationSummaryOutput {
                     success: false,
                     calibration_summary: vec![],
@@ -403,9 +397,7 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
         let json_result = match crate::get_library_version_internal() {
             Ok(json) => json,
             Err(e) => {
-                // Properly serialize error message to avoid JSON injection issues
-                let err_msg = format!("Failed to get version: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = GetVersionOutput {
                     success: false,
                     version: String::new(),
@@ -414,7 +406,6 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
                     retryable,
                 };
                 serde_json::to_string(&output).unwrap_or_else(|_| {
-                    // Fallback if serialization fails (shouldn't happen)
                     r#"{"success":false,"version":"","error":"Failed to serialize error message"}"#
                         .to_string()
                 })

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -10,8 +10,10 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
     {
         Ok(value) => value,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = AnalyzeParallelOutput {
                 success: false,
                 helpful_synapses: None,
@@ -29,9 +31,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 neuron_fingerprints: None,
                 fingerprint_cache_hits: None,
                 fingerprint_cache_misses: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -124,8 +126,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
-            let err_msg = e.to_string();
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = AnalyzeParallelOutput {
                 success: false,
                 helpful_synapses: None,
@@ -173,8 +174,10 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
     let input: RankFocusNeuronsInput = match serde_json::from_str(input_json) {
         Ok(value) => value,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = RankFocusNeuronsOutput {
                 success: false,
                 neurons: None,
@@ -184,9 +187,9 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
                 processed_neurons: None,
                 total_neurons: None,
                 duration_ms: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -252,8 +255,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
-            let err_msg = e.to_string();
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = RankFocusNeuronsOutput {
                 success: false,
                 neurons: None,
@@ -280,14 +282,16 @@ pub fn get_calibration_summary_internal(input_json: &str) -> Result<String> {
     let input: CalibrationSummaryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = CalibrationSummaryOutput {
                 success: false,
                 calibration_summary: vec![],
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -297,14 +301,16 @@ pub fn get_calibration_summary_internal(input_json: &str) -> Result<String> {
         match serde_json::from_str(&input.discovery_history) {
             Ok(h) => h,
             Err(e) => {
-                let err_msg = format!("Failed to parse discovery history: {e}");
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let typed = DiscoveryError::InvalidInput {
+                    detail: format!("Failed to parse discovery history: {e}"),
+                };
+                let kind = typed.error_kind();
                 let output = CalibrationSummaryOutput {
                     success: false,
                     calibration_summary: vec![],
-                    error: Some(err_msg),
-                    error_kind,
-                    retryable,
+                    error: Some(typed.to_string()),
+                    error_kind: Some(kind),
+                    retryable: Some(kind.is_retryable()),
                 };
                 return Ok(serde_json::to_string(&output)?);
             }

--- a/src/ffi_internal/gpu.rs
+++ b/src/ffi_internal/gpu.rs
@@ -11,15 +11,17 @@ pub fn check_gpu_available_internal() -> Result<String> {
     // On macOS, missing GPU is an error (Metal should always work).
     // On Linux, missing GPU gracefully disables discovery (common on headless servers).
     let output = if result.is_error {
-        let err_msg = "GPU required but not available".to_string();
-        let (error_kind, retryable) = error_fields(&err_msg);
+        let typed = DiscoveryError::GpuUnavailable {
+            reason: "GPU required but not available".to_string(),
+        };
+        let kind = typed.error_kind();
         CheckGpuOutput {
             success: false,
             gpu_available: false,
             reason: result.reason,
-            error: Some(err_msg),
-            error_kind,
-            retryable,
+            error: Some(typed.to_string()),
+            error_kind: Some(kind),
+            retryable: Some(kind.is_retryable()),
         }
     } else {
         let (error_kind, retryable) = no_error_fields();

--- a/src/ffi_internal/recording.rs
+++ b/src/ffi_internal/recording.rs
@@ -16,15 +16,17 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     let input: RecordDiscoveryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = RecordDiscoveryOutput {
                 success: false,
                 temp_dir: None,
                 file: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -34,8 +36,7 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     let result = match record::record_discovery_data(&input) {
         Ok(result) => result,
         Err(e) => {
-            let err_msg = e.to_string();
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = RecordDiscoveryOutput {
                 success: false,
                 temp_dir: None,

--- a/src/ffi_internal/utilities.rs
+++ b/src/ffi_internal/utilities.rs
@@ -9,28 +9,32 @@ pub fn merge_discovery_parquet_internal(input_json: &str) -> Result<String> {
     let input: MergeParquetInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = MergeParquetOutput {
                 success: false,
                 output_file: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
     };
 
     if input.input_files.is_empty() {
-        let err_msg = "No discovery parquet files provided for merge".to_string();
-        let (error_kind, retryable) = error_fields(&err_msg);
+        let typed = DiscoveryError::InvalidInput {
+            detail: "No discovery parquet files provided for merge".to_string(),
+        };
+        let kind = typed.error_kind();
         let output = MergeParquetOutput {
             success: false,
             output_file: None,
-            error: Some(err_msg),
-            error_kind,
-            retryable,
+            error: Some(typed.to_string()),
+            error_kind: Some(kind),
+            retryable: Some(kind.is_retryable()),
         };
         return Ok(serde_json::to_string(&output)?);
     }
@@ -48,8 +52,7 @@ pub fn merge_discovery_parquet_internal(input_json: &str) -> Result<String> {
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
-            let err_msg = e.to_string();
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = MergeParquetOutput {
                 success: false,
                 output_file: None,
@@ -71,15 +74,17 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
     let input: ExportVisualisationSnapshotInput = match serde_json::from_str(input_json) {
         Ok(value) => value,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = ExportVisualisationSnapshotOutput {
                 success: false,
                 out_file: None,
                 stats: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -116,8 +121,7 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
             Ok(serde_json::to_string(&output)?)
         }
         Err(e) => {
-            let err_msg = e.to_string();
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = ExportVisualisationSnapshotOutput {
                 success: false,
                 out_file: None,
@@ -142,14 +146,16 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
     let input: ReadDiscoveryInput = match serde_json::from_str(input_json) {
         Ok(input) => input,
         Err(e) => {
-            let err_msg = format!("Failed to parse input JSON: {e}");
-            let (error_kind, retryable) = error_fields(&err_msg);
+            let typed = DiscoveryError::InvalidInput {
+                detail: format!("Failed to parse input JSON: {e}"),
+            };
+            let kind = typed.error_kind();
             let output = ReadDiscoveryOutput {
                 success: false,
                 records: None,
-                error: Some(err_msg),
-                error_kind,
-                retryable,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
             };
             return Ok(serde_json::to_string(&output)?);
         }
@@ -160,8 +166,7 @@ pub fn read_discovery_records(input_json: &str) -> Result<String> {
         match read_records_from_parquet(&input.parquet_file, &input.neuron_uuid) {
             Ok(records) => records,
             Err(e) => {
-                let err_msg = e.to_string();
-                let (error_kind, retryable) = error_fields(&err_msg);
+                let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = ReadDiscoveryOutput {
                     success: false,
                     records: None,

--- a/src/ffi_types/error_classification.rs
+++ b/src/ffi_types/error_classification.rs
@@ -1,10 +1,16 @@
-//! Structured error classification for FFI responses (Issue #651).
+//! Structured error classification for FFI responses (Issue #651, #677).
 //!
-//! Classifies `anyhow::Error` messages into categories so the NEAT-AI controller
-//! can make informed retry decisions — retrying transient GPU errors but not
-//! retrying data validation failures.
+//! Provides both **typed error enums** (`DiscoveryError`) and string-based
+//! classification (`classify_error`) so the NEAT-AI controller can make informed
+//! retry decisions — retrying transient GPU errors but not retrying data
+//! validation failures.
+//!
+//! Prefer constructing a `DiscoveryError` variant when the error category is
+//! known at the call site. The string-based fallback handles third-party errors
+//! (wgpu, parquet, etc.) whose messages we cannot control.
 
 use serde::Serialize;
+use thiserror::Error;
 
 /// Classification of discovery errors for retry decision-making.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -37,6 +43,81 @@ impl DiscoveryErrorKind {
         )
     }
 }
+
+// ============================================================================
+// Typed domain error enum (Issue #677)
+// ============================================================================
+
+/// Typed domain errors for the discovery library.
+///
+/// Each variant maps to a `DiscoveryErrorKind` via `error_kind()`, removing the
+/// need for string matching when the error category is known at construction.
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    /// GPU is permanently unavailable (no device, unsupported hardware).
+    #[error("GPU unavailable: {reason}")]
+    GpuUnavailable { reason: String },
+
+    /// Transient GPU failure (device lost, driver reset).
+    #[error("GPU device lost: {detail}")]
+    GpuDeviceLost { detail: String },
+
+    /// Invalid input data (parse failure, missing fields, bad format).
+    #[error("Invalid input: {detail}")]
+    InvalidInput { detail: String },
+
+    /// Analysis deadline exceeded.
+    #[error("Deadline exceeded after {deadline_ms}ms")]
+    Timeout { deadline_ms: u64 },
+
+    /// Memory exhaustion (GPU buffer allocation, system OOM).
+    #[error("Memory exhausted: {detail}")]
+    MemoryExhausted { detail: String },
+
+    /// File I/O failure (parquet, file system).
+    #[error("I/O error: {detail}")]
+    Io { detail: String },
+}
+
+impl DiscoveryError {
+    /// Return the `DiscoveryErrorKind` for this typed error via pattern matching.
+    pub fn error_kind(&self) -> DiscoveryErrorKind {
+        match self {
+            Self::GpuUnavailable { .. } => DiscoveryErrorKind::GpuPermanent,
+            Self::GpuDeviceLost { .. } => DiscoveryErrorKind::GpuTransient,
+            Self::InvalidInput { .. } => DiscoveryErrorKind::DataValidation,
+            Self::Timeout { .. } => DiscoveryErrorKind::Timeout,
+            Self::MemoryExhausted { .. } => DiscoveryErrorKind::MemoryExhausted,
+            Self::Io { .. } => DiscoveryErrorKind::IoError,
+        }
+    }
+}
+
+// ============================================================================
+// Classify from anyhow::Error — downcast first, then fall back to strings
+// ============================================================================
+
+/// Classify an `anyhow::Error` by first attempting to downcast to a typed
+/// `DiscoveryError`, then falling back to string-based classification.
+pub fn classify_anyhow_error(err: &anyhow::Error) -> DiscoveryErrorKind {
+    if let Some(discovery_err) = err.downcast_ref::<DiscoveryError>() {
+        return discovery_err.error_kind();
+    }
+    classify_error(&err.to_string())
+}
+
+/// Return `(error_msg, error_kind, retryable)` from an `anyhow::Error`,
+/// preferring typed downcast over string matching.
+pub fn error_fields_from_anyhow(
+    err: &anyhow::Error,
+) -> (String, Option<DiscoveryErrorKind>, Option<bool>) {
+    let kind = classify_anyhow_error(err);
+    (err.to_string(), Some(kind), Some(kind.is_retryable()))
+}
+
+// ============================================================================
+// String-based classification (backward-compatible fallback)
+// ============================================================================
 
 /// Classify an error message into a `DiscoveryErrorKind`.
 ///

--- a/tests/issue_677_typed_error_enums.rs
+++ b/tests/issue_677_typed_error_enums.rs
@@ -1,0 +1,182 @@
+//! Integration tests for typed error enums (Issue #677).
+//!
+//! Verifies that `DiscoveryError` typed enums classify correctly via pattern
+//! matching instead of string matching, and that the external JSON format
+//! remains backward-compatible.
+
+use neat_ai_discovery::ffi_types::{
+    DiscoveryError, DiscoveryErrorKind, classify_anyhow_error, classify_error,
+};
+
+// ============================================================================
+// DiscoveryError variants map to correct DiscoveryErrorKind
+// ============================================================================
+
+#[test]
+fn gpu_unavailable_error_classifies_as_gpu_permanent() {
+    let err = DiscoveryError::GpuUnavailable {
+        reason: "No Metal device found".to_string(),
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::GpuPermanent);
+    assert!(!err.error_kind().is_retryable());
+}
+
+#[test]
+fn gpu_device_lost_error_classifies_as_gpu_transient() {
+    let err = DiscoveryError::GpuDeviceLost {
+        detail: "Device is lost".to_string(),
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::GpuTransient);
+    assert!(err.error_kind().is_retryable());
+}
+
+#[test]
+fn invalid_input_error_classifies_as_data_validation() {
+    let err = DiscoveryError::InvalidInput {
+        detail: "Missing required field 'creature'".to_string(),
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::DataValidation);
+    assert!(!err.error_kind().is_retryable());
+}
+
+#[test]
+fn timeout_error_classifies_as_timeout() {
+    let err = DiscoveryError::Timeout {
+        deadline_ms: 30_000,
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::Timeout);
+    assert!(err.error_kind().is_retryable());
+}
+
+#[test]
+fn memory_exhausted_error_classifies_as_memory_exhausted() {
+    let err = DiscoveryError::MemoryExhausted {
+        detail: "GPU buffer allocation failed".to_string(),
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::MemoryExhausted);
+    assert!(err.error_kind().is_retryable());
+}
+
+#[test]
+fn io_error_classifies_as_io_error() {
+    let err = DiscoveryError::Io {
+        detail: "File not found: /tmp/records.parquet".to_string(),
+    };
+    assert_eq!(err.error_kind(), DiscoveryErrorKind::IoError);
+    assert!(err.error_kind().is_retryable());
+}
+
+// ============================================================================
+// classify_anyhow_error — downcast to DiscoveryError first
+// ============================================================================
+
+#[test]
+fn classify_anyhow_error_downcasts_typed_error() {
+    let typed_err = DiscoveryError::Timeout { deadline_ms: 5_000 };
+    let anyhow_err: anyhow::Error = typed_err.into();
+    let kind = classify_anyhow_error(&anyhow_err);
+    assert_eq!(kind, DiscoveryErrorKind::Timeout);
+}
+
+#[test]
+fn classify_anyhow_error_falls_back_to_string_matching() {
+    // Create a non-DiscoveryError anyhow error with a known message pattern
+    let anyhow_err = anyhow::anyhow!("Device is lost during operation");
+    let kind = classify_anyhow_error(&anyhow_err);
+    assert_eq!(kind, DiscoveryErrorKind::GpuTransient);
+}
+
+#[test]
+fn classify_anyhow_error_unknown_for_unrecognised_error() {
+    let anyhow_err = anyhow::anyhow!("Something completely unexpected");
+    let kind = classify_anyhow_error(&anyhow_err);
+    assert_eq!(kind, DiscoveryErrorKind::Unknown);
+}
+
+// ============================================================================
+// DiscoveryError Display messages are human-readable
+// ============================================================================
+
+#[test]
+fn discovery_error_display_messages_are_descriptive() {
+    let err = DiscoveryError::GpuUnavailable {
+        reason: "No Metal device".to_string(),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("No Metal device"),
+        "Error message should include the reason"
+    );
+
+    let err = DiscoveryError::Timeout {
+        deadline_ms: 30_000,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("30000"),
+        "Timeout message should include the deadline"
+    );
+}
+
+// ============================================================================
+// Backward compatibility — string-based classify_error still works
+// ============================================================================
+
+#[test]
+fn string_based_classify_error_still_works_after_typed_errors() {
+    // Existing string-based classification must continue to work
+    assert_eq!(
+        classify_error("Device is lost"),
+        DiscoveryErrorKind::GpuTransient
+    );
+    assert_eq!(
+        classify_error("No GPU available"),
+        DiscoveryErrorKind::GpuPermanent
+    );
+    assert_eq!(
+        classify_error("Failed to parse input JSON"),
+        DiscoveryErrorKind::DataValidation
+    );
+    assert_eq!(
+        classify_error("Analysis deadline exceeded"),
+        DiscoveryErrorKind::Timeout
+    );
+    assert_eq!(
+        classify_error("Out of memory"),
+        DiscoveryErrorKind::MemoryExhausted
+    );
+    assert_eq!(
+        classify_error("parquet read error"),
+        DiscoveryErrorKind::IoError
+    );
+}
+
+// ============================================================================
+// FFI response shape — typed errors produce same JSON as string-matched errors
+// ============================================================================
+
+#[test]
+fn typed_error_produces_same_json_classification_as_string_error() {
+    // A typed InvalidInput error and a string "Failed to parse input JSON" should
+    // both produce DataValidation classification
+    let typed = DiscoveryError::InvalidInput {
+        detail: "bad JSON".to_string(),
+    };
+    assert_eq!(typed.error_kind(), DiscoveryErrorKind::DataValidation);
+    assert_eq!(
+        classify_error("Failed to parse input JSON: bad JSON"),
+        DiscoveryErrorKind::DataValidation
+    );
+}
+
+#[test]
+fn analyze_parallel_with_invalid_json_still_returns_data_validation() {
+    // Existing FFI behaviour must be preserved
+    let result = neat_ai_discovery::analyze_parallel_internal("not valid json");
+    let json_str = result.expect("Should return Ok with error JSON");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(value["success"], false);
+    assert_eq!(value["errorKind"], "data_validation");
+    assert_eq!(value["retryable"], false);
+}


### PR DESCRIPTION
## Summary

Introduce typed error enums using `thiserror` for domain errors instead of relying
solely on string matching for error classification. Closes #677.

### What changed

- Added `thiserror` dependency to `Cargo.toml`
- Defined `DiscoveryError` enum in `src/ffi_types/error_classification.rs` with
  typed variants: `GpuUnavailable`, `GpuDeviceLost`, `InvalidInput`, `Timeout`,
  `MemoryExhausted`, and `Io`
- Each variant maps to its `DiscoveryErrorKind` via pattern matching (`error_kind()`)
- Added `classify_anyhow_error()` which attempts downcast to `DiscoveryError`
  before falling back to string-based classification
- Added `error_fields_from_anyhow()` convenience function for FFI error handling
- Updated all FFI internal functions (`ffi_internal/`) and FFI boundary functions
  (`ffi/`) to use typed errors for known categories (e.g., JSON parse errors use
  `DiscoveryError::InvalidInput`) and `error_fields_from_anyhow` for `anyhow::Error`
- String-based `classify_error()` and `error_fields()` remain available as
  backward-compatible fallback for third-party errors

### Backward compatibility

The external JSON error response format is unchanged — `errorKind` and `retryable`
fields are serialised identically. The `classify_error()` string-based function
is preserved for errors from third-party crates (wgpu, parquet, etc.).

## Evidence

This is a backend/library change with no visual output. Evidence is provided by
the test suite:

- All 13 new integration tests pass (`tests/issue_677_typed_error_enums.rs`)
- All existing error classification tests pass (`tests/issue_651_error_classification.rs`)
- Full quality gate (`./quality.sh`) passes cleanly

## Test Plan

- Added `tests/issue_677_typed_error_enums.rs` with 13 tests covering:
  - Each `DiscoveryError` variant maps to correct `DiscoveryErrorKind`
  - `classify_anyhow_error` downcasts typed errors before string fallback
  - `classify_anyhow_error` falls back to string matching for non-typed errors
  - `DiscoveryError::Display` messages are human-readable
  - String-based `classify_error` backward compatibility preserved
  - Typed errors produce same JSON classification as string-matched errors
  - FFI response shape unchanged for existing error scenarios

---

## Automated Fix Details
This PR addresses issue #677: **Introduce typed error enums for domain errors instead of string matching**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #677