### PR TITLE
refactor: extract analyze_synapses_with_cache_impl into smaller functions (#714)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.3"
+version = "0.43.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.2"
+version = "0.43.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-714.md
+++ b/docs/pr-summary-714.md
@@ -1,0 +1,33 @@
+## Summary
+
+Refactored `analyze_synapses_with_cache_impl` from ~350 lines down to ~107 lines by extracting logical phases into well-named helper functions. Closes #714.
+
+### Extracted Functions
+
+1. **`preparation::build_creature_lookups()`** — Builds all HashMap/HashSet lookup structures from creature topology (ordered neurons, interned indices, existing synapses, squash/type/bias maps, input neuron tracking). Returns a `CreatureLookups` struct.
+
+2. **`preparation::compute_constant_source_threshold_from_cache()`** — Samples input neuron records to compute average standard deviation and derives the dynamic constant-source effect threshold.
+
+3. **`SharedResultCollectors`** struct with `merge_target_results()` method — Encapsulates all shared mutable state (Mutex-wrapped result vectors, atomic metadata flags) used during parallel target analysis. Replaces 10 separate parameters.
+
+4. **`finalise_synapse_results()`** — Collects results from shared state after the parallel loop, applies post-processing (collapse hidden, impact discounting, sorting), and builds the final `AnalyzeSynapsesResult`.
+
+### No Behavioural Changes
+
+This is a pure refactoring — the same code runs in the same order with the same inputs and outputs.
+
+## Evidence
+
+- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)
+- All 536 unit tests pass
+- No visual/UI changes — backend refactoring only
+
+## Test Plan
+
+- Added 5 unit tests for `build_creature_lookups()` in `preparation.rs`:
+  - `test_build_creature_lookups_ordered_neurons` — verifies ordered neurons and order map
+  - `test_build_creature_lookups_existing_synapses` — verifies existing synapse sets
+  - `test_build_creature_lookups_neuron_maps` — verifies squash, type, input, used inputs, and bias maps
+  - `test_build_creature_lookups_synapses_by_target` — verifies synapses grouped by target
+  - `test_build_creature_lookups_empty_creature` — verifies behaviour with empty input
+- All existing tests continue to pass unchanged

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -32,6 +32,7 @@ mod candidate_generation;
 mod filtering;
 mod gpu_evaluation;
 mod post_processing;
+mod preparation;
 mod scoring;
 mod structural_patterns;
 mod target_analysis;
@@ -76,8 +77,7 @@ pub(crate) use scoring::{
 // Imports for the core pipeline
 // =============================================================================
 
-use crate::intern::NeuronIndex;
-use crate::{AnalyzeSynapsesInput, CandidateSynapseJson, SynapseJson};
+use crate::{AnalyzeSynapsesInput, CandidateSynapseJson};
 use anyhow::Result;
 
 use crate::analysis::shared::AnalyzeSynapsesResult;
@@ -86,17 +86,15 @@ use crate::analysis::diagnostics::{TargetDiagnostics, require_unique_focus};
 
 use crate::analysis::utils::{
     build_deadline, deadline_passed, lock_or_bail, log_analysis_start, log_analysis_timeout,
-    order_focus_targets, verbose_enabled,
+    order_focus_targets,
 };
-
-use crate::analysis::samples::{compute_source_std_dev, get_constant_source_threshold};
 
 use crate::analysis::gpu::{GpuAnalyzer, GpuWorkQueue};
 
 use super::cache::RecordCache;
 
 use rayon::prelude::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 // =============================================================================
@@ -113,82 +111,18 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     cache: Arc<RecordCache>,
     gpu_queue: Arc<GpuWorkQueue>,
 ) -> Result<AnalyzeSynapsesResult> {
-    let ordered_neurons = build_ordered_neurons(&input.creature);
-    let order_map: HashMap<String, usize> = ordered_neurons
-        .iter()
-        .map(|neuron| (neuron.uuid.clone(), neuron.index))
-        .collect();
+    // Phase 1: Build creature lookup maps
+    let lookups = preparation::build_creature_lookups(input);
 
-    let mut neuron_index = NeuronIndex::with_capacity(
-        input.creature.neurons.len() + input.creature.input + input.creature.synapses.len() / 10,
-    );
-
-    // Pre-intern all neuron UUIDs
-    for i in 0..input.creature.input {
-        neuron_index.intern(&format!("input-{i}"));
-    }
-    for neuron in &input.creature.neurons {
-        neuron_index.intern(&neuron.uuid);
-    }
-
-    // Build existing_synapses using interned indices
-    let existing_synapses: HashSet<(u32, u32)> = input
-        .creature
-        .synapses
-        .iter()
-        .map(|synapse| {
-            (
-                neuron_index.intern(&synapse.from_uuid),
-                neuron_index.intern(&synapse.to_uuid),
-            )
-        })
-        .collect();
-
-    let existing_synapse_weights: HashMap<(u32, u32), f32> = input
-        .creature
-        .synapses
-        .iter()
-        .map(|synapse| {
-            (
-                (
-                    neuron_index.intern(&synapse.from_uuid),
-                    neuron_index.intern(&synapse.to_uuid),
-                ),
-                synapse.weight,
-            )
-        })
-        .collect();
-
-    let synapses_by_target: HashMap<u32, Vec<SynapseJson>> = input
-        .creature
-        .synapses
-        .iter()
-        .map(|synapse| (neuron_index.intern(&synapse.to_uuid), synapse.clone()))
-        .fold(HashMap::new(), |mut acc, (key, val)| {
-            acc.entry(key).or_default().push(val);
-            acc
-        });
-
-    let neuron_squash_map: HashMap<String, String> = input
-        .creature
-        .neurons
-        .iter()
-        .map(|n| (n.uuid.clone(), n.squash.clone()))
-        .collect();
-
+    // Phase 2: Focus target and diagnostics setup
     let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_synapses")?;
-
     let diagnostics = Arc::new(TargetDiagnostics::new(&unique_focus));
-
     let timing_collector = Arc::new(super::shared::TimingCollector::new(
         super::utils::gpu_timing_enabled(),
     ));
-
     let deadline = build_deadline(input.analysis_deadline_ms);
 
     let mut focus_order: Vec<String> = unique_focus.iter().map(|s| (*s).clone()).collect();
-
-    // Issue #468: Order focus targets by neuron type (hidden first)
     let focus_neuron_type_map: HashMap<&str, &str> = input
         .creature
         .neurons
@@ -196,7 +130,6 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         .map(|n| (n.uuid.as_str(), n.neuron_type.as_str()))
         .collect();
     order_focus_targets(&mut focus_order, input.random_seed, &focus_neuron_type_map);
-
     log_analysis_start(
         "synapse",
         input.analysis_deadline_ms,
@@ -207,109 +140,31 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     let total_focus_count = focus_order.len();
     let completed_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
-    // GPU is always required
     assert!(
         GpuAnalyzer::gpu_is_available(),
         "Discovery logic called without GPU - check_gpu_available should have prevented this"
     );
-    let gpu_used = true;
 
-    let helpful_results = Arc::new(Mutex::new(Vec::<CandidateSynapseJson>::new()));
-    let harmful_results = Arc::new(Mutex::new(Vec::<CandidateSynapseJson>::new()));
-    let coordinated_structural_results = Arc::new(Mutex::new(Vec::<
-        crate::CoordinatedStructuralCandidateJson,
-    >::new()));
-    let helpful_fallback = Arc::new(Mutex::new(Option::<CandidateSynapseJson>::None));
-    let analysis_timed_out = Arc::new(Mutex::new(false));
+    // Phase 3: Shared result collections for parallel processing
+    let collectors = SharedResultCollectors::new();
 
-    // Metadata tracking for observability
-    let metadata_target_value_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let metadata_saturation_aware_used = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let metadata_seen_any_input_with_records = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let metadata_input_min_with_records = Arc::new(std::sync::atomic::AtomicUsize::new(usize::MAX));
-    let metadata_input_max_with_records = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Phase 4: Compute constant-source threshold
+    let constant_source_effect_threshold =
+        preparation::compute_constant_source_threshold_from_cache(input, cache.as_ref());
 
-    let error_values_for_distribution = Arc::new(Mutex::new(Vec::<f32>::new()));
-
-    // Build comprehensive neuron type map
-    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
-    for input_index in 0..input.creature.input {
-        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
-    }
-    for neuron in &input.creature.neurons {
-        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
-    }
-
-    let input_neuron_uuids: HashSet<String> = (0..input.creature.input)
-        .map(|i| format!("input-{i}"))
-        .collect();
-
-    // Issue #182: Build used inputs set
-    let used_inputs: HashSet<String> = input
-        .creature
-        .synapses
-        .iter()
-        .filter(|s| crate::analysis::utils::parse_input_index(&s.from_uuid).is_some())
-        .map(|s| s.from_uuid.clone())
-        .collect();
-
-    // Neuron bias map for constant-source folding
-    let neuron_bias_map: HashMap<String, f32> = input
-        .creature
-        .neurons
-        .iter()
-        .map(|n| (n.uuid.clone(), n.bias))
-        .collect();
-
-    // Compute dynamic constant-source threshold
-    let source_std_dev_avg: Option<f32> = {
-        let mut std_dev_sum = 0.0f64;
-        let mut std_dev_count = 0u32;
-        let max_samples = input.creature.input.min(50);
-
-        for input_idx in 0..max_samples {
-            let input_uuid = format!("input-{input_idx}");
-            if let Ok(records) = cache.get(&input_uuid)
-                && records.len() >= 2
-            {
-                let std_dev = compute_source_std_dev(&records);
-                if std_dev.is_finite() {
-                    std_dev_sum += std_dev as f64;
-                    std_dev_count += 1;
-                }
-            }
-        }
-
-        if std_dev_count > 0 {
-            let avg = (std_dev_sum / std_dev_count as f64) as f32;
-            if verbose_enabled() {
-                tracing::debug!(
-                    avg_std_dev = %format!("{avg:.4}"),
-                    sampled_sources = std_dev_count,
-                    "Source variance profile"
-                );
-            }
-            Some(avg)
-        } else {
-            None
-        }
-    };
-
-    let constant_source_effect_threshold = get_constant_source_threshold(source_std_dev_avg);
-
-    // Build shared context for per-target analysis
+    // Phase 5: Build shared context for per-target analysis
     let ctx = Arc::new(target_analysis::TargetAnalysisContext {
-        ordered_neurons: Arc::new(ordered_neurons),
-        order_map: Arc::new(order_map),
-        neuron_index: Arc::new(neuron_index),
-        existing_synapses: Arc::new(existing_synapses),
-        existing_synapse_weights: Arc::new(existing_synapse_weights),
-        synapses_by_target: Arc::new(synapses_by_target),
-        neuron_squash_map: Arc::new(neuron_squash_map),
-        neuron_type_map: Arc::new(neuron_type_map),
-        input_neuron_uuids: Arc::new(input_neuron_uuids),
-        used_inputs: Arc::new(used_inputs),
-        neuron_bias_map: Arc::new(neuron_bias_map),
+        ordered_neurons: Arc::new(lookups.ordered_neurons),
+        order_map: Arc::new(lookups.order_map),
+        neuron_index: Arc::new(lookups.neuron_index),
+        existing_synapses: Arc::new(lookups.existing_synapses),
+        existing_synapse_weights: Arc::new(lookups.existing_synapse_weights),
+        synapses_by_target: Arc::new(lookups.synapses_by_target),
+        neuron_squash_map: Arc::new(lookups.neuron_squash_map),
+        neuron_type_map: Arc::new(lookups.neuron_type_map),
+        input_neuron_uuids: Arc::new(lookups.input_neuron_uuids),
+        used_inputs: Arc::new(lookups.used_inputs),
+        neuron_bias_map: Arc::new(lookups.neuron_bias_map),
         constant_source_effect_threshold,
         diagnostics: diagnostics.clone(),
         timing_collector: timing_collector.clone(),
@@ -317,14 +172,14 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         threshold: 0.0,
     });
 
-    // Process each focus neuron in parallel
+    // Phase 6: Process each focus neuron in parallel
     focus_order
         .par_iter()
         .try_for_each(|target_uuid| -> Result<()> {
-            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?
+            if *lock_or_bail(&collectors.analysis_timed_out, "analysis_timed_out")?
                 || deadline_passed(&deadline)
             {
-                *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
+                *lock_or_bail(&collectors.analysis_timed_out, "analysis_timed_out")? = true;
                 return Ok(());
             }
 
@@ -336,41 +191,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
                 &ctx,
             )?;
 
-            // Merge results into shared collections
-            if !target_results.helpful.is_empty() {
-                lock_or_bail(&helpful_results, "helpful_results")?
-                    .extend(target_results.helpful);
-            }
-            if !target_results.harmful.is_empty() {
-                lock_or_bail(&harmful_results, "harmful_results")?
-                    .extend(target_results.harmful);
-            }
-            if !target_results.coordinated.is_empty() {
-                lock_or_bail(&coordinated_structural_results, "coordinated_structural_results")?
-                    .extend(target_results.coordinated);
-            }
-            if !target_results.error_values.is_empty() {
-                lock_or_bail(&error_values_for_distribution, "error_values_for_distribution")?
-                    .extend(target_results.error_values);
-            }
-            if target_results.target_value_seen {
-                metadata_target_value_seen.store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-            if target_results.saturation_aware_used {
-                metadata_saturation_aware_used.store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-            if target_results.input_metadata.seen_any {
-                metadata_seen_any_input_with_records
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-                let _ = metadata_input_min_with_records.fetch_min(
-                    target_results.input_metadata.min_index,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-                let _ = metadata_input_max_with_records.fetch_max(
-                    target_results.input_metadata.max_index,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
+            collectors.merge_target_results(target_results)?;
 
             let completed =
                 completed_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
@@ -380,32 +201,149 @@ pub(crate) fn analyze_synapses_with_cache_impl(
             Ok(())
         })?;
 
-    let analysis_timed_out = *lock_or_bail(&analysis_timed_out, "analysis_timed_out")?;
+    // Phase 7: Collect results and build final output
+    finalise_synapse_results(&FinaliseParams {
+        collectors,
+        completed_count,
+        total_focus_count,
+        diagnostics,
+        timing_collector,
+        input,
+        cache,
+        order_map: &ctx.order_map,
+    })
+}
+
+/// Shared mutable state collected during parallel target analysis.
+struct SharedResultCollectors {
+    helpful_results: Arc<Mutex<Vec<CandidateSynapseJson>>>,
+    harmful_results: Arc<Mutex<Vec<CandidateSynapseJson>>>,
+    coordinated_structural_results: Arc<Mutex<Vec<crate::CoordinatedStructuralCandidateJson>>>,
+    helpful_fallback: Arc<Mutex<Option<CandidateSynapseJson>>>,
+    analysis_timed_out: Arc<Mutex<bool>>,
+    error_values_for_distribution: Arc<Mutex<Vec<f32>>>,
+    metadata_target_value_seen: Arc<std::sync::atomic::AtomicBool>,
+    metadata_saturation_aware_used: Arc<std::sync::atomic::AtomicBool>,
+    metadata_seen_any_input_with_records: Arc<std::sync::atomic::AtomicBool>,
+    metadata_input_min_with_records: Arc<std::sync::atomic::AtomicUsize>,
+    metadata_input_max_with_records: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl SharedResultCollectors {
+    fn new() -> Self {
+        Self {
+            helpful_results: Arc::new(Mutex::new(Vec::new())),
+            harmful_results: Arc::new(Mutex::new(Vec::new())),
+            coordinated_structural_results: Arc::new(Mutex::new(Vec::new())),
+            helpful_fallback: Arc::new(Mutex::new(None)),
+            analysis_timed_out: Arc::new(Mutex::new(false)),
+            error_values_for_distribution: Arc::new(Mutex::new(Vec::new())),
+            metadata_target_value_seen: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            metadata_saturation_aware_used: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            metadata_seen_any_input_with_records: Arc::new(std::sync::atomic::AtomicBool::new(
+                false,
+            )),
+            metadata_input_min_with_records: Arc::new(std::sync::atomic::AtomicUsize::new(
+                usize::MAX,
+            )),
+            metadata_input_max_with_records: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        }
+    }
+
+    /// Merge a single target's results into the shared collections.
+    fn merge_target_results(
+        &self,
+        target_results: target_analysis::TargetAnalysisResults,
+    ) -> Result<()> {
+        if !target_results.helpful.is_empty() {
+            lock_or_bail(&self.helpful_results, "helpful_results")?.extend(target_results.helpful);
+        }
+        if !target_results.harmful.is_empty() {
+            lock_or_bail(&self.harmful_results, "harmful_results")?.extend(target_results.harmful);
+        }
+        if !target_results.coordinated.is_empty() {
+            lock_or_bail(
+                &self.coordinated_structural_results,
+                "coordinated_structural_results",
+            )?
+            .extend(target_results.coordinated);
+        }
+        if !target_results.error_values.is_empty() {
+            lock_or_bail(
+                &self.error_values_for_distribution,
+                "error_values_for_distribution",
+            )?
+            .extend(target_results.error_values);
+        }
+        if target_results.target_value_seen {
+            self.metadata_target_value_seen
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        if target_results.saturation_aware_used {
+            self.metadata_saturation_aware_used
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+        if target_results.input_metadata.seen_any {
+            self.metadata_seen_any_input_with_records
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            let _ = self.metadata_input_min_with_records.fetch_min(
+                target_results.input_metadata.min_index,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            let _ = self.metadata_input_max_with_records.fetch_max(
+                target_results.input_metadata.max_index,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Parameters for the result finalisation phase.
+struct FinaliseParams<'a> {
+    collectors: SharedResultCollectors,
+    completed_count: Arc<std::sync::atomic::AtomicUsize>,
+    total_focus_count: usize,
+    diagnostics: Arc<TargetDiagnostics>,
+    timing_collector: Arc<super::shared::TimingCollector>,
+    input: &'a AnalyzeSynapsesInput,
+    cache: Arc<RecordCache>,
+    order_map: &'a HashMap<String, usize>,
+}
+
+/// Collect results from shared state, apply post-processing, and build the final output.
+fn finalise_synapse_results(params: &FinaliseParams<'_>) -> Result<AnalyzeSynapsesResult> {
+    let c = &params.collectors;
+    let analysis_timed_out = *lock_or_bail(&c.analysis_timed_out, "analysis_timed_out")?;
     let mut helpful_results =
-        std::mem::take(&mut *lock_or_bail(&helpful_results, "helpful_results")?);
+        std::mem::take(&mut *lock_or_bail(&c.helpful_results, "helpful_results")?);
     let mut harmful_results =
-        std::mem::take(&mut *lock_or_bail(&harmful_results, "harmful_results")?);
+        std::mem::take(&mut *lock_or_bail(&c.harmful_results, "harmful_results")?);
     let mut coordinated_structural_results = std::mem::take(&mut *lock_or_bail(
-        &coordinated_structural_results,
+        &c.coordinated_structural_results,
         "coordinated_structural_results",
     )?);
-    let mut helpful_fallback = lock_or_bail(&helpful_fallback, "helpful_fallback")?.take();
+    let mut helpful_fallback = lock_or_bail(&c.helpful_fallback, "helpful_fallback")?.take();
 
     if analysis_timed_out {
-        let completed = completed_count.load(std::sync::atomic::Ordering::Relaxed);
-        log_analysis_timeout("synapse", completed, total_focus_count);
+        let completed = params
+            .completed_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        log_analysis_timeout("synapse", completed, params.total_focus_count);
     }
 
     if helpful_results.is_empty()
         && let Some(candidate) = helpful_fallback.take()
     {
-        diagnostics.mark_candidate_selected(&candidate.to_neuron_uuid);
+        params
+            .diagnostics
+            .mark_candidate_selected(&candidate.to_neuron_uuid);
         helpful_results.push(candidate);
     }
 
     // Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
     let collapse_candidates =
-        structural_patterns::detect_collapsible_hidden_neurons(input, cache.as_ref());
+        structural_patterns::detect_collapsible_hidden_neurons(params.input, params.cache.as_ref());
     coordinated_structural_results.extend(collapse_candidates);
 
     // Post-processing: impact discounting, sorting, diversification, truncation
@@ -413,39 +351,49 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         &mut helpful_results,
         &mut harmful_results,
         &mut coordinated_structural_results,
-        input,
-        cache.as_ref(),
-        &ctx.order_map,
+        params.input,
+        params.cache.as_ref(),
+        params.order_map,
     );
 
-    let no_candidate_reasons = diagnostics.no_candidate_summaries();
-    diagnostics.emit_logs();
+    let no_candidate_reasons = params.diagnostics.no_candidate_summaries();
+    params.diagnostics.emit_logs();
 
     // Build metadata
-    let saw_any_input =
-        metadata_seen_any_input_with_records.load(std::sync::atomic::Ordering::Relaxed);
-    let input_min = metadata_input_min_with_records.load(std::sync::atomic::Ordering::Relaxed);
-    let input_max = metadata_input_max_with_records.load(std::sync::atomic::Ordering::Relaxed);
+    let saw_any_input = c
+        .metadata_seen_any_input_with_records
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let input_min = c
+        .metadata_input_min_with_records
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let input_max = c
+        .metadata_input_max_with_records
+        .load(std::sync::atomic::Ordering::Relaxed);
 
     let error_vec = std::mem::take(&mut *lock_or_bail(
-        &error_values_for_distribution,
+        &c.error_values_for_distribution,
         "error_values_for_distribution",
     )?);
 
     let metadata = post_processing::build_metadata(&post_processing::MetadataParams {
-        target_value_seen: metadata_target_value_seen.load(std::sync::atomic::Ordering::Relaxed),
-        saturation_aware_used: metadata_saturation_aware_used
+        target_value_seen: c
+            .metadata_target_value_seen
+            .load(std::sync::atomic::Ordering::Relaxed),
+        saturation_aware_used: c
+            .metadata_saturation_aware_used
             .load(std::sync::atomic::Ordering::Relaxed),
         candidates_found: pp_metrics.candidates_found,
         candidates_returned: pp_metrics.candidates_returned,
         analysis_timed_out,
-        completed_focus_neurons: completed_count.load(std::sync::atomic::Ordering::Relaxed),
-        total_focus_neurons: total_focus_count,
+        completed_focus_neurons: params
+            .completed_count
+            .load(std::sync::atomic::Ordering::Relaxed),
+        total_focus_neurons: params.total_focus_count,
         saw_any_input,
         input_min,
         input_max,
         error_values: &error_vec,
-        timing_collector: &timing_collector,
+        timing_collector: &params.timing_collector,
     });
 
     Ok(AnalyzeSynapsesResult {
@@ -454,7 +402,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         synapse_weight_updates: Vec::new(),
         coordinated_structural_candidates: coordinated_structural_results,
         candidate_clusters: Vec::new(),
-        gpu_used,
+        gpu_used: true,
         no_candidate_reasons,
         metadata,
     })

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -1,0 +1,324 @@
+//! Preparation helpers for synapse analysis
+//!
+//! This module extracts the creature lookup map building and constant-source
+//! threshold computation from `analyze_synapses_with_cache_impl`, keeping
+//! the main orchestration function concise.
+
+use crate::intern::NeuronIndex;
+use crate::{AnalyzeSynapsesInput, SynapseJson};
+use std::collections::{HashMap, HashSet};
+
+use crate::analysis::cache::RecordCache;
+use crate::analysis::samples::{compute_source_std_dev, get_constant_source_threshold};
+use crate::analysis::utils::verbose_enabled;
+
+use super::candidate_generation::build_ordered_neurons;
+use crate::analysis::utils::OrderedNeuron;
+
+/// All pre-computed lookup structures derived from a creature's topology.
+///
+/// Built once at the start of synapse analysis and shared (via `Arc`)
+/// across the per-target parallel loop.
+pub(crate) struct CreatureLookups {
+    pub ordered_neurons: Vec<OrderedNeuron>,
+    pub order_map: HashMap<String, usize>,
+    pub neuron_index: NeuronIndex,
+    pub existing_synapses: HashSet<(u32, u32)>,
+    pub existing_synapse_weights: HashMap<(u32, u32), f32>,
+    pub synapses_by_target: HashMap<u32, Vec<SynapseJson>>,
+    pub neuron_squash_map: HashMap<String, String>,
+    pub neuron_type_map: HashMap<String, String>,
+    pub input_neuron_uuids: HashSet<String>,
+    pub used_inputs: HashSet<String>,
+    pub neuron_bias_map: HashMap<String, f32>,
+}
+
+/// Build all creature lookup maps from the analysis input.
+///
+/// This includes ordered neurons, interned neuron indices, existing synapse
+/// sets, squash/type/bias maps, and input neuron tracking structures.
+pub(crate) fn build_creature_lookups(input: &AnalyzeSynapsesInput) -> CreatureLookups {
+    let ordered_neurons = build_ordered_neurons(&input.creature);
+    let order_map: HashMap<String, usize> = ordered_neurons
+        .iter()
+        .map(|neuron| (neuron.uuid.clone(), neuron.index))
+        .collect();
+
+    let mut neuron_index = NeuronIndex::with_capacity(
+        input.creature.neurons.len() + input.creature.input + input.creature.synapses.len() / 10,
+    );
+
+    // Pre-intern all neuron UUIDs
+    for i in 0..input.creature.input {
+        neuron_index.intern(&format!("input-{i}"));
+    }
+    for neuron in &input.creature.neurons {
+        neuron_index.intern(&neuron.uuid);
+    }
+
+    // Build existing_synapses using interned indices
+    let existing_synapses: HashSet<(u32, u32)> = input
+        .creature
+        .synapses
+        .iter()
+        .map(|synapse| {
+            (
+                neuron_index.intern(&synapse.from_uuid),
+                neuron_index.intern(&synapse.to_uuid),
+            )
+        })
+        .collect();
+
+    let existing_synapse_weights: HashMap<(u32, u32), f32> = input
+        .creature
+        .synapses
+        .iter()
+        .map(|synapse| {
+            (
+                (
+                    neuron_index.intern(&synapse.from_uuid),
+                    neuron_index.intern(&synapse.to_uuid),
+                ),
+                synapse.weight,
+            )
+        })
+        .collect();
+
+    let synapses_by_target: HashMap<u32, Vec<SynapseJson>> = input
+        .creature
+        .synapses
+        .iter()
+        .map(|synapse| (neuron_index.intern(&synapse.to_uuid), synapse.clone()))
+        .fold(HashMap::new(), |mut acc, (key, val)| {
+            acc.entry(key).or_default().push(val);
+            acc
+        });
+
+    let neuron_squash_map: HashMap<String, String> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.squash.clone()))
+        .collect();
+
+    // Build comprehensive neuron type map
+    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+    for input_index in 0..input.creature.input {
+        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
+    }
+    for neuron in &input.creature.neurons {
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
+    }
+
+    let input_neuron_uuids: HashSet<String> = (0..input.creature.input)
+        .map(|i| format!("input-{i}"))
+        .collect();
+
+    // Issue #182: Build used inputs set
+    let used_inputs: HashSet<String> = input
+        .creature
+        .synapses
+        .iter()
+        .filter(|s| crate::analysis::utils::parse_input_index(&s.from_uuid).is_some())
+        .map(|s| s.from_uuid.clone())
+        .collect();
+
+    // Neuron bias map for constant-source folding
+    let neuron_bias_map: HashMap<String, f32> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.bias))
+        .collect();
+
+    CreatureLookups {
+        ordered_neurons,
+        order_map,
+        neuron_index,
+        existing_synapses,
+        existing_synapse_weights,
+        synapses_by_target,
+        neuron_squash_map,
+        neuron_type_map,
+        input_neuron_uuids,
+        used_inputs,
+        neuron_bias_map,
+    }
+}
+
+/// Compute the dynamic constant-source effect threshold from cached records.
+///
+/// Samples up to 50 input neurons to compute the average standard deviation,
+/// then uses it to derive the threshold via `get_constant_source_threshold`.
+pub(crate) fn compute_constant_source_threshold_from_cache(
+    input: &AnalyzeSynapsesInput,
+    cache: &RecordCache,
+) -> Option<f32> {
+    let mut std_dev_sum = 0.0f64;
+    let mut std_dev_count = 0u32;
+    let max_samples = input.creature.input.min(50);
+
+    for input_idx in 0..max_samples {
+        let input_uuid = format!("input-{input_idx}");
+        if let Ok(records) = cache.get(&input_uuid)
+            && records.len() >= 2
+        {
+            let std_dev = compute_source_std_dev(&records);
+            if std_dev.is_finite() {
+                std_dev_sum += std_dev as f64;
+                std_dev_count += 1;
+            }
+        }
+    }
+
+    let source_std_dev_avg = if std_dev_count > 0 {
+        let avg = (std_dev_sum / std_dev_count as f64) as f32;
+        if verbose_enabled() {
+            tracing::debug!(
+                avg_std_dev = %format!("{avg:.4}"),
+                sampled_sources = std_dev_count,
+                "Source variance profile"
+            );
+        }
+        Some(avg)
+    } else {
+        None
+    };
+
+    get_constant_source_threshold(source_std_dev_avg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CreatureJson, NeuronJson, SynapseJson};
+
+    fn make_test_input() -> AnalyzeSynapsesInput {
+        AnalyzeSynapsesInput {
+            parquet_file: String::new(),
+            creature: CreatureJson {
+                input: 2,
+                output: 1,
+                neurons: vec![
+                    NeuronJson {
+                        uuid: "hidden-1".to_string(),
+                        squash: "TANH".to_string(),
+                        bias: 0.5,
+                        neuron_type: "hidden".to_string(),
+                    },
+                    NeuronJson {
+                        uuid: "output-1".to_string(),
+                        squash: "LOGISTIC".to_string(),
+                        bias: -0.1,
+                        neuron_type: "output".to_string(),
+                    },
+                ],
+                synapses: vec![
+                    SynapseJson {
+                        from_uuid: "input-0".to_string(),
+                        to_uuid: "hidden-1".to_string(),
+                        weight: 0.5,
+                        synapse_type: None,
+                    },
+                    SynapseJson {
+                        from_uuid: "hidden-1".to_string(),
+                        to_uuid: "output-1".to_string(),
+                        weight: -0.3,
+                        synapse_type: None,
+                    },
+                ],
+            },
+            focus_neurons: vec!["output-1".to_string()],
+            max_candidates: None,
+            random_seed: Some(42),
+            analysis_deadline_ms: None,
+        }
+    }
+
+    #[test]
+    fn test_build_creature_lookups_ordered_neurons() {
+        let input = make_test_input();
+        let lookups = build_creature_lookups(&input);
+
+        // Should have input neurons + hidden + output
+        assert_eq!(lookups.ordered_neurons.len(), 4); // 2 inputs + 2 neurons
+        assert_eq!(lookups.order_map.len(), 4);
+    }
+
+    #[test]
+    fn test_build_creature_lookups_existing_synapses() {
+        let input = make_test_input();
+        let lookups = build_creature_lookups(&input);
+
+        assert_eq!(lookups.existing_synapses.len(), 2);
+        assert_eq!(lookups.existing_synapse_weights.len(), 2);
+    }
+
+    #[test]
+    fn test_build_creature_lookups_neuron_maps() {
+        let input = make_test_input();
+        let lookups = build_creature_lookups(&input);
+
+        // Squash map should have hidden + output neurons
+        assert_eq!(lookups.neuron_squash_map.len(), 2);
+        assert_eq!(
+            lookups.neuron_squash_map.get("hidden-1"),
+            Some(&"TANH".to_string())
+        );
+
+        // Type map should have inputs + neurons
+        assert_eq!(lookups.neuron_type_map.len(), 4);
+        assert_eq!(
+            lookups.neuron_type_map.get("input-0"),
+            Some(&"input".to_string())
+        );
+        assert_eq!(
+            lookups.neuron_type_map.get("hidden-1"),
+            Some(&"hidden".to_string())
+        );
+
+        // Input neuron UUIDs
+        assert_eq!(lookups.input_neuron_uuids.len(), 2);
+        assert!(lookups.input_neuron_uuids.contains("input-0"));
+        assert!(lookups.input_neuron_uuids.contains("input-1"));
+
+        // Used inputs (only input-0 is used in a synapse)
+        assert_eq!(lookups.used_inputs.len(), 1);
+        assert!(lookups.used_inputs.contains("input-0"));
+
+        // Bias map
+        assert_eq!(lookups.neuron_bias_map.len(), 2);
+        assert_eq!(lookups.neuron_bias_map.get("hidden-1"), Some(&0.5));
+    }
+
+    #[test]
+    fn test_build_creature_lookups_synapses_by_target() {
+        let input = make_test_input();
+        let lookups = build_creature_lookups(&input);
+
+        // Two targets: hidden-1 and output-1
+        assert_eq!(lookups.synapses_by_target.len(), 2);
+    }
+
+    #[test]
+    fn test_build_creature_lookups_empty_creature() {
+        let input = AnalyzeSynapsesInput {
+            parquet_file: String::new(),
+            creature: CreatureJson {
+                input: 0,
+                output: 0,
+                neurons: vec![],
+                synapses: vec![],
+            },
+            focus_neurons: vec![],
+            max_candidates: None,
+            random_seed: None,
+            analysis_deadline_ms: None,
+        };
+        let lookups = build_creature_lookups(&input);
+
+        assert!(lookups.ordered_neurons.is_empty());
+        assert!(lookups.existing_synapses.is_empty());
+        assert!(lookups.neuron_type_map.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Refactored `analyze_synapses_with_cache_impl` from ~350 lines down to ~107 lines by extracting logical phases into well-named helper functions. Closes #714.

### Extracted Functions

1. **`preparation::build_creature_lookups()`** — Builds all HashMap/HashSet lookup structures from creature topology (ordered neurons, interned indices, existing synapses, squash/type/bias maps, input neuron tracking). Returns a `CreatureLookups` struct.

2. **`preparation::compute_constant_source_threshold_from_cache()`** — Samples input neuron records to compute average standard deviation and derives the dynamic constant-source effect threshold.

3. **`SharedResultCollectors`** struct with `merge_target_results()` method — Encapsulates all shared mutable state (Mutex-wrapped result vectors, atomic metadata flags) used during parallel target analysis. Replaces 10 separate parameters.

4. **`finalise_synapse_results()`** — Collects results from shared state after the parallel loop, applies post-processing (collapse hidden, impact discounting, sorting), and builds the final `AnalyzeSynapsesResult`.

### No Behavioural Changes

This is a pure refactoring — the same code runs in the same order with the same inputs and outputs.

## Evidence

- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)
- All 536 unit tests pass
- No visual/UI changes — backend refactoring only

## Test Plan

- Added 5 unit tests for `build_creature_lookups()` in `preparation.rs`:
  - `test_build_creature_lookups_ordered_neurons` — verifies ordered neurons and order map
  - `test_build_creature_lookups_existing_synapses` — verifies existing synapse sets
  - `test_build_creature_lookups_neuron_maps` — verifies squash, type, input, used inputs, and bias maps
  - `test_build_creature_lookups_synapses_by_target` — verifies synapses grouped by target
  - `test_build_creature_lookups_empty_creature` — verifies behaviour with empty input
- All existing tests continue to pass unchanged

---

## Automated Fix Details
This PR addresses issue #714: **Refactor analyze_synapses_with_cache_and_gpu_queue (362 lines) into smaller functions**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #714