### PR TITLE
refactor: replace too_many_arguments suppressions with parameter structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.13"
+version = "0.42.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.42.14"
+version = "0.42.15"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-715.md
+++ b/docs/pr-summary-715.md
@@ -1,0 +1,35 @@
+## Summary
+
+Refactor 9 functions to use parameter structs instead of long argument lists,
+removing all `#[allow(clippy::too_many_arguments)]` suppressions. Closes #715.
+
+### Parameter structs introduced
+
+| Struct | File | Functions served |
+|--------|------|-----------------|
+| `NeuronEvalContext` | `neuron/evaluation.rs` | `evaluate_neuron_candidates`, `evaluate_relu_split`, `evaluate_activation_specs` |
+| `NeuronResultParams` | `neuron/post_processing.rs` | `build_neuron_results` |
+| `ReplaceSynapseParams` | `synapse/filtering.rs` | `expected_gain_replace_synapse_with_hidden_neuron` |
+| `SubsetEvalParams` | `synapse/gpu_evaluation.rs` | `evaluate_activation_for_subset` |
+| `ActivationEvalParams` | `synapse/gpu_evaluation.rs` | `evaluate_activation_candidate` |
+| `ThreeHopContext` | `recommendation/multi_hop.rs` | `find_three_hop_extensions` |
+
+For `evaluate_all_activation_specs_batched` (6 params, under the clippy limit),
+the suppression was simply removed since no struct was needed.
+
+### No behavioural changes
+
+This is a pure refactoring. All call sites construct the new structs with the
+same values previously passed as positional arguments.
+
+## Evidence
+
+- `quality.sh` passes cleanly (fmt, clippy, check, tests, doc build, release build)
+- Zero `#[allow(clippy::too_many_arguments)]` annotations remain in the codebase
+- No UI changes; backend-only refactoring
+
+## Test Plan
+
+- All existing tests pass without modification (except updating one test call site
+  in `implementation_tests/optimal_weight_tests.rs` to use `ActivationEvalParams`)
+- No new tests needed — this is a signature-level refactoring with no behavioural change

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -129,17 +129,19 @@ pub(crate) fn convert_neurons_to_coordinated_replacements(
             candidate.bias,
         );
 
-        let mut expected_gain = synapse::expected_gain_replace_synapse_with_hidden_neuron(
-            shared_cache.as_ref(),
-            &candidate.source_neuron_uuid,
-            &candidate.target_neuron_uuid,
+        let replace_params = synapse::ReplaceSynapseParams {
+            cache: shared_cache.as_ref(),
+            source_uuid: &candidate.source_neuron_uuid,
+            target_uuid: &candidate.target_neuron_uuid,
             old_weight,
-            candidate.incoming_weight,
-            candidate.outgoing_weight,
-            candidate.bias,
-            &candidate.squash,
-        )
-        .unwrap_or(candidate.expected_creature_score_gain);
+            incoming_weight: candidate.incoming_weight,
+            outgoing_weight: candidate.outgoing_weight,
+            bias: candidate.bias,
+            squash: &candidate.squash,
+        };
+        let mut expected_gain =
+            synapse::expected_gain_replace_synapse_with_hidden_neuron(&replace_params)
+                .unwrap_or(candidate.expected_creature_score_gain);
 
         // Apply a conservative impact discount when the target is hidden.
         // This mirrors the synapse/neurons discounting semantics without requiring deep graph analysis.

--- a/src/analysis/implementation_tests/optimal_weight_tests.rs
+++ b/src/analysis/implementation_tests/optimal_weight_tests.rs
@@ -12,7 +12,7 @@ use super::common::*;
 use crate::analysis::activation::ActivationCandidateSpec;
 use crate::analysis::gpu::GpuEvaluator;
 use crate::analysis::samples::ReluStats;
-use crate::analysis::synapse::evaluate_activation_candidate;
+use crate::analysis::synapse::{ActivationEvalParams, evaluate_activation_candidate};
 use anyhow::anyhow;
 
 struct AlwaysFailGpuEvaluator;
@@ -106,9 +106,16 @@ fn identity_all_samples_fallback_uses_affine_fit_even_when_base_weight_is_none()
         });
     }
 
+    let eval_params = ActivationEvalParams {
+        source_uuid: "source-0",
+        target_uuid: "target-0",
+        samples: &samples,
+        threshold: 0.0,
+        spec: &spec,
+        target_squash: None,
+    };
     let candidate =
-        evaluate_activation_candidate(&gpu, "source-0", "target-0", &samples, 0.0, &spec, None)
-            .expect("Evaluation should succeed");
+        evaluate_activation_candidate(&gpu, &eval_params).expect("Evaluation should succeed");
 
     assert!(
         candidate.is_some(),

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -26,23 +26,28 @@ pub(crate) struct NeuronWorkResult {
     pub samples: Vec<HelpfulSample>,
 }
 
+/// Shared context for neuron candidate evaluation, grouping parameters that
+/// are passed through evaluate → relu_split / activation_specs.
+pub(crate) struct NeuronEvalContext<'a> {
+    pub gpu: &'a GpuWorkQueue,
+    pub neuron_squash_map: &'a Arc<HashMap<String, String>>,
+    pub timing_collector: &'a Arc<super::super::shared::TimingCollector>,
+    pub diagnostics: &'a Arc<NeuronDiagnostics>,
+    pub helpful_map: &'a Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
+    pub threshold: f32,
+}
+
 /// Evaluate neuron candidates for all sources with samples against a single
 /// target neuron using GPU shaders.
 ///
 /// This handles both ReLU split evaluation and batched activation spec
 /// evaluation, applying source variance discounting.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_neuron_candidates(
     work_results: &[NeuronWorkResult],
     target_uuid: &str,
-    gpu: &GpuWorkQueue,
-    neuron_squash_map_arc: &Arc<HashMap<String, String>>,
-    timing_collector: &Arc<super::super::shared::TimingCollector>,
+    ctx: &NeuronEvalContext<'_>,
     deadline: &Option<SystemTime>,
     analysis_timed_out: &Arc<Mutex<bool>>,
-    diagnostics: &Arc<NeuronDiagnostics>,
-    helpful_map: &Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
-    threshold: f32,
 ) -> Result<()> {
     for result in work_results {
         // Check deadline before each evaluation batch
@@ -56,7 +61,8 @@ pub(crate) fn evaluate_neuron_candidates(
         }
 
         // Get target_squash for accurate HARD_TANH modelling
-        let target_squash = neuron_squash_map_arc
+        let target_squash = ctx
+            .neuron_squash_map
             .get(target_uuid)
             .map(std::string::String::as_str);
 
@@ -70,57 +76,44 @@ pub(crate) fn evaluate_neuron_candidates(
 
         // ReLU evaluation: split by TARGET neuron's error sign.
         evaluate_relu_split(
-            gpu,
             &result.source_uuid,
             target_uuid,
             &result.samples,
-            threshold,
             target_squash,
             source_variance_discount,
-            timing_collector,
-            diagnostics,
-            helpful_map,
+            ctx,
         )?;
 
         // Issue #201: Evaluate all activation specs in a single batched GPU call
         evaluate_activation_specs(
-            gpu,
             &result.source_uuid,
             target_uuid,
             &result.samples,
-            threshold,
             target_squash,
             source_variance_discount,
-            timing_collector,
-            diagnostics,
-            helpful_map,
+            ctx,
         )?;
     }
     Ok(())
 }
 
 /// Evaluate ReLU candidates with positive/negative error split.
-#[allow(clippy::too_many_arguments)]
 fn evaluate_relu_split(
-    gpu: &GpuWorkQueue,
     source_uuid: &str,
     target_uuid: &str,
     samples: &[HelpfulSample],
-    threshold: f32,
     target_squash: Option<&str>,
     source_variance_discount: f32,
-    timing_collector: &Arc<super::super::shared::TimingCollector>,
-    diagnostics: &Arc<NeuronDiagnostics>,
-    helpful_map: &Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
+    ctx: &NeuronEvalContext<'_>,
 ) -> Result<()> {
     let split_result = {
-        let _timing = TimingScope::shader(timing_collector, "relu");
+        let _timing = TimingScope::shader(ctx.timing_collector, "relu");
         evaluate_relu_candidates_split(
-            gpu,
+            ctx.gpu,
             source_uuid,
             target_uuid,
             samples,
-            threshold,
+            ctx.threshold,
             target_squash,
         )?
     };
@@ -140,8 +133,8 @@ fn evaluate_relu_split(
                 "ReLU candidate identified"
             );
         }
-        diagnostics.mark_candidate_selected(target_uuid);
-        let mut map = lock_or_bail(helpful_map, "helpful_map")?;
+        ctx.diagnostics.mark_candidate_selected(target_uuid);
+        let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
         upsert_candidate(&mut map, candidate);
     }
 
@@ -160,8 +153,8 @@ fn evaluate_relu_split(
                 "ReLU candidate identified"
             );
         }
-        diagnostics.mark_candidate_selected(target_uuid);
-        let mut map = lock_or_bail(helpful_map, "helpful_map")?;
+        ctx.diagnostics.mark_candidate_selected(target_uuid);
+        let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
         upsert_candidate(&mut map, candidate);
     }
 
@@ -169,27 +162,22 @@ fn evaluate_relu_split(
 }
 
 /// Evaluate all activation function specs in a single batched GPU call.
-#[allow(clippy::too_many_arguments)]
 fn evaluate_activation_specs(
-    gpu: &GpuWorkQueue,
     source_uuid: &str,
     target_uuid: &str,
     samples: &[HelpfulSample],
-    threshold: f32,
     target_squash: Option<&str>,
     source_variance_discount: f32,
-    timing_collector: &Arc<super::super::shared::TimingCollector>,
-    diagnostics: &Arc<NeuronDiagnostics>,
-    helpful_map: &Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
+    ctx: &NeuronEvalContext<'_>,
 ) -> Result<()> {
     let batched_candidates = {
-        let _timing = TimingScope::shader(timing_collector, "activation");
+        let _timing = TimingScope::shader(ctx.timing_collector, "activation");
         evaluate_all_activation_specs_batched(
-            gpu,
+            ctx.gpu,
             source_uuid,
             target_uuid,
             samples,
-            threshold,
+            ctx.threshold,
             target_squash,
         )?
     };
@@ -199,8 +187,8 @@ fn evaluate_activation_specs(
         candidate.expected_creature_error_reduction *= source_variance_discount;
         candidate.expected_creature_score_gain *= source_variance_discount;
 
-        diagnostics.mark_candidate_selected(target_uuid);
-        let mut map = lock_or_bail(helpful_map, "helpful_map")?;
+        ctx.diagnostics.mark_candidate_selected(target_uuid);
+        let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
         upsert_candidate(&mut map, candidate);
     }
 

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -301,17 +301,20 @@ pub(crate) fn analyze_neurons_with_cache(
 
             // Phase 4: GPU evaluation
             if !is_threshold_target {
+                let eval_ctx = evaluation::NeuronEvalContext {
+                    gpu,
+                    neuron_squash_map: &neuron_squash_map_arc,
+                    timing_collector: &timing_collector,
+                    diagnostics: &diagnostics,
+                    helpful_map: &helpful_map,
+                    threshold,
+                };
                 evaluation::evaluate_neuron_candidates(
                     &work_results,
                     target_uuid,
-                    gpu,
-                    &neuron_squash_map_arc,
-                    &timing_collector,
+                    &eval_ctx,
                     &deadline,
                     &analysis_timed_out,
-                    &diagnostics,
-                    &helpful_map,
-                    threshold,
                 )?;
             }
 
@@ -325,19 +328,20 @@ pub(crate) fn analyze_neurons_with_cache(
         })?;
 
     // Post-processing: impact discounting, sorting, filtering, result assembly
-    post_processing::build_neuron_results(
-        &analysis_timed_out,
-        &helpful_map,
-        &completed_count,
+    let result_params = post_processing::NeuronResultParams {
+        analysis_timed_out: &analysis_timed_out,
+        helpful_map: &helpful_map,
+        completed_count: &completed_count,
         total_focus_count,
-        prep.original_focus_count,
-        &order_map_arc,
-        &prep.neuron_type_map,
+        original_focus_count: prep.original_focus_count,
+        order_map: &order_map_arc,
+        neuron_type_map: &prep.neuron_type_map,
         input,
-        &cache,
-        &error_values_for_distribution,
-        &timing_collector,
-        &diagnostics,
+        cache: &cache,
+        error_values_for_distribution: &error_values_for_distribution,
+        timing_collector: &timing_collector,
+        diagnostics: &diagnostics,
         gpu_used,
-    )
+    };
+    post_processing::build_neuron_results(&result_params)
 }

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -17,33 +17,39 @@ use crate::analysis::utils::{
     lock_or_bail, log_analysis_timeout, shuffle_within_top_k, verbose_enabled,
 };
 
+/// Parameters for building the final neuron analysis result.
+pub(crate) struct NeuronResultParams<'a> {
+    pub analysis_timed_out: &'a Arc<Mutex<bool>>,
+    pub helpful_map: &'a Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
+    pub completed_count: &'a Arc<std::sync::atomic::AtomicUsize>,
+    pub total_focus_count: usize,
+    pub original_focus_count: usize,
+    pub order_map: &'a Arc<HashMap<String, usize>>,
+    pub neuron_type_map: &'a HashMap<String, String>,
+    pub input: &'a AnalyzeNeuronsInput,
+    pub cache: &'a Arc<RecordCache>,
+    pub error_values_for_distribution: &'a Arc<Mutex<Vec<f32>>>,
+    pub timing_collector: &'a Arc<crate::analysis::shared::TimingCollector>,
+    pub diagnostics: &'a Arc<NeuronDiagnostics>,
+    pub gpu_used: bool,
+}
+
 /// Build the final neuron analysis result from the collected candidates.
 ///
 /// This applies impact-based discounting, pessimism discount, filtering,
 /// sorting, and assembles the result metadata.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_neuron_results(
-    analysis_timed_out: &Arc<Mutex<bool>>,
-    helpful_map: &Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
-    completed_count: &Arc<std::sync::atomic::AtomicUsize>,
-    total_focus_count: usize,
-    original_focus_count: usize,
-    order_map_arc: &Arc<HashMap<String, usize>>,
-    neuron_type_map: &HashMap<String, String>,
-    input: &AnalyzeNeuronsInput,
-    cache: &Arc<RecordCache>,
-    error_values_for_distribution: &Arc<Mutex<Vec<f32>>>,
-    timing_collector: &Arc<crate::analysis::shared::TimingCollector>,
-    diagnostics: &Arc<NeuronDiagnostics>,
-    gpu_used: bool,
+    params: &NeuronResultParams<'_>,
 ) -> Result<AnalyzeNeuronsResult> {
-    let analysis_timed_out = *lock_or_bail(analysis_timed_out, "analysis_timed_out")?;
-    let helpful_map = lock_or_bail(helpful_map, "helpful_map")?.clone();
+    let analysis_timed_out = *lock_or_bail(params.analysis_timed_out, "analysis_timed_out")?;
+    let helpful_map = lock_or_bail(params.helpful_map, "helpful_map")?.clone();
 
     // Log timeout with completion stats (always visible, not just verbose)
     if analysis_timed_out {
-        let completed = completed_count.load(std::sync::atomic::Ordering::Relaxed);
-        log_analysis_timeout("neuron", completed, total_focus_count);
+        let completed = params
+            .completed_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        log_analysis_timeout("neuron", completed, params.total_focus_count);
     }
 
     let mut helpful_results: Vec<CandidateNeuronJson> = helpful_map.into_values().collect();
@@ -51,10 +57,10 @@ pub(crate) fn build_neuron_results(
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     apply_impact_discounting(
         &mut helpful_results,
-        order_map_arc,
-        neuron_type_map,
-        input,
-        cache,
+        params.order_map,
+        params.neuron_type_map,
+        params.input,
+        params.cache,
     );
 
     // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
@@ -76,11 +82,11 @@ pub(crate) fn build_neuron_results(
     helpful_results = crate::analysis::utils::filter_candidates_to_sensible_ranges(helpful_results);
 
     // Deadline coverage (Jan 2026): diversify within the top-K
-    if input.analysis_deadline_ms.is_some() {
+    if params.input.analysis_deadline_ms.is_some() {
         use crate::analysis::constants::DIVERSIFY_TOP_K;
         shuffle_within_top_k(
             helpful_results.as_mut_slice(),
-            input.random_seed,
+            params.input.random_seed,
             "neuron:candidates:top_k",
             DIVERSIFY_TOP_K,
         );
@@ -90,19 +96,19 @@ pub(crate) fn build_neuron_results(
     let candidates_found = helpful_results.len();
 
     // Apply max_candidates limit (truncation)
-    if let Some(limit) = input.max_candidates {
+    if let Some(limit) = params.input.max_candidates {
         helpful_results.truncate(limit);
     }
 
     let candidates_returned = helpful_results.len();
 
-    let no_candidate_reasons = diagnostics.no_candidate_summaries();
-    diagnostics.emit_logs();
+    let no_candidate_reasons = params.diagnostics.no_candidate_summaries();
+    params.diagnostics.emit_logs();
 
     // Issue #486 / #192: Compute error distribution from collected target neuron error samples.
     let error_distribution = {
         let error_values = std::mem::take(&mut *lock_or_bail(
-            error_values_for_distribution,
+            params.error_values_for_distribution,
             "error_values_for_distribution",
         )?);
         crate::analysis::scoring::error_distribution::ErrorDistribution::from_errors(&error_values)
@@ -110,15 +116,17 @@ pub(crate) fn build_neuron_results(
 
     Ok(AnalyzeNeuronsResult {
         helpful_neurons: helpful_results,
-        gpu_used,
+        gpu_used: params.gpu_used,
         no_candidate_reasons,
         metadata: crate::analysis::shared::NeuronAnalysisMetadata {
             candidates_found,
             candidates_returned,
             timed_out: analysis_timed_out,
-            completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
-            total_focus_neurons: original_focus_count,
-            timing: timing_collector.finalize(),
+            completed_focus_neurons: params
+                .completed_count
+                .load(std::sync::atomic::Ordering::Relaxed),
+            total_focus_neurons: params.original_focus_count,
+            timing: params.timing_collector.finalize(),
             gpu_info: GpuAnalyzer::get_adapter_info(),
             error_distribution,
         },

--- a/src/analysis/recommendation/multi_hop.rs
+++ b/src/analysis/recommendation/multi_hop.rs
@@ -212,17 +212,17 @@ pub fn detect_multi_hop_candidates(
 
             // Try to extend to three-hop if path length allows
             if all_candidates.len() < MAX_TOTAL_CANDIDATES && MAX_PATH_LENGTH >= 3 {
-                find_three_hop_extensions(
+                let three_hop_ctx = ThreeHopContext {
                     intermediate_uuid,
                     target_uuid,
-                    corr,
-                    &source_candidate_uuids,
-                    &activation_by_obs,
-                    &existing_synapses,
-                    &output_uuids,
+                    intermediate_target_corr: corr,
+                    source_candidates: &source_candidate_uuids,
+                    activation_by_obs: &activation_by_obs,
+                    existing_synapses: &existing_synapses,
+                    output_uuids: &output_uuids,
                     target_errors,
-                    &mut all_candidates,
-                );
+                };
+                find_three_hop_extensions(&three_hop_ctx, &mut all_candidates);
             }
         }
     }
@@ -236,47 +236,54 @@ pub fn detect_multi_hop_candidates(
     all_candidates
 }
 
+/// Context for extending two-hop candidates into three-hop candidates.
+struct ThreeHopContext<'a> {
+    intermediate_uuid: &'a str,
+    target_uuid: &'a str,
+    intermediate_target_corr: f32,
+    source_candidates: &'a [&'a str],
+    activation_by_obs: &'a HashMap<&'a str, HashMap<u32, f32>>,
+    existing_synapses: &'a HashSet<(&'a str, &'a str)>,
+    output_uuids: &'a HashSet<&'a str>,
+    target_errors: &'a HashMap<u32, f32>,
+}
+
 /// Extend a two-hop candidate (intermediate → target) to a three-hop candidate
 /// (source → intermediate → target) by finding sources whose activation correlates
 /// with the intermediate's activation.
-#[allow(clippy::too_many_arguments)]
-fn find_three_hop_extensions(
-    intermediate_uuid: &str,
-    target_uuid: &str,
-    intermediate_target_corr: f32,
-    source_candidates: &[&str],
-    activation_by_obs: &HashMap<&str, HashMap<u32, f32>>,
-    existing_synapses: &HashSet<(&str, &str)>,
-    output_uuids: &HashSet<&str>,
-    target_errors: &HashMap<u32, f32>,
-    candidates: &mut Vec<MultiHopCandidate>,
-) {
-    let intermediate_activations = match activation_by_obs.get(intermediate_uuid) {
+fn find_three_hop_extensions(ctx: &ThreeHopContext<'_>, candidates: &mut Vec<MultiHopCandidate>) {
+    let intermediate_activations = match ctx.activation_by_obs.get(ctx.intermediate_uuid) {
         Some(a) => a,
         None => return,
     };
 
-    for &source_uuid in source_candidates {
-        if source_uuid == intermediate_uuid || source_uuid == target_uuid {
+    for &source_uuid in ctx.source_candidates {
+        if source_uuid == ctx.intermediate_uuid || source_uuid == ctx.target_uuid {
             continue;
         }
 
         // Skip output neurons as intermediates
-        if output_uuids.contains(source_uuid) {
+        if ctx.output_uuids.contains(source_uuid) {
             continue;
         }
 
         // Skip if source already connected to intermediate
-        if existing_synapses.contains(&(source_uuid, intermediate_uuid)) {
+        if ctx
+            .existing_synapses
+            .contains(&(source_uuid, ctx.intermediate_uuid))
+        {
             continue;
         }
 
         // Skip if source already connected to target
-        if existing_synapses.contains(&(source_uuid, target_uuid)) {
+        if ctx
+            .existing_synapses
+            .contains(&(source_uuid, ctx.target_uuid))
+        {
             continue;
         }
 
-        let source_activations = match activation_by_obs.get(source_uuid) {
+        let source_activations = match ctx.activation_by_obs.get(source_uuid) {
             Some(a) => a,
             None => continue,
         };
@@ -291,9 +298,10 @@ fn find_three_hop_extensions(
 
         // Combined correlation: geometric mean of the two correlations
         let combined_corr =
-            (source_intermediate_corr.abs() * intermediate_target_corr.abs()).sqrt();
+            (source_intermediate_corr.abs() * ctx.intermediate_target_corr.abs()).sqrt();
 
-        let estimated_improvement = combined_corr * compute_mean_abs_error(target_errors) * 0.005;
+        let estimated_improvement =
+            combined_corr * compute_mean_abs_error(ctx.target_errors) * 0.005;
 
         if estimated_improvement <= 0.0 {
             continue;
@@ -302,8 +310,8 @@ fn find_three_hop_extensions(
         candidates.push(MultiHopCandidate {
             path: vec![
                 source_uuid.to_string(),
-                intermediate_uuid.to_string(),
-                target_uuid.to_string(),
+                ctx.intermediate_uuid.to_string(),
+                ctx.target_uuid.to_string(),
             ],
             estimated_improvement,
             correlation_strength: combined_corr,

--- a/src/analysis/synapse/filtering.rs
+++ b/src/analysis/synapse/filtering.rs
@@ -44,24 +44,29 @@ pub(crate) fn deterministic_coordinated_neuron_uuid(
     format!("coordinated-hidden-{hash:016x}")
 }
 
+/// Parameters for computing expected gain when replacing a synapse with a
+/// hidden neuron.
+pub(crate) struct ReplaceSynapseParams<'a> {
+    pub cache: &'a RecordCache,
+    pub source_uuid: &'a str,
+    pub target_uuid: &'a str,
+    pub old_weight: f32,
+    pub incoming_weight: f32,
+    pub outgoing_weight: f32,
+    pub bias: f32,
+    pub squash: &'a str,
+}
+
 /// Compute expected gain for a coordinated "replace synapse with neuron" group.
 ///
 /// This models the coordinated operation sequence:
 /// 1) remove direct synapse (source -> target)
 /// 2) add hidden neuron with (source -> newNeuron) and (newNeuron -> target)
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
-    cache: &RecordCache,
-    source_uuid: &str,
-    target_uuid: &str,
-    old_weight: f32,
-    incoming_weight: f32,
-    outgoing_weight: f32,
-    bias: f32,
-    squash: &str,
+    params: &ReplaceSynapseParams<'_>,
 ) -> Option<f32> {
-    let from_records_arc = cache.get(source_uuid).ok()?;
-    let target_records_arc = cache.get(target_uuid).ok()?;
+    let from_records_arc = params.cache.get(params.source_uuid).ok()?;
+    let target_records_arc = params.cache.get(params.target_uuid).ok()?;
     if from_records_arc.is_empty() || target_records_arc.is_empty() {
         return None;
     }
@@ -78,7 +83,7 @@ pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
 
     // Adjust baseline errors for the removal of the existing direct synapse.
     for s in &mut samples {
-        s.avg_error += old_weight * s.activation;
+        s.avg_error += params.old_weight * s.activation;
     }
 
     let total_baseline_error_sq: f32 = samples.iter().map(|s| s.avg_error * s.avg_error).sum();
@@ -86,12 +91,12 @@ pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
         return None;
     }
 
-    if squash.eq_ignore_ascii_case("ReLU") {
+    if params.squash.eq_ignore_ascii_case("ReLU") {
         let (improvement, _improved, _total) = compute_relu_improvement_and_count(
             samples.as_slice(),
-            incoming_weight,
-            outgoing_weight,
-            bias,
+            params.incoming_weight,
+            params.outgoing_weight,
+            params.bias,
             total_baseline_error_sq,
             None, // linear domain
         );
@@ -99,7 +104,7 @@ pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
     }
 
     // Map squash names to activation functions
-    let activation_fn: fn(f32) -> f32 = match squash {
+    let activation_fn: fn(f32) -> f32 = match params.squash {
         "GELU" => gelu_activation,
         "ELU" => elu_activation,
         "Softplus" => softplus_activation,
@@ -120,9 +125,9 @@ pub(crate) fn expected_gain_replace_synapse_with_hidden_neuron(
 
     let (improvement, _improved, _total) = compute_activation_improvement_and_count(
         samples.as_slice(),
-        incoming_weight,
-        outgoing_weight,
-        bias,
+        params.incoming_weight,
+        params.outgoing_weight,
+        params.bias,
         activation_fn,
         total_baseline_error_sq,
         None, // linear domain

--- a/src/analysis/synapse/gpu_evaluation.rs
+++ b/src/analysis/synapse/gpu_evaluation.rs
@@ -183,6 +183,19 @@ pub(crate) fn evaluate_relu_candidates_split<G: GpuEvaluator>(
 // Activation Candidate Evaluation
 // =============================================================================
 
+/// Parameters for evaluating an activation function candidate from an error
+/// subset, computing net improvement across all samples.
+pub(crate) struct SubsetEvalParams<'a> {
+    pub source_uuid: &'a str,
+    pub target_uuid: &'a str,
+    pub subset_samples: &'a [HelpfulSample],
+    pub all_samples: &'a [HelpfulSample],
+    pub spec: &'a ActivationCandidateSpec,
+    pub target_squash: Option<&'a str>,
+    pub total_baseline_error_sq: f32,
+    pub target_activation_fn: Option<fn(f32) -> f32>,
+}
+
 /// Helper for split-error evaluation: compute optimal weight from subset, evaluate on all samples.
 ///
 /// This is the core of the split-error fix for non-ReLU activations. By computing
@@ -190,22 +203,15 @@ pub(crate) fn evaluate_relu_candidates_split<G: GpuEvaluator>(
 /// a weight that's tuned to help that subset. We then evaluate the NET improvement
 /// across ALL samples to ensure the candidate doesn't hurt the other subset more
 /// than it helps the target subset.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
     gpu: &G,
-    source_uuid: &str,
-    target_uuid: &str,
-    subset_samples: &[HelpfulSample], // Used to compute optimal weight
-    all_samples: &[HelpfulSample],    // Used to compute net improvement
-    spec: &ActivationCandidateSpec,
-    target_squash: Option<&str>,
-    total_baseline_error_sq: f32,
-    target_activation_fn: Option<fn(f32) -> f32>,
+    params: &SubsetEvalParams<'_>,
 ) -> Result<Option<CandidateNeuronJson>> {
-    if subset_samples.len() < MIN_NEURON_SAMPLE_COUNT {
+    if params.subset_samples.len() < MIN_NEURON_SAMPLE_COUNT {
         return Ok(None);
     }
 
+    let spec = params.spec;
     let activation_type = activation_name_to_gpu_id(spec.name);
 
     let mut best_candidate: Option<CandidateNeuronJson> = None;
@@ -221,7 +227,7 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
 
             // Compute optimal weight from SUBSET samples using GPU
             let (sum_activation_sq, sum_error_activation) = match gpu.evaluate_activation(
-                subset_samples,
+                params.subset_samples,
                 activation_type,
                 orientation,
                 scale,
@@ -231,7 +237,7 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
                     // Fall back to CPU on GPU error
                     let mut sum_act_sq = 0.0;
                     let mut sum_err_act = 0.0;
-                    for sample in subset_samples {
+                    for sample in params.subset_samples {
                         let pre_activation = incoming_weight * sample.activation;
                         let output = (spec.activation)(pre_activation);
                         if output.is_finite() {
@@ -244,8 +250,10 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
             };
 
             let (outgoing_weight, optimal_bias) = if spec.name == "IDENTITY" {
-                match calculate_optimal_identity_outgoing_and_bias(subset_samples, incoming_weight)
-                {
+                match calculate_optimal_identity_outgoing_and_bias(
+                    params.subset_samples,
+                    incoming_weight,
+                ) {
                     Some((w, b)) => (w, b),
                     None => continue,
                 }
@@ -262,20 +270,20 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
 
                 // Calculate optimal bias from subset
                 let optimal_bias = calculate_optimal_bias(
-                    subset_samples,
+                    params.subset_samples,
                     incoming_weight,
                     outgoing_weight,
                     spec.activation,
                     spec.name,
                     None,
-                    target_squash,
+                    params.target_squash,
                 );
                 (outgoing_weight, optimal_bias)
             };
 
             // Issue #123: Check for saturation - reject if neuron output is nearly constant.
             if !has_sufficient_output_variance(
-                all_samples,
+                params.all_samples,
                 incoming_weight,
                 optimal_bias,
                 spec.activation,
@@ -286,13 +294,13 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
             // CRITICAL: Evaluate NET improvement across ALL samples
             let (net_improvement, improved_count, total_count) =
                 compute_activation_improvement_and_count(
-                    all_samples,
+                    params.all_samples,
                     incoming_weight,
                     outgoing_weight,
                     optimal_bias,
                     spec.activation,
-                    total_baseline_error_sq,
-                    target_activation_fn,
+                    params.total_baseline_error_sq,
+                    params.target_activation_fn,
                 );
 
             // Only consider candidates with positive NET improvement
@@ -301,7 +309,7 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
             }
 
             // Apply validity filters
-            let absolute_improvement = net_improvement * total_baseline_error_sq;
+            let absolute_improvement = net_improvement * params.total_baseline_error_sq;
             if absolute_improvement < 0.001 {
                 continue;
             }
@@ -321,17 +329,18 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
 
                 best_net_improvement = net_improvement;
 
-                let target_stats = NeuronStats::from_samples(all_samples).map(|s| s.to_json());
+                let target_stats =
+                    NeuronStats::from_samples(params.all_samples).map(|s| s.to_json());
                 // Issue #128: Use creature-level metrics
                 // Issue #194: Compute confidence metrics for this prediction
                 let confidence_metrics = compute_confidence_metrics(
-                    all_samples,
+                    params.all_samples,
                     net_improvement,
                     None, // R² not available for neuron candidates
                 );
                 best_candidate = Some(CandidateNeuronJson {
-                    source_neuron_uuid: source_uuid.to_string(),
-                    target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_uuid: params.source_uuid.to_string(),
+                    target_neuron_uuid: params.target_uuid.to_string(),
                     source_neuron_index: None, // Set during impact discounting
                     target_neuron_index: None, // Set during impact discounting
                     incoming_weight,
@@ -356,20 +365,27 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
     Ok(best_candidate)
 }
 
+/// Parameters for evaluating activation candidates for a source-target pair.
+pub(crate) struct ActivationEvalParams<'a> {
+    pub source_uuid: &'a str,
+    pub target_uuid: &'a str,
+    pub samples: &'a [HelpfulSample],
+    pub threshold: f32,
+    pub spec: &'a ActivationCandidateSpec,
+    pub target_squash: Option<&'a str>,
+}
+
 /// Evaluate activation candidates for a given source-target pair.
 ///
 /// This function handles both split-error evaluation and fallback to all-samples
 /// evaluation when appropriate.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
     gpu: &G,
-    source_uuid: &str,
-    target_uuid: &str,
-    samples: &[HelpfulSample],
-    threshold: f32,
-    spec: &ActivationCandidateSpec,
-    target_squash: Option<&str>,
+    params: &ActivationEvalParams<'_>,
 ) -> Result<Option<CandidateNeuronJson>> {
+    let samples = params.samples;
+    let spec = params.spec;
+
     if samples.len() < MIN_NEURON_SAMPLE_COUNT {
         return Ok(None);
     }
@@ -377,7 +393,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
     let activation_type = activation_name_to_gpu_id(spec.name);
 
     let mut best_candidate: Option<CandidateNeuronJson> = None;
-    let mut best_score = threshold;
+    let mut best_score = params.threshold;
     let mut fallback_candidate: Option<CandidateNeuronJson> = None;
     let mut fallback_score = f32::MIN;
 
@@ -403,7 +419,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
     }
 
     // Get target activation function for net improvement calculation
-    let target_activation_fn = get_target_simulation_fn(samples, target_squash);
+    let target_activation_fn = get_target_simulation_fn(samples, params.target_squash);
 
     // v0.1.136: Track whether split-error evaluation was properly attempted.
     let positive_subset_valid = positive_error_samples.len() >= MIN_NEURON_SAMPLE_COUNT;
@@ -426,17 +442,17 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
             continue;
         }
 
-        if let Some(candidate) = evaluate_activation_for_subset(
-            gpu,
-            source_uuid,
-            target_uuid,
-            error_samples, // Compute weight from subset
-            samples,       // Evaluate improvement on ALL samples
+        let subset_params = SubsetEvalParams {
+            source_uuid: params.source_uuid,
+            target_uuid: params.target_uuid,
+            subset_samples: error_samples,
+            all_samples: samples,
             spec,
-            target_squash,
+            target_squash: params.target_squash,
             total_baseline_error_sq,
             target_activation_fn,
-        )? {
+        };
+        if let Some(candidate) = evaluate_activation_for_subset(gpu, &subset_params)? {
             let gain = candidate.expected_creature_score_gain;
             // Track best (above threshold) and fallback (above 0) candidates.
             if gain > best_score {
@@ -508,7 +524,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
             }
 
             // For non-linear targets, search for best outgoing_weight
-            let target_activation_fn = get_target_simulation_fn(samples, target_squash);
+            let target_activation_fn = get_target_simulation_fn(samples, params.target_squash);
             let (outgoing_weight, optimal_bias, neuron_error_improvement, final_improved_count) =
                 if spec.name == "IDENTITY" {
                     let (outgoing_weight, optimal_bias) =
@@ -573,7 +589,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                             spec.activation,
                             spec.name,
                             None,
-                            target_squash,
+                            params.target_squash,
                         );
 
                         // Single pass for improvement and count with target simulation
@@ -619,7 +635,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                         spec.activation,
                         spec.name,
                         None,
-                        target_squash,
+                        params.target_squash,
                     );
 
                     // CRITICAL FIX: Recompute optimal weight WITH the bias included.
@@ -700,8 +716,8 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                     None, // R² not available for neuron candidates
                 );
                 best_candidate = Some(CandidateNeuronJson {
-                    source_neuron_uuid: source_uuid.to_string(),
-                    target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_uuid: params.source_uuid.to_string(),
+                    target_neuron_uuid: params.target_uuid.to_string(),
                     source_neuron_index: None,
                     target_neuron_index: None,
                     incoming_weight,
@@ -733,8 +749,8 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                     None, // R² not available for neuron candidates
                 );
                 fallback_candidate = Some(CandidateNeuronJson {
-                    source_neuron_uuid: source_uuid.to_string(),
-                    target_neuron_uuid: target_uuid.to_string(),
+                    source_neuron_uuid: params.source_uuid.to_string(),
+                    target_neuron_uuid: params.target_uuid.to_string(),
                     source_neuron_index: None,
                     target_neuron_index: None,
                     incoming_weight,
@@ -767,7 +783,6 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
 ///
 /// Issue #201: This function reduces GPU round-trips by 10-20% by evaluating multiple
 /// activation function configurations in a single GPU command buffer submission.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_all_activation_specs_batched<G: GpuEvaluator>(
     gpu: &G,
     source_uuid: &str,
@@ -957,15 +972,15 @@ fn evaluate_all_activation_specs_sequential<G: GpuEvaluator>(
 ) -> Result<Vec<CandidateNeuronJson>> {
     let mut results = Vec::new();
     for spec in &ACTIVATION_SPECS {
-        if let Some(candidate) = evaluate_activation_candidate(
-            gpu,
+        let eval_params = ActivationEvalParams {
             source_uuid,
             target_uuid,
             samples,
             threshold,
             spec,
             target_squash,
-        )? {
+        };
+        if let Some(candidate) = evaluate_activation_candidate(gpu, &eval_params)? {
             results.push(candidate);
         }
     }

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -45,8 +45,8 @@ pub(crate) use candidate_generation::{
 };
 
 pub(crate) use filtering::{
-    deterministic_coordinated_neuron_uuid, expected_gain_replace_synapse_with_hidden_neuron,
-    truncate_combined_synapse_candidate_sets,
+    ReplaceSynapseParams, deterministic_coordinated_neuron_uuid,
+    expected_gain_replace_synapse_with_hidden_neuron, truncate_combined_synapse_candidate_sets,
 };
 
 pub(crate) use gpu_evaluation::{
@@ -65,7 +65,7 @@ pub(crate) use scoring::compute_synapse_improvement_and_count;
 #[cfg(test)]
 pub(crate) use candidate_generation::build_samples;
 #[cfg(test)]
-pub(crate) use gpu_evaluation::evaluate_activation_candidate;
+pub(crate) use gpu_evaluation::{ActivationEvalParams, evaluate_activation_candidate};
 #[cfg(test)]
 pub(crate) use scoring::{
     compute_net_improvement_with_squash, compute_relu_improvement_and_count,


### PR DESCRIPTION
## Summary

Refactor 9 functions to use parameter structs instead of long argument lists,
removing all `#[allow(clippy::too_many_arguments)]` suppressions. Closes #715.

### Parameter structs introduced

| Struct | File | Functions served |
|--------|------|-----------------|
| `NeuronEvalContext` | `neuron/evaluation.rs` | `evaluate_neuron_candidates`, `evaluate_relu_split`, `evaluate_activation_specs` |
| `NeuronResultParams` | `neuron/post_processing.rs` | `build_neuron_results` |
| `ReplaceSynapseParams` | `synapse/filtering.rs` | `expected_gain_replace_synapse_with_hidden_neuron` |
| `SubsetEvalParams` | `synapse/gpu_evaluation.rs` | `evaluate_activation_for_subset` |
| `ActivationEvalParams` | `synapse/gpu_evaluation.rs` | `evaluate_activation_candidate` |
| `ThreeHopContext` | `recommendation/multi_hop.rs` | `find_three_hop_extensions` |

For `evaluate_all_activation_specs_batched` (6 params, under the clippy limit),
the suppression was simply removed since no struct was needed.

### No behavioural changes

This is a pure refactoring. All call sites construct the new structs with the
same values previously passed as positional arguments.

## Evidence

- `quality.sh` passes cleanly (fmt, clippy, check, tests, doc build, release build)
- Zero `#[allow(clippy::too_many_arguments)]` annotations remain in the codebase
- No UI changes; backend-only refactoring

## Test Plan

- All existing tests pass without modification (except updating one test call site
  in `implementation_tests/optimal_weight_tests.rs` to use `ActivationEvalParams`)
- No new tests needed — this is a signature-level refactoring with no behavioural change

---

## Automated Fix Details
This PR addresses issue #715: **Reduce too_many_arguments clippy suppressions with parameter structs**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #715