### PR TITLE
feat: add high-error squash exploration to increase change-squash volume (#788)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.7"
+version = "0.52.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.52.8"
+version = "0.53.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-788.md
+++ b/docs/pr-summary-788.md
@@ -1,0 +1,48 @@
+## Summary
+
+Add a new **high-error squash exploration** detection module that proactively
+suggests alternative activation functions for hidden neurons with high prediction
+error. This increases change-squash candidate volume — the highest success-rate
+candidate type (65%) — by triggering on error magnitude rather than waiting for
+structural problems like saturation or mismatch. Closes #788.
+
+## Approach
+
+The module (`src/analysis/detection/high_error_squash_exploration.rs`) works by:
+
+1. For each hidden neuron with pre-activation data and mean absolute error
+   above a threshold (0.10), infer the target output as `activation + error`.
+2. Simulate each candidate activation function (TANH, LOGISTIC, IDENTITY,
+   SOFTSIGN, HARD_TANH, RELU, ELU, SELU, MISH, SWISH) on the pre-activation
+   values.
+3. If an alternative reduces mean absolute error by at least 15% versus the
+   current activation, recommend it as a `ChangeSquash` coordinated candidate.
+
+Conservative thresholds (15% error reduction minimum, 0.01 improvement scaling)
+are designed to maintain a high success rate (target: >30%).
+
+## Evidence
+
+- 9 integration tests covering all edge cases (detection, non-detection,
+  conversion, multi-neuron, skip conditions)
+- 3 unit tests for internal logic
+- Module count test updated from 43 to 44
+- `quality.sh` passes cleanly (fmt, clippy, check, tests, docs, release build)
+
+## Test Plan
+
+- `tests/issue_788_high_error_squash_exploration.rs` (9 integration tests):
+  - `high_error_neuron_with_pre_activation_data_triggers_exploration`
+  - `low_error_neuron_not_detected`
+  - `neuron_without_pre_activation_skipped`
+  - `insufficient_samples_returns_empty`
+  - `identity_neurons_skipped`
+  - `does_not_recommend_same_squash`
+  - `candidates_convert_to_coordinated_candidates`
+  - `multiple_high_error_neurons_detected`
+  - `neuron_without_records_returns_empty`
+- `src/analysis/detection/high_error_squash_exploration.rs` (3 unit tests):
+  - `test_is_skip_squash`
+  - `test_high_error_triggers_detection`
+  - `test_low_error_skips`
+- `src/analysis/module_dispatch_specs/mod.rs` module count assertion updated

--- a/src/analysis/detection/high_error_squash_exploration.rs
+++ b/src/analysis/detection/high_error_squash_exploration.rs
@@ -1,0 +1,329 @@
+//! High-error squash exploration detection module (Issue #788).
+//!
+//! Proactively explores alternative activation functions for hidden neurons
+//! that exhibit high prediction error. Unlike reactive modules (saturation,
+//! mismatch), this module triggers on **error magnitude** — if a neuron's
+//! mean absolute error is above a threshold, it simulates what each candidate
+//! activation function would produce from the neuron's pre-activation values
+//! and recommends the one that best reduces error.
+//!
+//! This increases change-squash candidate volume for the high-success-rate
+//! change-squash candidate type (65% success rate in GRQ-sampler analysis).
+//!
+//! ## Detection Criteria
+//!
+//! - Pre-activation (`value`) data available for ≥ `MIN_SAMPLES` records
+//! - Mean absolute error ≥ `MIN_MEAN_ERROR_THRESHOLD`
+//! - At least one alternative activation function reduces error by ≥
+//!   `MIN_ERROR_REDUCTION_FRACTION` relative to the current activation
+//! - The neuron's current activation is not IDENTITY (already linear)
+
+use crate::activations::apply_scalar_squash;
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Minimum mean absolute error required to consider a neuron for exploration.
+///
+/// Neurons with error below this threshold are performing well enough that
+/// changing the activation function is unlikely to yield meaningful improvement.
+const MIN_MEAN_ERROR_THRESHOLD: f32 = 0.10;
+
+/// Minimum relative error reduction to recommend a squash replacement.
+///
+/// The alternative must reduce mean absolute error by at least this fraction
+/// compared to the current activation. Set conservatively to maintain a high
+/// success rate (target: >30%).
+const MIN_ERROR_REDUCTION_FRACTION: f32 = 0.15;
+
+/// Candidate squash functions to evaluate as replacements.
+const CANDIDATE_SQUASHES: &[&str] = &[
+    "TANH",
+    "LOGISTIC",
+    "IDENTITY",
+    "SOFTSIGN",
+    "HARD_TANH",
+    "RELU",
+    "ELU",
+    "SELU",
+    "MISH",
+    "SWISH",
+];
+
+/// Squash functions that should not trigger this module (already flexible).
+fn is_skip_squash(squash: &str) -> bool {
+    matches!(squash, "IDENTITY")
+}
+
+/// Result of detecting a high-error squash exploration candidate.
+#[derive(Debug, Clone)]
+pub struct HighErrorSquashCandidate {
+    /// UUID of the neuron.
+    pub neuron_uuid: String,
+    /// Current activation function.
+    pub current_squash: String,
+    /// Recommended replacement activation function.
+    pub recommended_squash: Option<String>,
+    /// Mean absolute error of the neuron with its current activation.
+    pub mean_absolute_error: f32,
+    /// Fraction of error reduction achieved by the recommended activation.
+    pub error_reduction_fraction: f32,
+    /// Estimated improvement from switching activation.
+    pub estimated_improvement: f32,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// Detect neurons with high prediction error that could benefit from a
+/// different activation function.
+///
+/// For each neuron with sufficient pre-activation data and high error, this
+/// function simulates every candidate activation function and selects the
+/// one that most reduces the mean absolute error.
+///
+/// # Arguments
+/// * `neurons` - List of `(uuid, squash, bias)` tuples for hidden neurons.
+/// * `neuron_records` - List of `(uuid, records)` tuples with recorded samples.
+///
+/// # Returns
+/// A list of `HighErrorSquashCandidate` sorted by estimated improvement
+/// (descending).
+pub fn detect_high_error_squash_candidates(
+    neurons: &[(String, String, f32)],
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<HighErrorSquashCandidate> {
+    let records_map: std::collections::HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for (uuid, squash, _bias) in neurons {
+        if is_skip_squash(squash) {
+            continue;
+        }
+
+        let Some(records) = records_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        if records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        if let Some(candidate) = evaluate_neuron(uuid, squash, records) {
+            candidates.push(candidate);
+        }
+    }
+
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
+}
+
+/// Evaluate a single neuron for high-error squash exploration.
+///
+/// Uses inferred targets: for each sample, `target = activation + error`,
+/// representing what the neuron should be outputting. The current squash's
+/// MAE against this target equals the mean absolute error. We then check
+/// whether an alternative squash applied to the same pre-activation values
+/// would get closer to the target.
+fn evaluate_neuron(
+    uuid: &str,
+    current_squash: &str,
+    records: &[DiscoverRecord],
+) -> Option<HighErrorSquashCandidate> {
+    // Collect samples with pre-activation values, errors, and inferred targets
+    let samples: Vec<(f32, f32)> = records
+        .iter()
+        .filter_map(|r| {
+            let pre_act = r.value?;
+            let error = r.errors.first().copied().unwrap_or(0.0);
+            let target = r.activation + error;
+            Some((pre_act, target))
+        })
+        .collect();
+
+    if samples.len() < MIN_SAMPLES {
+        return None;
+    }
+
+    // The current activation's MAE equals the mean absolute error
+    // (since target = activation + error, |activation - target| = |error|)
+    let current_mae = compute_mae_for_squash(current_squash, &samples);
+
+    if current_mae < MIN_MEAN_ERROR_THRESHOLD {
+        return None;
+    }
+
+    // Try each candidate squash and find the best improvement
+    let mut best_squash: Option<&str> = None;
+    let mut best_mae = current_mae;
+
+    for &candidate_name in CANDIDATE_SQUASHES {
+        if candidate_name.eq_ignore_ascii_case(current_squash) {
+            continue;
+        }
+
+        let candidate_mae = compute_mae_for_squash(candidate_name, &samples);
+
+        if candidate_mae < best_mae {
+            best_mae = candidate_mae;
+            best_squash = Some(candidate_name);
+        }
+    }
+
+    let best_squash = best_squash?;
+
+    let reduction_fraction = (current_mae - best_mae) / current_mae;
+    if reduction_fraction < MIN_ERROR_REDUCTION_FRACTION {
+        return None;
+    }
+
+    // Scale improvement conservatively to maintain high success rate
+    let estimated_improvement = reduction_fraction * current_mae * 0.01;
+
+    Some(HighErrorSquashCandidate {
+        neuron_uuid: uuid.to_string(),
+        current_squash: current_squash.to_string(),
+        recommended_squash: Some(best_squash.to_string()),
+        mean_absolute_error: current_mae,
+        error_reduction_fraction: reduction_fraction,
+        estimated_improvement,
+        reason: format!(
+            "High error neuron (MAE={:.3}) — {} reduces simulated error by {:.0}% vs {}",
+            current_mae,
+            best_squash,
+            reduction_fraction * 100.0,
+            current_squash,
+        ),
+    })
+}
+
+/// Compute mean absolute error for a given squash function applied to
+/// pre-activation values, compared against inferred targets.
+///
+/// Each sample is `(pre_activation, target)` where
+/// `target = observed_activation + error`. The MAE measures how far
+/// `apply_squash(pre_act)` is from the inferred target.
+fn compute_mae_for_squash(squash: &str, samples: &[(f32, f32)]) -> f32 {
+    let mut total_error = 0.0f32;
+    let mut valid_count = 0usize;
+
+    for &(pre_act, target) in samples {
+        let Some(simulated) = apply_scalar_squash(squash, pre_act) else {
+            continue;
+        };
+
+        if !simulated.is_finite() {
+            continue;
+        }
+
+        total_error += (simulated - target).abs();
+        valid_count += 1;
+    }
+
+    if valid_count < MIN_SAMPLES {
+        return f32::INFINITY;
+    }
+
+    total_error / valid_count as f32
+}
+
+/// Convert high-error squash exploration candidates to coordinated structural
+/// candidates.
+///
+/// Each candidate becomes a single `ChangeSquash` operation.
+pub fn high_error_squash_to_coordinated_candidates(
+    candidates: &[HighErrorSquashCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    candidates
+        .iter()
+        .filter_map(|c| {
+            let recommended = c.recommended_squash.as_ref()?;
+
+            Some(CoordinatedStructuralCandidateJson {
+                operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                    neuron_uuid: c.neuron_uuid.clone(),
+                    squash: recommended.clone(),
+                }],
+                expected_creature_score_gain: c.estimated_improvement,
+                comment: Some(format!(
+                    "High-error squash exploration (Issue #788): {} → {}. {}",
+                    c.current_squash, recommended, c.reason,
+                )),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_record(
+        uuid: &str,
+        idx: u32,
+        value: Option<f32>,
+        activation: f32,
+        error: f32,
+    ) -> DiscoverRecord {
+        DiscoverRecord {
+            obs_index: idx,
+            neuron_uuid: uuid.to_string(),
+            value,
+            activation,
+            errors: vec![error],
+        }
+    }
+
+    #[test]
+    fn test_is_skip_squash() {
+        assert!(is_skip_squash("IDENTITY"));
+        assert!(!is_skip_squash("TANH"));
+        assert!(!is_skip_squash("RELU"));
+    }
+
+    #[test]
+    fn test_high_error_triggers_detection() {
+        // TANH neuron where target is linear — error = pre_act - tanh(pre_act)
+        let records: Vec<DiscoverRecord> = (0..50)
+            .map(|i| {
+                let pre_act = (i as f32 - 25.0) / 8.0;
+                let activation = pre_act.tanh();
+                let error = pre_act - activation;
+                make_record("h1", i, Some(pre_act), activation, error)
+            })
+            .collect();
+
+        let neurons = vec![("h1".to_string(), "TANH".to_string(), 0.0)];
+        let neuron_records = vec![("h1".to_string(), records)];
+
+        let result = detect_high_error_squash_candidates(&neurons, &neuron_records);
+
+        assert!(
+            !result.is_empty(),
+            "High error TANH neuron should trigger exploration"
+        );
+    }
+
+    #[test]
+    fn test_low_error_skips() {
+        let records: Vec<DiscoverRecord> = (0..50)
+            .map(|i| {
+                let pre_act = (i as f32 - 25.0) / 50.0;
+                make_record("h2", i, Some(pre_act), pre_act.tanh(), 0.001)
+            })
+            .collect();
+
+        let neurons = vec![("h2".to_string(), "TANH".to_string(), 0.0)];
+        let neuron_records = vec![("h2".to_string(), records)];
+
+        let result = detect_high_error_squash_candidates(&neurons, &neuron_records);
+
+        assert!(
+            result.is_empty(),
+            "Low error neuron should not trigger exploration"
+        );
+    }
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -17,6 +17,7 @@ pub mod dormant_synapse;
 pub mod error_plateau;
 pub mod fanin_polarity_conflict;
 pub mod hard_sample_cluster;
+pub mod high_error_squash_exploration;
 pub mod input_sensitivity;
 pub mod monotonicity;
 pub mod noise_signal;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -314,11 +314,11 @@ mod tests {
 
         let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
 
-        // We expect exactly 43 modules across all four spec groups.
+        // We expect exactly 44 modules across all four spec groups.
         assert_eq!(
             specs.len(),
-            43,
-            "Expected 43 discovery module specs, got {}",
+            44,
+            "Expected 44 discovery module specs, got {}",
             specs.len()
         );
 

--- a/src/analysis/module_dispatch_specs/neuron_specs.rs
+++ b/src/analysis/module_dispatch_specs/neuron_specs.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 
 use super::super::detection::{
     activation_mismatch, bias_perturbation, bimodal_neuron, bottleneck, co_adaptation, dead_neuron,
-    monotonicity, noise_signal, operating_point, oscillating_neuron, restricted_range, saturation,
-    squash_weight_rescale, symmetry_breaking, topology_cache::CreatureTopologyCache,
-    unbounded_capping,
+    high_error_squash_exploration, monotonicity, noise_signal, operating_point, oscillating_neuron,
+    restricted_range, saturation, squash_weight_rescale, symmetry_breaking,
+    topology_cache::CreatureTopologyCache, unbounded_capping,
 };
 use super::super::recommendation::activation_recommendation;
 use super::super::{cache, discovery_dispatch};
@@ -142,6 +142,15 @@ pub(crate) fn append_neuron_specs(
         records: cache.load_records_for_hidden(&hidden),
         detect: |records| activation_mismatch::detect_activation_mismatches(&hidden, &records),
         convert: |detected| activation_mismatch::activation_mismatch_to_coordinated_candidates(&detected),
+    );
+
+    // Issue #788: High-error squash exploration (proactive change-squash volume)
+    discovery_spec!(modules, "high error squash exploration", "high_error_squash_exploration",
+        cache = shared_cache, hidden = hidden_neurons =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| high_error_squash_exploration::detect_high_error_squash_candidates(&hidden, &records),
+        convert: |detected| high_error_squash_exploration::high_error_squash_to_coordinated_candidates(&detected),
     );
 
     // Issue #551: Bias perturbation for activation regime shifts (local minimum escape)

--- a/tests/issue_788_high_error_squash_exploration.rs
+++ b/tests/issue_788_high_error_squash_exploration.rs
@@ -1,0 +1,320 @@
+//! Issue #788: Integration tests for high-error squash exploration detection.
+//!
+//! Tests the `high_error_squash_exploration` detection module which identifies
+//! hidden neurons with high prediction error and proactively suggests alternative
+//! activation functions that may reduce the error.
+//!
+//! This module increases change-squash candidate volume by triggering on error
+//! magnitude rather than waiting for structural problems (saturation, mismatch).
+
+use neat_ai_discovery::analysis::detection::high_error_squash_exploration::{
+    HighErrorSquashCandidate, detect_high_error_squash_candidates,
+    high_error_squash_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(
+    uuid: &str,
+    idx: u32,
+    value: Option<f32>,
+    activation: f32,
+    error: f32,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value,
+        activation,
+        errors: vec![error],
+    }
+}
+
+/// Build hidden neuron tuples in the format expected by detection modules.
+fn hidden_neuron(uuid: &str, squash: &str, bias: f32) -> (String, String, f32) {
+    (uuid.to_string(), squash.to_string(), bias)
+}
+
+// =============================================================================
+// Neuron with high error and pre-activation data triggers exploration
+// =============================================================================
+
+#[test]
+fn high_error_neuron_with_pre_activation_data_triggers_exploration() {
+    // A TANH neuron where the true target is linear (pre_act itself), meaning
+    // TANH compresses the signal and causes large errors at the extremes.
+    // IDENTITY should be recommended because it matches the target exactly.
+    let neurons = vec![hidden_neuron("high-err", "TANH", 0.0)];
+
+    // Pre-activation values span a wide range. TANH compresses the extremes,
+    // so the error = target - activation = pre_act - tanh(pre_act) is large
+    // at the tails, producing high MAE. IDENTITY would produce exact match.
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "high-err".to_string(),
+        (0..50)
+            .map(|i| {
+                let pre_act = (i as f32 - 25.0) / 8.0; // range -3.1 to 3.0
+                let activation = pre_act.tanh(); // compressed by TANH
+                // Error reflects that the target is pre_act (linear output needed)
+                let error = pre_act - activation;
+                make_record("high-err", i, Some(pre_act), activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Neuron with high error should trigger squash exploration"
+    );
+
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "high-err");
+    assert_eq!(c.current_squash, "TANH");
+    assert!(
+        c.recommended_squash.is_some(),
+        "Should recommend an alternative activation"
+    );
+    assert!(
+        c.estimated_improvement > 0.0,
+        "Should have positive estimated improvement"
+    );
+    assert!(
+        c.mean_absolute_error > 0.0,
+        "Should report the mean absolute error"
+    );
+}
+
+// =============================================================================
+// Neuron with low error does NOT trigger exploration
+// =============================================================================
+
+#[test]
+fn low_error_neuron_not_detected() {
+    let neurons = vec![hidden_neuron("low-err", "TANH", 0.0)];
+
+    // Low error — no reason to change activation
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "low-err".to_string(),
+        (0..50)
+            .map(|i| {
+                let pre_act = (i as f32 - 25.0) / 50.0;
+                let activation = pre_act.tanh();
+                let error = 0.001; // very low error
+                make_record("low-err", i, Some(pre_act), activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Neuron with low error should NOT trigger squash exploration"
+    );
+}
+
+// =============================================================================
+// Neuron without pre-activation data is skipped
+// =============================================================================
+
+#[test]
+fn neuron_without_pre_activation_skipped() {
+    let neurons = vec![hidden_neuron("no-pre", "TANH", 0.0)];
+
+    // No pre-activation values (value = None)
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "no-pre".to_string(),
+        (0..50)
+            .map(|i| {
+                let activation = (i as f32 - 25.0) / 27.0;
+                make_record("no-pre", i, None, activation, 0.5)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Neuron without pre-activation data should be skipped"
+    );
+}
+
+// =============================================================================
+// Insufficient samples returns empty
+// =============================================================================
+
+#[test]
+fn insufficient_samples_returns_empty() {
+    let neurons = vec![hidden_neuron("few-samp", "TANH", 0.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "few-samp".to_string(),
+        (0..5)
+            .map(|i| make_record("few-samp", i, Some(0.5), 0.46, 0.5))
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Too few samples should return empty results"
+    );
+}
+
+// =============================================================================
+// IDENTITY neurons are skipped (already unbounded/linear)
+// =============================================================================
+
+#[test]
+fn identity_neurons_skipped() {
+    let neurons = vec![hidden_neuron("ident", "IDENTITY", 0.0)];
+
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "ident".to_string(),
+        (0..50)
+            .map(|i| {
+                let val = (i as f32 - 25.0) / 10.0;
+                make_record("ident", i, Some(val), val, 0.5)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "IDENTITY neurons should be skipped (already linear)"
+    );
+}
+
+// =============================================================================
+// Does not recommend the same activation function
+// =============================================================================
+
+#[test]
+fn does_not_recommend_same_squash() {
+    let neurons = vec![hidden_neuron("same-sq", "TANH", 0.0)];
+
+    // Even with high error, if no alternative is better, no recommendation
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
+        "same-sq".to_string(),
+        (0..50)
+            .map(|i| {
+                // Values in the ideal TANH operating range
+                let pre_act = (i as f32 - 25.0) / 25.0; // range -1 to 1
+                let activation = pre_act.tanh();
+                // Error is high but evenly distributed — TANH is still the best fit
+                let error = 0.2;
+                make_record("same-sq", i, Some(pre_act), activation, error)
+            })
+            .collect(),
+    )];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    // Any candidate found must recommend a DIFFERENT squash
+    for c in &candidates {
+        if let Some(ref rec) = c.recommended_squash {
+            assert_ne!(
+                rec, &c.current_squash,
+                "Must not recommend the same activation function"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Coordinated candidate conversion
+// =============================================================================
+
+#[test]
+fn candidates_convert_to_coordinated_candidates() {
+    let candidates = vec![HighErrorSquashCandidate {
+        neuron_uuid: "h1".to_string(),
+        current_squash: "TANH".to_string(),
+        recommended_squash: Some("IDENTITY".to_string()),
+        mean_absolute_error: 0.3,
+        error_reduction_fraction: 0.25,
+        estimated_improvement: 0.005,
+        reason: "High error neuron — IDENTITY reduces error by 25%".to_string(),
+    }];
+
+    let coordinated = high_error_squash_to_coordinated_candidates(&candidates);
+
+    assert_eq!(coordinated.len(), 1);
+    assert_eq!(coordinated[0].operations.len(), 1);
+    assert!(coordinated[0].expected_creature_score_gain > 0.0);
+    assert!(coordinated[0].comment.as_ref().unwrap().contains("788"));
+}
+
+// =============================================================================
+// Multiple neurons can produce multiple candidates
+// =============================================================================
+
+#[test]
+fn multiple_high_error_neurons_detected() {
+    let neurons = vec![
+        hidden_neuron("h-a", "TANH", 0.0),
+        hidden_neuron("h-b", "LOGISTIC", 0.0),
+    ];
+
+    // Both neurons have errors indicating their target is linear (pre_act),
+    // so both should trigger recommendations for IDENTITY or similar.
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "h-a".to_string(),
+            (0..50)
+                .map(|i| {
+                    let pre_act = (i as f32 - 25.0) / 8.0;
+                    let activation = pre_act.tanh();
+                    let error = pre_act - activation;
+                    make_record("h-a", i, Some(pre_act), activation, error)
+                })
+                .collect(),
+        ),
+        (
+            "h-b".to_string(),
+            (0..50)
+                .map(|i| {
+                    let pre_act = (i as f32 - 25.0) / 8.0;
+                    let logistic = 1.0 / (1.0 + (-pre_act).exp());
+                    let error = pre_act - logistic;
+                    make_record("h-b", i, Some(pre_act), logistic, error)
+                })
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    // Both should trigger (both have high error with linear target pattern)
+    assert!(
+        candidates.len() >= 2,
+        "Both high-error neurons should trigger exploration, got {}",
+        candidates.len()
+    );
+}
+
+// =============================================================================
+// Neuron not in records returns empty
+// =============================================================================
+
+#[test]
+fn neuron_without_records_returns_empty() {
+    let neurons = vec![hidden_neuron("missing", "RELU", 0.0)];
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![];
+
+    let candidates = detect_high_error_squash_candidates(&neurons, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Neuron without records should return empty"
+    );
+}


### PR DESCRIPTION
## Summary

Add a new **high-error squash exploration** detection module that proactively
suggests alternative activation functions for hidden neurons with high prediction
error. This increases change-squash candidate volume — the highest success-rate
candidate type (65%) — by triggering on error magnitude rather than waiting for
structural problems like saturation or mismatch. Closes #788.

## Approach

The module (`src/analysis/detection/high_error_squash_exploration.rs`) works by:

1. For each hidden neuron with pre-activation data and mean absolute error
   above a threshold (0.10), infer the target output as `activation + error`.
2. Simulate each candidate activation function (TANH, LOGISTIC, IDENTITY,
   SOFTSIGN, HARD_TANH, RELU, ELU, SELU, MISH, SWISH) on the pre-activation
   values.
3. If an alternative reduces mean absolute error by at least 15% versus the
   current activation, recommend it as a `ChangeSquash` coordinated candidate.

Conservative thresholds (15% error reduction minimum, 0.01 improvement scaling)
are designed to maintain a high success rate (target: >30%).

## Evidence

- 9 integration tests covering all edge cases (detection, non-detection,
  conversion, multi-neuron, skip conditions)
- 3 unit tests for internal logic
- Module count test updated from 43 to 44
- `quality.sh` passes cleanly (fmt, clippy, check, tests, docs, release build)

## Test Plan

- `tests/issue_788_high_error_squash_exploration.rs` (9 integration tests):
  - `high_error_neuron_with_pre_activation_data_triggers_exploration`
  - `low_error_neuron_not_detected`
  - `neuron_without_pre_activation_skipped`
  - `insufficient_samples_returns_empty`
  - `identity_neurons_skipped`
  - `does_not_recommend_same_squash`
  - `candidates_convert_to_coordinated_candidates`
  - `multiple_high_error_neurons_detected`
  - `neuron_without_records_returns_empty`
- `src/analysis/detection/high_error_squash_exploration.rs` (3 unit tests):
  - `test_is_skip_squash`
  - `test_high_error_triggers_detection`
  - `test_low_error_skips`
- `src/analysis/module_dispatch_specs/mod.rs` module count assertion updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)