### PR TITLE
refactor: reduce boilerplate in discovery module spec builders with macro (#773)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.51.3"
+version = "0.51.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.51.2"
+version = "0.51.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-773.md
+++ b/docs/pr-summary-773.md
@@ -1,0 +1,40 @@
+## Summary
+
+Introduce `discovery_spec!` macro to eliminate repetitive boilerplate in the
+discovery module spec builders (`neuron_specs.rs`, `synapse_specs.rs`,
+`structural_specs.rs`, `scoring_specs.rs`). Closes #773.
+
+The macro handles the common clone → guard → detect → convert → wrap pipeline
+with four variants:
+- **Standard** — optional pre-record `guard` for hidden-neuron emptiness
+- **guard_records** — post-record emptiness check (for modules loading all/typed records)
+- **guard_min** — minimum-count guard (e.g. `hidden.len() < 2` for pair detectors)
+- **custom** — full closure for modules with non-standard logic
+
+### Line reduction
+
+| File | Before | After | Reduction |
+|------|--------|-------|-----------|
+| `neuron_specs.rs` | 479 | 200 | 58% |
+| `synapse_specs.rs` | 274 | 109 | 60% |
+| `structural_specs.rs` | 233 | 127 | 45% |
+| `scoring_specs.rs` | 331 | 171 | 48% |
+| **Spec files total** | **1317** | **607** | **54%** |
+
+New modules can now be added with a single `discovery_spec!()` invocation
+instead of ~15 lines of boilerplate.
+
+## Evidence
+
+This is a pure refactoring with no visual or performance changes. All 43
+discovery module specs are preserved with identical behaviour, verified by:
+- Unit tests confirming correct spec count, unique phase names, and empty-guard
+  short-circuiting
+- Full `quality.sh` pass (fmt, clippy, check, all tests, doc build, release build)
+
+## Test Plan
+
+- Added `test_build_discovery_module_specs_produces_all_modules` — verifies 43 specs with non-empty names/phases
+- Added `test_discovery_module_specs_have_unique_phase_names` — verifies no duplicate phase names
+- Added `test_discovery_specs_with_empty_hidden_return_none` — verifies all specs return `None` with empty hidden neurons and no records
+- All existing integration tests pass unchanged

--- a/src/analysis/module_dispatch_specs/macros.rs
+++ b/src/analysis/module_dispatch_specs/macros.rs
@@ -1,0 +1,172 @@
+//! Macros for reducing boilerplate in discovery module spec builders (Issue #773).
+//!
+//! The `discovery_spec!` macro encapsulates the common clone → guard → detect →
+//! convert pipeline shared by all discovery module specs. Each invocation produces
+//! a `DiscoveryModuleSpec` and pushes it onto the target vector.
+//!
+//! # Why a macro?
+//!
+//! A helper function cannot capture the heterogeneous closure types produced by
+//! each module's detect/convert pair without boxing them individually. The macro
+//! generates the boilerplate inline, preserving zero-cost move semantics while
+//! reducing ~33 nearly identical code blocks to concise declarations.
+//!
+//! # Usage
+//!
+//! See the four `*_specs.rs` files for real-world examples of every variant.
+
+/// Build and push a `DiscoveryModuleSpec` with the standard detect → convert
+/// pipeline.
+///
+/// # Variants
+///
+/// ## Standard (with optional pre-record guard)
+///
+/// ```ignore
+/// discovery_spec!(modules, "name", "phase", cache = shared_cache, hidden = hidden_neurons =>
+///     guard: hidden,
+///     records: cache.load_records_for_hidden(&hidden),
+///     detect: |records| module::detect(&hidden, &records),
+///     convert: |detected| module::to_candidates(&detected),
+/// );
+/// ```
+///
+/// ## Post-record emptiness guard
+///
+/// ```ignore
+/// discovery_spec!(modules, "name", "phase", cache = shared_cache, creature = creature =>
+///     records: cache.load_records_for_neuron_types(&creature, &["input"]),
+///     guard_records,
+///     detect: |records| module::detect(&creature, &records),
+///     convert: |detected| module::to_candidates(&detected),
+/// );
+/// ```
+///
+/// ## Minimum count guard
+///
+/// ```ignore
+/// discovery_spec!(modules, "name", "phase", cache = shared_cache, hidden = hidden_neurons =>
+///     guard_min: hidden 2,
+///     records: cache.load_records_for_hidden(&hidden),
+///     detect: |records| module::detect(&creature, &records),
+///     convert: |detected| module::to_candidates(&detected),
+/// );
+/// ```
+///
+/// ## Custom closure (non-standard logic)
+///
+/// ```ignore
+/// discovery_spec!(modules, "name", "phase", cache = shared_cache, creature = creature =>
+///     custom: move || { /* ... */ },
+/// );
+/// ```
+macro_rules! discovery_spec {
+    // ── Standard pipeline with optional pre-record guard ──
+    ($modules:expr, $name:expr, $phase:expr,
+     $($clone_name:ident = $clone_src:expr),+ =>
+        $(guard: $guard:ident,)?
+        records: $load_records:expr,
+        detect: |$rec:ident| $detect_expr:expr,
+        convert: |$det:ident| $convert_expr:expr $(,)?
+    ) => {
+        {
+            $( let $clone_name = ::std::sync::Arc::clone(&$clone_src); )+
+            $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
+                module_name: $name.to_string(),
+                phase_name: $phase,
+                detect_fn: Box::new(move || {
+                    $( if $guard.is_empty() { return None; } )?
+                    let $rec = $load_records;
+                    let $det = $detect_expr;
+                    if $det.is_empty() {
+                        return None;
+                    }
+                    let candidates = $convert_expr;
+                    Some($crate::analysis::discovery_dispatch::DiscoveryDetectionResult {
+                        detected_count: $det.len(),
+                        candidates,
+                    })
+                }),
+            });
+        }
+    };
+
+    // ── Standard pipeline with post-record emptiness guard ──
+    ($modules:expr, $name:expr, $phase:expr,
+     $($clone_name:ident = $clone_src:expr),+ =>
+        records: $load_records:expr,
+        guard_records,
+        detect: |$rec:ident| $detect_expr:expr,
+        convert: |$det:ident| $convert_expr:expr $(,)?
+    ) => {
+        {
+            $( let $clone_name = ::std::sync::Arc::clone(&$clone_src); )+
+            $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
+                module_name: $name.to_string(),
+                phase_name: $phase,
+                detect_fn: Box::new(move || {
+                    let $rec = $load_records;
+                    if $rec.is_empty() {
+                        return None;
+                    }
+                    let $det = $detect_expr;
+                    if $det.is_empty() {
+                        return None;
+                    }
+                    let candidates = $convert_expr;
+                    Some($crate::analysis::discovery_dispatch::DiscoveryDetectionResult {
+                        detected_count: $det.len(),
+                        candidates,
+                    })
+                }),
+            });
+        }
+    };
+
+    // ── Minimum-count guard variant ──
+    ($modules:expr, $name:expr, $phase:expr,
+     $($clone_name:ident = $clone_src:expr),+ =>
+        guard_min: $guard_var:ident $min_count:expr,
+        records: $load_records:expr,
+        detect: |$rec:ident| $detect_expr:expr,
+        convert: |$det:ident| $convert_expr:expr $(,)?
+    ) => {
+        {
+            $( let $clone_name = ::std::sync::Arc::clone(&$clone_src); )+
+            $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
+                module_name: $name.to_string(),
+                phase_name: $phase,
+                detect_fn: Box::new(move || {
+                    if $guard_var.len() < $min_count {
+                        return None;
+                    }
+                    let $rec = $load_records;
+                    let $det = $detect_expr;
+                    if $det.is_empty() {
+                        return None;
+                    }
+                    let candidates = $convert_expr;
+                    Some($crate::analysis::discovery_dispatch::DiscoveryDetectionResult {
+                        detected_count: $det.len(),
+                        candidates,
+                    })
+                }),
+            });
+        }
+    };
+
+    // ── Custom closure (for non-standard detection logic) ──
+    ($modules:expr, $name:expr, $phase:expr,
+     $($clone_name:ident = $clone_src:expr),+ =>
+        custom: $closure:expr $(,)?
+    ) => {
+        {
+            $( let $clone_name = ::std::sync::Arc::clone(&$clone_src); )+
+            $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
+                module_name: $name.to_string(),
+                phase_name: $phase,
+                detect_fn: Box::new($closure),
+            });
+        }
+    };
+}

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -9,7 +9,14 @@
 //! - `synapse_specs` — synapse-focused dispatch specs
 //! - `structural_specs` — structural discovery specs
 //! - `scoring_specs` — scoring and recommendation specs
+//!
+//! ## `discovery_spec!` macro (Issue #773)
+//!
+//! The `discovery_spec!` macro eliminates the repetitive clone-guard-detect-convert
+//! boilerplate shared by ~33 discovery module specs. See `macros.rs` for details.
 
+#[macro_use]
+mod macros;
 mod neuron_specs;
 mod scoring_specs;
 mod structural_specs;
@@ -249,4 +256,129 @@ pub(crate) fn apply_ensemble_scoring(syn: &mut shared::AnalyzeSynapsesResult) {
         + syn.coordinated_structural_candidates.len();
 
     crate::watchdog::beat("analysis::analyze_all → ensemble scoring finished");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DiscoverRecord;
+    use crate::{CreatureJson, NeuronJson, SynapseJson};
+
+    fn test_creature() -> CreatureJson {
+        CreatureJson {
+            neurons: vec![
+                NeuronJson {
+                    uuid: "h1".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "TANH".to_string(),
+                    bias: 0.0,
+                },
+                NeuronJson {
+                    uuid: "o1".to_string(),
+                    neuron_type: "output".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: vec![SynapseJson {
+                from_uuid: "h1".to_string(),
+                to_uuid: "o1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            }],
+            input: 1,
+            output: 1,
+        }
+    }
+
+    fn empty_cache() -> cache::RecordCache {
+        cache::RecordCache::with_loader(
+            "test.parquet",
+            Arc::new(
+                |_file: &str, _uuid: &str| -> anyhow::Result<Vec<DiscoverRecord>> { Ok(vec![]) },
+            ),
+        )
+    }
+
+    /// Verify that `build_discovery_module_specs` produces the expected number
+    /// of module specs and that each spec has a non-empty name and phase.
+    #[test]
+    fn test_build_discovery_module_specs_produces_all_modules() {
+        let creature = Arc::new(test_creature());
+        let hidden: Arc<Vec<(String, String, f32)>> =
+            Arc::new(vec![("h1".to_string(), "TANH".to_string(), 0.0)]);
+        let cache = Arc::new(empty_cache());
+        let topo = Arc::new(
+            super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
+        );
+
+        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+
+        // We expect exactly 43 modules across all four spec groups.
+        assert_eq!(
+            specs.len(),
+            43,
+            "Expected 43 discovery module specs, got {}",
+            specs.len()
+        );
+
+        // Every spec must have a non-empty module name and phase name.
+        for (i, spec) in specs.iter().enumerate() {
+            assert!(
+                !spec.module_name.is_empty(),
+                "Module spec {i} has empty module_name"
+            );
+            assert!(
+                !spec.phase_name.is_empty(),
+                "Module spec {i} has empty phase_name"
+            );
+        }
+    }
+
+    /// Verify that all module specs have unique phase names (no duplicates).
+    #[test]
+    fn test_discovery_module_specs_have_unique_phase_names() {
+        let creature = Arc::new(test_creature());
+        let hidden: Arc<Vec<(String, String, f32)>> =
+            Arc::new(vec![("h1".to_string(), "TANH".to_string(), 0.0)]);
+        let cache = Arc::new(empty_cache());
+        let topo = Arc::new(
+            super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
+        );
+
+        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+        let mut phase_names: Vec<&str> = specs.iter().map(|s| s.phase_name).collect();
+        let total = phase_names.len();
+        phase_names.sort();
+        phase_names.dedup();
+        assert_eq!(
+            phase_names.len(),
+            total,
+            "Duplicate phase names found in discovery module specs"
+        );
+    }
+
+    /// Verify that detection closures for empty hidden neurons return None
+    /// (modules with hidden guards should short-circuit).
+    #[test]
+    fn test_discovery_specs_with_empty_hidden_return_none() {
+        let creature = Arc::new(test_creature());
+        let hidden: Arc<Vec<(String, String, f32)>> = Arc::new(vec![]);
+        let cache = Arc::new(empty_cache());
+        let topo = Arc::new(
+            super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
+        );
+
+        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+
+        // With empty hidden neurons and no records, all modules should return None.
+        for spec in specs {
+            let result = (spec.detect_fn)();
+            assert!(
+                result.is_none(),
+                "Module '{}' returned Some with empty hidden neurons and no records",
+                spec.module_name,
+            );
+        }
+    }
 }

--- a/src/analysis/module_dispatch_specs/neuron_specs.rs
+++ b/src/analysis/module_dispatch_specs/neuron_specs.rs
@@ -25,455 +25,176 @@ pub(crate) fn append_neuron_specs(
     topo: &Arc<CreatureTopologyCache>,
 ) {
     // Issue #342: Saturated neuron detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "saturation detection".to_string(),
-            phase_name: "saturation_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = saturation::detect_saturated_neurons(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = saturation::saturated_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "saturation detection", "saturation_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| saturation::detect_saturated_neurons(&hidden, &records),
+        convert: |detected| saturation::saturated_neurons_to_coordinated_candidates(&detected),
+    );
 
     // Issue #343: Bottleneck neuron detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "bottleneck detection".to_string(),
-            phase_name: "bottleneck_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected =
-                    bottleneck::detect_bottleneck_neurons(&creature, &records, Some(&topo));
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = bottleneck::bottleneck_neurons_to_coordinated_candidates(
-                    &detected,
-                    &creature,
-                    Some(&topo),
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "bottleneck detection", "bottleneck_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| bottleneck::detect_bottleneck_neurons(&creature, &records, Some(&topo)),
+        convert: |detected| bottleneck::bottleneck_neurons_to_coordinated_candidates(&detected, &creature, Some(&topo)),
+    );
 
     // Issue #341: Dead neuron detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "dead neuron detection".to_string(),
-            phase_name: "dead_neuron_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = dead_neuron::detect_dead_neurons(&creature, &records, Some(&topo));
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = dead_neuron::dead_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "dead neuron detection", "dead_neuron_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| dead_neuron::detect_dead_neurons(&creature, &records, Some(&topo)),
+        convert: |detected| dead_neuron::dead_neurons_to_coordinated_candidates(&detected),
+    );
 
     // Issue #358: Oscillating neuron detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "oscillating neuron detection".to_string(),
-            phase_name: "oscillating_neuron_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = oscillating_neuron::detect_oscillating_neurons(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    oscillating_neuron::oscillating_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "oscillating neuron detection", "oscillating_neuron_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| oscillating_neuron::detect_oscillating_neurons(&hidden, &records),
+        convert: |detected| oscillating_neuron::oscillating_neurons_to_coordinated_candidates(&detected),
+    );
 
     // Issue #399: Restricted activation range detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "restricted range detection".to_string(),
-            phase_name: "restricted_range_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let config = restricted_range::RestrictedRangeConfig::default();
-                let detected =
-                    restricted_range::detect_restricted_range_neurons(&creature, &records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = restricted_range::restricted_range_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "restricted range detection", "restricted_range_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| {
+            let config = restricted_range::RestrictedRangeConfig::default();
+            restricted_range::detect_restricted_range_neurons(&creature, &records, &config)
+        },
+        convert: |detected| restricted_range::restricted_range_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #401: Hidden neuron operating-point analysis
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "operating point analysis".to_string(),
-            phase_name: "operating_point_analysis",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let config = operating_point::OperatingPointConfig::default();
-                let detected =
-                    operating_point::detect_operating_point_issues(&creature, &records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = operating_point::operating_point_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "operating point analysis", "operating_point_analysis",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| {
+            let config = operating_point::OperatingPointConfig::default();
+            operating_point::detect_operating_point_issues(&creature, &records, &config)
+        },
+        convert: |detected| operating_point::operating_point_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #441: Unbounded activation capping detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "unbounded capping detection".to_string(),
-            phase_name: "unbounded_capping_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected =
-                    unbounded_capping::detect_unbounded_capping_candidates(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    unbounded_capping::unbounded_capping_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "unbounded capping detection", "unbounded_capping_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| unbounded_capping::detect_unbounded_capping_candidates(&hidden, &records),
+        convert: |detected| unbounded_capping::unbounded_capping_to_coordinated_candidates(&detected),
+    );
 
     // Issue #434: Noise-to-signal ratio detection for neurons
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "noisy neuron detection".to_string(),
-            phase_name: "noisy_neuron_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = noise_signal::detect_noisy_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = noise_signal::noisy_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "noisy neuron detection", "noisy_neuron_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| noise_signal::detect_noisy_neurons(&creature, &records),
+        convert: |detected| noise_signal::noisy_neurons_to_coordinated_candidates(&detected),
+    );
 
-    // Issue #417: Proactive activation function recommendation
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "activation recommendation".to_string(),
-            phase_name: "activation_recommendation",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
+    // Issue #417: Proactive activation function recommendation (custom logic)
+    discovery_spec!(modules, "activation recommendation", "activation_recommendation",
+        cache = shared_cache, hidden = hidden_neurons =>
+        custom: move || {
+            if hidden.is_empty() {
+                return None;
+            }
+            let records = cache.load_records_for_hidden(&hidden);
+            let mut recommendations = Vec::new();
+            for (uuid, squash, _bias) in hidden.iter() {
+                if let Some(neuron_records) = records.iter().find(|(u, _)| u == uuid)
+                    && let Some(rec) = activation_recommendation::recommend_activation_function(
+                        &neuron_records.1,
+                        squash,
+                    )
+                {
+                    recommendations.push(rec);
                 }
-                let records = cache.load_records_for_hidden(&hidden);
-                let mut recommendations = Vec::new();
-                for (uuid, squash, _bias) in hidden.iter() {
-                    if let Some(neuron_records) = records.iter().find(|(u, _)| u == uuid)
-                        && let Some(rec) = activation_recommendation::recommend_activation_function(
-                            &neuron_records.1,
-                            squash,
-                        )
-                    {
-                        recommendations.push(rec);
-                    }
-                }
-                if recommendations.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    activation_recommendation::recommendations_to_coordinated_candidates(
-                        &recommendations,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: recommendations.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+            }
+            if recommendations.is_empty() {
+                return None;
+            }
+            let candidates =
+                activation_recommendation::recommendations_to_coordinated_candidates(
+                    &recommendations,
+                );
+            Some(discovery_dispatch::DiscoveryDetectionResult {
+                detected_count: recommendations.len(),
+                candidates,
+            })
+        },
+    );
 
     // Issue #543: Activation mismatch detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "activation mismatch detection".to_string(),
-            phase_name: "activation_mismatch_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = activation_mismatch::detect_activation_mismatches(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    activation_mismatch::activation_mismatch_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "activation mismatch detection", "activation_mismatch_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| activation_mismatch::detect_activation_mismatches(&hidden, &records),
+        convert: |detected| activation_mismatch::activation_mismatch_to_coordinated_candidates(&detected),
+    );
 
     // Issue #551: Bias perturbation for activation regime shifts (local minimum escape)
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "bias perturbation regime shift detection".to_string(),
-            phase_name: "bias_perturbation_regime_shift_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected =
-                    bias_perturbation::detect_bias_perturbation_candidates(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    bias_perturbation::bias_perturbation_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "bias perturbation regime shift detection", "bias_perturbation_regime_shift_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| bias_perturbation::detect_bias_perturbation_candidates(&hidden, &records),
+        convert: |detected| bias_perturbation::bias_perturbation_to_coordinated_candidates(&detected),
+    );
 
     // Issue #569: Symmetry-breaking detection for converged duplicate neurons
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "symmetry breaking detection".to_string(),
-            phase_name: "symmetry_breaking_detection",
-            detect_fn: Box::new(move || {
-                if hidden.len() < 2 {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = symmetry_breaking::detect_symmetric_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    symmetry_breaking::symmetric_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "symmetry breaking detection", "symmetry_breaking_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard_min: hidden 2,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| symmetry_breaking::detect_symmetric_neurons(&creature, &records),
+        convert: |detected| symmetry_breaking::symmetric_neurons_to_coordinated_candidates(&detected),
+    );
 
     // Issue #571: Activation co-adaptation detection for redundant neuron pairs
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "co-adaptation detection".to_string(),
-            phase_name: "co_adaptation_detection",
-            detect_fn: Box::new(move || {
-                if hidden.len() < 2 {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = co_adaptation::detect_co_adapted_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    co_adaptation::co_adapted_pairs_to_coordinated_candidates(&detected, &creature);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "co-adaptation detection", "co_adaptation_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard_min: hidden 2,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| co_adaptation::detect_co_adapted_neurons(&creature, &records),
+        convert: |detected| co_adaptation::co_adapted_pairs_to_coordinated_candidates(&detected, &creature),
+    );
 
-    // Issue #548: Squash + weight rescale detection (coordinated multi-neuron squash exploration)
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "squash weight rescale detection".to_string(),
-            phase_name: "squash_weight_rescale_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = squash_weight_rescale::detect_squash_weight_rescale_candidates(
-                    &creature, &hidden, &records,
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    squash_weight_rescale::squash_weight_rescale_to_coordinated_candidates(
-                        &detected,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    // Issue #548: Squash + weight rescale detection
+    discovery_spec!(modules, "squash weight rescale detection", "squash_weight_rescale_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| squash_weight_rescale::detect_squash_weight_rescale_candidates(&creature, &hidden, &records),
+        convert: |detected| squash_weight_rescale::squash_weight_rescale_to_coordinated_candidates(&detected),
+    );
 
     // Issue #643: Activation-error monotonicity detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "monotonicity detection".to_string(),
-            phase_name: "monotonicity_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = monotonicity::detect_non_monotonic_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = monotonicity::non_monotonic_neurons_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "monotonicity detection", "monotonicity_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| monotonicity::detect_non_monotonic_neurons(&creature, &records),
+        convert: |detected| monotonicity::non_monotonic_neurons_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #640: Bimodal neuron detection (pre-activation distribution shape)
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "bimodal neuron detection".to_string(),
-            phase_name: "bimodal_neuron_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let detected = bimodal_neuron::detect_bimodal_neurons(&hidden, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    bimodal_neuron::bimodal_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "bimodal neuron detection", "bimodal_neuron_detection",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| bimodal_neuron::detect_bimodal_neurons(&hidden, &records),
+        convert: |detected| bimodal_neuron::bimodal_neurons_to_coordinated_candidates(&detected),
+    );
 }

--- a/src/analysis/module_dispatch_specs/scoring_specs.rs
+++ b/src/analysis/module_dispatch_specs/scoring_specs.rs
@@ -21,311 +21,151 @@ pub(crate) fn append_scoring_specs(
     shared_cache: &Arc<cache::RecordCache>,
 ) {
     // Issue #361: Output bias drift detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "output bias drift detection".to_string(),
-            phase_name: "output_bias_drift_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["output"]);
-                let detected = output_bias_drift::detect_output_bias_drift(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "output bias drift detection", "output_bias_drift_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["output"]),
+        detect: |records| output_bias_drift::detect_output_bias_drift(&creature, &records),
+        convert: |detected| output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected),
+    );
 
     // Issue #395: Bounded range detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "bounded range detection".to_string(),
-            phase_name: "bounded_range_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["input", "hidden"]);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected = bounded_range::detect_bounded_range_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = bounded_range::bounded_range_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "bounded range detection", "bounded_range_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["input", "hidden"]),
+        guard_records,
+        detect: |records| bounded_range::detect_bounded_range_neurons(&creature, &records),
+        convert: |detected| bounded_range::bounded_range_to_coordinated_candidates(&detected),
+    );
 
     // Issue #400: Sentinel value gating
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "sentinel value gating".to_string(),
-            phase_name: "sentinel_value_gating",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["input"]);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected =
-                    sentinel_gating::detect_sentinel_gating_candidates(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = sentinel_gating::sentinel_gating_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "sentinel value gating", "sentinel_value_gating",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["input"]),
+        guard_records,
+        detect: |records| sentinel_gating::detect_sentinel_gating_candidates(&creature, &records),
+        convert: |detected| sentinel_gating::sentinel_gating_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #543: Observation utilisation detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "observation utilisation detection".to_string(),
-            phase_name: "observation_utilisation_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["input"]);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected =
-                    observation_utilisation::detect_underutilised_observations(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    observation_utilisation::observation_utilisation_to_coordinated_candidates(
-                        &detected, &creature,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "observation utilisation detection", "observation_utilisation_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["input"]),
+        guard_records,
+        detect: |records| observation_utilisation::detect_underutilised_observations(&creature, &records),
+        convert: |detected| observation_utilisation::observation_utilisation_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #435: Input sensitivity analysis for dominant inputs
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "dominant input detection".to_string(),
-            phase_name: "dominant_input_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["input", "output"]);
-                if records.is_empty() {
-                    return None;
-                }
-                let config = input_sensitivity::InputSensitivityConfig::default();
-                let detected =
-                    input_sensitivity::detect_dominant_inputs(&creature, &records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    input_sensitivity::dominant_inputs_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "dominant input detection", "dominant_input_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["input", "output"]),
+        guard_records,
+        detect: |records| {
+            let config = input_sensitivity::InputSensitivityConfig::default();
+            input_sensitivity::detect_dominant_inputs(&creature, &records, &config)
+        },
+        convert: |detected| input_sensitivity::dominant_inputs_to_coordinated_candidates(&detected),
+    );
 
     // Issue #435: Input sensitivity analysis for threshold effects
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "threshold effect detection".to_string(),
-            phase_name: "threshold_effect_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let config = input_sensitivity::InputSensitivityConfig::default();
-                let detected =
-                    input_sensitivity::detect_threshold_effects(&creature, &records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    input_sensitivity::threshold_effects_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "threshold effect detection", "threshold_effect_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| {
+            let config = input_sensitivity::InputSensitivityConfig::default();
+            input_sensitivity::detect_threshold_effects(&creature, &records, &config)
+        },
+        convert: |detected| input_sensitivity::threshold_effects_to_coordinated_candidates(&detected),
+    );
 
     // Issue #423: Sample-weighted discovery — prioritise high-error samples
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "sample-weighted discovery".to_string(),
-            phase_name: "sample_weighted_discovery",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                if records.is_empty() {
-                    return None;
-                }
-                let config = sample_weighted::SampleWeightedConfig::default();
-                let detected = sample_weighted::detect_high_error_neurons(&records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    sample_weighted::high_error_neurons_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "sample-weighted discovery", "sample_weighted_discovery",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        guard_records,
+        detect: |records| {
+            let config = sample_weighted::SampleWeightedConfig::default();
+            sample_weighted::detect_high_error_neurons(&records, &config)
+        },
+        convert: |detected| sample_weighted::high_error_neurons_to_coordinated_candidates(&detected),
+    );
 
     // Issue #421: Gradient-based synapse adjustment — directional improvement hints
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "gradient-based discovery".to_string(),
-            phase_name: "gradient_based_discovery",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected = gradient_discovery::detect_gradient_candidates(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = gradient_discovery::gradient_candidates_to_coordinated(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "gradient-based discovery", "gradient_based_discovery",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        guard_records,
+        detect: |records| gradient_discovery::detect_gradient_candidates(&creature, &records),
+        convert: |detected| gradient_discovery::gradient_candidates_to_coordinated(&detected),
+    );
 
     // Issue #645: Output range compression detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "output range compression detection".to_string(),
-            phase_name: "output_range_compression_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_neuron_types(&creature, &["output"]);
-                if records.is_empty() {
-                    return None;
-                }
-                let config = output_range_compression::OutputRangeCompressionConfig::default();
-                let detected = output_range_compression::detect_output_range_compression(
-                    &creature, &records, &config,
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    output_range_compression::output_range_compression_to_coordinated_candidates(
-                        &detected, &creature,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "output range compression detection", "output_range_compression_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_neuron_types(&creature, &["output"]),
+        guard_records,
+        detect: |records| {
+            let config = output_range_compression::OutputRangeCompressionConfig::default();
+            output_range_compression::detect_output_range_compression(&creature, &records, &config)
+        },
+        convert: |detected| output_range_compression::output_range_compression_to_coordinated_candidates(&detected, &creature),
+    );
 
-    // Issue #545: Output squash mismatch detection (local minimum escape)
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "output squash mismatch detection".to_string(),
-            phase_name: "output_squash_mismatch_detection",
-            detect_fn: Box::new(move || {
-                let output_neurons: Vec<(String, String, f32)> = creature
-                    .neurons
-                    .iter()
-                    .filter(|n| n.neuron_type == "output")
-                    .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
-                    .collect();
-                if output_neurons.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_neuron_types(&creature, &["output"]);
-                let detected = output_squash_mismatch::detect_output_squash_mismatches(
-                    &output_neurons,
-                    &records,
+    // Issue #545: Output squash mismatch detection (local minimum escape, custom logic)
+    discovery_spec!(modules, "output squash mismatch detection", "output_squash_mismatch_detection",
+        cache = shared_cache, creature = creature =>
+        custom: move || {
+            let output_neurons: Vec<(String, String, f32)> = creature
+                .neurons
+                .iter()
+                .filter(|n| n.neuron_type == "output")
+                .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+                .collect();
+            if output_neurons.is_empty() {
+                return None;
+            }
+            let records = cache.load_records_for_neuron_types(&creature, &["output"]);
+            let detected = output_squash_mismatch::detect_output_squash_mismatches(
+                &output_neurons,
+                &records,
+            );
+            if detected.is_empty() {
+                return None;
+            }
+            let candidates =
+                output_squash_mismatch::output_squash_mismatch_to_coordinated_candidates(
+                    &detected,
                 );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    output_squash_mismatch::output_squash_mismatch_to_coordinated_candidates(
-                        &detected,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+            Some(discovery_dispatch::DiscoveryDetectionResult {
+                detected_count: detected.len(),
+                candidates,
+            })
+        },
+    );
 
-    // Issue #545: Error stagnation plateau detection (local minimum escape)
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "error plateau detection".to_string(),
-            phase_name: "error_plateau_detection",
-            detect_fn: Box::new(move || {
-                let output_neurons: Vec<(String, String, f32)> = creature
-                    .neurons
-                    .iter()
-                    .filter(|n| n.neuron_type == "output")
-                    .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
-                    .collect();
-                if output_neurons.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_neuron_types(&creature, &["output"]);
-                let detected = error_plateau::detect_error_plateaus(&output_neurons, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = error_plateau::error_plateaus_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    // Issue #545: Error stagnation plateau detection (local minimum escape, custom logic)
+    discovery_spec!(modules, "error plateau detection", "error_plateau_detection",
+        cache = shared_cache, creature = creature =>
+        custom: move || {
+            let output_neurons: Vec<(String, String, f32)> = creature
+                .neurons
+                .iter()
+                .filter(|n| n.neuron_type == "output")
+                .map(|n| (n.uuid.clone(), n.squash.clone(), n.bias))
+                .collect();
+            if output_neurons.is_empty() {
+                return None;
+            }
+            let records = cache.load_records_for_neuron_types(&creature, &["output"]);
+            let detected = error_plateau::detect_error_plateaus(&output_neurons, &records);
+            if detected.is_empty() {
+                return None;
+            }
+            let candidates = error_plateau::error_plateaus_to_coordinated_candidates(&detected);
+            Some(discovery_dispatch::DiscoveryDetectionResult {
+                detected_count: detected.len(),
+                candidates,
+            })
+        },
+    );
 }

--- a/src/analysis/module_dispatch_specs/structural_specs.rs
+++ b/src/analysis/module_dispatch_specs/structural_specs.rs
@@ -21,213 +21,107 @@ pub(crate) fn append_structural_specs(
     shared_cache: &Arc<cache::RecordCache>,
     topo: &Arc<CreatureTopologyCache>,
 ) {
-    // Issue #344: Correlated error detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "correlated error detection".to_string(),
-            phase_name: "correlated_error_detection",
-            detect_fn: Box::new(move || {
-                let output_count = creature
-                    .neurons
-                    .iter()
-                    .filter(|n| n.neuron_type == "output")
-                    .count();
-                if output_count < 2 {
-                    return None;
-                }
-                let records = cache.load_records_for_neuron_types(&creature, &["output", "input"]);
-                let detected =
-                    correlated_error::detect_correlated_error_patterns(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = correlated_error::correlated_errors_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    // Issue #344: Correlated error detection (custom: output count pre-check)
+    discovery_spec!(modules, "correlated error detection", "correlated_error_detection",
+        cache = shared_cache, creature = creature =>
+        custom: move || {
+            let output_count = creature
+                .neurons
+                .iter()
+                .filter(|n| n.neuron_type == "output")
+                .count();
+            if output_count < 2 {
+                return None;
+            }
+            let records = cache.load_records_for_neuron_types(&creature, &["output", "input"]);
+            let detected =
+                correlated_error::detect_correlated_error_patterns(&creature, &records);
+            if detected.is_empty() {
+                return None;
+            }
+            let candidates = correlated_error::correlated_errors_to_coordinated_candidates(
+                &detected, &creature,
+            );
+            Some(discovery_dispatch::DiscoveryDetectionResult {
+                detected_count: detected.len(),
+                candidates,
+            })
+        },
+    );
 
     // Issue #230: Multi-hop candidate analysis
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "multi-hop analysis".to_string(),
-            phase_name: "multi_hop_analysis",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected = multi_hop::detect_multi_hop_candidates(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    multi_hop::multi_hop_to_coordinated_candidates(&detected, &creature);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "multi-hop analysis", "multi_hop_analysis",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| multi_hop::detect_multi_hop_candidates(&creature, &records),
+        convert: |detected| multi_hop::multi_hop_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #422: Topology-aware network structure analysis
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "topology structure analysis".to_string(),
-            phase_name: "topology_structure_analysis",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected = topology::detect_topology_issues(&creature, &records, Some(&topo));
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = topology::topology_issues_to_coordinated_candidates(
-                    &detected,
-                    &creature,
-                    Some(&topo),
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "topology structure analysis", "topology_structure_analysis",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| topology::detect_topology_issues(&creature, &records, Some(&topo)),
+        convert: |detected| topology::topology_issues_to_coordinated_candidates(&detected, &creature, Some(&topo)),
+    );
 
     // Issue #549: Topology diversification for structural jumps
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "topology diversification detection".to_string(),
-            phase_name: "topology_diversification_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected = topology_diversification::detect_topology_diversification_candidates(
-                    &creature, &records,
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    topology_diversification::topology_diversification_to_coordinated_candidates(
-                        &detected, &creature,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "topology diversification detection", "topology_diversification_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| topology_diversification::detect_topology_diversification_candidates(&creature, &records),
+        convert: |detected| topology_diversification::topology_diversification_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #570: Skip-connection discovery for beneficial residual connections
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "skip connection discovery".to_string(),
-            phase_name: "skip_connection_discovery",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected =
-                    skip_connection::detect_skip_connection_candidates(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = skip_connection::skip_connections_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "skip connection discovery", "skip_connection_discovery",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| skip_connection::detect_skip_connection_candidates(&creature, &records),
+        convert: |detected| skip_connection::skip_connections_to_coordinated_candidates(&detected, &creature),
+    );
 
-    // Issue #639: Per-output error disaggregation for hidden neurons
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "output conflict detection".to_string(),
-            phase_name: "output_conflict_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let output_count = creature
-                    .neurons
-                    .iter()
-                    .filter(|n| n.neuron_type == "output")
-                    .count();
-                if output_count < 2 {
-                    return None;
-                }
-                let records = cache.load_records_for_neuron_types(&creature, &["hidden"]);
-                let detected = output_conflict::detect_output_conflict_neurons(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = output_conflict::output_conflicts_to_coordinated_candidates(
-                    &detected, &creature,
-                );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    // Issue #639: Per-output error disaggregation for hidden neurons (custom: output count check)
+    discovery_spec!(modules, "output conflict detection", "output_conflict_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        custom: move || {
+            if hidden.is_empty() {
+                return None;
+            }
+            let output_count = creature
+                .neurons
+                .iter()
+                .filter(|n| n.neuron_type == "output")
+                .count();
+            if output_count < 2 {
+                return None;
+            }
+            let records = cache.load_records_for_neuron_types(&creature, &["hidden"]);
+            let detected = output_conflict::detect_output_conflict_neurons(&creature, &records);
+            if detected.is_empty() {
+                return None;
+            }
+            let candidates = output_conflict::output_conflicts_to_coordinated_candidates(
+                &detected, &creature,
+            );
+            Some(discovery_dispatch::DiscoveryDetectionResult {
+                detected_count: detected.len(),
+                candidates,
+            })
+        },
+    );
 
     // Issue #642: Hard sample cluster detection (cross-network high-error observations)
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "hard sample cluster detection".to_string(),
-            phase_name: "hard_sample_cluster_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let config = hard_sample_cluster::HardSampleClusterConfig::default();
-                let detected =
-                    hard_sample_cluster::detect_hard_sample_clusters(&creature, &records, &config);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    hard_sample_cluster::hard_sample_clusters_to_coordinated_candidates(
-                        &detected, &creature,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "hard sample cluster detection", "hard_sample_cluster_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| {
+            let config = hard_sample_cluster::HardSampleClusterConfig::default();
+            hard_sample_cluster::detect_hard_sample_clusters(&creature, &records, &config)
+        },
+        convert: |detected| hard_sample_cluster::hard_sample_clusters_to_coordinated_candidates(&detected, &creature),
+    );
 }

--- a/src/analysis/module_dispatch_specs/synapse_specs.rs
+++ b/src/analysis/module_dispatch_specs/synapse_specs.rs
@@ -22,253 +22,88 @@ pub(crate) fn append_synapse_specs(
     topo: &Arc<CreatureTopologyCache>,
 ) {
     // Issue #359: Dormant synapse detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "dormant synapse detection".to_string(),
-            phase_name: "dormant_synapse_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_synapse_sources(&creature);
-                let detected = dormant_synapse::detect_dormant_synapses(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    dormant_synapse::dormant_synapses_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "dormant synapse detection", "dormant_synapse_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_synapse_sources(&creature),
+        detect: |records| dormant_synapse::detect_dormant_synapses(&creature, &records),
+        convert: |detected| dormant_synapse::dormant_synapses_to_coordinated_candidates(&detected),
+    );
 
     // Issue #360: Opposing synapse detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "opposing synapse detection".to_string(),
-            phase_name: "opposing_synapse_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected = opposing_synapse::detect_opposing_synapses(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    opposing_synapse::opposing_synapses_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "opposing synapse detection", "opposing_synapse_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| opposing_synapse::detect_opposing_synapses(&creature, &records),
+        convert: |detected| opposing_synapse::opposing_synapses_to_coordinated_candidates(&detected),
+    );
 
     // Issue #437: Weight coherence validation - incoherent weight ratios
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "weight coherence ratio detection".to_string(),
-            phase_name: "weight_coherence_ratio_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let config = weight_coherence::WeightCoherenceConfig::default();
-                let detected = weight_coherence::detect_incoherent_weight_ratios(
-                    &creature,
-                    &records,
-                    &config,
-                    Some(&topo),
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    weight_coherence::incoherent_ratios_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "weight coherence ratio detection", "weight_coherence_ratio_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| {
+            let config = weight_coherence::WeightCoherenceConfig::default();
+            weight_coherence::detect_incoherent_weight_ratios(&creature, &records, &config, Some(&topo))
+        },
+        convert: |detected| weight_coherence::incoherent_ratios_to_coordinated_candidates(&detected),
+    );
 
     // Issue #437: Weight coherence validation - near-constant output paths
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "near-constant path detection".to_string(),
-            phase_name: "near_constant_path_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_hidden(&hidden);
-                let config = weight_coherence::WeightCoherenceConfig::default();
-                let detected = weight_coherence::detect_near_constant_paths(
-                    &creature,
-                    &records,
-                    &config,
-                    Some(&topo),
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    weight_coherence::near_constant_paths_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "near-constant path detection", "near_constant_path_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| {
+            let config = weight_coherence::WeightCoherenceConfig::default();
+            weight_coherence::detect_near_constant_paths(&creature, &records, &config, Some(&topo))
+        },
+        convert: |detected| weight_coherence::near_constant_paths_to_coordinated_candidates(&detected),
+    );
 
     // Issue #437: Weight coherence validation - symmetric weight cancellation
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        let topo = Arc::clone(topo);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "symmetric cancellation detection".to_string(),
-            phase_name: "symmetric_cancellation_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let config = weight_coherence::WeightCoherenceConfig::default();
-                let detected = weight_coherence::detect_symmetric_cancellation(
-                    &creature,
-                    &records,
-                    &config,
-                    Some(&topo),
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    weight_coherence::symmetric_cancellation_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "symmetric cancellation detection", "symmetric_cancellation_detection",
+        cache = shared_cache, creature = creature, topo = topo =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| {
+            let config = weight_coherence::WeightCoherenceConfig::default();
+            weight_coherence::detect_symmetric_cancellation(&creature, &records, &config, Some(&topo))
+        },
+        convert: |detected| weight_coherence::symmetric_cancellation_to_coordinated_candidates(&detected),
+    );
 
     // Issue #434: Noise-to-signal ratio detection for synapses
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "noisy synapse detection".to_string(),
-            phase_name: "noisy_synapse_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected = noise_signal::detect_noisy_synapses(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates = noise_signal::noisy_synapses_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "noisy synapse detection", "noisy_synapse_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| noise_signal::detect_noisy_synapses(&creature, &records),
+        convert: |detected| noise_signal::noisy_synapses_to_coordinated_candidates(&detected),
+    );
 
     // Issue #550: Weight magnitude reset for stuck synapses (local minimum escape)
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "weight magnitude reset detection".to_string(),
-            phase_name: "weight_magnitude_reset_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected =
-                    weight_magnitude_reset::detect_stuck_synapse_weight_resets(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "weight magnitude reset detection", "weight_magnitude_reset_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        guard_records,
+        detect: |records| weight_magnitude_reset::detect_stuck_synapse_weight_resets(&creature, &records),
+        convert: |detected| weight_magnitude_reset::stuck_synapses_to_coordinated_candidates(&detected),
+    );
 
     // Issue #641: Fan-in weight polarity conflict detection
-    {
-        let cache = Arc::clone(shared_cache);
-        let hidden = Arc::clone(hidden_neurons);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "fan-in polarity conflict detection".to_string(),
-            phase_name: "fanin_polarity_conflict_detection",
-            detect_fn: Box::new(move || {
-                if hidden.is_empty() {
-                    return None;
-                }
-                let records = cache.load_records_for_all_neurons(&creature);
-                let detected =
-                    fanin_polarity_conflict::detect_fanin_polarity_conflicts(&creature, &records);
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    fanin_polarity_conflict::fanin_polarity_conflicts_to_coordinated_candidates(
-                        &detected, &creature,
-                    );
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "fan-in polarity conflict detection", "fanin_polarity_conflict_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| fanin_polarity_conflict::detect_fanin_polarity_conflicts(&creature, &records),
+        convert: |detected| fanin_polarity_conflict::fanin_polarity_conflicts_to_coordinated_candidates(&detected, &creature),
+    );
 
     // Issue #644: Weight polarity flip detection (gradient-weight sign disagreement)
-    {
-        let cache = Arc::clone(shared_cache);
-        let creature = Arc::clone(creature);
-        modules.push(discovery_dispatch::DiscoveryModuleSpec {
-            module_name: "weight polarity flip detection".to_string(),
-            phase_name: "weight_polarity_flip_detection",
-            detect_fn: Box::new(move || {
-                let records = cache.load_records_for_all_neurons(&creature);
-                if records.is_empty() {
-                    return None;
-                }
-                let detected = weight_polarity_flip::detect_weight_polarity_flip_candidates(
-                    &creature, &records,
-                );
-                if detected.is_empty() {
-                    return None;
-                }
-                let candidates =
-                    weight_polarity_flip::polarity_flip_candidates_to_coordinated(&detected);
-                Some(discovery_dispatch::DiscoveryDetectionResult {
-                    detected_count: detected.len(),
-                    candidates,
-                })
-            }),
-        });
-    }
+    discovery_spec!(modules, "weight polarity flip detection", "weight_polarity_flip_detection",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        guard_records,
+        detect: |records| weight_polarity_flip::detect_weight_polarity_flip_candidates(&creature, &records),
+        convert: |detected| weight_polarity_flip::polarity_flip_candidates_to_coordinated(&detected),
+    );
 }


### PR DESCRIPTION
## Summary

Introduce `discovery_spec!` macro to eliminate repetitive boilerplate in the
discovery module spec builders (`neuron_specs.rs`, `synapse_specs.rs`,
`structural_specs.rs`, `scoring_specs.rs`). Closes #773.

The macro handles the common clone → guard → detect → convert → wrap pipeline
with four variants:
- **Standard** — optional pre-record `guard` for hidden-neuron emptiness
- **guard_records** — post-record emptiness check (for modules loading all/typed records)
- **guard_min** — minimum-count guard (e.g. `hidden.len() < 2` for pair detectors)
- **custom** — full closure for modules with non-standard logic

### Line reduction

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `neuron_specs.rs` | 479 | 200 | 58% |
| `synapse_specs.rs` | 274 | 109 | 60% |
| `structural_specs.rs` | 233 | 127 | 45% |
| `scoring_specs.rs` | 331 | 171 | 48% |
| **Spec files total** | **1317** | **607** | **54%** |

New modules can now be added with a single `discovery_spec!()` invocation
instead of ~15 lines of boilerplate.

## Evidence

This is a pure refactoring with no visual or performance changes. All 43
discovery module specs are preserved with identical behaviour, verified by:
- Unit tests confirming correct spec count, unique phase names, and empty-guard
  short-circuiting
- Full `quality.sh` pass (fmt, clippy, check, all tests, doc build, release build)

## Test Plan

- Added `test_build_discovery_module_specs_produces_all_modules` — verifies 43 specs with non-empty names/phases
- Added `test_discovery_module_specs_have_unique_phase_names` — verifies no duplicate phase names
- Added `test_discovery_specs_with_empty_hidden_return_none` — verifies all specs return `None` with empty hidden neurons and no records
- All existing integration tests pass unchanged

---

## Automated Fix Details
This PR addresses issue #773: **Reduce boilerplate in discovery module spec builders with macro or helper**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #773