### PR TITLE
ci: stricter Cargo.toml validation — exclude comments, exact field match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         fi
         
         for field in "name" "version" "edition"; do
-          if ! grep -q "$field = " Cargo.toml; then
+          if ! grep -vE "^[[:space:]]*#" Cargo.toml | grep -qE "^[[:space:]]*${field}[[:space:]]*="; then
             echo "❌ Missing '$field' field in Cargo.toml"
             exit 1
           fi

--- a/docs/pr-summary-691.md
+++ b/docs/pr-summary-691.md
@@ -1,0 +1,27 @@
+## Summary
+
+Stricter Cargo.toml validation in CI to exclude comment lines and require exact field matches. Closes #691.
+
+The previous `grep -q "$field = "` pattern had two false-positive risks:
+1. Commented-out fields (e.g. `# name = "old"`) would still match
+2. Substring matches (e.g. `rust-version` matching `version`)
+
+Updated to use a two-stage grep:
+- `grep -vE "^[[:space:]]*#"` strips comment lines
+- `grep -qE "^[[:space:]]*${field}[[:space:]]*="` requires the field at line start
+
+## Evidence
+
+This is a CI/shell change with no visual output. Verified by:
+- Shell test script `tests/test_cargo_toml_validation.sh` covering 16 test cases
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Added `tests/test_cargo_toml_validation.sh` with 16 test cases:
+  - Uncommented fields are correctly detected
+  - Commented-out fields are excluded
+  - Substring fields (e.g. `rust-version`) do not match `version`
+  - Varying whitespace is handled
+  - Real `Cargo.toml` passes validation
+  - Regression tests for old pattern false positives

--- a/tests/test_cargo_toml_validation.sh
+++ b/tests/test_cargo_toml_validation.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Test script for stricter Cargo.toml field validation (Issue #691)
+#
+# Validates that the CI grep pattern:
+# 1. Skips comment lines (lines starting with optional whitespace + #)
+# 2. Requires exact field match at start of line (e.g. "version" must not match "rust-version")
+# 3. Accepts valid uncommented fields
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+assert_detected() {
+  local description="$1"
+  local toml_content="$2"
+  local field="$3"
+
+  if echo "$toml_content" | grep -vE "^[[:space:]]*#" | grep -qE "^[[:space:]]*${field}[[:space:]]*="; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $description — expected field '$field' to be detected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_detected() {
+  local description="$1"
+  local toml_content="$2"
+  local field="$3"
+
+  if echo "$toml_content" | grep -vE "^[[:space:]]*#" | grep -qE "^[[:space:]]*${field}[[:space:]]*="; then
+    echo "FAIL: $description — expected field '$field' NOT to be detected"
+    FAIL=$((FAIL + 1))
+  else
+    PASS=$((PASS + 1))
+  fi
+}
+
+# --- Test: uncommented fields are detected ---
+assert_detected \
+  "Uncommented name field" \
+  'name = "my-crate"' \
+  "name"
+
+assert_detected \
+  "Uncommented version field" \
+  'version = "1.0.0"' \
+  "version"
+
+assert_detected \
+  "Uncommented edition field" \
+  'edition = "2021"' \
+  "edition"
+
+# --- Test: commented-out fields are NOT detected ---
+assert_not_detected \
+  "Commented-out name field" \
+  '# name = "my-crate"' \
+  "name"
+
+assert_not_detected \
+  "Commented-out version field with leading whitespace" \
+  '  # version = "1.0.0"' \
+  "version"
+
+assert_not_detected \
+  "Commented-out edition field" \
+  '# edition = "2021"' \
+  "edition"
+
+# --- Test: substring fields must NOT match ---
+assert_not_detected \
+  "rust-version must not match version" \
+  'rust-version = "1.70"' \
+  "version"
+
+assert_not_detected \
+  "build-edition must not match edition" \
+  'build-edition = "2021"' \
+  "edition"
+
+# --- Test: fields with varying whitespace ---
+assert_detected \
+  "Field with spaces around equals" \
+  'name   =   "my-crate"' \
+  "name"
+
+assert_detected \
+  "Field with leading whitespace" \
+  '  version = "1.0.0"' \
+  "version"
+
+assert_detected \
+  "Field with tab before equals" \
+  "$(printf 'edition\t= \"2021\"')" \
+  "edition"
+
+# --- Test: real Cargo.toml has required fields ---
+if [ -f Cargo.toml ]; then
+  for field in "name" "version" "edition"; do
+    assert_detected \
+      "Real Cargo.toml contains $field" \
+      "$(cat Cargo.toml)" \
+      "$field"
+  done
+fi
+
+# --- Test: old pattern false positives (regression) ---
+# The old pattern `grep -q "$field = "` would match these incorrectly
+assert_not_detected \
+  "Old pattern regression: commented name" \
+  '# name = "commented-out"' \
+  "name"
+
+assert_not_detected \
+  "Old pattern regression: rust-version matching version" \
+  'rust-version = "1.70"' \
+  "version"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "❌ Some validation tests failed"
+  exit 1
+fi
+
+echo "✅ All validation tests passed"


### PR DESCRIPTION
## Summary

Stricter Cargo.toml validation in CI to exclude comment lines and require exact field matches. Closes #691.

The previous `grep -q "$field = "` pattern had two false-positive risks:
1. Commented-out fields (e.g. `# name = "old"`) would still match
2. Substring matches (e.g. `rust-version` matching `version`)

Updated to use a two-stage grep:
- `grep -vE "^[[:space:]]*#"` strips comment lines
- `grep -qE "^[[:space:]]*${field}[[:space:]]*="` requires the field at line start

## Evidence

This is a CI/shell change with no visual output. Verified by:
- Shell test script `tests/test_cargo_toml_validation.sh` covering 16 test cases
- `quality.sh` passes cleanly

## Test Plan

- Added `tests/test_cargo_toml_validation.sh` with 16 test cases:
  - Uncommented fields are correctly detected
  - Commented-out fields are excluded
  - Substring fields (e.g. `rust-version`) do not match `version`
  - Varying whitespace is handled
  - Real `Cargo.toml` passes validation
  - Regression tests for old pattern false positives

---

## Automated Fix Details
This PR addresses issue #691: **CI: Stricter Cargo.toml validation (exclude comments, exact field match)**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #691