### PR TITLE
fix: improve coordinated-structural success rate (#732)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.17"
+version = "0.43.18"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.43.16"
+version = "0.43.17"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-732.md
+++ b/docs/pr-summary-732.md
@@ -1,0 +1,27 @@
+## Summary
+
+Improve coordinated-structural success rate by addressing compounding prediction errors in multi-operation candidates. Closes #732.
+
+The coordinated-structural module had a 1.9% success rate (232/12,005) because multi-operation candidates (e.g., RemoveSynapse + AddNeuron + AddSynapse × 2) combine several predictions, each with its own uncertainty. This change introduces three improvements:
+
+1. **Operation-count discount**: Each additional operation beyond the first applies a 0.8× compounding discount (e.g., 4-op candidates receive 0.8³ ≈ 0.512 discount), reducing over-prediction.
+2. **Minimum gain threshold**: Multi-operation candidates must exceed `MIN_COORDINATED_MULTI_OP_GAIN` (1e-5) after discounting, filtering near-zero predictions that almost never succeed.
+3. **Capped ensemble boost**: The agreement boost from ensemble scoring is reduced proportionally to operation count, preventing amplification of weak multi-operation signals.
+
+## Evidence
+
+This is a backend-only change with no UI impact. Tests verify the mathematical correctness of the discount, threshold, and boost-capping logic.
+
+## Test Plan
+
+- Added `tests/issue_732_coordinated_structural_success_rate.rs` with 8 tests:
+  - `single_operation_has_no_discount` — verifies single-op candidates are unaffected
+  - `multi_operation_candidate_is_discounted` — verifies 4-op candidates receive discount
+  - `more_operations_produce_larger_discount` — verifies discount increases with op count
+  - `tiny_gain_rejected_for_multi_op_candidate` — verifies minimum gain threshold filters weak candidates
+  - `reasonable_gain_accepted_for_multi_op_candidate` — verifies valid candidates pass threshold
+  - `single_op_with_small_gain_accepted` — verifies single-op candidates have lower threshold
+  - `ensemble_boost_capped_for_multi_operation_candidates` — verifies ensemble boost is reduced for complex candidates
+  - `single_op_ensemble_boost_unchanged` — verifies single-op ensemble boost is unaffected
+- All existing tests pass (including ensemble scoring tests from Issue #572)
+- `quality.sh` passes cleanly

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -15,11 +15,43 @@ use crate::{
     CoordinatedStructuralOpJson,
 };
 
+use super::constants::{COORDINATED_OPERATION_DISCOUNT, MIN_COORDINATED_MULTI_OP_GAIN};
 use super::{cache, shared, synapse};
+
+/// Compute the operation-count discount for a coordinated candidate (Issue #732).
+///
+/// Multi-operation candidates suffer compounding prediction uncertainty.
+/// Each additional operation beyond the first applies a multiplicative discount
+/// of `COORDINATED_OPERATION_DISCOUNT`, so a 4-operation candidate receives
+/// `COORDINATED_OPERATION_DISCOUNT^3` ≈ 0.512 discount.
+///
+/// Single-operation candidates receive no discount (returns original gain).
+pub fn apply_operation_count_discount(candidate: &CoordinatedStructuralCandidateJson) -> f32 {
+    let op_count = candidate.operations.len();
+    if op_count <= 1 {
+        return candidate.expected_creature_score_gain;
+    }
+    let exponent = (op_count - 1) as f32;
+    candidate.expected_creature_score_gain * COORDINATED_OPERATION_DISCOUNT.powf(exponent)
+}
+
+/// Validate whether a coordinated candidate's gain exceeds the minimum threshold (Issue #732).
+///
+/// Single-operation candidates only require positive gain. Multi-operation
+/// candidates (>= 2 operations) must exceed `MIN_COORDINATED_MULTI_OP_GAIN`
+/// to filter out near-zero predictions that almost never succeed in practice.
+pub fn validate_coordinated_candidate_gain(candidate: &CoordinatedStructuralCandidateJson) -> bool {
+    if candidate.operations.len() <= 1 {
+        return candidate.expected_creature_score_gain > 0.0;
+    }
+    let discounted = apply_operation_count_discount(candidate);
+    discounted > MIN_COORDINATED_MULTI_OP_GAIN
+}
 
 /// Merge coordinated structural replacement candidates into the synapse result.
 ///
 /// Filters out candidates with non-positive expected gain (Issue #557),
+/// applies operation-count discount for multi-operation candidates (Issue #732),
 /// sorts by expected gain (unless diversified), and truncates to the
 /// combined synapse candidate limit.
 pub(crate) fn merge_coordinated_structural_replacements(
@@ -35,6 +67,26 @@ pub(crate) fn merge_coordinated_structural_replacements(
     // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
     // Only candidates predicted to improve the creature's score should be returned.
     replacements.retain(|c| c.expected_creature_score_gain > 0.0);
+    if replacements.is_empty() {
+        return;
+    }
+
+    // Issue #732: Apply operation-count discount and minimum gain validation.
+    // Multi-operation candidates have compounding prediction uncertainty.
+    for c in &mut replacements {
+        if c.operations.len() > 1 {
+            c.expected_creature_score_gain = apply_operation_count_discount(c);
+        }
+    }
+    // After discounting, filter out candidates below the minimum gain threshold.
+    // Note: we check the gain directly here since discounting has already been applied.
+    replacements.retain(|c| {
+        if c.operations.len() <= 1 {
+            c.expected_creature_score_gain > 0.0
+        } else {
+            c.expected_creature_score_gain > MIN_COORDINATED_MULTI_OP_GAIN
+        }
+    });
     if replacements.is_empty() {
         return;
     }

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -248,3 +248,36 @@ pub fn cmp_f32_asc(a: &f32, b: &f32) -> std::cmp::Ordering {
 pub fn cmp_f64_desc(a: &f64, b: &f64) -> std::cmp::Ordering {
     b.total_cmp(a)
 }
+
+// =============================================================================
+// Coordinated-Structural Validation (Issue #732)
+// =============================================================================
+
+/// Per-operation compounding uncertainty discount for multi-operation candidates.
+///
+/// Production analysis shows coordinated-structural candidates have a 1.9% success
+/// rate because each operation's prediction uncertainty compounds when combined.
+/// For a candidate with N operations, the discount is:
+///
+/// ```text
+/// discount = COORDINATED_OPERATION_DISCOUNT ^ (N - 1)
+/// ```
+///
+/// With a factor of 0.8, a 4-operation candidate receives 0.8^3 = 0.512 discount,
+/// roughly halving the predicted gain to account for inter-operation interference.
+///
+/// ## Valid Range
+/// Must be in (0.0, 1.0). Values below 0.5 may over-discount legitimate candidates.
+/// Values above 0.95 provide insufficient correction.
+pub const COORDINATED_OPERATION_DISCOUNT: f32 = 0.8;
+
+/// Minimum absolute gain required for a multi-operation coordinated candidate.
+///
+/// Single-operation candidates are accepted with any positive gain, but
+/// multi-operation candidates (>= 2 operations) must exceed this threshold
+/// after discounting. This prevents near-zero predictions from generating
+/// candidates that almost never succeed.
+///
+/// ## Valid Range
+/// Must be > 0.0. Values above 1e-4 may filter too aggressively.
+pub const MIN_COORDINATED_MULTI_OP_GAIN: f32 = 1e-5;

--- a/src/analysis/ensemble_scoring.rs
+++ b/src/analysis/ensemble_scoring.rs
@@ -232,7 +232,19 @@ fn combine_agreeing_candidates(
     // Apply agreement boost to the best raw score.
     // boost = 1.0 + AGREEMENT_BOOST_FACTOR * (n - 1) / n
     // For n=2: 1.15, n=3: 1.20, n=4: 1.225, etc.
-    let boost = 1.0 + AGREEMENT_BOOST_FACTOR * (n - 1.0) / n;
+    //
+    // Issue #732: Cap the boost for multi-operation candidates. Complex coordinated
+    // candidates (multiple operations) have compounding prediction uncertainty, so
+    // the ensemble agreement boost is reduced proportionally to the operation count.
+    let max_ops = group.iter().map(|c| c.operations.len()).max().unwrap_or(1);
+    let base_boost = AGREEMENT_BOOST_FACTOR * (n - 1.0) / n;
+    let capped_boost = if max_ops > 1 {
+        // Scale down boost: 1 op = full boost, 4 ops = ~33% of boost
+        base_boost / (max_ops as f32)
+    } else {
+        base_boost
+    };
+    let boost = 1.0 + capped_boost;
     let ensemble_score = best_raw_gain * boost;
 
     // Use the best-weighted candidate as the template, update its score and comment.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -58,7 +58,7 @@ pub mod recommendation;
 pub mod scoring;
 
 // Orchestration sub-modules (Issue #562)
-pub(crate) mod candidate_aggregation;
+pub mod candidate_aggregation;
 pub(crate) mod module_dispatch_specs;
 mod orchestration;
 

--- a/tests/issue_732_coordinated_structural_success_rate.rs
+++ b/tests/issue_732_coordinated_structural_success_rate.rs
@@ -1,0 +1,201 @@
+//! Tests for improved coordinated-structural success rate (Issue #732).
+//!
+//! Validates that multi-operation coordinated candidates are properly discounted
+//! for compounding prediction uncertainty, and that ensemble boost is capped
+//! for complex candidates.
+
+mod common;
+
+use neat_ai_discovery::analysis::candidate_aggregation::{
+    apply_operation_count_discount, validate_coordinated_candidate_gain,
+};
+use neat_ai_discovery::analysis::ensemble_scoring::apply_ensemble_scoring;
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_single_op_candidate(gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: "neuron-a".to_string(),
+            bias: 0.5,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some("test module".to_string()),
+    }
+}
+
+fn make_multi_op_candidate(op_count: usize, gain: f32) -> CoordinatedStructuralCandidateJson {
+    let mut operations = Vec::with_capacity(op_count);
+
+    // Build a realistic multi-operation candidate (RemoveSynapse + AddNeuron + AddSynapse × N)
+    operations.push(CoordinatedStructuralOpJson::RemoveSynapse {
+        from_neuron_uuid: "source".to_string(),
+        to_neuron_uuid: "target".to_string(),
+    });
+
+    if op_count >= 2 {
+        operations.push(CoordinatedStructuralOpJson::AddNeuron {
+            neuron_uuid: "new-hidden".to_string(),
+            neuron_type: "hidden".to_string(),
+            squash: "LOGISTIC".to_string(),
+            bias: 0.0,
+            insert_before_neuron_uuid: Some("target".to_string()),
+        });
+    }
+
+    for i in 2..op_count {
+        operations.push(CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: format!("node-{i}"),
+            to_neuron_uuid: "new-hidden".to_string(),
+            weight: 0.1,
+        });
+    }
+
+    CoordinatedStructuralCandidateJson {
+        operations,
+        expected_creature_score_gain: gain,
+        comment: Some("test coordinated module".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Operation-count discount tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_operation_has_no_discount() {
+    let candidate = make_single_op_candidate(0.01);
+    let discounted = apply_operation_count_discount(&candidate);
+    // Single operation should not be discounted
+    assert!(
+        (discounted - 0.01).abs() < 1e-6,
+        "single-op candidate should not be discounted, got {discounted}"
+    );
+}
+
+#[test]
+fn multi_operation_candidate_is_discounted() {
+    let candidate = make_multi_op_candidate(4, 0.01);
+    let discounted = apply_operation_count_discount(&candidate);
+    // 4 operations should receive a meaningful discount
+    assert!(
+        discounted < 0.01,
+        "4-op candidate should be discounted below 0.01, got {discounted}"
+    );
+    assert!(
+        discounted > 0.0,
+        "discounted gain should remain positive, got {discounted}"
+    );
+}
+
+#[test]
+fn more_operations_produce_larger_discount() {
+    let two_ops = make_multi_op_candidate(2, 0.01);
+    let four_ops = make_multi_op_candidate(4, 0.01);
+
+    let discount_2 = apply_operation_count_discount(&two_ops);
+    let discount_4 = apply_operation_count_discount(&four_ops);
+
+    assert!(
+        discount_4 < discount_2,
+        "4-op discount ({discount_4}) should be less than 2-op discount ({discount_2})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Minimum gain validation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tiny_gain_rejected_for_multi_op_candidate() {
+    // A very small gain (e.g. 1e-7) on a 4-op candidate should be rejected
+    let candidate = make_multi_op_candidate(4, 1e-7);
+    let valid = validate_coordinated_candidate_gain(&candidate);
+    assert!(!valid, "tiny gain on multi-op candidate should be rejected");
+}
+
+#[test]
+fn reasonable_gain_accepted_for_multi_op_candidate() {
+    let candidate = make_multi_op_candidate(4, 0.001);
+    let valid = validate_coordinated_candidate_gain(&candidate);
+    assert!(valid, "reasonable gain on multi-op candidate should pass");
+}
+
+#[test]
+fn single_op_with_small_gain_accepted() {
+    // Single-op candidates have lower thresholds
+    let candidate = make_single_op_candidate(1e-6);
+    let valid = validate_coordinated_candidate_gain(&candidate);
+    assert!(
+        valid,
+        "single-op candidate with small positive gain should pass"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ensemble boost capping for multi-operation candidates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ensemble_boost_capped_for_multi_operation_candidates() {
+    // Two modules agree on a 4-operation coordinated candidate.
+    let candidates = vec![make_multi_op_candidate(4, 0.01), {
+        let mut c = make_multi_op_candidate(4, 0.012);
+        c.comment = Some("another module".to_string());
+        c
+    }];
+
+    let result = apply_ensemble_scoring(candidates, &Default::default());
+
+    // The boost for multi-op candidates should be capped lower than for single-op.
+    // Single-op 2-module agreement gives ~15% boost (0.012 * 1.15 = 0.0138).
+    // Multi-op should get a reduced boost.
+    let best = result
+        .candidates
+        .iter()
+        .max_by(|a, b| {
+            a.expected_creature_score_gain
+                .total_cmp(&b.expected_creature_score_gain)
+        })
+        .expect("should have candidates");
+
+    // The boosted score should be less than the uncapped single-op boost would give
+    let uncapped_single_op_boost = 0.012 * (1.0 + 0.3 * 0.5); // 1.15 × 0.012 = 0.0138
+    assert!(
+        best.expected_creature_score_gain <= uncapped_single_op_boost,
+        "multi-op ensemble boost should be capped, got {} (uncapped would be {})",
+        best.expected_creature_score_gain,
+        uncapped_single_op_boost
+    );
+}
+
+#[test]
+fn single_op_ensemble_boost_unchanged() {
+    // Two modules agree on a single-operation candidate — boost should work normally.
+    let candidates = vec![make_single_op_candidate(0.02), {
+        let mut c = make_single_op_candidate(0.03);
+        c.comment = Some("another module".to_string());
+        c
+    }];
+
+    let result = apply_ensemble_scoring(candidates, &Default::default());
+
+    let best = result
+        .candidates
+        .iter()
+        .max_by(|a, b| {
+            a.expected_creature_score_gain
+                .total_cmp(&b.expected_creature_score_gain)
+        })
+        .expect("should have candidates");
+
+    // Single-op agreement should still boost above best individual
+    assert!(
+        best.expected_creature_score_gain > 0.03,
+        "single-op ensemble should boost above 0.03, got {}",
+        best.expected_creature_score_gain
+    );
+}


### PR DESCRIPTION
## Summary

Improve coordinated-structural success rate by addressing compounding prediction errors in multi-operation candidates. Closes #732.

The coordinated-structural module had a 1.9% success rate (232/12,005) because multi-operation candidates (e.g., RemoveSynapse + AddNeuron + AddSynapse × 2) combine several predictions, each with its own uncertainty. This change introduces three improvements:

1. **Operation-count discount**: Each additional operation beyond the first applies a 0.8× compounding discount (e.g., 4-op candidates receive 0.8³ ≈ 0.512 discount), reducing over-prediction.
2. **Minimum gain threshold**: Multi-operation candidates must exceed `MIN_COORDINATED_MULTI_OP_GAIN` (1e-5) after discounting, filtering near-zero predictions that almost never succeed.
3. **Capped ensemble boost**: The agreement boost from ensemble scoring is reduced proportionally to operation count, preventing amplification of weak multi-operation signals.

## Evidence

This is a backend-only change with no UI impact. Tests verify the mathematical correctness of the discount, threshold, and boost-capping logic.

## Test Plan

- Added `tests/issue_732_coordinated_structural_success_rate.rs` with 8 tests:
  - `single_operation_has_no_discount` — verifies single-op candidates are unaffected
  - `multi_operation_candidate_is_discounted` — verifies 4-op candidates receive discount
  - `more_operations_produce_larger_discount` — verifies discount increases with op count
  - `tiny_gain_rejected_for_multi_op_candidate` — verifies minimum gain threshold filters weak candidates
  - `reasonable_gain_accepted_for_multi_op_candidate` — verifies valid candidates pass threshold
  - `single_op_with_small_gain_accepted` — verifies single-op candidates have lower threshold
  - `ensemble_boost_capped_for_multi_operation_candidates` — verifies ensemble boost is reduced for complex candidates
  - `single_op_ensemble_boost_unchanged` — verifies single-op ensemble boost is unaffected
- All existing tests pass (including ensemble scoring tests from Issue #572)
- `quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #732: **Improve coordinated-structural success rate (currently 1.9%)**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #732