### PR TITLE
perf: remove redundant .to_uppercase() calls on already-normalised squash strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.50.6"
+version = "0.50.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.50.7"
+version = "0.51.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-771.md
+++ b/docs/pr-summary-771.md
@@ -1,0 +1,18 @@
+## Summary
+
+Remove redundant `.to_uppercase()` calls on squash strings that are already normalised to uppercase at load time (Issue #753). Closes #771.
+
+**Changes:**
+
+- `input_sensitivity.rs`: Replaced two `.to_uppercase().as_str()` calls with direct `&str` matching, since squash strings from `orchestration.rs` are guaranteed uppercase.
+- `activation_properties.rs`: Replaced `.to_uppercase().as_str()` in `is_saturating_squash()` with `eq_ignore_ascii_case()` to remain case-insensitive (public API) while avoiding String allocations.
+
+## Evidence
+
+This is a backend-only change with no visual output. All existing tests pass, and `quality.sh` passes cleanly. No `.to_uppercase()` calls remain in detection modules.
+
+## Test Plan
+
+- All existing tests continue to pass (including `test_is_saturating_squash` in `weight_coherence.rs` which tests both uppercase and lowercase inputs)
+- Doc tests for `is_saturating_squash` verify case-insensitive behaviour is preserved
+- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

--- a/docs/pr-summary-771.md
+++ b/docs/pr-summary-771.md
@@ -4,7 +4,7 @@ Remove redundant `.to_uppercase()` calls on squash strings that are already norm
 
 **Changes:**
 
-- `input_sensitivity.rs`: Replaced two `.to_uppercase().as_str()` calls with direct `&str` matching, since squash strings from `orchestration.rs` are guaranteed uppercase.
+- `input_sensitivity.rs`: Replaced two `.to_uppercase().as_str()` calls with direct `&str` matching, since squash strings from `orchestration.rs` are guaranteed uppercase
 - `activation_properties.rs`: Replaced `.to_uppercase().as_str()` in `is_saturating_squash()` with `eq_ignore_ascii_case()` to remain case-insensitive (public API) while avoiding String allocations.
 
 ## Evidence

--- a/src/analysis/detection/activation_properties.rs
+++ b/src/analysis/detection/activation_properties.rs
@@ -48,7 +48,8 @@ pub fn is_bounded_squash(squash: &str) -> bool {
 /// whose gradients vanish at extreme input values, causing weight coherence
 /// issues.
 ///
-/// The input is case-insensitive — it is converted to uppercase before matching.
+/// The input is case-insensitive — it uses `eq_ignore_ascii_case` to avoid
+/// String allocations (Issue #771).
 ///
 /// # Examples
 ///
@@ -61,10 +62,12 @@ pub fn is_bounded_squash(squash: &str) -> bool {
 /// assert!(!is_saturating_squash("IDENTITY"));
 /// ```
 pub fn is_saturating_squash(squash: &str) -> bool {
-    matches!(
-        squash.to_uppercase().as_str(),
-        "TANH" | "LOGISTIC" | "SIGMOID" | "HARD_TANH" | "CLIPPED" | "SOFTSIGN"
-    )
+    squash.eq_ignore_ascii_case("TANH")
+        || squash.eq_ignore_ascii_case("LOGISTIC")
+        || squash.eq_ignore_ascii_case("SIGMOID")
+        || squash.eq_ignore_ascii_case("HARD_TANH")
+        || squash.eq_ignore_ascii_case("CLIPPED")
+        || squash.eq_ignore_ascii_case("SOFTSIGN")
 }
 
 /// Returns whether a squash function can have a dead zone (all outputs at zero).

--- a/src/analysis/detection/input_sensitivity.rs
+++ b/src/analysis/detection/input_sensitivity.rs
@@ -382,10 +382,10 @@ pub fn detect_threshold_effects(
 
             // Check if this is a steep activation region
             // Steep activations: TANH, LOGISTIC near threshold with large weight
-            let is_steep_activation = matches!(
-                squash.to_uppercase().as_str(),
-                "TANH" | "LOGISTIC" | "HARD_TANH" | "SOFTSIGN"
-            );
+            // Squash strings are normalised to uppercase at load time (Issue #753),
+            // so no allocation needed here (Issue #771).
+            let is_steep_activation =
+                matches!(squash, "TANH" | "LOGISTIC" | "HARD_TANH" | "SOFTSIGN");
 
             if !is_steep_activation {
                 continue;
@@ -458,7 +458,8 @@ pub fn detect_threshold_effects(
             // For TANH: threshold is around value = 0
             // For LOGISTIC: threshold is around value = 0
             let mean_value = compute_mean(&matched_values);
-            let threshold_proximity = match squash.to_uppercase().as_str() {
+            // Squash strings are normalised to uppercase at load time (Issue #753, #771).
+            let threshold_proximity = match squash {
                 "TANH" | "HARD_TANH" | "SOFTSIGN" => {
                     // Threshold at 0, steepest when |value| < 1
                     1.0 / (1.0 + mean_value.abs())


### PR DESCRIPTION
## Summary

Remove redundant `.to_uppercase()` calls on squash strings that are already normalised to uppercase at load time (Issue #753). Closes #771.

**Changes:**

- `input_sensitivity.rs`: Replaced two `.to_uppercase().as_str()` calls with direct `&str` matching, since squash strings from `orchestration.rs` are guaranteed uppercase
- `activation_properties.rs`: Replaced `.to_uppercase().as_str()` in `is_saturating_squash()` with `eq_ignore_ascii_case()` to remain case-insensitive (public API) while avoiding String allocations.

## Evidence

This is a backend-only change with no visual output. All existing tests pass, and `quality.sh` passes cleanly. No `.to_uppercase()` calls remain in detection modules.

## Test Plan

- All existing tests continue to pass (including `test_is_saturating_squash` in `weight_coherence.rs` which tests both uppercase and lowercase inputs)
- Doc tests for `is_saturating_squash` verify case-insensitive behaviour is preserved
- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

---

## Automated Fix Details
This PR addresses issue #771: **Remove redundant .to_uppercase() calls on already-normalised squash strings**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #771