### PR TITLE
refactor: promote spearman_rank_correlation to shared stats module (#775)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.1"
+version = "0.52.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.0"
+version = "0.52.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-775.md
+++ b/docs/pr-summary-775.md
@@ -27,4 +27,4 @@ This is a backend refactor with no UI changes. All tests pass and `quality.sh` p
 - `spearman_monotonic_nonlinear` — nonlinear monotonic (x³) returns ~1.0
 - `spearman_with_ties` — tied values still produce correct correlation
 - `spearman_zero_variance_returns_zero` — constant input returns 0.0
-- `spearman_no_monotonic_relationship` — U-shaped data returns near-zero
+- `spearman_no_monotonic_relationship` — U-shaped data returns near-zero.

--- a/docs/pr-summary-775.md
+++ b/docs/pr-summary-775.md
@@ -1,0 +1,30 @@
+## Summary
+
+Promote `spearman_rank_correlation` and `compute_ranks` from private functions in `monotonicity.rs` to public shared functions in the `stats` module (`src/analysis/detection/stats.rs`). This follows the same pattern as Pearson correlation (Issue #767) and makes Spearman rank correlation available for future modules. Closes #775.
+
+## Changes
+
+- **`src/analysis/detection/stats.rs`**: Added `compute_ranks()` and `spearman_rank_correlation()` as public functions with documentation.
+- **`src/analysis/detection/monotonicity.rs`**: Removed local copies of `spearman_rank_correlation` and `compute_ranks`, replaced with import from `super::stats::spearman_rank_correlation`.
+- **`tests/issue_775_stats_spearman_correlation.rs`**: 14 integration tests covering edge cases.
+
+## Evidence
+
+This is a backend refactor with no UI changes. All tests pass and `quality.sh` passes cleanly.
+
+## Test Plan
+
+- `compute_ranks_empty_input` — empty slice returns empty ranks
+- `compute_ranks_single_element` — single element gets rank 1.0
+- `compute_ranks_sorted_values` — already sorted values get sequential ranks
+- `compute_ranks_reverse_sorted` — reverse sorted values get descending ranks
+- `compute_ranks_with_ties` — tied values receive average rank
+- `compute_ranks_all_tied` — all equal values receive same average rank
+- `spearman_empty_input_returns_zero` — empty input returns 0.0
+- `spearman_single_element_returns_zero` — single element returns 0.0
+- `spearman_perfect_positive` — perfectly monotonic increasing returns ~1.0
+- `spearman_perfect_negative` — perfectly monotonic decreasing returns ~-1.0
+- `spearman_monotonic_nonlinear` — nonlinear monotonic (x³) returns ~1.0
+- `spearman_with_ties` — tied values still produce correct correlation
+- `spearman_zero_variance_returns_zero` — constant input returns 0.0
+- `spearman_no_monotonic_relationship` — U-shaped data returns near-zero

--- a/src/analysis/detection/monotonicity.rs
+++ b/src/analysis/detection/monotonicity.rs
@@ -30,6 +30,7 @@ use std::collections::HashSet;
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
 
+use super::stats::spearman_rank_correlation;
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES_FOR_DETECTION;
 
 /// Minimum |rho| below which a neuron is considered non-monotonic.
@@ -49,72 +50,6 @@ pub struct MonotonicityCandidate {
     pub sample_count: usize,
     /// Estimated creature score improvement from restructuring this neuron.
     pub estimated_improvement: f32,
-}
-
-/// Compute Spearman's rank correlation coefficient between two slices.
-///
-/// Returns a value in [-1.0, 1.0] where:
-/// - +1.0 = perfectly monotonically increasing
-/// - -1.0 = perfectly monotonically decreasing
-/// - 0.0 = no monotonic relationship
-fn spearman_rank_correlation(x: &[f32], y: &[f32]) -> f32 {
-    let n = x.len();
-    if n < 2 {
-        return 0.0;
-    }
-
-    let rank_x = compute_ranks(x);
-    let rank_y = compute_ranks(y);
-
-    // Pearson correlation on ranks
-    let n_f = n as f32;
-    let mean_rx: f32 = rank_x.iter().sum::<f32>() / n_f;
-    let mean_ry: f32 = rank_y.iter().sum::<f32>() / n_f;
-
-    let mut cov = 0.0f32;
-    let mut var_x = 0.0f32;
-    let mut var_y = 0.0f32;
-
-    for i in 0..n {
-        let dx = rank_x[i] - mean_rx;
-        let dy = rank_y[i] - mean_ry;
-        cov += dx * dy;
-        var_x += dx * dx;
-        var_y += dy * dy;
-    }
-
-    let denom = (var_x * var_y).sqrt();
-    if denom < 1e-12 {
-        return 0.0;
-    }
-
-    cov / denom
-}
-
-/// Compute fractional ranks for a slice of f32 values.
-/// Ties receive the average of their ranks.
-fn compute_ranks(values: &[f32]) -> Vec<f32> {
-    let n = values.len();
-    let mut indexed: Vec<(usize, f32)> = values.iter().copied().enumerate().collect();
-    indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
-
-    let mut ranks = vec![0.0f32; n];
-    let mut i = 0;
-    while i < n {
-        let mut j = i;
-        // Find all ties
-        while j < n && indexed[j].1.total_cmp(&indexed[i].1) == std::cmp::Ordering::Equal {
-            j += 1;
-        }
-        // Average rank for tied values (1-based)
-        let avg_rank = (i + j) as f32 / 2.0 + 0.5;
-        for item in indexed.iter().take(j).skip(i) {
-            ranks[item.0] = avg_rank;
-        }
-        i = j;
-    }
-
-    ranks
 }
 
 /// Detect neurons with non-monotonic activation-error relationships.

--- a/src/analysis/detection/stats.rs
+++ b/src/analysis/detection/stats.rs
@@ -148,3 +148,76 @@ pub fn pearson_correlation_hashmaps(
 
     cov / denom
 }
+
+/// Compute fractional ranks for a slice of f32 values.
+///
+/// Ties receive the average of their ranks (1-based).
+/// Returns an empty vector for empty input.
+pub fn compute_ranks(values: &[f32]) -> Vec<f32> {
+    let n = values.len();
+    let mut indexed: Vec<(usize, f32)> = values.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
+
+    let mut ranks = vec![0.0f32; n];
+    let mut i = 0;
+    while i < n {
+        let mut j = i;
+        // Find all ties
+        while j < n && indexed[j].1.total_cmp(&indexed[i].1) == std::cmp::Ordering::Equal {
+            j += 1;
+        }
+        // Average rank for tied values (1-based)
+        let avg_rank = (i + j) as f32 / 2.0 + 0.5;
+        for item in indexed.iter().take(j).skip(i) {
+            ranks[item.0] = avg_rank;
+        }
+        i = j;
+    }
+
+    ranks
+}
+
+/// Compute Spearman's rank correlation coefficient between two slices.
+///
+/// This is equivalent to computing the Pearson correlation on the ranks of
+/// the input values.
+///
+/// Returns a value in `[-1.0, 1.0]` where:
+/// - `+1.0` = perfectly monotonically increasing
+/// - `-1.0` = perfectly monotonically decreasing
+/// - `0.0` = no monotonic relationship
+///
+/// Returns `0.0` for inputs with fewer than 2 elements or zero variance.
+pub fn spearman_rank_correlation(x: &[f32], y: &[f32]) -> f32 {
+    let n = x.len();
+    if n < 2 {
+        return 0.0;
+    }
+
+    let rank_x = compute_ranks(x);
+    let rank_y = compute_ranks(y);
+
+    // Pearson correlation on ranks
+    let n_f = n as f32;
+    let mean_rx: f32 = rank_x.iter().sum::<f32>() / n_f;
+    let mean_ry: f32 = rank_y.iter().sum::<f32>() / n_f;
+
+    let mut cov = 0.0f32;
+    let mut var_x = 0.0f32;
+    let mut var_y = 0.0f32;
+
+    for i in 0..n {
+        let dx = rank_x[i] - mean_rx;
+        let dy = rank_y[i] - mean_ry;
+        cov += dx * dy;
+        var_x += dx * dx;
+        var_y += dy * dy;
+    }
+
+    let denom = (var_x * var_y).sqrt();
+    if denom < 1e-12 {
+        return 0.0;
+    }
+
+    cov / denom
+}

--- a/tests/issue_775_stats_spearman_correlation.rs
+++ b/tests/issue_775_stats_spearman_correlation.rs
@@ -1,0 +1,115 @@
+//! Integration tests for Spearman rank correlation in stats module (Issue #775).
+
+use neat_ai_discovery::analysis::detection::stats::{compute_ranks, spearman_rank_correlation};
+
+// ── compute_ranks ────────────────────────────────────────────────────────
+
+#[test]
+fn compute_ranks_empty_input() {
+    let ranks = compute_ranks(&[]);
+    assert!(ranks.is_empty());
+}
+
+#[test]
+fn compute_ranks_single_element() {
+    let ranks = compute_ranks(&[42.0]);
+    assert_eq!(ranks, vec![1.0]);
+}
+
+#[test]
+fn compute_ranks_sorted_values() {
+    let ranks = compute_ranks(&[10.0, 20.0, 30.0, 40.0]);
+    assert_eq!(ranks, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn compute_ranks_reverse_sorted() {
+    let ranks = compute_ranks(&[40.0, 30.0, 20.0, 10.0]);
+    assert_eq!(ranks, vec![4.0, 3.0, 2.0, 1.0]);
+}
+
+#[test]
+fn compute_ranks_with_ties() {
+    // Values: [3, 1, 1, 2] → sorted ranks: 1→1.5, 1→1.5, 2→3, 3→4
+    let ranks = compute_ranks(&[3.0, 1.0, 1.0, 2.0]);
+    assert_eq!(ranks[0], 4.0); // 3.0 is rank 4
+    assert_eq!(ranks[1], 1.5); // 1.0 tied at ranks 1-2 → avg 1.5
+    assert_eq!(ranks[2], 1.5); // 1.0 tied at ranks 1-2 → avg 1.5
+    assert_eq!(ranks[3], 3.0); // 2.0 is rank 3
+}
+
+#[test]
+fn compute_ranks_all_tied() {
+    let ranks = compute_ranks(&[5.0, 5.0, 5.0]);
+    // All share average rank of (1+2+3)/3 = 2.0
+    assert_eq!(ranks, vec![2.0, 2.0, 2.0]);
+}
+
+// ── spearman_rank_correlation ────────────────────────────────────────────
+
+#[test]
+fn spearman_empty_input_returns_zero() {
+    assert_eq!(spearman_rank_correlation(&[], &[]), 0.0);
+}
+
+#[test]
+fn spearman_single_element_returns_zero() {
+    assert_eq!(spearman_rank_correlation(&[1.0], &[2.0]), 0.0);
+}
+
+#[test]
+fn spearman_perfect_positive() {
+    let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let y = vec![10.0, 20.0, 30.0, 40.0, 50.0];
+    let rho = spearman_rank_correlation(&x, &y);
+    assert!((rho - 1.0).abs() < 1e-5, "expected ~1.0, got {rho}");
+}
+
+#[test]
+fn spearman_perfect_negative() {
+    let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let y = vec![50.0, 40.0, 30.0, 20.0, 10.0];
+    let rho = spearman_rank_correlation(&x, &y);
+    assert!((rho + 1.0).abs() < 1e-5, "expected ~-1.0, got {rho}");
+}
+
+#[test]
+fn spearman_monotonic_nonlinear() {
+    // y = x^3 is monotonically increasing, so Spearman should be +1.0
+    let x = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let y: Vec<f32> = x.iter().map(|v| v * v * v).collect();
+    let rho = spearman_rank_correlation(&x, &y);
+    assert!(
+        (rho - 1.0).abs() < 1e-5,
+        "expected ~1.0 for monotonic nonlinear, got {rho}"
+    );
+}
+
+#[test]
+fn spearman_with_ties() {
+    // Ties in input: ranks should use average
+    let x = vec![1.0, 2.0, 2.0, 3.0];
+    let y = vec![10.0, 20.0, 20.0, 30.0];
+    let rho = spearman_rank_correlation(&x, &y);
+    assert!(
+        (rho - 1.0).abs() < 1e-5,
+        "expected ~1.0 with ties, got {rho}"
+    );
+}
+
+#[test]
+fn spearman_zero_variance_returns_zero() {
+    let x = vec![5.0, 5.0, 5.0, 5.0];
+    let y = vec![1.0, 2.0, 3.0, 4.0];
+    assert_eq!(spearman_rank_correlation(&x, &y), 0.0);
+}
+
+#[test]
+fn spearman_no_monotonic_relationship() {
+    // U-shaped relationship: not monotonic
+    let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let y = vec![10.0, 5.0, 2.0, 1.0, 2.0, 5.0, 10.0];
+    let rho = spearman_rank_correlation(&x, &y);
+    // Should be near zero for symmetric U-shape
+    assert!(rho.abs() < 0.3, "expected near-zero for U-shape, got {rho}");
+}


### PR DESCRIPTION
## Summary

Promote `spearman_rank_correlation` and `compute_ranks` from private functions in `monotonicity.rs` to public shared functions in the `stats` module (`src/analysis/detection/stats.rs`). This follows the same pattern as Pearson correlation (Issue #767) and makes Spearman rank correlation available for future modules. Closes #775.

## Changes

- **`src/analysis/detection/stats.rs`**: Added `compute_ranks()` and `spearman_rank_correlation()` as public functions with documentation.
- **`src/analysis/detection/monotonicity.rs`**: Removed local copies of `spearman_rank_correlation` and `compute_ranks`, replaced with import from `super::stats::spearman_rank_correlation`.
- **`tests/issue_775_stats_spearman_correlation.rs`**: 14 integration tests covering edge cases.

## Evidence

This is a backend refactor with no UI changes. All tests pass and `quality.sh` passes cleanly.

## Test Plan

- `compute_ranks_empty_input` — empty slice returns empty ranks
- `compute_ranks_single_element` — single element gets rank 1.0
- `compute_ranks_sorted_values` — already sorted values get sequential ranks
- `compute_ranks_reverse_sorted` — reverse sorted values get descending ranks
- `compute_ranks_with_ties` — tied values receive average rank
- `compute_ranks_all_tied` — all equal values receive same average rank
- `spearman_empty_input_returns_zero` — empty input returns 0.0
- `spearman_single_element_returns_zero` — single element returns 0.0
- `spearman_perfect_positive` — perfectly monotonic increasing returns ~1.0
- `spearman_perfect_negative` — perfectly monotonic decreasing returns ~-1.0
- `spearman_monotonic_nonlinear` — nonlinear monotonic (x³) returns ~1.0
- `spearman_with_ties` — tied values still produce correct correlation
- `spearman_zero_variance_returns_zero` — constant input returns 0.0
- `spearman_no_monotonic_relationship` — U-shaped data returns near-zero

---

## Automated Fix Details
This PR addresses issue #775: **Promote spearman_rank_correlation to shared stats module**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #775