### PR TITLE
fix: add SAFETY comments to all unsafe blocks in production code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.9"
+version = "0.43.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.8"
+version = "0.43.9"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-712.md
+++ b/docs/pr-summary-712.md
@@ -1,0 +1,20 @@
+## Summary
+
+Add missing `// SAFETY:` comments to the two remaining undocumented `unsafe` blocks in
+`src/analysis/utils/platform.rs` (lines 31 and 36). These blocks call `env::set_var()` for
+`MESA_GLSL_CACHE_DISABLE` and `MESA_DEBUG` inside a `Once::call_once` guard, matching the
+existing comment on the adjacent `EGL_LOG_LEVEL` block.
+
+All other `unsafe` blocks in `src/` already had `// SAFETY:` comments from prior work
+(#711/#724 for FFI blocks, and earlier commits for test env-var blocks). Closes #712.
+
+## Evidence
+
+No UI or performance changes. This is a documentation-only change (comments added to
+existing code). Verified by running `quality.sh` which passes all checks including
+`cargo clippy`, `cargo test`, and `cargo build --release`.
+
+## Test Plan
+
+- No new tests required — this change only adds comments to existing code
+- All existing tests continue to pass (`quality.sh` green)

--- a/src/analysis/utils/platform.rs
+++ b/src/analysis/utils/platform.rs
@@ -28,11 +28,13 @@ pub fn suppress_mesa_warnings_if_requested() {
 
             // Suppress Mesa GLSL shader cache warnings
             if env::var("MESA_GLSL_CACHE_DISABLE").is_err() {
+                // SAFETY: single-threaded at this point (Once guard) and before GPU init
                 unsafe { env::set_var("MESA_GLSL_CACHE_DISABLE", "true") };
             }
 
             // Suppress general Mesa debug output
             if env::var("MESA_DEBUG").is_err() {
+                // SAFETY: single-threaded at this point (Once guard) and before GPU init
                 unsafe { env::set_var("MESA_DEBUG", "silent") };
             }
         }


### PR DESCRIPTION
## Summary

Add missing `// SAFETY:` comments to the two remaining undocumented `unsafe` blocks in
`src/analysis/utils/platform.rs` (lines 31 and 36). These blocks call `env::set_var()` for
`MESA_GLSL_CACHE_DISABLE` and `MESA_DEBUG` inside a `Once::call_once` guard, matching the
existing comment on the adjacent `EGL_LOG_LEVEL` block.

All other `unsafe` blocks in `src/` already had `// SAFETY:` comments from prior work
(#711/#724 for FFI blocks, and earlier commits for test env-var blocks). Closes #712.

## Evidence

No UI or performance changes. This is a documentation-only change (comments added to
existing code). Verified by running `quality.sh` which passes all checks including
`cargo clippy`, `cargo test`, and `cargo build --release`.

## Test Plan

- No new tests required — this change only adds comments to existing code
- All existing tests continue to pass (`quality.sh` green)

---

## Automated Fix Details
This PR addresses issue #712: **Add SAFETY comments to all unsafe blocks in production code**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #712