### PR TITLE
fix: tune pessimism discount to improve add-neurons success rate (#733)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.44.1"
+version = "0.44.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.44.0"
+version = "0.44.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-733.md
+++ b/docs/pr-summary-733.md
@@ -1,0 +1,42 @@
+## Summary
+
+Tune pessimism discount and add neuron candidate filtering to improve add-neurons success rate above the 14.1% baseline. Closes #733.
+
+### Changes
+
+1. **Concave pessimism discount curve** (`src/analysis/constants.rs`, `src/analysis/synapse/scoring.rs`):
+   - Replaced the linear pessimism discount formula with a concave (power) curve using `PESSIMISM_CURVE_EXPONENT = 0.6`
+   - The concave curve is more forgiving at moderate improved ratios (30-60%), retaining add-neuron candidates with genuine signal
+   - Still aggressive at very low ratios (<10%) to filter noise
+   - Formula: `adjusted_ratio = ratio^0.6`, then `discount = FLOOR + (1 - FLOOR) × adjusted_ratio`
+
+2. **Neuron candidate improved ratio filtering** (`src/analysis/neuron/evaluation.rs`, `src/analysis/constants.rs`):
+   - Added `NEURON_MIN_IMPROVED_RATIO = 0.4` threshold for neuron candidates
+   - Filters out neuron candidates where fewer than 40% of samples show improvement
+   - Applied to both ReLU and activation spec evaluation paths
+   - Reduces candidate volume (fewer low-quality candidates proposed) while retaining higher-quality ones
+
+3. **Updated existing tests** (`tests/issue_506_*.rs`, `tests/issue_522_*.rs`):
+   - Modified 3 tests that checked exact linear formula values to work with the new concave curve
+   - Business logic change documented: Issue #733 changed pessimism discount from linear to concave
+
+## Evidence
+
+This is a backend/algorithm change with no visual output. Evidence is provided by unit tests:
+- 8 new tests validate the concave curve behaviour, constant ranges, and monotonicity
+- All 16 existing pessimism discount tests pass (3 updated for new formula)
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Added `tests/issue_733_add_neurons_pessimism_tuning.rs` with 8 tests:
+  - `pessimism_discount_concave_curve_more_forgiving_at_moderate_ratios` — validates concave > linear at 40%
+  - `pessimism_discount_still_aggressive_at_very_low_ratios` — validates aggression at 5%
+  - `pessimism_discount_monotonically_increasing_with_concave_curve` — monotonicity check
+  - `pessimism_discount_full_ratio_gives_full_gain` — ratio=1.0 edge case
+  - `pessimism_discount_zero_total_gives_floor_gain` — total=0 edge case
+  - `neuron_min_improved_ratio_is_sensible` — const range validation
+  - `neuron_min_improved_ratio_not_more_strict_than_synapse` — cross-module consistency
+  - `pessimism_discount_practical_add_neuron_improvement` — realistic scenario check
+- Modified `tests/issue_506_score_prediction_pessimism_discount.rs` (2 tests updated for concave curve)
+- Modified `tests/issue_522_synapse_scoring.rs` (1 test updated for concave curve)

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -191,6 +191,19 @@ pub const MAX_INDIVIDUAL_HARM_FOR_PAIRING: f32 = 0.0;
 /// Values above 0.75 may over-filter legitimate candidates.
 pub const MIN_IMPROVED_RATIO: f32 = 0.5;
 
+/// Minimum ratio of improved samples required for a neuron candidate to be accepted.
+///
+/// Issue #733: The add-neurons module had a 14.1% success rate. Neuron candidates
+/// are inherently noisier than synapse candidates because they involve two new
+/// connections (incoming + outgoing) rather than one. A slightly lower threshold
+/// than `MIN_IMPROVED_RATIO` allows moderate-quality candidates through while
+/// still filtering out clearly bad ones.
+///
+/// ## Valid Range
+/// Must be in (0.0, 1.0). Values below 0.3 provide insufficient filtering.
+/// Values above MIN_IMPROVED_RATIO may be too strict for neuron candidates.
+pub const NEURON_MIN_IMPROVED_RATIO: f32 = 0.4;
+
 /// Minimum pessimism discount applied to all score predictions.
 ///
 /// Production analysis (creature b2ff6e45, GRQ-sampler commit a1340f8d) showed
@@ -200,21 +213,45 @@ pub const MIN_IMPROVED_RATIO: f32 = 0.5;
 /// fraction of a single target neuron's squared error explained by sampled
 /// data, but this does not generalise directly to creature-level score gain.
 ///
-/// The pessimism discount scales predictions down based on the ratio of
-/// samples that actually improved (`improved_count / total_count`):
+/// The pessimism discount scales predictions down using a concave (power) curve
+/// based on the ratio of samples that actually improved:
 ///
 /// ```text
-/// discount = FLOOR + (1 - FLOOR) × (improved_count / total_count)
+/// improved_ratio = improved_count / total_count
+/// adjusted_ratio = improved_ratio ^ PESSIMISM_CURVE_EXPONENT
+/// discount = FLOOR + (1 - FLOOR) × adjusted_ratio
 /// discounted_gain = raw_gain × discount
 /// ```
 ///
-/// When all samples improve (ratio = 1.0), the discount equals 1.0 (only the
-/// floor applies). When few samples improve, the discount approaches the floor.
+/// Issue #733: Changed from linear to concave curve. The linear formula was
+/// too aggressive for add-neurons candidates (14.1% success rate), discounting
+/// moderate-quality candidates (30-60% improved ratio) excessively. The concave
+/// curve is more forgiving at moderate ratios while remaining aggressive at
+/// very low ratios (<10%).
 ///
 /// ## Valid Range
 /// Must be in (0.0, 1.0). Values below 0.1 risk zeroing-out legitimate candidates.
 /// Values above 0.5 provide insufficient correction.
 pub const PESSIMISM_DISCOUNT_FLOOR: f32 = 0.15;
+
+/// Exponent for the concave pessimism discount curve (Issue #733).
+///
+/// The improved ratio is raised to this power before being used in the discount
+/// formula. An exponent < 1.0 produces a concave curve that is:
+/// - More forgiving at moderate ratios (30-60%): retains add-neuron candidates
+///   with genuine but moderate signal
+/// - Still aggressive at very low ratios (<10%): filters out noise
+///
+/// With exponent 0.6:
+/// - ratio 0.1 → 0.1^0.6 ≈ 0.251 (aggressive)
+/// - ratio 0.4 → 0.4^0.6 ≈ 0.575 (forgiving vs linear 0.4)
+/// - ratio 0.7 → 0.7^0.6 ≈ 0.802 (forgiving vs linear 0.7)
+/// - ratio 1.0 → 1.0 (unchanged)
+///
+/// ## Valid Range
+/// Must be in (0.0, 1.0]. Values below 0.3 may over-flatten the curve.
+/// Values above 0.9 give near-linear behaviour with minimal benefit.
+pub const PESSIMISM_CURVE_EXPONENT: f32 = 0.6;
 
 // =============================================================================
 // NaN-safe Floating-Point Comparison Helpers (Issue #483)

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -119,43 +119,71 @@ fn evaluate_relu_split(
     };
 
     if let Some(mut candidate) = split_result.positive_error_candidate {
-        // Issue #130: Apply source variance discount
-        candidate.expected_creature_error_reduction *= source_variance_discount;
-        candidate.expected_creature_score_gain *= source_variance_discount;
+        // Issue #733: Filter neuron candidates where insufficient samples improve.
+        if !passes_neuron_improved_ratio(&candidate) {
+            if verbose_enabled() {
+                tracing::trace!(
+                    direction = "push UP",
+                    source_uuid = %source_uuid,
+                    target_uuid = %target_uuid,
+                    improved = candidate.improved_count,
+                    total = candidate.total_count,
+                    "ReLU candidate filtered by NEURON_MIN_IMPROVED_RATIO"
+                );
+            }
+        } else {
+            // Issue #130: Apply source variance discount
+            candidate.expected_creature_error_reduction *= source_variance_discount;
+            candidate.expected_creature_score_gain *= source_variance_discount;
 
-        if verbose_enabled() {
-            tracing::trace!(
-                direction = "push UP",
-                source_uuid = %source_uuid,
-                target_uuid = %target_uuid,
-                improvement_pct = format_args!("{:.2}", candidate.expected_creature_score_gain * 100.0),
-                variance_discount = format_args!("{:.2}", source_variance_discount),
-                "ReLU candidate identified"
-            );
+            if verbose_enabled() {
+                tracing::trace!(
+                    direction = "push UP",
+                    source_uuid = %source_uuid,
+                    target_uuid = %target_uuid,
+                    improvement_pct = format_args!("{:.2}", candidate.expected_creature_score_gain * 100.0),
+                    variance_discount = format_args!("{:.2}", source_variance_discount),
+                    "ReLU candidate identified"
+                );
+            }
+            ctx.diagnostics.mark_candidate_selected(target_uuid);
+            let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
+            upsert_candidate(&mut map, candidate);
         }
-        ctx.diagnostics.mark_candidate_selected(target_uuid);
-        let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
-        upsert_candidate(&mut map, candidate);
     }
 
     if let Some(mut candidate) = split_result.negative_error_candidate {
-        // Issue #130: Apply source variance discount
-        candidate.expected_creature_error_reduction *= source_variance_discount;
-        candidate.expected_creature_score_gain *= source_variance_discount;
+        // Issue #733: Filter neuron candidates where insufficient samples improve.
+        if !passes_neuron_improved_ratio(&candidate) {
+            if verbose_enabled() {
+                tracing::trace!(
+                    direction = "push DOWN",
+                    source_uuid = %source_uuid,
+                    target_uuid = %target_uuid,
+                    improved = candidate.improved_count,
+                    total = candidate.total_count,
+                    "ReLU candidate filtered by NEURON_MIN_IMPROVED_RATIO"
+                );
+            }
+        } else {
+            // Issue #130: Apply source variance discount
+            candidate.expected_creature_error_reduction *= source_variance_discount;
+            candidate.expected_creature_score_gain *= source_variance_discount;
 
-        if verbose_enabled() {
-            tracing::trace!(
-                direction = "push DOWN",
-                source_uuid = %source_uuid,
-                target_uuid = %target_uuid,
-                improvement_pct = format_args!("{:.2}", candidate.expected_creature_score_gain * 100.0),
-                variance_discount = format_args!("{:.2}", source_variance_discount),
-                "ReLU candidate identified"
-            );
+            if verbose_enabled() {
+                tracing::trace!(
+                    direction = "push DOWN",
+                    source_uuid = %source_uuid,
+                    target_uuid = %target_uuid,
+                    improvement_pct = format_args!("{:.2}", candidate.expected_creature_score_gain * 100.0),
+                    variance_discount = format_args!("{:.2}", source_variance_discount),
+                    "ReLU candidate identified"
+                );
+            }
+            ctx.diagnostics.mark_candidate_selected(target_uuid);
+            let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
+            upsert_candidate(&mut map, candidate);
         }
-        ctx.diagnostics.mark_candidate_selected(target_uuid);
-        let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
-        upsert_candidate(&mut map, candidate);
     }
 
     Ok(())
@@ -183,6 +211,11 @@ fn evaluate_activation_specs(
     };
 
     for mut candidate in batched_candidates {
+        // Issue #733: Filter neuron candidates where insufficient samples improve.
+        if !passes_neuron_improved_ratio(&candidate) {
+            continue;
+        }
+
         // Issue #130: Apply source variance discount
         candidate.expected_creature_error_reduction *= source_variance_discount;
         candidate.expected_creature_score_gain *= source_variance_discount;
@@ -193,4 +226,18 @@ fn evaluate_activation_specs(
     }
 
     Ok(())
+}
+
+/// Issue #733: Check whether a neuron candidate passes the minimum improved ratio threshold.
+///
+/// Filters out neuron candidates where insufficient samples show improvement,
+/// reducing candidate volume while retaining higher-quality candidates.
+fn passes_neuron_improved_ratio(candidate: &CandidateNeuronJson) -> bool {
+    use crate::analysis::constants::NEURON_MIN_IMPROVED_RATIO;
+
+    if candidate.total_count == 0 {
+        return false;
+    }
+    let improved_ratio = candidate.improved_count as f32 / candidate.total_count as f32;
+    improved_ratio >= NEURON_MIN_IMPROVED_RATIO
 }

--- a/src/analysis/synapse/scoring.rs
+++ b/src/analysis/synapse/scoring.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 
 // Boosting and discount constants
 use crate::analysis::constants::{
-    EXISTING_HIDDEN_TARGET_BOOST, INPUT_SOURCE_BOOST, PESSIMISM_DISCOUNT_FLOOR,
+    EXISTING_HIDDEN_TARGET_BOOST, INPUT_SOURCE_BOOST, PESSIMISM_CURVE_EXPONENT,
+    PESSIMISM_DISCOUNT_FLOOR,
 };
 
 // =============================================================================
@@ -580,9 +581,14 @@ pub(crate) fn compute_synapse_improvement_and_count(
 ///
 /// ## Formula
 ///
+/// Issue #733: Changed from linear to concave (power) curve. The linear formula
+/// was too aggressive for add-neurons candidates, discounting moderate-quality
+/// candidates excessively.
+///
 /// ```text
 /// improved_ratio = improved_count / total_count
-/// discount = PESSIMISM_DISCOUNT_FLOOR + (1 - PESSIMISM_DISCOUNT_FLOOR) × improved_ratio
+/// adjusted_ratio = improved_ratio ^ PESSIMISM_CURVE_EXPONENT
+/// discount = PESSIMISM_DISCOUNT_FLOOR + (1 - PESSIMISM_DISCOUNT_FLOOR) × adjusted_ratio
 /// result = gain × discount
 /// ```
 ///
@@ -594,7 +600,8 @@ pub fn apply_pessimism_discount(gain: f32, improved_count: u32, total_count: u32
         return gain * PESSIMISM_DISCOUNT_FLOOR;
     }
     let improved_ratio = improved_count as f32 / total_count as f32;
-    let discount = PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * improved_ratio;
+    let adjusted_ratio = improved_ratio.powf(PESSIMISM_CURVE_EXPONENT);
+    let discount = PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * adjusted_ratio;
     gain * discount
 }
 

--- a/tests/issue_506_score_prediction_pessimism_discount.rs
+++ b/tests/issue_506_score_prediction_pessimism_discount.rs
@@ -18,8 +18,9 @@ fn test_pessimism_discount_partial_improvement() {
     // Only 60% of samples improved
     let discounted = apply_pessimism_discount(0.05, 60, 100);
 
-    // discount = 0.15 + 0.85 × 0.6 = 0.66
-    // discounted = 0.05 × 0.66 = 0.033
+    // Issue #733: Changed from linear to concave curve.
+    // discount = 0.15 + 0.85 × 0.6^0.6 ≈ 0.15 + 0.85 × 0.736 ≈ 0.776
+    // discounted = 0.05 × 0.776 ≈ 0.0388
     assert!(
         discounted < 0.05,
         "Pessimism discount should reduce gain when only 60% of samples improved, got {discounted}"
@@ -28,10 +29,10 @@ fn test_pessimism_discount_partial_improvement() {
         discounted > 0.0,
         "Discounted gain should remain positive, got {discounted}"
     );
-    // Verify roughly correct magnitude
+    // Concave curve gives higher result than old linear (0.033)
     assert!(
-        (discounted - 0.033).abs() < 0.002,
-        "Expected ~0.033, got {discounted}"
+        discounted > 0.033,
+        "Issue #733: Concave curve at 60% should give higher result than old linear (0.033), got {discounted}"
     );
 }
 
@@ -123,11 +124,12 @@ fn test_pessimism_discount_reduces_weak_signal_significantly() {
     // Only 30% of samples improved — weak signal
     let discounted = apply_pessimism_discount(raw_gain, 60, 200);
 
-    // discount = 0.15 + 0.85 × 0.3 = 0.405
-    // discounted = 0.0205 × 0.405 ≈ 0.0083
+    // Issue #733: With concave curve, 30% ratio gives a higher discount than
+    // the old linear formula, but the prediction should still be meaningfully
+    // reduced (at least 40% reduction).
     assert!(
-        discounted < raw_gain * 0.5,
-        "Weak signal (30% improved) should reduce prediction by at least 50%: raw={raw_gain}, discounted={discounted}"
+        discounted < raw_gain * 0.6,
+        "Weak signal (30% improved) should reduce prediction by at least 40%: raw={raw_gain}, discounted={discounted}"
     );
     assert!(discounted > 0.0, "Discounted gain should remain positive");
 }

--- a/tests/issue_522_synapse_scoring.rs
+++ b/tests/issue_522_synapse_scoring.rs
@@ -48,14 +48,22 @@ fn pessimism_discount_no_samples_improved_gives_floor() {
 
 #[test]
 fn pessimism_discount_half_samples_improved() {
-    // When half improve, discount = FLOOR + (1 - FLOOR) × 0.5
+    // Issue #733: Changed from linear to concave curve.
+    // When half improve, discount = FLOOR + (1 - FLOOR) × 0.5^EXPONENT
+    // With EXPONENT=0.6: 0.5^0.6 ≈ 0.660, discount ≈ 0.15 + 0.85 × 0.660 ≈ 0.711
     let gain = 0.10;
     let result = apply_pessimism_discount(gain, 50, 100);
-    let expected_discount = PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * 0.5;
-    let expected = gain * expected_discount;
+
+    // The concave curve should give a higher result than the old linear formula
+    let old_linear = gain * (PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * 0.5);
     assert!(
-        (result - expected).abs() < 1e-6,
-        "Half samples improved: expected {expected}, got {result}"
+        result > old_linear,
+        "Issue #733: Concave curve should be more forgiving at 50% ratio: got {result}, old linear {old_linear}"
+    );
+    // Should still be less than the full gain
+    assert!(
+        result < gain,
+        "Half samples improved should still discount: got {result}, full gain {gain}"
     );
 }
 

--- a/tests/issue_733_add_neurons_pessimism_tuning.rs
+++ b/tests/issue_733_add_neurons_pessimism_tuning.rs
@@ -1,0 +1,164 @@
+//! Issue #733: Tune pessimism discount to improve add-neurons success rate
+//!
+//! Tests for:
+//! 1. Logistic pessimism discount curve (more forgiving above 30%, more aggressive below 10%)
+//! 2. MIN_IMPROVED_RATIO filtering applied to neuron candidates
+//! 3. Adaptive pessimism constant validation
+
+mod common;
+
+use neat_ai_discovery::analysis::constants::{NEURON_MIN_IMPROVED_RATIO, PESSIMISM_DISCOUNT_FLOOR};
+use neat_ai_discovery::analysis::synapse::apply_pessimism_discount;
+
+// =============================================================================
+// Logistic pessimism discount curve tests (Issue #733)
+// =============================================================================
+
+/// Issue #733: The pessimism discount should use a concave curve that is more
+/// forgiving for moderate improved ratios (30-60%) compared to the old linear
+/// formula. This helps retain add-neuron candidates that have genuine signal.
+#[test]
+fn pessimism_discount_concave_curve_more_forgiving_at_moderate_ratios() {
+    let gain = 0.10;
+
+    // Old linear formula: discount = 0.15 + 0.85 × 0.4 = 0.49
+    // New concave curve should give a higher discount (more forgiving)
+    let result_40pct = apply_pessimism_discount(gain, 40, 100);
+    let old_linear_40pct =
+        gain * (PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * 0.4);
+
+    assert!(
+        result_40pct > old_linear_40pct,
+        "Issue #733: Concave curve at 40% ratio should be more forgiving than linear. \
+         Got {result_40pct:.6}, old linear would give {old_linear_40pct:.6}"
+    );
+}
+
+/// Issue #733: The pessimism discount should still be aggressive for very low
+/// ratios (below 10%) to filter out noise.
+#[test]
+fn pessimism_discount_still_aggressive_at_very_low_ratios() {
+    let gain = 0.10;
+
+    // At 5% ratio, the discount should still be close to the floor
+    let result_5pct = apply_pessimism_discount(gain, 5, 100);
+    let floor_gain = gain * PESSIMISM_DISCOUNT_FLOOR;
+
+    // Should be within 2× of the floor gain (still quite aggressive)
+    assert!(
+        result_5pct < floor_gain * 2.5,
+        "Issue #733: At 5% ratio, discount should remain aggressive. \
+         Got {result_5pct:.6}, floor would give {floor_gain:.6}"
+    );
+}
+
+/// Issue #733: Monotonicity must still hold — higher ratios always produce
+/// higher discounted gains.
+#[test]
+fn pessimism_discount_monotonically_increasing_with_concave_curve() {
+    let gain = 0.10;
+    let mut prev = apply_pessimism_discount(gain, 0, 100);
+    for improved in (5..=100).step_by(5) {
+        let current = apply_pessimism_discount(gain, improved, 100);
+        assert!(
+            current >= prev - 1e-7,
+            "Issue #733: Discount should be monotonically non-decreasing: \
+             at {improved}/100, got {current:.6} < previous {prev:.6}"
+        );
+        prev = current;
+    }
+}
+
+/// Issue #733: Full improvement (ratio = 1.0) should still give full gain.
+#[test]
+fn pessimism_discount_full_ratio_gives_full_gain() {
+    let gain = 0.10;
+    let result = apply_pessimism_discount(gain, 100, 100);
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Issue #733: All samples improved should give full gain: expected {gain}, got {result}"
+    );
+}
+
+/// Issue #733: Zero total should give floor discount (edge case).
+#[test]
+fn pessimism_discount_zero_total_gives_floor_gain() {
+    let gain = 0.10;
+    let result = apply_pessimism_discount(gain, 0, 0);
+    let expected = gain * PESSIMISM_DISCOUNT_FLOOR;
+    assert!(
+        (result - expected).abs() < 1e-6,
+        "Issue #733: Zero total should give floor discount: expected {expected}, got {result}"
+    );
+}
+
+// =============================================================================
+// NEURON_MIN_IMPROVED_RATIO constant validation (Issue #733)
+// =============================================================================
+
+/// Issue #733: NEURON_MIN_IMPROVED_RATIO should be a sensible threshold for
+/// filtering add-neuron candidates that have insufficient sample improvement.
+#[test]
+fn neuron_min_improved_ratio_is_sensible() {
+    const {
+        assert!(NEURON_MIN_IMPROVED_RATIO > 0.0);
+        assert!(NEURON_MIN_IMPROVED_RATIO <= 0.75);
+        assert!(NEURON_MIN_IMPROVED_RATIO >= 0.3);
+    }
+
+    // Runtime check: a 55% ratio should pass neuron threshold
+    let test_ratio_good = 0.55_f32;
+    assert!(
+        test_ratio_good >= NEURON_MIN_IMPROVED_RATIO,
+        "A 55% improved ratio should pass the neuron threshold"
+    );
+
+    // Runtime check: a 20% ratio should fail neuron threshold
+    let test_ratio_bad = 0.20_f32;
+    assert!(
+        test_ratio_bad < NEURON_MIN_IMPROVED_RATIO,
+        "A 20% improved ratio should fail the neuron threshold"
+    );
+}
+
+/// Issue #733: NEURON_MIN_IMPROVED_RATIO should be <= MIN_IMPROVED_RATIO
+/// (neuron candidates are inherently noisier, so we allow a slightly lower bar).
+#[test]
+fn neuron_min_improved_ratio_not_more_strict_than_synapse() {
+    use neat_ai_discovery::analysis::constants::MIN_IMPROVED_RATIO;
+
+    const {
+        assert!(NEURON_MIN_IMPROVED_RATIO <= MIN_IMPROVED_RATIO);
+    }
+}
+
+// =============================================================================
+// Combined discount behaviour tests
+// =============================================================================
+
+/// Issue #733: The concave curve should give a meaningfully higher gain for
+/// a typical add-neuron scenario (40-60% improved ratio) compared to the
+/// old linear approach with the same floor.
+#[test]
+fn pessimism_discount_practical_add_neuron_improvement() {
+    let gain = 0.02; // Typical small add-neuron gain
+
+    // Typical add-neuron candidate: 45% of samples improve
+    let discounted = apply_pessimism_discount(gain, 45, 100);
+
+    // Old linear: 0.02 × (0.15 + 0.85 × 0.45) = 0.02 × 0.5325 = 0.01065
+    let old_linear = gain * (PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * 0.45);
+
+    assert!(
+        discounted > old_linear,
+        "Issue #733: Add-neuron candidate at 45% ratio should get higher score. \
+         New={discounted:.6}, old linear={old_linear:.6}"
+    );
+
+    // The improvement should be meaningful (at least 10% better)
+    let improvement_pct = (discounted - old_linear) / old_linear * 100.0;
+    assert!(
+        improvement_pct > 5.0,
+        "Issue #733: Improvement should be at least 5% better. Got {improvement_pct:.1}%"
+    );
+}


### PR DESCRIPTION
## Summary

Tune pessimism discount and add neuron candidate filtering to improve add-neurons success rate above the 14.1% baseline. Closes #733.

### Changes

1. **Concave pessimism discount curve** (`src/analysis/constants.rs`, `src/analysis/synapse/scoring.rs`):
   - Replaced the linear pessimism discount formula with a concave (power) curve using `PESSIMISM_CURVE_EXPONENT = 0.6`
   - The concave curve is more forgiving at moderate improved ratios (30-60%), retaining add-neuron candidates with genuine signal
   - Still aggressive at very low ratios (<10%) to filter noise
   - Formula: `adjusted_ratio = ratio^0.6`, then `discount = FLOOR + (1 - FLOOR) × adjusted_ratio`

2. **Neuron candidate improved ratio filtering** (`src/analysis/neuron/evaluation.rs`, `src/analysis/constants.rs`):
   - Added `NEURON_MIN_IMPROVED_RATIO = 0.4` threshold for neuron candidates
   - Filters out neuron candidates where fewer than 40% of samples show improvement
   - Applied to both ReLU and activation spec evaluation paths
   - Reduces candidate volume (fewer low-quality candidates proposed) while retaining higher-quality ones

3. **Updated existing tests** (`tests/issue_506_*.rs`, `tests/issue_522_*.rs`):
   - Modified 3 tests that checked exact linear formula values to work with the new concave curve
   - Business logic change documented: Issue #733 changed pessimism discount from linear to concave

## Evidence

This is a backend/algorithm change with no visual output. Evidence is provided by unit tests:
- 8 new tests validate the concave curve behaviour, constant ranges, and monotonicity
- All 16 existing pessimism discount tests pass (3 updated for new formula)
- `quality.sh` passes cleanly

## Test Plan

- Added `tests/issue_733_add_neurons_pessimism_tuning.rs` with 8 tests:
  - `pessimism_discount_concave_curve_more_forgiving_at_moderate_ratios` — validates concave > linear at 40%
  - `pessimism_discount_still_aggressive_at_very_low_ratios` — validates aggression at 5%
  - `pessimism_discount_monotonically_increasing_with_concave_curve` — monotonicity check
  - `pessimism_discount_full_ratio_gives_full_gain` — ratio=1.0 edge case
  - `pessimism_discount_zero_total_gives_floor_gain` — total=0 edge case
  - `neuron_min_improved_ratio_is_sensible` — const range validation
  - `neuron_min_improved_ratio_not_more_strict_than_synapse` — cross-module consistency
  - `pessimism_discount_practical_add_neuron_improvement` — realistic scenario check
- Modified `tests/issue_506_score_prediction_pessimism_discount.rs` (2 tests updated for concave curve)
- Modified `tests/issue_522_synapse_scoring.rs` (1 test updated for concave curve)

---

## Automated Fix Details
This PR addresses issue #733: **Tune pessimism discount to improve add-neurons success rate (currently 14.1%)**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #733