### PR TITLE
perf: eliminate String allocations in topology cache synapse lookups (#769)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.50.2"
+version = "0.50.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,10 @@ harness = false
 name = "bfs_allocation"
 harness = false
 
+[[bench]]
+name = "synapse_lookup"
+harness = false
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.50.3"
+version = "0.50.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/synapse_lookup.rs
+++ b/benches/synapse_lookup.rs
@@ -1,0 +1,157 @@
+//! Benchmark for Issue #769: Zero-allocation synapse lookups.
+//!
+//! Measures the cost of `synapse_exists()` and `synapse_weight()` calls
+//! on `CreatureTopologyCache`, which are called in hot loops in
+//! `bottleneck.rs` and `topology.rs`.
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use neat_ai_discovery::analysis::detection::topology_cache::CreatureTopologyCache;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Create a creature with the given number of hidden neurons and ~3× synapses.
+fn create_test_creature(hidden_count: usize) -> CreatureJson {
+    let input_count = (hidden_count / 5).max(2);
+    let output_count = (hidden_count / 10).max(1);
+
+    let mut neurons = Vec::with_capacity(input_count + hidden_count + output_count);
+    let mut synapses = Vec::new();
+
+    for i in 0..input_count {
+        neurons.push(NeuronJson {
+            uuid: format!("inp-{i}"),
+            neuron_type: "input".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        });
+    }
+
+    for i in 0..hidden_count {
+        neurons.push(NeuronJson {
+            uuid: format!("hid-{i}"),
+            neuron_type: "hidden".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.1 * (i % 5) as f32,
+        });
+    }
+
+    for i in 0..output_count {
+        neurons.push(NeuronJson {
+            uuid: format!("out-{i}"),
+            neuron_type: "output".to_string(),
+            squash: "LOGISTIC".to_string(),
+            bias: 0.0,
+        });
+    }
+
+    for i in 0..hidden_count {
+        let inp_idx = i % input_count;
+        synapses.push(SynapseJson {
+            from_uuid: format!("inp-{inp_idx}"),
+            to_uuid: format!("hid-{i}"),
+            weight: 0.5 - 0.1 * (i % 10) as f32,
+            ..Default::default()
+        });
+
+        if i + 1 < hidden_count {
+            synapses.push(SynapseJson {
+                from_uuid: format!("hid-{i}"),
+                to_uuid: format!("hid-{}", i + 1),
+                weight: 0.3,
+                ..Default::default()
+            });
+        }
+
+        if i % 3 == 0 {
+            let out_idx = i % output_count;
+            synapses.push(SynapseJson {
+                from_uuid: format!("hid-{i}"),
+                to_uuid: format!("out-{out_idx}"),
+                weight: 0.7,
+                ..Default::default()
+            });
+        }
+    }
+
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn bench_synapse_lookup(c: &mut Criterion) {
+    let sizes: &[usize] = &[50, 200, 500];
+
+    let mut group = c.benchmark_group("synapse_lookup");
+
+    for &size in sizes {
+        let creature = create_test_creature(size);
+        let cache = CreatureTopologyCache::new(&creature);
+        let id = format!("{size}_neurons");
+
+        // Benchmark synapse_exists in a loop (simulates hot-path usage)
+        group.bench_with_input(
+            BenchmarkId::new("synapse_exists", &id),
+            &cache,
+            |b, cache| {
+                b.iter(|| {
+                    for i in 0..size {
+                        let from = format!("hid-{i}");
+                        let to = format!("hid-{}", (i + 1) % size);
+                        black_box(cache.synapse_exists(&from, &to));
+                    }
+                });
+            },
+        );
+
+        // Benchmark synapse_weight in a loop
+        group.bench_with_input(
+            BenchmarkId::new("synapse_weight", &id),
+            &cache,
+            |b, cache| {
+                b.iter(|| {
+                    for i in 0..size {
+                        let from = format!("hid-{i}");
+                        let to = format!("hid-{}", (i + 1) % size);
+                        black_box(cache.synapse_weight(&from, &to));
+                    }
+                });
+            },
+        );
+
+        // Benchmark with pre-allocated strings (shows overhead of method itself)
+        let lookup_pairs: Vec<(String, String)> = (0..size)
+            .map(|i| (format!("hid-{i}"), format!("hid-{}", (i + 1) % size)))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("synapse_exists_prealloc", &id),
+            &(&cache, &lookup_pairs),
+            |b, (cache, pairs)| {
+                b.iter(|| {
+                    for (from, to) in *pairs {
+                        black_box(cache.synapse_exists(from, to));
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("synapse_weight_prealloc", &id),
+            &(&cache, &lookup_pairs),
+            |b, (cache, pairs)| {
+                b.iter(|| {
+                    for (from, to) in *pairs {
+                        black_box(cache.synapse_weight(from, to));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_synapse_lookup);
+criterion_main!(benches);

--- a/docs/pr-summary-769.md
+++ b/docs/pr-summary-769.md
@@ -1,0 +1,39 @@
+## Summary
+
+Eliminate per-call `String` heap allocations in `CreatureTopologyCache::synapse_exists()` and `synapse_weight()` by switching from flat `HashSet<(String, String)>` / `HashMap<(String, String), f32>` to nested `HashMap<String, HashSet<String>>` / `HashMap<String, HashMap<String, f32>>`. This allows zero-copy lookups with `&str` keys since `String: Borrow<str>`. Closes #769.
+
+## Changes
+
+- **`src/analysis/detection/topology_cache.rs`**: Replaced `existing_synapses: HashSet<(String, String)>` with `existing_synapse_set: HashMap<String, HashSet<String>>` and `synapse_weights: HashMap<(String, String), f32>` with `synapse_weight_map: HashMap<String, HashMap<String, f32>>`. Fields are now private. Added `synapse_count()` accessor.
+- **`tests/issue_769_zero_alloc_synapse_lookup.rs`**: New integration test covering exists/weight lookups, missing synapses, multiple in/out, and empty creatures.
+- **`benches/synapse_lookup.rs`**: New benchmark measuring synapse lookup performance with and without string pre-allocation.
+- **`tests/issue_576_benchmark_regression_tracking.rs`**: Added `synapse_lookup` to expected benchmarks list.
+
+## Evidence
+
+Benchmark results (500 neurons, pre-allocated keys isolate pure lookup cost):
+
+| Method | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| `synapse_exists` (prealloc) | 18.59 µs | 10.75 µs | **42% faster** |
+| `synapse_weight` (prealloc) | 19.99 µs | 14.93 µs | **25% faster** |
+| `synapse_exists` (with format) | 36.71 µs | 27.38 µs | **25% faster** |
+| `synapse_weight` (with format) | 38.51 µs | 33.35 µs | **13% faster** |
+
+The "with format" benchmarks include `format!()` overhead for creating test lookup strings, which masks the improvement. The "prealloc" results show the true lookup improvement.
+
+No visual changes — backend-only performance optimisation.
+
+## Test Plan
+
+- Added `tests/issue_769_zero_alloc_synapse_lookup.rs` (8 tests):
+  - `synapse_exists_returns_true_for_existing_synapses`
+  - `synapse_exists_returns_false_for_missing_synapses`
+  - `synapse_weight_returns_correct_values`
+  - `synapse_weight_returns_none_for_missing`
+  - `synapse_count_matches_creature_synapses`
+  - `multiple_outgoing_from_same_source`
+  - `multiple_incoming_to_same_target`
+  - `empty_creature_has_no_synapses`
+- All existing tests pass including `issue_754_topology_cache` (6 tests)
+- `quality.sh` passes cleanly

--- a/src/analysis/detection/topology_cache.rs
+++ b/src/analysis/detection/topology_cache.rs
@@ -24,10 +24,12 @@ pub struct CreatureTopologyCache {
     pub output_uuids: HashSet<String>,
     /// UUIDs of input neurons.
     pub input_uuids: HashSet<String>,
-    /// Set of existing synapse pairs `(from_uuid, to_uuid)`.
-    pub existing_synapses: HashSet<(String, String)>,
-    /// Synapse weights keyed by `(from_uuid, to_uuid)`.
-    pub synapse_weights: HashMap<(String, String), f32>,
+    /// Nested map for zero-copy synapse existence checks: `from_uuid → {to_uuid, …}`.
+    existing_synapse_set: HashMap<String, HashSet<String>>,
+    /// Nested map for zero-copy synapse weight lookups: `from_uuid → (to_uuid → weight)`.
+    synapse_weight_map: HashMap<String, HashMap<String, f32>>,
+    /// Total number of synapses (for diagnostics).
+    synapse_count: usize,
 }
 
 impl CreatureTopologyCache {
@@ -60,8 +62,10 @@ impl CreatureTopologyCache {
         // Build synapse maps in a single pass.
         let mut fan_in: HashMap<String, Vec<String>> = HashMap::with_capacity(neuron_count);
         let mut fan_out: HashMap<String, Vec<String>> = HashMap::with_capacity(neuron_count);
-        let mut existing_synapses = HashSet::with_capacity(synapse_count);
-        let mut synapse_weights = HashMap::with_capacity(synapse_count);
+        let mut existing_synapse_set: HashMap<String, HashSet<String>> =
+            HashMap::with_capacity(neuron_count);
+        let mut synapse_weight_map: HashMap<String, HashMap<String, f32>> =
+            HashMap::with_capacity(neuron_count);
 
         for s in &creature.synapses {
             fan_in
@@ -72,8 +76,14 @@ impl CreatureTopologyCache {
                 .entry(s.from_uuid.clone())
                 .or_default()
                 .push(s.to_uuid.clone());
-            existing_synapses.insert((s.from_uuid.clone(), s.to_uuid.clone()));
-            synapse_weights.insert((s.from_uuid.clone(), s.to_uuid.clone()), s.weight);
+            existing_synapse_set
+                .entry(s.from_uuid.clone())
+                .or_default()
+                .insert(s.to_uuid.clone());
+            synapse_weight_map
+                .entry(s.from_uuid.clone())
+                .or_default()
+                .insert(s.to_uuid.clone(), s.weight);
         }
 
         Self {
@@ -82,8 +92,9 @@ impl CreatureTopologyCache {
             hidden_uuids,
             output_uuids,
             input_uuids,
-            existing_synapses,
-            synapse_weights,
+            existing_synapse_set,
+            synapse_weight_map,
+            synapse_count,
         }
     }
 
@@ -97,17 +108,24 @@ impl CreatureTopologyCache {
         self.fan_out.get(uuid).map_or(&[], |v| v.as_slice())
     }
 
-    /// Check whether a synapse already exists.
+    /// Check whether a synapse already exists (zero heap allocations).
     pub fn synapse_exists(&self, from_uuid: &str, to_uuid: &str) -> bool {
-        self.existing_synapses
-            .contains(&(from_uuid.to_string(), to_uuid.to_string()))
+        self.existing_synapse_set
+            .get(from_uuid)
+            .is_some_and(|targets| targets.contains(to_uuid))
     }
 
-    /// Get a synapse weight (returns `None` if the synapse does not exist).
+    /// Get a synapse weight (zero heap allocations, returns `None` if absent).
     pub fn synapse_weight(&self, from_uuid: &str, to_uuid: &str) -> Option<f32> {
-        self.synapse_weights
-            .get(&(from_uuid.to_string(), to_uuid.to_string()))
+        self.synapse_weight_map
+            .get(from_uuid)
+            .and_then(|targets| targets.get(to_uuid))
             .copied()
+    }
+
+    /// Return the total number of synapses in the cache.
+    pub fn synapse_count(&self) -> usize {
+        self.synapse_count
     }
 }
 
@@ -233,6 +251,6 @@ mod tests {
     fn test_existing_synapses_count() {
         let creature = make_test_creature();
         let cache = CreatureTopologyCache::new(&creature);
-        assert_eq!(cache.existing_synapses.len(), 4);
+        assert_eq!(cache.synapse_count(), 4);
     }
 }

--- a/tests/issue_576_benchmark_regression_tracking.rs
+++ b/tests/issue_576_benchmark_regression_tracking.rs
@@ -28,6 +28,7 @@ const EXPECTED_BENCHMARKS: &[&str] = &[
     "squash_normalisation",
     "topology_cache",
     "bfs_allocation",
+    "synapse_lookup",
 ];
 
 #[test]

--- a/tests/issue_769_zero_alloc_synapse_lookup.rs
+++ b/tests/issue_769_zero_alloc_synapse_lookup.rs
@@ -1,0 +1,172 @@
+//! Issue #769: Zero-allocation synapse lookups in `CreatureTopologyCache`.
+//!
+//! Verifies that `synapse_exists()` and `synapse_weight()` return correct
+//! results using the nested `HashMap` internal storage that avoids per-call
+//! `String` allocations.
+
+use neat_ai_discovery::analysis::detection::topology_cache::CreatureTopologyCache;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "i1".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "i2".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "h1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.1,
+            },
+            NeuronJson {
+                uuid: "h2".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "RELU".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "o1".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "LOGISTIC".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "i1".to_string(),
+                to_uuid: "h1".to_string(),
+                weight: 0.5,
+                ..Default::default()
+            },
+            SynapseJson {
+                from_uuid: "i2".to_string(),
+                to_uuid: "h1".to_string(),
+                weight: -0.3,
+                ..Default::default()
+            },
+            SynapseJson {
+                from_uuid: "i1".to_string(),
+                to_uuid: "h2".to_string(),
+                weight: 0.7,
+                ..Default::default()
+            },
+            SynapseJson {
+                from_uuid: "h1".to_string(),
+                to_uuid: "o1".to_string(),
+                weight: 0.8,
+                ..Default::default()
+            },
+            SynapseJson {
+                from_uuid: "h2".to_string(),
+                to_uuid: "o1".to_string(),
+                weight: -0.4,
+                ..Default::default()
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+#[test]
+fn synapse_exists_returns_true_for_existing_synapses() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    assert!(cache.synapse_exists("i1", "h1"));
+    assert!(cache.synapse_exists("i2", "h1"));
+    assert!(cache.synapse_exists("i1", "h2"));
+    assert!(cache.synapse_exists("h1", "o1"));
+    assert!(cache.synapse_exists("h2", "o1"));
+}
+
+#[test]
+fn synapse_exists_returns_false_for_missing_synapses() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    // Reverse direction
+    assert!(!cache.synapse_exists("h1", "i1"));
+    // No direct connection
+    assert!(!cache.synapse_exists("i1", "o1"));
+    assert!(!cache.synapse_exists("h1", "h2"));
+    // Non-existent neuron
+    assert!(!cache.synapse_exists("nope", "h1"));
+    assert!(!cache.synapse_exists("h1", "nope"));
+}
+
+#[test]
+fn synapse_weight_returns_correct_values() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    assert_eq!(cache.synapse_weight("i1", "h1"), Some(0.5));
+    assert_eq!(cache.synapse_weight("i2", "h1"), Some(-0.3));
+    assert_eq!(cache.synapse_weight("i1", "h2"), Some(0.7));
+    assert_eq!(cache.synapse_weight("h1", "o1"), Some(0.8));
+    assert_eq!(cache.synapse_weight("h2", "o1"), Some(-0.4));
+}
+
+#[test]
+fn synapse_weight_returns_none_for_missing() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    assert_eq!(cache.synapse_weight("h1", "i1"), None);
+    assert_eq!(cache.synapse_weight("nope", "h1"), None);
+    assert_eq!(cache.synapse_weight("h1", "nope"), None);
+}
+
+#[test]
+fn synapse_count_matches_creature_synapses() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+    assert_eq!(cache.synapse_count(), 5);
+}
+
+#[test]
+fn multiple_outgoing_from_same_source() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    // i1 has two outgoing synapses: i1→h1 and i1→h2
+    assert!(cache.synapse_exists("i1", "h1"));
+    assert!(cache.synapse_exists("i1", "h2"));
+    assert_eq!(cache.synapse_weight("i1", "h1"), Some(0.5));
+    assert_eq!(cache.synapse_weight("i1", "h2"), Some(0.7));
+}
+
+#[test]
+fn multiple_incoming_to_same_target() {
+    let cache = CreatureTopologyCache::new(&make_creature());
+
+    // o1 has two incoming synapses: h1→o1 and h2→o1
+    assert!(cache.synapse_exists("h1", "o1"));
+    assert!(cache.synapse_exists("h2", "o1"));
+    assert_eq!(cache.synapse_weight("h1", "o1"), Some(0.8));
+    assert_eq!(cache.synapse_weight("h2", "o1"), Some(-0.4));
+}
+
+#[test]
+fn empty_creature_has_no_synapses() {
+    let creature = CreatureJson {
+        neurons: vec![NeuronJson {
+            uuid: "i1".to_string(),
+            neuron_type: "input".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: vec![],
+        input: 1,
+        output: 0,
+    };
+    let cache = CreatureTopologyCache::new(&creature);
+
+    assert!(!cache.synapse_exists("i1", "anything"));
+    assert_eq!(cache.synapse_weight("i1", "anything"), None);
+    assert_eq!(cache.synapse_count(), 0);
+}


### PR DESCRIPTION
## Summary

Eliminate per-call `String` heap allocations in `CreatureTopologyCache::synapse_exists()` and `synapse_weight()` by switching from flat `HashSet<(String, String)>` / `HashMap<(String, String), f32>` to nested `HashMap<String, HashSet<String>>` / `HashMap<String, HashMap<String, f32>>`. This allows zero-copy lookups with `&str` keys since `String: Borrow<str>`. Closes #769.

## Changes

- **`src/analysis/detection/topology_cache.rs`**: Replaced `existing_synapses: HashSet<(String, String)>` with `existing_synapse_set: HashMap<String, HashSet<String>>` and `synapse_weights: HashMap<(String, String), f32>` with `synapse_weight_map: HashMap<String, HashMap<String, f32>>`. Fields are now private. Added `synapse_count()` accessor.
- **`tests/issue_769_zero_alloc_synapse_lookup.rs`**: New integration test covering exists/weight lookups, missing synapses, multiple in/out, and empty creatures.
- **`benches/synapse_lookup.rs`**: New benchmark measuring synapse lookup performance with and without string pre-allocation.
- **`tests/issue_576_benchmark_regression_tracking.rs`**: Added `synapse_lookup` to expected benchmarks list.

## Evidence

Benchmark results (500 neurons, pre-allocated keys isolate pure lookup cost):

| Method | Before | After | Improvement |
|--------|--------|-------|-------------|
| `synapse_exists` (prealloc) | 18.59 µs | 10.75 µs | **42% faster** |
| `synapse_weight` (prealloc) | 19.99 µs | 14.93 µs | **25% faster** |
| `synapse_exists` (with format) | 36.71 µs | 27.38 µs | **25% faster** |
| `synapse_weight` (with format) | 38.51 µs | 33.35 µs | **13% faster** |

The "with format" benchmarks include `format!()` overhead for creating test lookup strings, which masks the improvement. The "prealloc" results show the true lookup improvement.

No visual changes — backend-only performance optimisation.

## Test Plan

- Added `tests/issue_769_zero_alloc_synapse_lookup.rs` (8 tests):
  - `synapse_exists_returns_true_for_existing_synapses`
  - `synapse_exists_returns_false_for_missing_synapses`
  - `synapse_weight_returns_correct_values`
  - `synapse_weight_returns_none_for_missing`
  - `synapse_count_matches_creature_synapses`
  - `multiple_outgoing_from_same_source`
  - `multiple_incoming_to_same_target`
  - `empty_creature_has_no_synapses`
- All existing tests pass including `issue_754_topology_cache` (6 tests)
- `quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #769: **perf: eliminate String allocations in topology_cache synapse lookups**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #769