### PR TITLE
perf: remove HashMap used solely for iteration in weight_coherence.rs (#776)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.2"
+version = "0.52.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.3"
+version = "0.52.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-776.md
+++ b/docs/pr-summary-776.md
@@ -1,0 +1,23 @@
+## Summary
+
+Remove HashMap collections used solely for iteration in `weight_coherence.rs`. Closes #776.
+
+Two changes:
+1. **`hidden_squash` HashMap eliminated** — `detect_near_constant_paths` previously built a `HashMap<&str, &str>` mapping neuron UUID to squash function, then iterated hidden UUIDs and looked up each one. Replaced with direct iteration over `creature.neurons` filtered by `topo.hidden_uuids.contains()`, accessing the squash field directly from the neuron.
+2. **`synapses_by_target` HashMap eliminated** — `detect_symmetric_cancellation` previously built a `HashMap<&str, Vec<(&str, f32)>>` grouping synapses by target, then iterated it. Replaced with direct iteration over `topo.fan_in`, building the incoming synapses vec inline per target.
+
+Both changes avoid unnecessary hash computation during construction of collections that were only iterated.
+
+## Evidence
+
+This is a backend refactoring with no visual changes. All existing tests pass, plus 4 new tests verify the refactored functions produce correct results.
+
+## Test Plan
+
+- Added `tests/issue_776_hashset_hashmap_iteration.rs` with 4 tests:
+  - `test_near_constant_paths_detects_saturated_hidden_neuron` — verifies detection of saturated TANH neurons
+  - `test_near_constant_paths_skips_variable_neurons` — verifies neurons with sufficient variance are not flagged
+  - `test_symmetric_cancellation_detects_opposite_correlated_inputs` — verifies detection of correlated opposite-weight inputs
+  - `test_symmetric_cancellation_skips_uncorrelated_inputs` — verifies uncorrelated inputs are not flagged
+- All 16 existing weight coherence tests continue to pass
+- `quality.sh` passes cleanly

--- a/src/analysis/detection/weight_coherence.rs
+++ b/src/analysis/detection/weight_coherence.rs
@@ -271,24 +271,19 @@ pub fn detect_near_constant_paths(
         }
     };
 
-    // Build squash lookup for hidden neurons (not available in topology cache).
-    let hidden_squash: HashMap<&str, &str> = creature
-        .neurons
-        .iter()
-        .filter(|n| topo.hidden_uuids.contains(&n.uuid))
-        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
-        .collect();
-
     // Build records lookup
     let records_map: HashMap<String, &Vec<DiscoverRecord>> = records
         .iter()
         .map(|(uuid, recs)| (uuid.clone(), recs))
         .collect();
 
-    for neuron_uuid in &topo.hidden_uuids {
-        let Some(&squash) = hidden_squash.get(neuron_uuid.as_str()) else {
+    // Iterate hidden neurons directly to avoid building a separate squash lookup map.
+    for neuron in &creature.neurons {
+        if !topo.hidden_uuids.contains(&neuron.uuid) {
             continue;
-        };
+        }
+        let neuron_uuid = &neuron.uuid;
+        let squash = neuron.squash.as_str();
         let Some(neuron_records) = records_map.get(neuron_uuid) else {
             continue;
         };
@@ -388,21 +383,15 @@ pub fn detect_symmetric_cancellation(
         .map(|(uuid, recs)| (uuid.clone(), recs))
         .collect();
 
-    // Build synapses by target from topology cache: target → [(from_uuid, weight)]
-    let mut synapses_by_target: HashMap<&str, Vec<(&str, f32)>> = HashMap::new();
-    for (to_uuid, from_uuids) in &topo.fan_in {
-        for from_uuid in from_uuids {
-            if let Some(weight) = topo.synapse_weight(from_uuid, to_uuid) {
-                synapses_by_target
-                    .entry(to_uuid.as_str())
-                    .or_default()
-                    .push((from_uuid.as_str(), weight));
-            }
-        }
-    }
-
-    // Check each target neuron for symmetric cancellation
-    for (target_uuid, incoming_synapses) in &synapses_by_target {
+    // Iterate fan-in directly to avoid building a separate synapses-by-target map.
+    for (target_uuid, from_uuids) in &topo.fan_in {
+        let incoming_synapses: Vec<(&str, f32)> = from_uuids
+            .iter()
+            .filter_map(|from_uuid| {
+                topo.synapse_weight(from_uuid, target_uuid)
+                    .map(|weight| (from_uuid.as_str(), weight))
+            })
+            .collect();
         if incoming_synapses.len() < 2 {
             continue;
         }
@@ -449,7 +438,7 @@ pub fn detect_symmetric_cancellation(
                         candidates.push(SymmetricCancellationCandidate {
                             source1_neuron_uuid: source1_uuid.to_string(),
                             source2_neuron_uuid: source2_uuid.to_string(),
-                            target_neuron_uuid: target_uuid.to_string(),
+                            target_neuron_uuid: target_uuid.clone(),
                             weight1: *weight1,
                             weight2: *weight2,
                             correlation: corr,

--- a/tests/issue_776_hashset_hashmap_iteration.rs
+++ b/tests/issue_776_hashset_hashmap_iteration.rs
@@ -1,0 +1,170 @@
+//! Tests for Issue #776: Replace HashSet/HashMap used only for iteration.
+//!
+//! Verifies that weight coherence detection functions produce correct results
+//! after replacing HashMap/HashSet with Vec where collections are only iterated.
+
+mod common;
+
+use common::{make_creature, neuron, synapse};
+use neat_ai_discovery::analysis::detection::weight_coherence::{
+    WeightCoherenceConfig, detect_near_constant_paths, detect_symmetric_cancellation,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Helper to build discovery records for a neuron with specified activations.
+fn make_records(uuid: &str, activations: &[f32]) -> (String, Vec<DiscoverRecord>) {
+    let records = activations
+        .iter()
+        .enumerate()
+        .map(|(i, &activation)| DiscoverRecord {
+            obs_index: i as u32,
+            neuron_uuid: uuid.to_string(),
+            value: Some(activation),
+            activation,
+            errors: vec![0.01],
+        })
+        .collect();
+    (uuid.to_string(), records)
+}
+
+// =============================================================================
+// Test: detect_near_constant_paths produces correct results
+// =============================================================================
+
+/// Verify near-constant path detection works correctly with hidden neurons
+/// that have very low activation variance (saturated TANH).
+#[test]
+fn test_near_constant_paths_detects_saturated_hidden_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("h-saturated", "hidden", "TANH"),
+            neuron("out-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-1", "h-saturated", 100.0), // Large weight causes saturation
+            synapse("h-saturated", "out-1", 0.5),
+        ],
+    );
+
+    // Near-constant activations (saturated at ~1.0)
+    let activations: Vec<f32> = (0..50).map(|_| 0.9999).collect();
+    let records = vec![make_records("h-saturated", &activations)];
+
+    let config = WeightCoherenceConfig::default();
+    let candidates = detect_near_constant_paths(&creature, &records, &config, None);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect near-constant path for saturated neuron"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "h-saturated");
+    assert!(
+        candidates[0].activation_variance < config.min_activation_variance,
+        "Variance should be below threshold"
+    );
+    // Saturating squash (TANH) with high mean → should recommend setBias
+    assert_eq!(candidates[0].recommended_action, "setBias");
+}
+
+/// Verify that neurons with sufficient variance are NOT flagged.
+#[test]
+fn test_near_constant_paths_skips_variable_neurons() {
+    let creature = make_creature(
+        vec![
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("h-active", "hidden", "TANH"),
+            neuron("out-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-1", "h-active", 1.0),
+            synapse("h-active", "out-1", 0.5),
+        ],
+    );
+
+    // Varied activations — should NOT be flagged
+    let activations: Vec<f32> = (0..50).map(|i| (i as f32 * 0.1).sin()).collect();
+    let records = vec![make_records("h-active", &activations)];
+
+    let config = WeightCoherenceConfig::default();
+    let candidates = detect_near_constant_paths(&creature, &records, &config, None);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not flag neurons with sufficient activation variance"
+    );
+}
+
+// =============================================================================
+// Test: detect_symmetric_cancellation produces correct results
+// =============================================================================
+
+/// Verify symmetric cancellation detection finds opposite-sign, correlated inputs.
+#[test]
+fn test_symmetric_cancellation_detects_opposite_correlated_inputs() {
+    let creature = make_creature(
+        vec![
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("h-target", "hidden", "TANH"),
+            neuron("out-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-1", "h-target", 2.0),  // Positive weight
+            synapse("in-2", "h-target", -2.0), // Negative weight (opposite sign, same magnitude)
+            synapse("h-target", "out-1", 1.0),
+        ],
+    );
+
+    // Highly correlated activations for both inputs
+    let act1: Vec<f32> = (0..50).map(|i| i as f32 * 0.1).collect();
+    let act2: Vec<f32> = (0..50).map(|i| i as f32 * 0.1 + 0.01).collect(); // Nearly identical
+
+    let records = vec![make_records("in-1", &act1), make_records("in-2", &act2)];
+
+    let config = WeightCoherenceConfig::default();
+    let candidates = detect_symmetric_cancellation(&creature, &records, &config, None);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect symmetric cancellation between correlated opposite-weight inputs"
+    );
+    assert_eq!(candidates[0].target_neuron_uuid, "h-target");
+    assert!(
+        candidates[0].correlation.abs() >= config.min_correlation_for_cancellation,
+        "Correlation should exceed threshold: {}",
+        candidates[0].correlation
+    );
+}
+
+/// Verify that uncorrelated inputs are NOT flagged even with opposite weights.
+#[test]
+fn test_symmetric_cancellation_skips_uncorrelated_inputs() {
+    let creature = make_creature(
+        vec![
+            neuron("in-1", "input", "IDENTITY"),
+            neuron("in-2", "input", "IDENTITY"),
+            neuron("h-target", "hidden", "TANH"),
+            neuron("out-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("in-1", "h-target", 2.0),
+            synapse("in-2", "h-target", -2.0),
+            synapse("h-target", "out-1", 1.0),
+        ],
+    );
+
+    // Uncorrelated activations
+    let act1: Vec<f32> = (0..50).map(|i| (i as f32 * 0.7).sin()).collect();
+    let act2: Vec<f32> = (0..50).map(|i| (i as f32 * 1.3).cos()).collect();
+
+    let records = vec![make_records("in-1", &act1), make_records("in-2", &act2)];
+
+    let config = WeightCoherenceConfig::default();
+    let candidates = detect_symmetric_cancellation(&creature, &records, &config, None);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not flag uncorrelated inputs even with opposite weights"
+    );
+}


### PR DESCRIPTION
## Summary

Remove HashMap collections used solely for iteration in `weight_coherence.rs`. Closes #776.

Two changes:
1. **`hidden_squash` HashMap eliminated** — `detect_near_constant_paths` previously built a `HashMap<&str, &str>` mapping neuron UUID to squash function, then iterated hidden UUIDs and looked up each one. Replaced with direct iteration over `creature.neurons` filtered by `topo.hidden_uuids.contains()`, accessing the squash field directly from the neuron.
2. **`synapses_by_target` HashMap eliminated** — `detect_symmetric_cancellation` previously built a `HashMap<&str, Vec<(&str, f32)>>` grouping synapses by target, then iterated it. Replaced with direct iteration over `topo.fan_in`, building the incoming synapses vec inline per target.

Both changes avoid unnecessary hash computation during construction of collections that were only iterated.

## Evidence

This is a backend refactoring with no visual changes. All existing tests pass, plus 4 new tests verify the refactored functions produce correct results.

## Test Plan

- Added `tests/issue_776_hashset_hashmap_iteration.rs` with 4 tests:
  - `test_near_constant_paths_detects_saturated_hidden_neuron` — verifies detection of saturated TANH neurons
  - `test_near_constant_paths_skips_variable_neurons` — verifies neurons with sufficient variance are not flagged
  - `test_symmetric_cancellation_detects_opposite_correlated_inputs` — verifies detection of correlated opposite-weight inputs
  - `test_symmetric_cancellation_skips_uncorrelated_inputs` — verifies uncorrelated inputs are not flagged
- All 16 existing weight coherence tests continue to pass
- `quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #776: **Fix HashSet/HashMap used only for iteration in weight_coherence.rs**

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #776