### PR TITLE
feat: improve add-neurons prediction accuracy (#791)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.6"
+version = "0.52.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.5"
+version = "0.52.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-791.md
+++ b/docs/pr-summary-791.md
@@ -1,0 +1,39 @@
+## Summary
+
+Improve add-neurons prediction accuracy by implementing two complementary improvements from Issue #791:
+
+1. **Neuron-specific pessimism calibration** — The generic pessimism discount (floor=0.15, exponent=0.6) treats neuron and synapse candidates identically, but GRQ-sampler data shows add-neurons has a 15% success rate (3,812/25,812) vs higher synapse rates. New neuron-specific constants (floor=0.10, exponent=0.75) apply more aggressive discounting: ~28% more aggressive at low ratios, ~13% at moderate ratios.
+
+2. **Cross-validation brittleness filtering** — Integrates the existing cross-validation infrastructure (from `scoring/cross_validation.rs`) into the neuron evaluation pipeline. Candidates are now evaluated across k-fold sample subsets; those showing inconsistent improvement across folds receive a brittleness penalty that reduces their expected score gain. This filters candidates that overfit to specific data subsets.
+
+Closes #791.
+
+## Evidence
+
+### Neuron-specific pessimism discount values
+
+| Improved ratio | Synapse discount | Neuron discount | Reduction |
+|---------------|-----------------|-----------------|-----------|
+| 10%           | 0.363           | 0.260           | 28%       |
+| 40%           | 0.639           | 0.555           | 13%       |
+| 70%           | 0.832           | 0.770           | 7%        |
+| 100%          | 1.000           | 1.000           | 0%        |
+
+### Cross-validation integration
+
+The cross-validation brittleness penalty is applied during GPU evaluation of neuron candidates (in `evaluation.rs`). Candidates with high variance across folds receive a penalty factor of up to 0.5 (50% reduction), filtering out overfitting candidates before they reach post-processing.
+
+## Test Plan
+
+Added `tests/issue_791_improve_add_neurons_prediction.rs` with 11 tests:
+- `neuron_pessimism_floor_more_aggressive_than_synapse` — Validates neuron floor < synapse floor
+- `neuron_pessimism_exponent_less_forgiving_than_synapse` — Validates neuron exponent > synapse exponent
+- `neuron_pessimism_constants_in_valid_ranges` — Compile-time range validation
+- `neuron_pessimism_more_aggressive_at_all_moderate_ratios` — Neuron discount <= synapse discount at all ratios 5–95%
+- `neuron_pessimism_full_ratio_gives_full_gain` — 100% ratio gives full gain
+- `neuron_pessimism_monotonically_increasing` — Monotonicity invariant
+- `neuron_pessimism_zero_total_gives_floor` — Edge case: zero total
+- `neuron_pessimism_practical_difference` — Meaningful reduction at typical 45% ratio
+- `cross_validation_penalises_brittle_neuron_candidates` — Brittle samples get penalty > 0
+- `cross_validation_does_not_penalise_consistent_candidates` — Consistent samples get low penalty
+- `cross_validation_skips_with_insufficient_samples` — Graceful skip with too few samples

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -254,6 +254,45 @@ pub const PESSIMISM_DISCOUNT_FLOOR: f32 = 0.15;
 pub const PESSIMISM_CURVE_EXPONENT: f32 = 0.6;
 
 // =============================================================================
+// Neuron-Specific Pessimism Discount (Issue #791)
+// =============================================================================
+
+/// Minimum pessimism discount floor for neuron candidates (Issue #791).
+///
+/// GRQ-sampler analysis (Issue #787) shows add-neurons has a 15% success rate
+/// (3,812 / 25,812) — substantially lower than synapse candidates. The generic
+/// pessimism parameters (PESSIMISM_DISCOUNT_FLOOR = 0.15, PESSIMISM_CURVE_EXPONENT
+/// = 0.6) are calibrated for the overall candidate pool and are too generous for
+/// neuron candidates specifically.
+///
+/// A lower floor applies more aggressive base discounting to neuron predictions,
+/// reducing the expected gain for candidates with few samples improving.
+///
+/// ## Valid Range
+/// Must be in (0.0, PESSIMISM_DISCOUNT_FLOOR). Values below 0.05 risk
+/// zeroing-out legitimate neuron candidates.
+pub const NEURON_PESSIMISM_DISCOUNT_FLOOR: f32 = 0.10;
+
+/// Exponent for the neuron-specific pessimism discount curve (Issue #791).
+///
+/// A higher exponent (closer to linear) produces a less forgiving curve at
+/// moderate ratios compared to the generic exponent (0.6). This is appropriate
+/// for neuron candidates because their 15% success rate suggests moderate
+/// improved ratios (30–60%) are less reliable predictors of actual success
+/// than they are for synapse candidates.
+///
+/// With exponent 0.75 and floor 0.10 (discount = 0.10 + 0.90 × ratio^0.75):
+/// - ratio 0.1 → 0.1^0.75 ≈ 0.178 → discount ≈ 0.260
+/// - ratio 0.4 → 0.4^0.75 ≈ 0.506 → discount ≈ 0.555
+/// - ratio 0.7 → 0.7^0.75 ≈ 0.744 → discount ≈ 0.770
+/// - ratio 1.0 → 1.0       → discount = 1.000
+///
+/// ## Valid Range
+/// Must be in (PESSIMISM_CURVE_EXPONENT, 1.0]. Values above 0.9 give
+/// near-linear behaviour.
+pub const NEURON_PESSIMISM_CURVE_EXPONENT: f32 = 0.75;
+
+// =============================================================================
 // NaN-safe Floating-Point Comparison Helpers (Issue #483)
 // =============================================================================
 

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -12,6 +12,9 @@ use std::time::SystemTime;
 use crate::analysis::diagnostics::NeuronDiagnostics;
 use crate::analysis::gpu::GpuWorkQueue;
 use crate::analysis::samples::{EPSILON, HelpfulSample, compute_source_variance_discount};
+use crate::analysis::scoring::cross_validation::{
+    CrossValidationConfig, compute_cross_validation_score,
+};
 use crate::analysis::shared::TimingScope;
 use crate::analysis::utils::{deadline_passed, lock_or_bail, verbose_enabled};
 
@@ -136,6 +139,9 @@ fn evaluate_relu_split(
             candidate.expected_creature_error_reduction *= source_variance_discount;
             candidate.expected_creature_score_gain *= source_variance_discount;
 
+            // Issue #791: Apply cross-validation brittleness penalty
+            apply_cross_validation_penalty(&mut candidate, samples);
+
             if verbose_enabled() {
                 tracing::trace!(
                     direction = "push UP",
@@ -169,6 +175,9 @@ fn evaluate_relu_split(
             // Issue #130: Apply source variance discount
             candidate.expected_creature_error_reduction *= source_variance_discount;
             candidate.expected_creature_score_gain *= source_variance_discount;
+
+            // Issue #791: Apply cross-validation brittleness penalty
+            apply_cross_validation_penalty(&mut candidate, samples);
 
             if verbose_enabled() {
                 tracing::trace!(
@@ -220,6 +229,9 @@ fn evaluate_activation_specs(
         candidate.expected_creature_error_reduction *= source_variance_discount;
         candidate.expected_creature_score_gain *= source_variance_discount;
 
+        // Issue #791: Apply cross-validation brittleness penalty
+        apply_cross_validation_penalty(&mut candidate, samples);
+
         ctx.diagnostics.mark_candidate_selected(target_uuid);
         let mut map = lock_or_bail(ctx.helpful_map, "helpful_map")?;
         upsert_candidate(&mut map, candidate);
@@ -240,4 +252,34 @@ fn passes_neuron_improved_ratio(candidate: &CandidateNeuronJson) -> bool {
     }
     let improved_ratio = candidate.improved_count as f32 / candidate.total_count as f32;
     improved_ratio >= NEURON_MIN_IMPROVED_RATIO
+}
+
+/// Issue #791: Apply cross-validation brittleness penalty to a neuron candidate.
+///
+/// Splits the samples into k folds and checks whether the candidate's improvement
+/// is consistent across all subsets. Candidates that only improve on specific data
+/// subsets are penalised, reducing their expected score gain.
+///
+/// This addresses the 15% success rate for add-neurons by filtering candidates
+/// that overfit to noise in the discovery samples.
+fn apply_cross_validation_penalty(candidate: &mut CandidateNeuronJson, samples: &[HelpfulSample]) {
+    let config = CrossValidationConfig::default();
+    if let Some(cv_result) = compute_cross_validation_score(samples, &config)
+        && cv_result.brittleness_penalty > 0.0
+    {
+        let penalty_factor = 1.0 - cv_result.brittleness_penalty;
+        candidate.expected_creature_error_reduction *= penalty_factor;
+        candidate.expected_creature_score_gain *= penalty_factor;
+
+        if verbose_enabled() {
+            tracing::trace!(
+                source_uuid = %candidate.source_neuron_uuid,
+                target_uuid = %candidate.target_neuron_uuid,
+                penalty = format_args!("{:.4}", cv_result.brittleness_penalty),
+                variance = format_args!("{:.6}", cv_result.variance.variance),
+                mean_ratio = format_args!("{:.3}", cv_result.variance.mean_improvement_ratio),
+                "Neuron candidate cross-validation brittleness penalty applied"
+            );
+        }
+    }
 }

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -12,7 +12,7 @@ use crate::analysis::cache::RecordCache;
 use crate::analysis::diagnostics::{NeuronDiagnostics, compute_impact_scores_for_discounting};
 use crate::analysis::gpu::GpuAnalyzer;
 use crate::analysis::shared::AnalyzeNeuronsResult;
-use crate::analysis::synapse::apply_pessimism_discount;
+use crate::analysis::synapse::apply_neuron_pessimism_discount;
 use crate::analysis::utils::{
     lock_or_bail, log_analysis_timeout, shuffle_within_top_k, verbose_enabled,
 };
@@ -171,8 +171,10 @@ fn apply_impact_discounting(
         candidate.expected_creature_error_reduction *= impact;
         candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
 
-        // Issue #506: Apply pessimism discount based on improved sample ratio.
-        candidate.expected_creature_score_gain = apply_pessimism_discount(
+        // Issue #791: Apply neuron-specific pessimism discount based on improved sample ratio.
+        // Neuron candidates have a 15% success rate (vs higher synapse rates), so they
+        // use more aggressive discounting parameters (lower floor, higher exponent).
+        candidate.expected_creature_score_gain = apply_neuron_pessimism_discount(
             candidate.expected_creature_score_gain,
             candidate.improved_count,
             candidate.total_count,

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -38,7 +38,10 @@ mod structural_patterns;
 mod target_analysis;
 
 // Re-export items used by code outside this module (analysis/mod.rs, neuron.rs, implementation_tests).
-pub use scoring::{apply_pessimism_discount, apply_source_type_boost, apply_target_type_boost};
+pub use scoring::{
+    apply_neuron_pessimism_discount, apply_pessimism_discount, apply_source_type_boost,
+    apply_target_type_boost,
+};
 
 pub(crate) use candidate_generation::{
     MIN_GROUP_SIZE_FOR_LOCALITY, build_ordered_neurons, build_samples_for_locality_group,

--- a/src/analysis/synapse/scoring.rs
+++ b/src/analysis/synapse/scoring.rs
@@ -13,8 +13,8 @@ use std::collections::HashMap;
 
 // Boosting and discount constants
 use crate::analysis::constants::{
-    EXISTING_HIDDEN_TARGET_BOOST, INPUT_SOURCE_BOOST, PESSIMISM_CURVE_EXPONENT,
-    PESSIMISM_DISCOUNT_FLOOR,
+    EXISTING_HIDDEN_TARGET_BOOST, INPUT_SOURCE_BOOST, NEURON_PESSIMISM_CURVE_EXPONENT,
+    NEURON_PESSIMISM_DISCOUNT_FLOOR, PESSIMISM_CURVE_EXPONENT, PESSIMISM_DISCOUNT_FLOOR,
 };
 
 // =============================================================================
@@ -602,6 +602,35 @@ pub fn apply_pessimism_discount(gain: f32, improved_count: u32, total_count: u32
     let improved_ratio = improved_count as f32 / total_count as f32;
     let adjusted_ratio = improved_ratio.powf(PESSIMISM_CURVE_EXPONENT);
     let discount = PESSIMISM_DISCOUNT_FLOOR + (1.0 - PESSIMISM_DISCOUNT_FLOOR) * adjusted_ratio;
+    gain * discount
+}
+
+/// Apply a neuron-specific pessimism discount to an expected score gain (Issue #791).
+///
+/// GRQ-sampler analysis shows add-neurons has a 15% success rate (3,812 / 25,812),
+/// indicating the generic pessimism parameters are too generous for neuron candidates.
+/// This function uses neuron-calibrated constants that apply more aggressive
+/// discounting:
+///
+/// - Lower floor (0.10 vs 0.15): stronger base discount at low ratios
+/// - Higher exponent (0.75 vs 0.6): less forgiving at moderate ratios
+///
+/// ## Formula
+///
+/// ```text
+/// improved_ratio = improved_count / total_count
+/// adjusted_ratio = improved_ratio ^ NEURON_PESSIMISM_CURVE_EXPONENT
+/// discount = NEURON_PESSIMISM_DISCOUNT_FLOOR + (1 - NEURON_PESSIMISM_DISCOUNT_FLOOR) × adjusted_ratio
+/// result = gain × discount
+/// ```
+pub fn apply_neuron_pessimism_discount(gain: f32, improved_count: u32, total_count: u32) -> f32 {
+    if total_count == 0 {
+        return gain * NEURON_PESSIMISM_DISCOUNT_FLOOR;
+    }
+    let improved_ratio = improved_count as f32 / total_count as f32;
+    let adjusted_ratio = improved_ratio.powf(NEURON_PESSIMISM_CURVE_EXPONENT);
+    let discount =
+        NEURON_PESSIMISM_DISCOUNT_FLOOR + (1.0 - NEURON_PESSIMISM_DISCOUNT_FLOOR) * adjusted_ratio;
     gain * discount
 }
 

--- a/tests/issue_791_improve_add_neurons_prediction.rs
+++ b/tests/issue_791_improve_add_neurons_prediction.rs
@@ -1,0 +1,248 @@
+//! Issue #791: Improve add-neurons prediction accuracy (15% success rate)
+//!
+//! Tests for:
+//! 1. Neuron-specific pessimism calibration (more aggressive than synapse)
+//! 2. Cross-validation brittleness filtering for neuron candidates
+
+mod common;
+
+use neat_ai_discovery::analysis::constants::{
+    NEURON_PESSIMISM_CURVE_EXPONENT, NEURON_PESSIMISM_DISCOUNT_FLOOR, PESSIMISM_CURVE_EXPONENT,
+    PESSIMISM_DISCOUNT_FLOOR,
+};
+use neat_ai_discovery::analysis::synapse::{
+    apply_neuron_pessimism_discount, apply_pessimism_discount,
+};
+
+use neat_ai_discovery::analysis::scoring::cross_validation::{
+    CrossValidationConfig, compute_cross_validation_score,
+};
+
+// =============================================================================
+// Neuron-specific pessimism constants (Issue #791)
+// =============================================================================
+
+/// Issue #791: Neuron-specific pessimism floor should be lower than the synapse
+/// floor, applying more aggressive base discounting given the 15% success rate.
+#[test]
+fn neuron_pessimism_floor_more_aggressive_than_synapse() {
+    const {
+        assert!(NEURON_PESSIMISM_DISCOUNT_FLOOR < PESSIMISM_DISCOUNT_FLOOR);
+    }
+}
+
+/// Issue #791: Neuron-specific pessimism exponent should be higher than the synapse
+/// exponent, making the curve less forgiving at moderate ratios.
+#[test]
+fn neuron_pessimism_exponent_less_forgiving_than_synapse() {
+    const {
+        assert!(NEURON_PESSIMISM_CURVE_EXPONENT > PESSIMISM_CURVE_EXPONENT);
+    }
+}
+
+/// Issue #791: Both neuron pessimism constants should be within valid ranges.
+#[test]
+fn neuron_pessimism_constants_in_valid_ranges() {
+    const {
+        assert!(NEURON_PESSIMISM_DISCOUNT_FLOOR > 0.0);
+        assert!(NEURON_PESSIMISM_DISCOUNT_FLOOR < 0.5);
+        assert!(NEURON_PESSIMISM_CURVE_EXPONENT > 0.0);
+        assert!(NEURON_PESSIMISM_CURVE_EXPONENT <= 1.0);
+    }
+}
+
+// =============================================================================
+// Neuron-specific pessimism discount function (Issue #791)
+// =============================================================================
+
+/// Issue #791: Neuron pessimism discount should be more aggressive than synapse
+/// pessimism at all improved ratios between 0% and 100% (exclusive).
+#[test]
+fn neuron_pessimism_more_aggressive_at_all_moderate_ratios() {
+    let gain = 0.10;
+
+    // Test at various ratios from 5% to 95%
+    for improved in (5..=95).step_by(5) {
+        let synapse_result = apply_pessimism_discount(gain, improved, 100);
+        let neuron_result = apply_neuron_pessimism_discount(gain, improved, 100);
+
+        assert!(
+            neuron_result <= synapse_result,
+            "Issue #791: Neuron pessimism at {improved}% should be <= synapse pessimism. \
+             Neuron={neuron_result:.6}, Synapse={synapse_result:.6}"
+        );
+    }
+}
+
+/// Issue #791: Neuron pessimism discount should still give full gain at 100% ratio.
+#[test]
+fn neuron_pessimism_full_ratio_gives_full_gain() {
+    let gain = 0.10;
+    let result = apply_neuron_pessimism_discount(gain, 100, 100);
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Issue #791: All samples improved should give full gain: expected {gain}, got {result}"
+    );
+}
+
+/// Issue #791: Neuron pessimism should be monotonically non-decreasing.
+#[test]
+fn neuron_pessimism_monotonically_increasing() {
+    let gain = 0.10;
+    let mut prev = apply_neuron_pessimism_discount(gain, 0, 100);
+    for improved in (5..=100).step_by(5) {
+        let current = apply_neuron_pessimism_discount(gain, improved, 100);
+        assert!(
+            current >= prev - 1e-7,
+            "Issue #791: Neuron discount should be monotonically non-decreasing: \
+             at {improved}/100, got {current:.6} < previous {prev:.6}"
+        );
+        prev = current;
+    }
+}
+
+/// Issue #791: Zero total should give floor discount.
+#[test]
+fn neuron_pessimism_zero_total_gives_floor() {
+    let gain = 0.10;
+    let result = apply_neuron_pessimism_discount(gain, 0, 0);
+    let expected = gain * NEURON_PESSIMISM_DISCOUNT_FLOOR;
+    assert!(
+        (result - expected).abs() < 1e-6,
+        "Issue #791: Zero total should give floor discount: expected {expected}, got {result}"
+    );
+}
+
+/// Issue #791: Typical add-neuron candidate at 45% ratio should get a lower
+/// score with neuron-specific pessimism than with generic pessimism.
+#[test]
+fn neuron_pessimism_practical_difference() {
+    let gain = 0.02; // Typical small add-neuron gain
+
+    let synapse_discounted = apply_pessimism_discount(gain, 45, 100);
+    let neuron_discounted = apply_neuron_pessimism_discount(gain, 45, 100);
+
+    assert!(
+        neuron_discounted < synapse_discounted,
+        "Issue #791: Neuron-specific discount at 45% ratio should be lower. \
+         Neuron={neuron_discounted:.6}, Synapse={synapse_discounted:.6}"
+    );
+
+    // The difference should be meaningful (at least 5%)
+    let reduction_pct = (synapse_discounted - neuron_discounted) / synapse_discounted * 100.0;
+    assert!(
+        reduction_pct > 5.0,
+        "Issue #791: Neuron discount reduction should be at least 5%. Got {reduction_pct:.1}%"
+    );
+}
+
+// =============================================================================
+// Cross-validation filtering for neuron candidates (Issue #791)
+// =============================================================================
+
+/// Issue #791: Cross-validation should detect brittle candidates that perform
+/// inconsistently across sample subsets.
+#[test]
+fn cross_validation_penalises_brittle_neuron_candidates() {
+    use neat_ai_discovery::analysis::samples::HelpfulSample;
+
+    // Create brittle samples: first half has strong signal, second half has none.
+    // This mimics a candidate that overfits to a specific data subset.
+    let mut samples = Vec::new();
+    for i in 0..100 {
+        if i < 50 {
+            // Strong positive correlation in first half
+            samples.push(HelpfulSample {
+                activation: i as f32 * 0.02,
+                avg_error: i as f32 * 0.01,
+                target_value: None,
+                target_activation: None,
+            });
+        } else {
+            // No meaningful correlation in second half
+            samples.push(HelpfulSample {
+                activation: 0.5,
+                avg_error: if i % 2 == 0 { 0.1 } else { -0.1 },
+                target_value: None,
+                target_activation: None,
+            });
+        }
+    }
+
+    let config = CrossValidationConfig::default();
+    let result = compute_cross_validation_score(&samples, &config);
+
+    assert!(
+        result.is_some(),
+        "Should have enough samples for cross-validation"
+    );
+    let cv_result = result.unwrap();
+
+    // Brittle candidates should have a non-zero penalty
+    assert!(
+        cv_result.brittleness_penalty > 0.0,
+        "Issue #791: Brittle candidate should receive a penalty. Got {:.4}",
+        cv_result.brittleness_penalty
+    );
+}
+
+/// Issue #791: Cross-validation should not penalise consistent candidates
+/// that perform well across all sample subsets.
+#[test]
+fn cross_validation_does_not_penalise_consistent_candidates() {
+    use neat_ai_discovery::analysis::samples::HelpfulSample;
+
+    // Create consistent samples: strong correlation throughout
+    let mut samples = Vec::new();
+    for i in 0..100 {
+        let activation = (i as f32) * 0.01;
+        let error = activation * 0.5 + 0.01; // Consistent linear relationship
+        samples.push(HelpfulSample {
+            activation,
+            avg_error: error,
+            target_value: None,
+            target_activation: None,
+        });
+    }
+
+    let config = CrossValidationConfig::default();
+    let result = compute_cross_validation_score(&samples, &config);
+
+    assert!(
+        result.is_some(),
+        "Should have enough samples for cross-validation"
+    );
+    let cv_result = result.unwrap();
+
+    // Consistent candidates should have low or zero penalty
+    assert!(
+        cv_result.brittleness_penalty < 0.1,
+        "Issue #791: Consistent candidate should have low penalty. Got {:.4}",
+        cv_result.brittleness_penalty
+    );
+}
+
+/// Issue #791: Cross-validation should skip gracefully when there are too
+/// few samples for meaningful fold evaluation.
+#[test]
+fn cross_validation_skips_with_insufficient_samples() {
+    use neat_ai_discovery::analysis::samples::HelpfulSample;
+
+    // Only 10 samples — not enough for 5-fold CV with min 15 per fold
+    let samples: Vec<HelpfulSample> = (0..10)
+        .map(|i| HelpfulSample {
+            activation: i as f32 * 0.1,
+            avg_error: 0.05,
+            target_value: None,
+            target_activation: None,
+        })
+        .collect();
+
+    let config = CrossValidationConfig::default();
+    let result = compute_cross_validation_score(&samples, &config);
+
+    assert!(
+        result.is_none(),
+        "Issue #791: Should return None with insufficient samples"
+    );
+}


### PR DESCRIPTION
## Summary

Improve add-neurons prediction accuracy by implementing two complementary improvements from Issue #791:

1. **Neuron-specific pessimism calibration** — The generic pessimism discount (floor=0.15, exponent=0.6) treats neuron and synapse candidates identically, but GRQ-sampler data shows add-neurons has a 15% success rate (3,812/25,812) vs higher synapse rates. New neuron-specific constants (floor=0.10, exponent=0.75) apply more aggressive discounting: ~28% more aggressive at low ratios, ~13% at moderate ratios.

2. **Cross-validation brittleness filtering** — Integrates the existing cross-validation infrastructure (from `scoring/cross_validation.rs`) into the neuron evaluation pipeline. Candidates are now evaluated across k-fold sample subsets; those showing inconsistent improvement across folds receive a brittleness penalty that reduces their expected score gain. This filters candidates that overfit to specific data subsets.

Closes #791.

## Evidence

### Neuron-specific pessimism discount values

| Improved ratio | Synapse discount | Neuron discount | Reduction |
|---------------|-----------------|-----------------|-----------|
| 10%           | 0.363           | 0.260           | 28%       |
| 40%           | 0.639           | 0.555           | 13%       |
| 70%           | 0.832           | 0.770           | 7%        |
| 100%          | 1.000           | 1.000           | 0%        |

### Cross-validation integration

The cross-validation brittleness penalty is applied during GPU evaluation of neuron candidates (in `evaluation.rs`). Candidates with high variance across folds receive a penalty factor of up to 0.5 (50% reduction), filtering out overfitting candidates before they reach post-processing.

## Test Plan

Added `tests/issue_791_improve_add_neurons_prediction.rs` with 11 tests:
- `neuron_pessimism_floor_more_aggressive_than_synapse` — Validates neuron floor < synapse floor
- `neuron_pessimism_exponent_less_forgiving_than_synapse` — Validates neuron exponent > synapse exponent
- `neuron_pessimism_constants_in_valid_ranges` — Compile-time range validation
- `neuron_pessimism_more_aggressive_at_all_moderate_ratios` — Neuron discount <= synapse discount at all ratios 5–95%
- `neuron_pessimism_full_ratio_gives_full_gain` — 100% ratio gives full gain
- `neuron_pessimism_monotonically_increasing` — Monotonicity invariant
- `neuron_pessimism_zero_total_gives_floor` — Edge case: zero total
- `neuron_pessimism_practical_difference` — Meaningful reduction at typical 45% ratio
- `cross_validation_penalises_brittle_neuron_candidates` — Brittle samples get penalty > 0
- `cross_validation_does_not_penalise_consistent_candidates` — Consistent samples get low penalty
- `cross_validation_skips_with_insufficient_samples` — Graceful skip with too few samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)