### PR TITLE
fix: replace panicking expect/unwrap in FFI and GPU paths (#772)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.51.0"
+version = "0.51.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.51.1"
+version = "0.51.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-772.md
+++ b/docs/pr-summary-772.md
@@ -1,0 +1,40 @@
+## Summary
+
+Replace panicking `expect()` and `unwrap()` calls in GPU evaluation and FFI paths with proper error handling. Closes #772.
+
+### GPU evaluation changes (6 sites)
+- Replaced `.expect("GPU device must be available...")` with `.context("GPU device unavailable for ... analysis")?` in all 5 GPU evaluation files (helpful, harmful, ReLU, bias, activation — 6 call sites total).
+- These now return `Err` through the existing `Result` return type instead of panicking.
+
+### FFI serialisation changes (~40 sites)
+- Created `src/ffi/helpers.rs` with three shared helpers:
+  - `to_ffi_json<T: Serialize>(&T) -> *mut c_char` — serialises and converts to C string without panicking
+  - `ffi_error_literal(&str) -> *mut c_char` — converts static error strings safely
+  - `panic_to_ffi_json(Box<dyn Any + Send>) -> *mut c_char` — builds panic error response safely
+- Replaced all `serde_json::to_string(&output).unwrap()` + `CString::new(json).unwrap().into_raw()` patterns with `to_ffi_json(&output)`
+- Replaced all `CString::new(error_literal).unwrap().into_raw()` patterns with `ffi_error_literal(error_literal)`
+- Replaced all duplicated panic handler blocks with `panic_to_ffi_json`
+- All FFI functions retain `panic::catch_unwind` at the boundary as a safety net
+
+### Result
+- Net deletion of ~280 lines of duplicated boilerplate
+- Zero `unwrap()` calls in non-test FFI code
+- Zero `expect()` calls for GPU device availability in evaluation code
+- All existing tests pass, `quality.sh` passes
+
+## Evidence
+
+This is a backend/library change with no visual output. Evidence is provided by:
+- All 6 unit tests in `src/ffi/helpers.rs` covering `to_ffi_json`, `ffi_error_literal`, `panic_to_ffi_json`
+- All existing integration and unit tests pass (verified via `quality.sh`)
+
+## Test Plan
+
+- Added 6 unit tests in `src/ffi/helpers.rs`:
+  - `test_to_ffi_json_success` — verifies successful serialisation round-trip
+  - `test_ffi_error_literal_returns_valid_string` — verifies literal conversion
+  - `test_panic_to_ffi_json_with_string_message` — String panic message
+  - `test_panic_to_ffi_json_with_str_message` — &str panic message
+  - `test_panic_to_ffi_json_with_unknown_type` — non-string panic type
+  - `test_panic_to_ffi_json_escapes_special_chars` — JSON escaping of special characters
+- All existing tests continue to pass unchanged

--- a/src/analysis/gpu/activation_evaluation.rs
+++ b/src/analysis/gpu/activation_evaluation.rs
@@ -185,7 +185,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for activation analysis")?;
         let queue = self
             .queue
             .as_ref()
@@ -473,7 +473,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for activation analysis")?;
         let queue = self
             .queue
             .as_ref()

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -371,7 +371,6 @@ impl GpuAnalyzer {
                 // GPU is required - return an error instead of a CPU-only analyzer.
                 // TypeScript calls check_gpu_available() before discovery, but the GPU
                 // could become unavailable due to race conditions or resource exhaustion.
-                // Returning an error here prevents panics in GPU methods that .expect() on device.
                 anyhow::bail!(
                     "GPU adapter not available. Discovery requires GPU acceleration. \
                      This may indicate a transient GPU resource issue - consider retrying."
@@ -400,7 +399,6 @@ impl GpuAnalyzer {
                     // GPU is required - return an error instead of a CPU-only analyzer.
                     // TypeScript calls check_gpu_available() before discovery, but the GPU
                     // could become unavailable due to race conditions or resource exhaustion.
-                    // Returning an error here prevents panics in GPU methods that .expect() on device.
                     anyhow::bail!(
                         "GPU device creation failed: {e}. Discovery requires GPU acceleration. \
                      This may indicate a transient GPU resource issue - consider retrying."

--- a/src/analysis/gpu/bias_evaluation.rs
+++ b/src/analysis/gpu/bias_evaluation.rs
@@ -125,7 +125,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for bias analysis")?;
         let queue = self
             .queue
             .as_ref()

--- a/src/analysis/gpu/harmful_evaluation.rs
+++ b/src/analysis/gpu/harmful_evaluation.rs
@@ -188,7 +188,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for batched harmful analysis")?;
         let queue = self
             .queue
             .as_ref()

--- a/src/analysis/gpu/helpful_evaluation.rs
+++ b/src/analysis/gpu/helpful_evaluation.rs
@@ -185,7 +185,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for batched helpful analysis")?;
         let queue = self
             .queue
             .as_ref()

--- a/src/analysis/gpu/relu_evaluation.rs
+++ b/src/analysis/gpu/relu_evaluation.rs
@@ -113,7 +113,7 @@ impl GpuAnalyzer {
         let device = self
             .device
             .as_ref()
-            .expect("GPU device must be available - discovery should be disabled without GPU");
+            .context("GPU device unavailable for ReLU analysis")?;
         let queue = self
             .queue
             .as_ref()

--- a/src/ffi/analysis.rs
+++ b/src/ffi/analysis.rs
@@ -1,5 +1,6 @@
 //! Analysis FFI entry points — `rank_focus_neurons` and `analyze_parallel`.
 
+use super::helpers::{ffi_error_literal, panic_to_ffi_json, to_ffi_json};
 use crate::ffi_types::*;
 use crate::log_version_once;
 
@@ -28,14 +29,14 @@ pub unsafe extern "C" fn rank_focus_neurons(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -57,41 +58,18 @@ pub unsafe extern "C" fn rank_focus_neurons(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize output"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -119,14 +97,14 @@ pub unsafe extern "C" fn analyze_parallel(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -156,39 +134,16 @@ pub unsafe extern "C" fn analyze_parallel(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }

--- a/src/ffi/gpu.rs
+++ b/src/ffi/gpu.rs
@@ -1,5 +1,6 @@
 //! GPU probe FFI entry points.
 
+use super::helpers::{ffi_error_literal, panic_to_ffi_json, to_ffi_json};
 use crate::ffi_types::*;
 use crate::log_version_once;
 
@@ -25,39 +26,16 @@ pub extern "C" fn check_gpu_available() -> *mut std::ffi::c_char {
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"gpuAvailable":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
-            Err(_) => {
-                let error = r#"{"success":false,"gpuAvailable":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
-            }
+            Err(_) => ffi_error_literal(
+                r#"{"success":false,"gpuAvailable":false,"error":"Failed to create output string"}"#,
+            ),
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"gpuAvailable\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"gpuAvailable":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }

--- a/src/ffi/helpers.rs
+++ b/src/ffi/helpers.rs
@@ -1,0 +1,154 @@
+//! Shared FFI helpers for safe JSON-to-C-string conversion (Issue #772).
+//!
+//! These helpers eliminate `unwrap()` calls at the FFI boundary by handling
+//! serialisation failures and null-byte edge cases gracefully, returning a
+//! JSON error response instead of panicking.
+
+use serde::Serialize;
+use std::ffi::CString;
+
+/// Serialise a value to JSON and return it as an FFI-safe `*mut c_char`.
+///
+/// On serialisation or `CString` creation failure, returns a JSON error
+/// string instead of panicking. The caller must free the returned pointer
+/// with `free_discovery_result`.
+pub fn to_ffi_json<T: Serialize>(value: &T) -> *mut std::ffi::c_char {
+    let json = match serde_json::to_string(value) {
+        Ok(j) => j,
+        Err(_) => {
+            return ffi_error_literal(
+                r#"{"success":false,"error":"Failed to serialise response"}"#,
+            );
+        }
+    };
+    match CString::new(json) {
+        Ok(c) => c.into_raw(),
+        Err(_) => ffi_error_literal(r#"{"success":false,"error":"Response contains null byte"}"#),
+    }
+}
+
+/// Convert a static error string literal to an FFI-safe `*mut c_char`.
+///
+/// The input **must not** contain null bytes (compile-time string literals
+/// that are valid JSON never do). If `CString::new` somehow fails, returns
+/// a null pointer as a last resort — the Deno FFI layer treats null as an
+/// empty string, which is safer than unwinding across the FFI boundary.
+pub fn ffi_error_literal(msg: &str) -> *mut std::ffi::c_char {
+    CString::new(msg)
+        .map(CString::into_raw)
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// Build an FFI-safe error response from a caught panic.
+///
+/// Extracts the panic message and returns a JSON error string as
+/// `*mut c_char`. Never panics itself.
+pub fn panic_to_ffi_json(panic_info: Box<dyn std::any::Any + Send>) -> *mut std::ffi::c_char {
+    let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic_info.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic".to_string()
+    };
+    let error_json = format!(
+        "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
+        msg.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    match CString::new(error_json) {
+        Ok(c) => c.into_raw(),
+        Err(_) => ffi_error_literal(
+            r#"{"success":false,"error":"Internal panic caught (message not representable)"}"#,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct TestOutput {
+        success: bool,
+        value: i32,
+    }
+
+    #[test]
+    fn test_to_ffi_json_success() {
+        let output = TestOutput {
+            success: true,
+            value: 42,
+        };
+        let ptr = to_ffi_json(&output);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        let json: serde_json::Value = serde_json::from_str(result.to_str().unwrap()).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["value"], 42);
+    }
+
+    #[test]
+    fn test_ffi_error_literal_returns_valid_string() {
+        let msg = r#"{"success":false,"error":"test"}"#;
+        let ptr = ffi_error_literal(msg);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        assert_eq!(result.to_str().unwrap(), msg);
+    }
+
+    #[test]
+    fn test_panic_to_ffi_json_with_string_message() {
+        let panic_info: Box<dyn std::any::Any + Send> =
+            Box::new("something went wrong".to_string());
+        let ptr = panic_to_ffi_json(panic_info);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        let json: serde_json::Value = serde_json::from_str(result.to_str().unwrap()).unwrap();
+        assert_eq!(json["success"], false);
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap()
+                .contains("something went wrong")
+        );
+    }
+
+    #[test]
+    fn test_panic_to_ffi_json_with_str_message() {
+        let panic_info: Box<dyn std::any::Any + Send> = Box::new("str panic");
+        let ptr = panic_to_ffi_json(panic_info);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        let json: serde_json::Value = serde_json::from_str(result.to_str().unwrap()).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("str panic"));
+    }
+
+    #[test]
+    fn test_panic_to_ffi_json_with_unknown_type() {
+        let panic_info: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        let ptr = panic_to_ffi_json(panic_info);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        let json: serde_json::Value = serde_json::from_str(result.to_str().unwrap()).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("Unknown panic"));
+    }
+
+    #[test]
+    fn test_panic_to_ffi_json_escapes_special_chars() {
+        let panic_info: Box<dyn std::any::Any + Send> =
+            Box::new("error with \"quotes\" and \\backslash".to_string());
+        let ptr = panic_to_ffi_json(panic_info);
+        assert!(!ptr.is_null());
+        // SAFETY: we just created this pointer via CString::into_raw
+        let result = unsafe { CString::from_raw(ptr) };
+        // Should be valid JSON despite special characters
+        let json: serde_json::Value = serde_json::from_str(result.to_str().unwrap()).unwrap();
+        assert_eq!(json["success"], false);
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -18,6 +18,7 @@ pub use utilities::*;
 
 mod analysis;
 mod gpu;
+pub(crate) mod helpers;
 mod recording;
 mod utilities;
 

--- a/src/ffi/recording.rs
+++ b/src/ffi/recording.rs
@@ -1,5 +1,6 @@
 //! Recording FFI entry points — single-call and streaming.
 
+use super::helpers::{ffi_error_literal, panic_to_ffi_json, to_ffi_json};
 use crate::ffi_types::*;
 use crate::{log_version_once, streaming};
 
@@ -30,14 +31,14 @@ pub unsafe extern "C" fn record_discovery(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -54,9 +55,7 @@ pub unsafe extern "C" fn record_discovery(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
@@ -64,32 +63,11 @@ pub unsafe extern "C" fn record_discovery(
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -136,7 +114,7 @@ pub unsafe extern "C" fn record_discovery(
 pub unsafe extern "C" fn start_discovery_session(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    use std::ffi::{CStr, CString};
+    use std::ffi::CStr;
     use std::panic;
 
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
@@ -146,14 +124,14 @@ pub unsafe extern "C" fn start_discovery_session(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -172,8 +150,7 @@ pub unsafe extern "C" fn start_discovery_session(
                     error_kind: Some(kind),
                     retryable: Some(kind.is_retryable()),
                 };
-                let json = serde_json::to_string(&output).unwrap();
-                return CString::new(json).unwrap().into_raw();
+                return to_ffi_json(&output);
             }
         };
 
@@ -200,28 +177,9 @@ pub unsafe extern "C" fn start_discovery_session(
             }
         };
 
-        let json = serde_json::to_string(&output).unwrap();
-        CString::new(json).unwrap().into_raw()
+        to_ffi_json(&output)
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 /// Append records to an existing streaming session.
@@ -256,7 +214,7 @@ pub unsafe extern "C" fn start_discovery_session(
 pub unsafe extern "C" fn append_discovery_records(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    use std::ffi::{CStr, CString};
+    use std::ffi::CStr;
     use std::panic;
 
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
@@ -264,14 +222,14 @@ pub unsafe extern "C" fn append_discovery_records(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -290,8 +248,7 @@ pub unsafe extern "C" fn append_discovery_records(
                     error_kind: Some(kind),
                     retryable: Some(kind.is_retryable()),
                 };
-                let json = serde_json::to_string(&output).unwrap();
-                return CString::new(json).unwrap().into_raw();
+                return to_ffi_json(&output);
             }
         };
 
@@ -325,28 +282,9 @@ pub unsafe extern "C" fn append_discovery_records(
             }
         };
 
-        let json = serde_json::to_string(&output).unwrap();
-        CString::new(json).unwrap().into_raw()
+        to_ffi_json(&output)
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 /// Finish a streaming session and finalise the Parquet file.
@@ -376,7 +314,7 @@ pub unsafe extern "C" fn append_discovery_records(
 pub unsafe extern "C" fn finish_discovery_session(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    use std::ffi::{CStr, CString};
+    use std::ffi::CStr;
     use std::panic;
 
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
@@ -384,14 +322,14 @@ pub unsafe extern "C" fn finish_discovery_session(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -412,8 +350,7 @@ pub unsafe extern "C" fn finish_discovery_session(
                     error_kind: Some(kind),
                     retryable: Some(kind.is_retryable()),
                 };
-                let json = serde_json::to_string(&output).unwrap();
-                return CString::new(json).unwrap().into_raw();
+                return to_ffi_json(&output);
             }
         };
 
@@ -444,28 +381,9 @@ pub unsafe extern "C" fn finish_discovery_session(
             }
         };
 
-        let json = serde_json::to_string(&output).unwrap();
-        CString::new(json).unwrap().into_raw()
+        to_ffi_json(&output)
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 /// Cancel a streaming session without finalising.
@@ -494,7 +412,7 @@ pub unsafe extern "C" fn finish_discovery_session(
 pub unsafe extern "C" fn cancel_discovery_session(
     input_json: *const std::ffi::c_char,
 ) -> *mut std::ffi::c_char {
-    use std::ffi::{CStr, CString};
+    use std::ffi::CStr;
     use std::panic;
 
     panic::catch_unwind(panic::AssertUnwindSafe(|| {
@@ -502,14 +420,14 @@ pub unsafe extern "C" fn cancel_discovery_session(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -527,8 +445,7 @@ pub unsafe extern "C" fn cancel_discovery_session(
                     error_kind: Some(kind),
                     retryable: Some(kind.is_retryable()),
                 };
-                let json = serde_json::to_string(&output).unwrap();
-                return CString::new(json).unwrap().into_raw();
+                return to_ffi_json(&output);
             }
         };
 
@@ -553,26 +470,7 @@ pub unsafe extern "C" fn cancel_discovery_session(
             }
         };
 
-        let json = serde_json::to_string(&output).unwrap();
-        CString::new(json).unwrap().into_raw()
+        to_ffi_json(&output)
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -1,5 +1,6 @@
 //! Utility FFI entry points — merge, read, export, and version.
 
+use super::helpers::{ffi_error_literal, panic_to_ffi_json, to_ffi_json};
 use crate::ffi_types::*;
 use crate::log_version_once;
 
@@ -28,14 +29,14 @@ pub unsafe extern "C" fn merge_discovery_parquet(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -51,41 +52,18 @@ pub unsafe extern "C" fn merge_discovery_parquet(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -115,14 +93,14 @@ pub unsafe extern "C" fn read_discovery_records_ffi(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -138,9 +116,7 @@ pub unsafe extern "C" fn read_discovery_records_ffi(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
@@ -148,32 +124,11 @@ pub unsafe extern "C" fn read_discovery_records_ffi(
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -222,14 +177,14 @@ pub unsafe extern "C" fn export_visualisation_snapshot(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(r#"{"success":false,"error":"Null input pointer"}"#);
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -246,39 +201,18 @@ pub unsafe extern "C" fn export_visualisation_snapshot(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
             Err(_) => {
-                let error = r#"{"success":false,"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
+                ffi_error_literal(r#"{"success":false,"error":"Failed to create output string"}"#)
             }
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -330,14 +264,16 @@ pub unsafe extern "C" fn get_calibration_summary(
         // null-terminated C string. We validate null and UTF-8 before use.
         let input_str = unsafe {
             if input_json.is_null() {
-                let error = r#"{"success":false,"calibrationSummary":[],"error":"Null input pointer"}"#;
-                return CString::new(error).unwrap().into_raw();
+                return ffi_error_literal(
+                    r#"{"success":false,"calibrationSummary":[],"error":"Null input pointer"}"#,
+                );
             }
             match CStr::from_ptr(input_json).to_str() {
                 Ok(s) => s,
                 Err(_) => {
-                    let error = r#"{"success":false,"calibrationSummary":[],"error":"Invalid UTF-8 in input"}"#;
-                    return CString::new(error).unwrap().into_raw();
+                    return ffi_error_literal(
+                        r#"{"success":false,"calibrationSummary":[],"error":"Invalid UTF-8 in input"}"#,
+                    );
                 }
             }
         };
@@ -353,39 +289,18 @@ pub unsafe extern "C" fn get_calibration_summary(
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"calibrationSummary":[],"error":"Failed to serialize error message"}"#.to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
-            Err(_) => {
-                let error = r#"{"success":false,"calibrationSummary":[],"error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
-            }
+            Err(_) => ffi_error_literal(
+                r#"{"success":false,"calibrationSummary":[],"error":"Failed to create output string"}"#,
+            ),
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"calibrationSummary\":[],\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"calibrationSummary":[],"error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }
 
 // ============================================================================
@@ -420,41 +335,16 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
                     error_kind,
                     retryable,
                 };
-                serde_json::to_string(&output).unwrap_or_else(|_| {
-                    r#"{"success":false,"version":"","error":"Failed to serialize error message"}"#
-                        .to_string()
-                })
+                return to_ffi_json(&output);
             }
         };
 
         match CString::new(json_result) {
             Ok(c_string) => c_string.into_raw(),
-            Err(_) => {
-                let error =
-                    r#"{"success":false,"version":"","error":"Failed to create output string"}"#;
-                CString::new(error).unwrap().into_raw()
-            }
+            Err(_) => ffi_error_literal(
+                r#"{"success":false,"version":"","error":"Failed to create output string"}"#,
+            ),
         }
     }))
-    .unwrap_or_else(|panic_info| {
-        // If panic occurred, create a safe error response
-        let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-            s.to_string()
-        } else if let Some(s) = panic_info.downcast_ref::<String>() {
-            s.clone()
-        } else {
-            "Unknown panic".to_string()
-        };
-        let error_json = format!(
-            "{{\"success\":false,\"version\":\"\",\"error\":\"Internal panic caught: {}\"}}",
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        );
-        // This should never fail, but if it does, we return null pointer
-        CString::new(error_json)
-            .unwrap_or_else(|_| {
-                CString::new(r#"{"success":false,"version":"","error":"Failed to create panic error string"}"#)
-                    .unwrap()
-            })
-            .into_raw()
-    })
+    .unwrap_or_else(panic_to_ffi_json)
 }


### PR DESCRIPTION
## Summary

Replace panicking `expect()` and `unwrap()` calls in GPU evaluation and FFI paths with proper error handling. Closes #772.

### GPU evaluation changes (6 sites)
- Replaced `.expect("GPU device must be available...")` with `.context("GPU device unavailable for ... analysis")?` in all 5 GPU evaluation files (helpful, harmful, ReLU, bias, activation — 6 call sites total).
- These now return `Err` through the existing `Result` return type instead of panicking.

### FFI serialisation changes (~40 sites)
- Created `src/ffi/helpers.rs` with three shared helpers:
  - `to_ffi_json<T: Serialize>(&T) -> *mut c_char` — serialises and converts to C string without panicking
  - `ffi_error_literal(&str) -> *mut c_char` — converts static error strings safely
  - `panic_to_ffi_json(Box<dyn Any + Send>) -> *mut c_char` — builds panic error response safely
- Replaced all `serde_json::to_string(&output).unwrap()` + `CString::new(json).unwrap().into_raw()` patterns with `to_ffi_json(&output)`
- Replaced all `CString::new(error_literal).unwrap().into_raw()` patterns with `ffi_error_literal(error_literal)`
- Replaced all duplicated panic handler blocks with `panic_to_ffi_json`
- All FFI functions retain `panic::catch_unwind` at the boundary as a safety net

### Result
- Net deletion of ~280 lines of duplicated boilerplate
- Zero `unwrap()` calls in non-test FFI code
- Zero `expect()` calls for GPU device availability in evaluation code
- All existing tests pass, `quality.sh` passes

## Evidence

This is a backend/library change with no visual output. Evidence is provided by:
- All 6 unit tests in `src/ffi/helpers.rs` covering `to_ffi_json`, `ffi_error_literal`, `panic_to_ffi_json`
- All existing integration and unit tests pass (verified via `quality.sh`)

## Test Plan

- Added 6 unit tests in `src/ffi/helpers.rs`:
  - `test_to_ffi_json_success` — verifies successful serialisation round-trip
  - `test_ffi_error_literal_returns_valid_string` — verifies literal conversion
  - `test_panic_to_ffi_json_with_string_message` — String panic message
  - `test_panic_to_ffi_json_with_str_message` — &str panic message
  - `test_panic_to_ffi_json_with_unknown_type` — non-string panic type
  - `test_panic_to_ffi_json_escapes_special_chars` — JSON escaping of special characters
- All existing tests continue to pass unchanged

---

## Automated Fix Details
This PR addresses issue #772: **Replace panicking expect/unwrap in FFI and GPU paths with proper error handling**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #772