### PR TITLE
feat: improve bimodal detection with cluster coherence validation (#751)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.47.0"
+version = "0.47.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.47.1"
+version = "0.47.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-751.md
+++ b/docs/pr-summary-751.md
@@ -10,7 +10,7 @@ No UI changes — backend detection logic only. Verified via test results:
 
 - All 14 existing bimodal tests continue to pass (no regression)
 - 5 new tests added covering the issue's TDD plan
-- `quality.sh` passes cleanly
+- `quality.sh` passes cleanly.
 
 ## Test Plan
 

--- a/docs/pr-summary-751.md
+++ b/docs/pr-summary-751.md
@@ -1,0 +1,23 @@
+## Summary
+
+Add cluster coherence validation to bimodal neuron detection to reduce false positives from skewed unimodal distributions. Closes #751.
+
+After the existing gap-based detection finds a candidate split point, a new validation step checks that both resulting clusters have variance below 50% of the overall variance (`MAX_CLUSTER_VARIANCE_RATIO = 0.5`). This follows the Hartigan Dip Test principle: true bimodal distributions have clusters with variance far below the overall (typically < 10%), while false positives from scattered outlier groups or heavy-tailed distributions have cluster variance near or above 50% of overall.
+
+## Evidence
+
+No UI changes — backend detection logic only. Verified via test results:
+
+- All 14 existing bimodal tests continue to pass (no regression)
+- 5 new tests added covering the issue's TDD plan
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+New test file: `tests/issue_751_bimodal_cluster_coherence.rs`
+
+- `test_uniform_distribution_not_bimodal` — uniform distribution correctly rejected
+- `test_bimodal_equal_modes_detected` — equal-sized bimodal correctly detected
+- `test_bimodal_unequal_modes_detected` — 70/30 split bimodal correctly detected
+- `test_unimodal_with_scattered_outlier_group_not_bimodal` — scattered outlier group (80 points in [0,1] + 20 in [10,50]) correctly rejected by coherence check
+- `test_heavy_tail_skewed_not_bimodal` — heavy-tailed distribution (80 points in [0,2] + 20 in [15,300]) correctly rejected by coherence check

--- a/src/analysis/detection/bimodal_neuron.rs
+++ b/src/analysis/detection/bimodal_neuron.rs
@@ -43,6 +43,18 @@ const MIN_GAP_RATIO: f32 = 5.0;
 /// Prevents flagging distributions where one "cluster" has very few points.
 const MIN_CLUSTER_FRACTION: f32 = 0.15;
 
+/// Maximum allowed ratio of within-cluster variance to overall variance (Issue #751).
+///
+/// After detecting a gap, both clusters must have variance below this fraction
+/// of the overall variance. This ensures each cluster is internally coherent
+/// rather than a broad spread of values that happens to sit on one side of a gap.
+///
+/// A value of 0.5 means each cluster's variance must be less than half the
+/// overall variance. True bimodal distributions typically have ratios well
+/// below 0.1, while false positives from skewed unimodal distributions have
+/// ratios near 1.0.
+const MAX_CLUSTER_VARIANCE_RATIO: f32 = 0.5;
+
 /// Result of detecting a bimodal neuron.
 #[derive(Debug, Clone)]
 pub struct BimodalNeuronCandidate {
@@ -200,6 +212,21 @@ fn compute_bimodality(values: &[f32]) -> Option<BimodalityResult> {
     let lower = &values[..best_split_index];
     let upper = &values[best_split_index..];
 
+    // Cluster coherence validation (Issue #751): verify that both clusters
+    // have variance meaningfully lower than the overall variance. This rejects
+    // false positives from skewed unimodal distributions where a large gap
+    // exists but one or both "clusters" are not internally coherent.
+    let overall_var = variance(values);
+    if overall_var > 1e-10 {
+        let lower_var = variance(lower);
+        let upper_var = variance(upper);
+        if lower_var / overall_var > MAX_CLUSTER_VARIANCE_RATIO
+            || upper_var / overall_var > MAX_CLUSTER_VARIANCE_RATIO
+        {
+            return None;
+        }
+    }
+
     Some(BimodalityResult {
         gap_ratio,
         lower_mean: mean(lower),
@@ -211,6 +238,12 @@ fn compute_bimodality(values: &[f32]) -> Option<BimodalityResult> {
 
 fn mean(values: &[f32]) -> f32 {
     values.iter().sum::<f32>() / values.len() as f32
+}
+
+/// Compute population variance of a slice of f32 values.
+fn variance(values: &[f32]) -> f32 {
+    let m = mean(values);
+    values.iter().map(|&v| (v - m) * (v - m)).sum::<f32>() / values.len() as f32
 }
 
 /// Convert bimodal neuron candidates into coordinated structural candidates.

--- a/tests/issue_751_bimodal_cluster_coherence.rs
+++ b/tests/issue_751_bimodal_cluster_coherence.rs
@@ -1,0 +1,170 @@
+//! Tests for Issue #751: Improve bimodal detection with cluster coherence validation.
+//!
+//! Adds a secondary validation step to bimodal detection: after detecting a gap,
+//! verify that both resulting clusters have activation variance meaningfully lower
+//! than the overall variance (i.e., each cluster is internally coherent). This
+//! follows the Hartigan Dip Test principle without requiring the full statistical
+//! machinery.
+//!
+//! ## TDD Plan
+//! 1. Uniform distribution → no bimodality detected
+//! 2. Bimodal with equal-sized modes → detected
+//! 3. Bimodal with unequal-sized modes → detected
+//! 4. Unimodal with one outlier → should NOT be flagged as bimodal
+//! 5. Heavy-tailed unimodal → should NOT be flagged as bimodal
+
+use neat_ai_discovery::analysis::detection::bimodal_neuron::detect_bimodal_neurons;
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper: create a DiscoverRecord with a specific pre-activation value.
+fn make_record(neuron_uuid: &str, obs_index: u32, value: Option<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value,
+        activation: value.unwrap_or(0.0).tanh(),
+        errors: vec![0.01],
+    }
+}
+
+/// Test 1: Uniform distribution → no bimodality detected.
+#[test]
+fn test_uniform_distribution_not_bimodal() {
+    let neurons = vec![("uniform".to_string(), "TANH".to_string(), 0.0)];
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let value = -5.0 + 10.0 * (i as f32 / 99.0);
+            make_record("uniform", i, Some(value))
+        })
+        .collect();
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("uniform".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Uniform distribution should not be flagged as bimodal"
+    );
+}
+
+/// Test 2: Bimodal with equal-sized modes → detected.
+///
+/// Two well-separated clusters of equal size should be detected as bimodal.
+/// Each cluster is internally tight (low variance) while the overall
+/// distribution has high variance.
+#[test]
+fn test_bimodal_equal_modes_detected() {
+    let neurons = vec![("equal-modes".to_string(), "TANH".to_string(), 0.0)];
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let value = if i < 50 {
+                -3.0 + 0.1 * (i as f32 * 0.1).sin()
+            } else {
+                3.0 + 0.1 * ((i - 50) as f32 * 0.1).sin()
+            };
+            make_record("equal-modes", i, Some(value))
+        })
+        .collect();
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("equal-modes".to_string(), records)]);
+
+    assert!(
+        !candidates.is_empty(),
+        "Bimodal distribution with equal-sized modes should be detected"
+    );
+    let c = &candidates[0];
+    assert_eq!(c.lower_mode_count, 50);
+    assert_eq!(c.upper_mode_count, 50);
+}
+
+/// Test 3: Bimodal with unequal-sized modes → detected.
+///
+/// Two well-separated clusters with 70/30 split should still be detected.
+/// Both clusters are internally coherent despite unequal sizes.
+#[test]
+fn test_bimodal_unequal_modes_detected() {
+    let neurons = vec![("unequal-modes".to_string(), "TANH".to_string(), 0.0)];
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let value = if i < 70 {
+                -2.0 + 0.05 * (i as f32 * 0.1).sin()
+            } else {
+                4.0 + 0.05 * ((i - 70) as f32 * 0.1).sin()
+            };
+            make_record("unequal-modes", i, Some(value))
+        })
+        .collect();
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("unequal-modes".to_string(), records)]);
+
+    assert!(
+        !candidates.is_empty(),
+        "Bimodal distribution with unequal-sized modes should be detected"
+    );
+}
+
+/// Test 4: Unimodal with scattered outlier group → should NOT be flagged as bimodal.
+///
+/// 80 points tightly clustered in [0, 1], then 20 points spread widely across
+/// [10, 50]. The gap creates a large ratio, but the outlier group is NOT a
+/// coherent cluster — its internal variance is nearly as high as the overall
+/// variance. Cluster coherence validation should reject this.
+#[test]
+fn test_unimodal_with_scattered_outlier_group_not_bimodal() {
+    let neurons = vec![("scattered-outlier".to_string(), "TANH".to_string(), 0.0)];
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+
+    // Main cluster: 80 points uniformly in [0, 1]
+    for i in 0..80 {
+        let value = i as f32 / 79.0;
+        records.push(make_record("scattered-outlier", i, Some(value)));
+    }
+
+    // Scattered outlier group: 20 points uniformly in [10, 50]
+    // This creates a large gap (10 - 1 = 9) but the "cluster" has high
+    // internal variance (range of 40) — not a coherent mode.
+    for i in 80..100 {
+        let value = 10.0 + 40.0 * ((i - 80) as f32 / 19.0);
+        records.push(make_record("scattered-outlier", i, Some(value)));
+    }
+
+    let candidates =
+        detect_bimodal_neurons(&neurons, &[("scattered-outlier".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Scattered outlier group should NOT be flagged as bimodal — \
+         the outlier 'cluster' has variance comparable to overall distribution"
+    );
+}
+
+/// Test 5: Heavy-tailed skewed distribution → should NOT be flagged as bimodal.
+///
+/// A distribution where 80 points are in [0, 2] and 20 points follow a
+/// geometric progression from 15 to 300. The large gap between 2 and 15
+/// triggers gap-based detection, but the tail is not a coherent cluster.
+#[test]
+fn test_heavy_tail_skewed_not_bimodal() {
+    let neurons = vec![("heavy-skew".to_string(), "TANH".to_string(), 0.0)];
+    let mut records: Vec<DiscoverRecord> = Vec::new();
+
+    // Main body: 80 points uniformly in [0, 2]
+    for i in 0..80 {
+        let value = 2.0 * (i as f32 / 79.0);
+        records.push(make_record("heavy-skew", i, Some(value)));
+    }
+
+    // Heavy tail: 20 points spread in [15, 300] (geometric-like spacing)
+    for i in 80..100 {
+        let t = (i - 80) as f32 / 19.0; // 0.0 to 1.0
+        let value = 15.0 + 285.0 * t * t; // quadratic spacing for heavy tail
+        records.push(make_record("heavy-skew", i, Some(value)));
+    }
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("heavy-skew".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Heavy-tailed skewed distribution should NOT be flagged as bimodal — \
+         the tail 'cluster' has very high internal variance"
+    );
+}


### PR DESCRIPTION
## Summary

Add cluster coherence validation to bimodal neuron detection to reduce false positives from skewed unimodal distributions. Closes #751.

After the existing gap-based detection finds a candidate split point, a new validation step checks that both resulting clusters have variance below 50% of the overall variance (`MAX_CLUSTER_VARIANCE_RATIO = 0.5`). This follows the Hartigan Dip Test principle: true bimodal distributions have clusters with variance far below the overall (typically < 10%), while false positives from scattered outlier groups or heavy-tailed distributions have cluster variance near or above 50% of overall.

## Evidence

No UI changes — backend detection logic only. Verified via test results:

- All 14 existing bimodal tests continue to pass (no regression)
- 5 new tests added covering the issue's TDD plan
- `quality.sh` passes cleanly.

## Test Plan

New test file: `tests/issue_751_bimodal_cluster_coherence.rs`

- `test_uniform_distribution_not_bimodal` — uniform distribution correctly rejected
- `test_bimodal_equal_modes_detected` — equal-sized bimodal correctly detected
- `test_bimodal_unequal_modes_detected` — 70/30 split bimodal correctly detected
- `test_unimodal_with_scattered_outlier_group_not_bimodal` — scattered outlier group (80 points in [0,1] + 20 in [10,50]) correctly rejected by coherence check
- `test_heavy_tail_skewed_not_bimodal` — heavy-tailed distribution (80 points in [0,2] + 20 in [15,300]) correctly rejected by coherence check

---

## Automated Fix Details
This PR addresses issue #751: **Improve bimodal detection with cluster coherence validation**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #751