### PR TITLE
ci: add clippy::filter_next and clippy::collapsible_if lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
       run: cargo fmt --all -- --check
       
     - name: Run linter
-      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
+      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if
       
     - name: Check types
       run: cargo check --all-targets --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,7 +393,7 @@ so do not skip this step.
 1. Bash syntax check (all `.sh` files)
 2. `cargo build` (debug, quick feedback)
 3. `cargo fmt --all` (auto-formatting)
-4. `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args`
+4. `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if`
 5. `cargo check --all-targets --all-features`
 6. `cargo test --lib --tests --all-features -- --test-threads=2`
 7. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` (documentation build)
@@ -596,7 +596,7 @@ cargo bench --bench <bench_name>
 cargo fmt --all -- --check
 
 # Lint
-cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
+cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if
 ```
 
 ---

--- a/docs/pr-summary-692.md
+++ b/docs/pr-summary-692.md
@@ -1,0 +1,17 @@
+## Summary
+
+Add `clippy::filter_next` and `clippy::collapsible_if` denial lints to the Clippy invocation in CI (`ci.yml`), the local quality gate (`quality.sh`), and documentation (`AGENTS.md`) for consistency with sibling Rust repositories. Closes #692.
+
+- `clippy::filter_next` — suggests `.find()` instead of `.filter().next()`
+- `clippy::collapsible_if` — suggests merging nested `if` blocks where appropriate
+
+No existing code violated these lints, so no source changes were required.
+
+## Evidence
+
+This is a CI/tooling change with no visual output. Verified by running `./quality.sh` locally — all checks pass cleanly with the new lints enabled.
+
+## Test Plan
+
+- Ran `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if` — zero warnings
+- Ran full `./quality.sh` — all steps pass (fmt, clippy, check, tests, docs, release build)

--- a/quality.sh
+++ b/quality.sh
@@ -26,7 +26,7 @@ echo "🪄 Auto-formatting code..."
 cargo fmt --all
 
 echo "🔧 Running linter..."
-cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args
+cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if
 
 echo "✅ Running type checks..."
 cargo check --all-targets --all-features


### PR DESCRIPTION
## Summary

Add `clippy::filter_next` and `clippy::collapsible_if` denial lints to the Clippy invocation in CI (`ci.yml`), the local quality gate (`quality.sh`), and documentation (`AGENTS.md`) for consistency with sibling Rust repositories. Closes #692.

- `clippy::filter_next` — suggests `.find()` instead of `.filter().next()`
- `clippy::collapsible_if` — suggests merging nested `if` blocks where appropriate

No existing code violated these lints, so no source changes were required.

## Evidence

This is a CI/tooling change with no visual output. Verified by running `./quality.sh` locally — all checks pass cleanly with the new lints enabled.

## Test Plan

- Ran `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args -D clippy::filter_next -D clippy::collapsible_if` — zero warnings
- Ran full `./quality.sh` — all steps pass (fmt, clippy, check, tests, docs, release build)

---

## Automated Fix Details
This PR addresses issue #692: **CI: Add extra Clippy lints (filter_next, collapsible_if) for consistency**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #692