### PR TITLE
Fix test thread count inconsistency between quality.sh and CI (#673)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,8 +374,9 @@ tests.** If you need to confirm performance, create proper benchmarks.
 - **Modified test** — requires justification (did requirements change?).
 - **Removed/skipped test** — red flag; must be justified.
 
-Tests run sequentially (`--test-threads=1`) due to shared global state
-(deadline overrides, GPU failure guards, environment variables).
+Tests that mutate shared global state (environment variables, deadline
+overrides, watchdog) are marked with `#[serial]` from the `serial_test` crate.
+All other tests may run in parallel (`--test-threads=2`).
 
 GPU-dependent tests include `skip_without_gpu!()` and are skipped automatically
 on machines without a GPU.
@@ -394,7 +395,7 @@ so do not skip this step.
 3. `cargo fmt --all` (auto-formatting)
 4. `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args`
 5. `cargo check --all-targets --all-features`
-6. `cargo test --lib --tests --all-features -- --test-threads=1`
+6. `cargo test --lib --tests --all-features -- --test-threads=2`
 7. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (documentation build)
 8. `cargo build --release --lib`
 
@@ -583,7 +584,7 @@ with success/failure rates and detailed descriptions.
 ./quality.sh
 
 # Run all tests
-cargo test --lib --tests --all-features -- --test-threads=1
+cargo test --lib --tests --all-features -- --test-threads=2
 
 # Run specific test
 cargo test --test <test_name>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ and signs it on macOS for FFI compatibility.
 
 ```bash
 # Run all tests (unit + integration)
-cargo test --lib --tests --all-features -- --test-threads=1
+cargo test --lib --tests --all-features -- --test-threads=2
 
 # Run specific test file
 cargo test --test <test_name>
@@ -54,8 +54,9 @@ cargo test test_hidden_neuron
 cargo bench --bench <bench_name>
 ```
 
-Tests run sequentially (`--test-threads=1`) due to shared global state (deadline
-overrides, GPU failure guards, environment variables).
+Tests that mutate shared global state (environment variables, deadline overrides,
+watchdog) are marked with `#[serial]` from the `serial_test` crate and will not
+run concurrently with each other. All other tests run in parallel (`--test-threads=2`).
 
 ---
 
@@ -80,7 +81,7 @@ We follow strict TDD:
 3. `cargo fmt --all` (auto-formatting)
 4. `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args`
 5. `cargo check --all-targets --all-features`
-6. `cargo test --lib --tests --all-features -- --test-threads=1`
+6. `cargo test --lib --tests --all-features -- --test-threads=2`
 7. `cargo build --release --lib`
 
 If any step fails, fix the issue and re-run. Do **not** commit code that fails

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.6"
+version = "0.42.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.7"
+version = "0.42.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 ./quality.sh
 
 # Run all tests
-cargo test --lib --tests --all-features -- --test-threads=1
+cargo test --lib --tests --all-features -- --test-threads=2
 
 # Run benchmarks
 cargo bench --bench <bench_name>

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -95,8 +95,8 @@ echo "════════════════════════�
 git checkout -q "$BASELINE_COMMIT"
 cargo build --release -q 2>/dev/null
 
-BASELINE_UNIT=$(run_benchmark "Unit tests" "cargo test --lib -- --test-threads=1")
-BASELINE_FULL=$(run_benchmark "Full test suite" "cargo test --all-targets --all-features -- --test-threads=1")
+BASELINE_UNIT=$(run_benchmark "Unit tests" "cargo test --lib -- --test-threads=2")
+BASELINE_FULL=$(run_benchmark "Full test suite" "cargo test --all-targets --all-features -- --test-threads=2")
 
 if [ -n "$PARQUET_FILE" ] && [ -f "$PARQUET_FILE" ]; then
     echo "⏱️  Running: Parquet analysis ($PARQUET_FILE)"
@@ -123,8 +123,8 @@ echo "📊 CURRENT (${CURRENT_BRANCH:-$CURRENT_REF})"
 echo "═══════════════════════════════════════"
 cargo build --release -q 2>/dev/null
 
-CURRENT_UNIT=$(run_benchmark "Unit tests" "cargo test --lib -- --test-threads=1")
-CURRENT_FULL=$(run_benchmark "Full test suite" "cargo test --all-targets --all-features -- --test-threads=1")
+CURRENT_UNIT=$(run_benchmark "Unit tests" "cargo test --lib -- --test-threads=2")
+CURRENT_FULL=$(run_benchmark "Full test suite" "cargo test --all-targets --all-features -- --test-threads=2")
 
 if [ -n "$PARQUET_FILE" ] && [ -f "$PARQUET_FILE" ]; then
     echo "⏱️  Running: Parquet analysis ($PARQUET_FILE)"

--- a/docs/pr-summary-673.md
+++ b/docs/pr-summary-673.md
@@ -1,0 +1,61 @@
+## Summary
+
+Fix test thread count inconsistency between `quality.sh` (`--test-threads=1`)
+and CI (`--test-threads=2`) by marking tests that mutate shared global state
+with `#[serial]` from the `serial_test` crate, and aligning both environments
+to `--test-threads=2`. Closes #673.
+
+### Root Cause
+
+Tests that set environment variables (e.g. `NEAT_AI_DISCOVERY_GPU_TIMING`,
+`NEAT_AI_DISCOVERY_ZERO_COPY`, `NEAT_AI_DISCOVERY_BLOCK_SIZE`) were relying
+on `--test-threads=1` for correctness instead of explicit serialisation. This
+meant CI (which used `--test-threads=2`) could see env-var races that local
+`quality.sh` (which used `--test-threads=1`) would never trigger.
+
+### Changes
+
+1. **Added `#[serial]`** to all tests that mutate environment variables (22
+   tests across 10 files — 7 integration test files and 3 inline `src/` test
+   modules).
+2. **Aligned `quality.sh`** from `--test-threads=1` to `--test-threads=2` to
+   match CI.
+3. **Updated SAFETY comments** from "Tests run single-threaded
+   (`--test-threads=1`)" to "Serialised via `#[serial]`" across all affected
+   files.
+4. **Updated documentation** in `AGENTS.md`, `README.md`, `CONTRIBUTING.md`,
+   and `benchmark.sh` to reflect the new `--test-threads=2` setting and
+   `#[serial]` convention.
+
+Tests using `lock_for_test_serialisation()` (watchdog/dispatch tests) already
+had their own serialisation mechanism and did not need `#[serial]`.
+
+## Evidence
+
+This is a backend/infrastructure change with no visual output.
+
+- `./quality.sh` passes with `--test-threads=2` (all tests pass, including the
+  newly serialised env-var tests).
+- CI already used `--test-threads=2`, so the same thread count is now
+  consistent in both environments.
+
+## Test Plan
+
+- No new tests added — this change marks existing tests with `#[serial]` to
+  make them safe under parallel execution.
+- Verified all tests pass under `--test-threads=2` via `./quality.sh`.
+
+### Files with `#[serial]` additions
+
+| File | Tests marked `#[serial]` |
+|------|--------------------------|
+| `tests/observability.rs` | 3 tests (TIMING, PROFILE, GPU_METRICS env vars) |
+| `tests/gpu_timing.rs` | 4 tests (GPU_TIMING env var) |
+| `tests/issue_228_zero_copy_buffer.rs` | 3 tests (ZERO_COPY env var) |
+| `tests/issue_193_streaming_parquet.rs` | 4 tests (BLOCK_SIZE env var) |
+| `tests/issue_192_error_distribution_analysis.rs` | 3 tests (OUTLIER_ANALYSIS env var) |
+| `tests/issue_527_diagnostic_tracking.rs` | 2 tests (NEURON_TARGETS_OUTPUT_ONLY env var) |
+| `tests/issue_156_hidden_focus_neurons_filtered.rs` | 1 test (NEURON_TARGETS_OUTPUT_ONLY env var) |
+| `src/analysis/streaming.rs` | 2 inline tests (BLOCK_SIZE, PRELOAD_ALL env vars) |
+| `src/analysis/scoring/error_distribution.rs` | 1 inline test (OUTLIER env vars) |
+| `src/analysis/samples/mod.rs` | 1 inline test (CONSTANT_SOURCE_EFFECT_THRESHOLD env var) |

--- a/quality.sh
+++ b/quality.sh
@@ -32,9 +32,10 @@ echo "✅ Running type checks..."
 cargo check --all-targets --all-features
 
 echo "🧪 Running tests..."
-# Run tests sequentially to avoid interference from shared global state (deadline override, GPU failure guard, env vars)
+# Tests that mutate shared global state (env vars, deadline overrides, watchdog) are marked
+# with #[serial] from the serial_test crate and will not run concurrently with each other.
 # Note: Exclude benchmarks (--benches) since criterion benchmarks use custom harness and fail with --test-threads
-cargo test --lib --tests --all-features -- --test-threads=1
+cargo test --lib --tests --all-features -- --test-threads=2
 
 echo "📖 Building documentation..."
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps

--- a/src/analysis/samples/mod.rs
+++ b/src/analysis/samples/mod.rs
@@ -482,9 +482,10 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_get_constant_source_threshold_no_env_var() {
         // Remove env var to test dynamic threshold
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::remove_var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD");
         }

--- a/src/analysis/scoring/error_distribution.rs
+++ b/src/analysis/scoring/error_distribution.rs
@@ -584,8 +584,9 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_env_var_defaults() {
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::remove_var("NEAT_AI_DISCOVERY_OUTLIER_ANALYSIS");
             std::env::remove_var("NEAT_AI_DISCOVERY_OUTLIER_PERCENTILE");

--- a/src/analysis/streaming.rs
+++ b/src/analysis/streaming.rs
@@ -702,9 +702,10 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn is_streaming_enabled_default() {
         // When env var is not set, streaming should be enabled
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::remove_var("NEAT_AI_DISCOVERY_PRELOAD_ALL");
         }
@@ -720,14 +721,15 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn block_size_respects_minimum() {
         // Even with small values, block size should be at least MIN_BLOCK_SIZE
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::set_var("NEAT_AI_DISCOVERY_BLOCK_SIZE", "1");
         }
         assert!(get_block_size() >= MIN_BLOCK_SIZE);
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::remove_var("NEAT_AI_DISCOVERY_BLOCK_SIZE");
         }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn watchdog_config_disabled_by_default() {
         let _lock = lock_for_test_serialisation();
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via lock_for_test_serialisation() — no concurrent env access.
         unsafe {
             std::env::remove_var("NEAT_AI_DISCOVERY_WATCHDOG_STALL_SECS");
         }

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -17,6 +17,7 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_neurons, analyze_synapses
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeNeuronsInput, AnalyzeSynapsesInput, CreatureJson, NeuronJson};
+use serial_test::serial;
 use std::env;
 use tempfile::tempdir;
 
@@ -104,11 +105,12 @@ fn timing_collector_disabled() {
 
 /// Test that timing IS collected when the environment variable is set.
 #[test]
+#[serial]
 fn timing_enabled_via_env_var() {
     skip_without_gpu!();
 
     // Set the environment variable to enable timing
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_GPU_TIMING", "1") };
 
     let (parquet_file, creature) = create_test_data();
@@ -164,10 +166,11 @@ fn timing_enabled_via_env_var() {
 
 /// Test that per-shader timing is collected.
 #[test]
+#[serial]
 fn per_shader_timing_collected() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_GPU_TIMING", "1") };
 
     let (parquet_file, creature) = create_test_data();
@@ -200,10 +203,11 @@ fn per_shader_timing_collected() {
 
 /// Test that timing output is included in JSON response when enabled.
 #[test]
+#[serial]
 fn timing_in_json_output() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_GPU_TIMING", "1") };
 
     let (parquet_file, creature) = create_test_data();
@@ -301,10 +305,11 @@ fn timing_collector_disabled_vs_enabled_behaviour() {
 /// This tests the neuron analysis code path to ensure timing is properly
 /// integrated there (not just synapse analysis).
 #[test]
+#[serial]
 fn neuron_analysis_timing_collected() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_GPU_TIMING", "1") };
 
     let (parquet_file, creature) = create_test_data();

--- a/tests/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/issue_156_hidden_focus_neurons_filtered.rs
@@ -12,6 +12,7 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_neurons};
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 /// Skip test if no GPU available.
@@ -24,7 +25,7 @@ macro_rules! skip_without_gpu {
     };
 }
 
-/// Minimal env var guard so tests remain isolated (quality.sh runs tests with 1 thread, but keep it tidy).
+/// Minimal env var guard so tests remain isolated (env var tests are serialised via `#[serial]`).
 struct EnvVarGuard {
     key: &'static str,
     previous: Option<String>,
@@ -33,7 +34,7 @@ struct EnvVarGuard {
 impl EnvVarGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe {
             std::env::set_var(key, value);
         }
@@ -43,7 +44,7 @@ impl EnvVarGuard {
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         match &self.previous {
             Some(v) => unsafe { std::env::set_var(self.key, v) },
             None => unsafe { std::env::remove_var(self.key) },
@@ -52,6 +53,7 @@ impl Drop for EnvVarGuard {
 }
 
 #[test]
+#[serial]
 fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled() {
     skip_without_gpu!();
 

--- a/tests/issue_182_focus_unused_observations.rs
+++ b/tests/issue_182_focus_unused_observations.rs
@@ -37,7 +37,7 @@ struct EnvVarGuard {
 impl EnvVarGuard {
     fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var(key).ok();
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
@@ -45,7 +45,7 @@ impl EnvVarGuard {
 
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
         match &self.previous {
             Some(v) => unsafe { std::env::set_var(self.key, v) },
             None => unsafe { std::env::remove_var(self.key) },
@@ -159,8 +159,7 @@ fn issue_182_env_var_parsing() {
 #[serial]
 fn issue_182_env_var_parsing_not_set() {
     // Test with env var explicitly removed (using guard to restore)
-    // Note: This test may fail if run in parallel with other tests that set the env var.
-    // quality.sh runs tests with --test-threads=1 to avoid this.
+    // Note: This test is serialised via #[serial] to avoid concurrent env var access.
     let _guard = EnvVarGuard::set("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS", "");
     // Empty string should be treated as disabled
     assert!(
@@ -266,7 +265,7 @@ fn issue_182_without_env_var_no_prioritisation() {
     skip_without_gpu!();
 
     // Ensure env var is NOT set
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { std::env::remove_var("NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS") };
 
     let creature = create_test_creature();

--- a/tests/issue_192_error_distribution_analysis.rs
+++ b/tests/issue_192_error_distribution_analysis.rs
@@ -19,6 +19,7 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_synapses};
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 /// Skip test if no GPU available
@@ -371,9 +372,10 @@ fn test_detect_error_modes_unimodal() {
 
 /// Test: outlier_analysis_enabled returns false by default.
 #[test]
+#[serial]
 fn test_outlier_analysis_disabled_by_default() {
     // Ensure env var is not set
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { std::env::remove_var("NEAT_AI_DISCOVERY_OUTLIER_ANALYSIS") };
 
     let enabled = outlier_analysis_enabled();
@@ -382,8 +384,9 @@ fn test_outlier_analysis_disabled_by_default() {
 
 /// Test: outlier_percentile_from_env returns 90 by default.
 #[test]
+#[serial]
 fn test_outlier_percentile_default() {
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { std::env::remove_var("NEAT_AI_DISCOVERY_OUTLIER_PERCENTILE") };
 
     let percentile = outlier_percentile_from_env();
@@ -500,11 +503,12 @@ fn test_synapse_analysis_includes_error_distribution() {
 
 /// Test: Candidate includes outlier information when outlier analysis is enabled.
 #[test]
+#[serial]
 fn test_candidate_includes_outlier_info_when_enabled() {
     skip_without_gpu!();
 
     // Enable outlier analysis
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { std::env::set_var("NEAT_AI_DISCOVERY_OUTLIER_ANALYSIS", "1") };
 
     let creature = create_test_creature(

--- a/tests/issue_193_streaming_parquet.rs
+++ b/tests/issue_193_streaming_parquet.rs
@@ -21,6 +21,7 @@ mod common;
 
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
+use serial_test::serial;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::TempDir;
@@ -28,7 +29,7 @@ use tempfile::TempDir;
 /// Set up small block size for testing (10 records per block).
 /// This ensures multiple blocks are created from small test datasets.
 fn setup_test_block_size() {
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_BLOCK_SIZE", "10");
     }
@@ -36,7 +37,7 @@ fn setup_test_block_size() {
 
 /// Restore default block size after tests.
 fn teardown_test_block_size() {
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::remove_var("NEAT_AI_DISCOVERY_BLOCK_SIZE");
     }
@@ -119,6 +120,7 @@ fn streaming_cache_respects_max_blocks() {
 
 /// Test that LRU eviction works correctly.
 #[test]
+#[serial]
 fn streaming_cache_evicts_least_recently_used() {
     use neat_ai_discovery::analysis::cache::StreamingRecordCache;
 
@@ -160,6 +162,7 @@ fn streaming_cache_evicts_least_recently_used() {
 
 /// Test that prefetch mechanism loads adjacent blocks.
 #[test]
+#[serial]
 fn streaming_cache_prefetches_adjacent_blocks() {
     use neat_ai_discovery::analysis::cache::StreamingRecordCache;
     use std::thread;
@@ -288,6 +291,7 @@ fn streaming_cache_stats_are_accurate() {
 
 /// Test that streaming cache memory usage is bounded.
 #[test]
+#[serial]
 fn streaming_cache_bounds_memory_usage() {
     use neat_ai_discovery::analysis::cache::StreamingRecordCache;
 
@@ -344,6 +348,7 @@ fn new_adaptive_uses_streaming_for_memory_constraints() {
 
 /// Test that streaming mode provides same data as pre-loaded mode.
 #[test]
+#[serial]
 fn streaming_mode_matches_preloaded_data() {
     use neat_ai_discovery::analysis::cache::{RecordCache, StreamingRecordCache};
 

--- a/tests/issue_199_dynamic_constant_source_threshold.rs
+++ b/tests/issue_199_dynamic_constant_source_threshold.rs
@@ -27,7 +27,7 @@ fn issue_199_low_variance_sources_use_default_threshold() {
     skip_without_gpu!();
 
     // Clear any env override to use dynamic threshold
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::remove_var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD");
     }
@@ -127,7 +127,7 @@ fn issue_199_high_variance_sources_scale_threshold() {
     skip_without_gpu!();
 
     // Clear any env override to use dynamic threshold
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::remove_var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD");
     }
@@ -241,7 +241,7 @@ fn issue_199_env_var_override_takes_precedence() {
     skip_without_gpu!();
 
     // Set explicit threshold via env var - should override dynamic calculation
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD", "1e-3");
     }
@@ -325,7 +325,7 @@ fn issue_199_env_var_zero_disables_folding() {
     skip_without_gpu!();
 
     // Set threshold to 0 to disable folding entirely
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD", "0");
     }

--- a/tests/issue_228_zero_copy_buffer.rs
+++ b/tests/issue_228_zero_copy_buffer.rs
@@ -22,6 +22,7 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_synapses, supports_unifie
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson};
+use serial_test::serial;
 use tempfile::tempdir;
 
 /// Skip test if no GPU available
@@ -106,10 +107,11 @@ fn zero_copy_config_default() {
 
 /// Test that ZeroCopyBufferConfig respects environment variable override.
 #[test]
+#[serial]
 fn zero_copy_config_env_override() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     // Test enabling via env var
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_ZERO_COPY", "1");
@@ -147,6 +149,7 @@ fn zero_copy_config_env_override() {
 ///
 /// This test verifies that enabling zero-copy doesn't change the analysis results.
 #[test]
+#[serial]
 fn zero_copy_produces_correct_results() {
     skip_without_gpu!();
 
@@ -191,7 +194,7 @@ fn zero_copy_produces_correct_results() {
         synapses: Vec::new(),
     };
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     // Run analysis with zero-copy enabled (if supported)
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_ZERO_COPY", "1");
@@ -342,6 +345,7 @@ fn metadata_includes_zero_copy_status() {
 /// This test creates multiple analysis requests that would be processed
 /// concurrently, verifying that the ring buffer synchronisation is correct.
 #[test]
+#[serial]
 fn zero_copy_no_data_corruption() {
     skip_without_gpu!();
 
@@ -388,7 +392,7 @@ fn zero_copy_no_data_corruption() {
         synapses: Vec::new(),
     };
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     // Enable zero-copy
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_ZERO_COPY", "1");

--- a/tests/issue_527_diagnostic_tracking.rs
+++ b/tests/issue_527_diagnostic_tracking.rs
@@ -19,6 +19,7 @@ use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{
     AnalyzeNeuronsInput, AnalyzeSynapsesInput, CreatureJson, analyze_parallel_internal,
 };
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 /// Skip test if no GPU available.
@@ -76,6 +77,7 @@ fn write_minimal_records(path: &str, neuron_uuids: &[&str], obs_count: u32) {
 // =============================================================================
 
 #[test]
+#[serial]
 fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
     skip_without_gpu!();
 
@@ -89,7 +91,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
     );
 
     // Enable output-only mode so hidden neurons get filtered
-    // SAFETY: Tests run single-threaded (--test-threads=1)
+    // SAFETY: Serialised via #[serial] — no concurrent env access
     let prev = std::env::var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY").ok();
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY", "1");
@@ -107,7 +109,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
     let result = analyze_neurons(&input).expect("analysis should succeed");
 
     // Restore env var
-    // SAFETY: Tests run single-threaded (--test-threads=1)
+    // SAFETY: Serialised via #[serial] — no concurrent env access
     match &prev {
         Some(v) => unsafe { std::env::set_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY", v) },
         None => unsafe { std::env::remove_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY") },
@@ -309,6 +311,7 @@ fn json_output_includes_diagnostic_fields() {
 // =============================================================================
 
 #[test]
+#[serial]
 fn json_diagnostic_reasons_use_snake_case() {
     skip_without_gpu!();
 
@@ -322,7 +325,7 @@ fn json_diagnostic_reasons_use_snake_case() {
     );
 
     // Enable output-only mode so hidden neurons get filtered and generate diagnostics
-    // SAFETY: Tests run single-threaded (--test-threads=1)
+    // SAFETY: Serialised via #[serial] — no concurrent env access
     let prev = std::env::var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY").ok();
     unsafe {
         std::env::set_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY", "1");
@@ -344,7 +347,7 @@ fn json_diagnostic_reasons_use_snake_case() {
         serde_json::from_str(&output_json).expect("output should be valid JSON");
 
     // Restore env var
-    // SAFETY: Tests run single-threaded (--test-threads=1)
+    // SAFETY: Serialised via #[serial] — no concurrent env access
     match &prev {
         Some(v) => unsafe { std::env::set_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY", v) },
         None => unsafe { std::env::remove_var("NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY") },

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -19,6 +19,7 @@ use neat_ai_discovery::observability::{
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson};
+use serial_test::serial;
 use std::env;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -357,11 +358,12 @@ fn create_test_data() -> (String, CreatureJson) {
 
 /// Test that timing output includes phase breakdown when NEAT_AI_DISCOVERY_TIMING=1.
 #[test]
+#[serial]
 fn integration_timing_output() {
     skip_without_gpu!();
 
     // Set environment variable
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_TIMING", "1") };
 
     let (parquet_file, creature) = create_test_data();
@@ -388,10 +390,11 @@ fn integration_timing_output() {
 
 /// Test that JSON profile output is structured correctly when NEAT_AI_DISCOVERY_PROFILE=json.
 #[test]
+#[serial]
 fn integration_json_profile() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_PROFILE", "json") };
 
     let (parquet_file, creature) = create_test_data();
@@ -423,10 +426,11 @@ fn integration_json_profile() {
 
 /// Test that GPU metrics are collected when NEAT_AI_DISCOVERY_GPU_METRICS=1.
 #[test]
+#[serial]
 fn integration_gpu_metrics() {
     skip_without_gpu!();
 
-    // SAFETY: Tests run single-threaded (--test-threads=1), no concurrent env access.
+    // SAFETY: Serialised via #[serial] — no concurrent env access.
     unsafe { env::set_var("NEAT_AI_DISCOVERY_GPU_METRICS", "1") };
 
     let (parquet_file, creature) = create_test_data();


### PR DESCRIPTION
## Summary

Fix test thread count inconsistency between `quality.sh` (`--test-threads=1`)
and CI (`--test-threads=2`) by marking tests that mutate shared global state
with `#[serial]` from the `serial_test` crate, and aligning both environments
to `--test-threads=2`. Closes #673.

### Root Cause

Tests that set environment variables (e.g. `NEAT_AI_DISCOVERY_GPU_TIMING`,
`NEAT_AI_DISCOVERY_ZERO_COPY`, `NEAT_AI_DISCOVERY_BLOCK_SIZE`) were relying
on `--test-threads=1` for correctness instead of explicit serialisation. This
meant CI (which used `--test-threads=2`) could see env-var races that local
`quality.sh` (which used `--test-threads=1`) would never trigger.

### Changes

1. **Added `#[serial]`** to all tests that mutate environment variables (22
   tests across 10 files — 7 integration test files and 3 inline `src/` test
   modules).
2. **Aligned `quality.sh`** from `--test-threads=1` to `--test-threads=2` to
   match CI.
3. **Updated SAFETY comments** from "Tests run single-threaded
   (`--test-threads=1`)" to "Serialised via `#[serial]`" across all affected
   files.
4. **Updated documentation** in `AGENTS.md`, `README.md`, `CONTRIBUTING.md`,
   and `benchmark.sh` to reflect the new `--test-threads=2` setting and
   `#[serial]` convention.

Tests using `lock_for_test_serialisation()` (watchdog/dispatch tests) already
had their own serialisation mechanism and did not need `#[serial]`.

## Evidence

This is a backend/infrastructure change with no visual output.

- `./quality.sh` passes with `--test-threads=2` (all tests pass, including the
  newly serialised env-var tests).
- CI already used `--test-threads=2`, so the same thread count is now
  consistent in both environments.

## Test Plan

- No new tests added — this change marks existing tests with `#[serial]` to
  make them safe under parallel execution.
- Verified all tests pass under `--test-threads=2` via `./quality.sh`.

### Files with `#[serial]` additions

| File | Tests marked `#[serial]` |
|------|--------------------------|
| `tests/observability.rs` | 3 tests (TIMING, PROFILE, GPU_METRICS env vars) |
| `tests/gpu_timing.rs` | 4 tests (GPU_TIMING env var) |
| `tests/issue_228_zero_copy_buffer.rs` | 3 tests (ZERO_COPY env var) |
| `tests/issue_193_streaming_parquet.rs` | 4 tests (BLOCK_SIZE env var) |
| `tests/issue_192_error_distribution_analysis.rs` | 3 tests (OUTLIER_ANALYSIS env var) |
| `tests/issue_527_diagnostic_tracking.rs` | 2 tests (NEURON_TARGETS_OUTPUT_ONLY env var) |
| `tests/issue_156_hidden_focus_neurons_filtered.rs` | 1 test (NEURON_TARGETS_OUTPUT_ONLY env var) |
| `src/analysis/streaming.rs` | 2 inline tests (BLOCK_SIZE, PRELOAD_ALL env vars) |
| `src/analysis/scoring/error_distribution.rs` | 1 inline test (OUTLIER env vars) |
| `src/analysis/samples/mod.rs` | 1 inline test (CONSTANT_SOURCE_EFFECT_THRESHOLD env var) |

---

## Automated Fix Details
This PR addresses issue #673: **Fix test thread count inconsistency between quality.sh and CI**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #673