### PR TITLE
feat: add synapse-specific pessimism discount to improve add-synapses success rate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.53.0"
+version = "0.53.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.53.1"
+version = "0.53.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-789.md
+++ b/docs/pr-summary-789.md
@@ -1,0 +1,50 @@
+## Summary
+
+Improve add-synapses success rate by adding synapse-specific pessimism discounting and raising the MIN_IMPROVED_RATIO threshold. Closes #789.
+
+### Root Cause Analysis
+
+GRQ-sampler discovery cache (Issue #787) showed add-synapses had a **0% success rate** (0/31 candidates). Investigation revealed two contributing factors:
+
+1. **Generic pessimism discount too generous**: Synapse candidates used the same generic pessimism parameters (floor=0.15, exponent=0.6) as the overall pool, despite having the worst success rate. Neuron candidates already received more aggressive discounting (floor=0.10, exponent=0.75) via Issue #791, but synapses still used generic parameters.
+
+2. **MIN_IMPROVED_RATIO threshold too low**: All 31 candidates passed the 0.5 threshold but still failed ablation. The multi-weight search (9 weight variants) creates selection bias — picking the best weight for sample data that does not generalise to full evaluation.
+
+### Changes
+
+- **Added synapse-specific pessimism constants** (`SYNAPSE_PESSIMISM_DISCOUNT_FLOOR = 0.05`, `SYNAPSE_PESSIMISM_CURVE_EXPONENT = 0.85`) — the most aggressive of all candidate types
+- **Added `apply_synapse_pessimism_discount()`** function using the synapse-calibrated parameters
+- **Raised `MIN_IMPROVED_RATIO`** from 0.5 to 0.6 — requires 60% of samples to improve before a synapse candidate is accepted
+- **Updated synapse post-processing** to use `apply_synapse_pessimism_discount()` instead of generic `apply_pessimism_discount()` for both helpful and harmful candidates
+- **Updated two existing tests** to provide sufficient sample data for the raised threshold
+
+### Discount Comparison
+
+| Ratio | Generic (0.15/0.6) | Neuron (0.10/0.75) | **Synapse (0.05/0.85)** |
+|-------|--------------------|--------------------|------------------------|
+| 0.1   | 0.363              | 0.260              | **0.184**              |
+| 0.4   | 0.639              | 0.555              | **0.480**              |
+| 0.6   | 0.766              | 0.688              | **0.659**              |
+| 0.7   | 0.832              | 0.770              | **0.754**              |
+| 1.0   | 1.000              | 1.000              | **1.000**              |
+
+## Evidence
+
+- 12 new tests verify synapse pessimism constants, function behaviour, and MIN_IMPROVED_RATIO threshold
+- All existing tests pass with the raised threshold (2 tests updated with additional sample data)
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Added `tests/issue_789_improve_add_synapses_success_rate.rs` with 11 tests:
+  - Synapse pessimism floor more aggressive than generic and neuron
+  - Synapse pessimism exponent less forgiving than generic and neuron
+  - Constants within valid ranges
+  - Discount more aggressive at all moderate ratios (5%–95%)
+  - Full ratio gives full gain
+  - Monotonically non-decreasing
+  - Zero total gives floor discount
+  - Practical difference at 60% ratio
+  - MIN_IMPROVED_RATIO in valid range (> 0.5, <= 0.75)
+- Updated `tests/issue_134_direction_flip.rs` — added 3 more observations for robust improved ratio
+- Updated `tests/synapse_candidate_indices.rs` — added 4 more sample patterns for robust improved ratio

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -179,17 +179,17 @@ pub const MAX_INDIVIDUAL_HARM_FOR_PAIRING: f32 = 0.0;
 /// Minimum ratio of improved samples required for a synapse candidate to be accepted.
 ///
 /// Issue #730: The add-synapses module had a 0% success rate because candidates
-/// where more samples worsened than improved were still being proposed. This
-/// threshold requires that at least this fraction of samples must improve before
-/// a candidate is considered viable.
+/// where more samples worsened than improved were still being proposed.
 ///
-/// A ratio of 0.5 means at least half the samples must improve, filtering out
-/// candidates that hurt more than they help.
+/// Issue #789: Raised from 0.5 to 0.6. GRQ-sampler cache data (Issue #787) showed
+/// all 31 candidates that passed the 0.5 threshold still failed ablation testing.
+/// Requiring 60% of samples to improve filters out marginal candidates where the
+/// multi-weight search found a local optimum that does not generalise.
 ///
 /// ## Valid Range
 /// Must be in (0.0, 1.0). Values below 0.3 provide insufficient filtering.
 /// Values above 0.75 may over-filter legitimate candidates.
-pub const MIN_IMPROVED_RATIO: f32 = 0.5;
+pub const MIN_IMPROVED_RATIO: f32 = 0.6;
 
 /// Minimum ratio of improved samples required for a neuron candidate to be accepted.
 ///
@@ -291,6 +291,47 @@ pub const NEURON_PESSIMISM_DISCOUNT_FLOOR: f32 = 0.10;
 /// Must be in (PESSIMISM_CURVE_EXPONENT, 1.0]. Values above 0.9 give
 /// near-linear behaviour.
 pub const NEURON_PESSIMISM_CURVE_EXPONENT: f32 = 0.75;
+
+// =============================================================================
+// Synapse-Specific Pessimism Discount (Issue #789)
+// =============================================================================
+
+/// Minimum pessimism discount floor for synapse candidates (Issue #789).
+///
+/// GRQ-sampler analysis (Issue #787) shows add-synapses has a 0% success rate
+/// (0 / 31) — the worst of all candidate types. The generic pessimism parameters
+/// (PESSIMISM_DISCOUNT_FLOOR = 0.15, PESSIMISM_CURVE_EXPONENT = 0.6) and even the
+/// neuron-specific parameters (0.10, 0.75) are too generous for synapse candidates.
+///
+/// A lower floor applies more aggressive base discounting to synapse predictions,
+/// reducing the expected gain for candidates with marginal improved ratios. This
+/// accounts for the multi-weight search (9 variants) creating selection bias that
+/// overfits to sample data.
+///
+/// ## Valid Range
+/// Must be in (0.0, NEURON_PESSIMISM_DISCOUNT_FLOOR]. Values below 0.02 risk
+/// zeroing-out all synapse candidates.
+pub const SYNAPSE_PESSIMISM_DISCOUNT_FLOOR: f32 = 0.05;
+
+/// Exponent for the synapse-specific pessimism discount curve (Issue #789).
+///
+/// A higher exponent (closer to linear) produces a less forgiving curve at
+/// moderate ratios. With a 0% success rate, synapse candidates need the most
+/// aggressive discounting of all candidate types. The multi-weight search
+/// (9 weight variants) creates selection bias where the best weight for the
+/// sample data does not generalise to the full evaluation.
+///
+/// With exponent 0.85 and floor 0.05 (discount = 0.05 + 0.95 × ratio^0.85):
+/// - ratio 0.1 → 0.1^0.85 ≈ 0.141 → discount ≈ 0.184
+/// - ratio 0.4 → 0.4^0.85 ≈ 0.453 → discount ≈ 0.480
+/// - ratio 0.6 → 0.6^0.85 ≈ 0.641 → discount ≈ 0.659
+/// - ratio 0.7 → 0.7^0.85 ≈ 0.741 → discount ≈ 0.754
+/// - ratio 1.0 → 1.0       → discount = 1.000
+///
+/// ## Valid Range
+/// Must be in (NEURON_PESSIMISM_CURVE_EXPONENT, 1.0]. Values above 0.95 give
+/// near-linear behaviour.
+pub const SYNAPSE_PESSIMISM_CURVE_EXPONENT: f32 = 0.85;
 
 // =============================================================================
 // NaN-safe Floating-Point Comparison Helpers (Issue #483)

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -40,7 +40,7 @@ mod target_analysis;
 // Re-export items used by code outside this module (analysis/mod.rs, neuron.rs, implementation_tests).
 pub use scoring::{
     apply_neuron_pessimism_discount, apply_pessimism_discount, apply_source_type_boost,
-    apply_target_type_boost,
+    apply_synapse_pessimism_discount, apply_target_type_boost,
 };
 
 pub(crate) use candidate_generation::{

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -10,7 +10,9 @@ use crate::analysis::utils::{shuffle_within_top_k, verbose_enabled};
 use std::collections::HashMap;
 
 use super::filtering::truncate_combined_synapse_candidate_sets;
-use super::scoring::{apply_pessimism_discount, apply_source_type_boost, apply_target_type_boost};
+use super::scoring::{
+    apply_source_type_boost, apply_synapse_pessimism_discount, apply_target_type_boost,
+};
 use crate::analysis::cache::RecordCache;
 use crate::analysis::samples::EPSILON;
 
@@ -119,10 +121,13 @@ fn apply_impact_to_helpful(
     candidate.expected_creature_error_reduction *= impact;
     candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
 
-    // Issue #506: Apply pessimism discount based on improved sample ratio.
+    // Issue #789: Apply synapse-specific pessimism discount based on improved sample ratio.
     // Raw improvement percentages are neuron-level estimates that do not generalise
     // directly to creature-level score gains (18,500× over-estimation in production).
-    candidate.expected_creature_score_gain = apply_pessimism_discount(
+    // Synapse candidates use the most aggressive discounting because the multi-weight
+    // search (9 variants) creates selection bias that overfits to sample data,
+    // contributing to the 0% success rate observed in GRQ-sampler cache data.
+    candidate.expected_creature_score_gain = apply_synapse_pessimism_discount(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
         candidate.total_count,
@@ -180,8 +185,8 @@ fn apply_impact_to_harmful(
     candidate.expected_creature_error_reduction *= impact;
     candidate.expected_creature_score_gain = candidate.expected_creature_error_reduction;
 
-    // Issue #506: Apply pessimism discount based on improved sample ratio.
-    candidate.expected_creature_score_gain = apply_pessimism_discount(
+    // Issue #789: Apply synapse-specific pessimism discount based on improved sample ratio.
+    candidate.expected_creature_score_gain = apply_synapse_pessimism_discount(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
         candidate.total_count,

--- a/src/analysis/synapse/scoring.rs
+++ b/src/analysis/synapse/scoring.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use crate::analysis::constants::{
     EXISTING_HIDDEN_TARGET_BOOST, INPUT_SOURCE_BOOST, NEURON_PESSIMISM_CURVE_EXPONENT,
     NEURON_PESSIMISM_DISCOUNT_FLOOR, PESSIMISM_CURVE_EXPONENT, PESSIMISM_DISCOUNT_FLOOR,
+    SYNAPSE_PESSIMISM_CURVE_EXPONENT, SYNAPSE_PESSIMISM_DISCOUNT_FLOOR,
 };
 
 // =============================================================================
@@ -631,6 +632,38 @@ pub fn apply_neuron_pessimism_discount(gain: f32, improved_count: u32, total_cou
     let adjusted_ratio = improved_ratio.powf(NEURON_PESSIMISM_CURVE_EXPONENT);
     let discount =
         NEURON_PESSIMISM_DISCOUNT_FLOOR + (1.0 - NEURON_PESSIMISM_DISCOUNT_FLOOR) * adjusted_ratio;
+    gain * discount
+}
+
+/// Apply a synapse-specific pessimism discount to an expected score gain (Issue #789).
+///
+/// GRQ-sampler analysis shows add-synapses has a 0% success rate (0 / 31),
+/// indicating both the generic and neuron-specific pessimism parameters are too
+/// generous for synapse candidates. This function uses synapse-calibrated constants
+/// that apply the most aggressive discounting of all candidate types:
+///
+/// - Lowest floor (0.05 vs 0.10 neuron vs 0.15 generic): strongest base discount
+/// - Highest exponent (0.85 vs 0.75 neuron vs 0.6 generic): least forgiving curve
+///
+/// The aggressive discounting accounts for the multi-weight search (9 weight
+/// variants) creating selection bias that overfits to sample data.
+///
+/// ## Formula
+///
+/// ```text
+/// improved_ratio = improved_count / total_count
+/// adjusted_ratio = improved_ratio ^ SYNAPSE_PESSIMISM_CURVE_EXPONENT
+/// discount = SYNAPSE_PESSIMISM_DISCOUNT_FLOOR + (1 - SYNAPSE_PESSIMISM_DISCOUNT_FLOOR) × adjusted_ratio
+/// result = gain × discount
+/// ```
+pub fn apply_synapse_pessimism_discount(gain: f32, improved_count: u32, total_count: u32) -> f32 {
+    if total_count == 0 {
+        return gain * SYNAPSE_PESSIMISM_DISCOUNT_FLOOR;
+    }
+    let improved_ratio = improved_count as f32 / total_count as f32;
+    let adjusted_ratio = improved_ratio.powf(SYNAPSE_PESSIMISM_CURVE_EXPONENT);
+    let discount = SYNAPSE_PESSIMISM_DISCOUNT_FLOOR
+        + (1.0 - SYNAPSE_PESSIMISM_DISCOUNT_FLOOR) * adjusted_ratio;
     gain * discount
 }
 

--- a/tests/issue_134_direction_flip.rs
+++ b/tests/issue_134_direction_flip.rs
@@ -109,6 +109,9 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
 
     let arctan_1 = std::f32::consts::FRAC_PI_4;
 
+    // Issue #789: Use 5 observations (not 2) so the improved ratio can exceed the
+    // raised MIN_IMPROVED_RATIO threshold of 0.6. With only 2 samples, 1/2=0.5
+    // would be filtered out.
     let records = vec![
         DiscoverRecord::new(0, "input-0".to_string(), None, arctan_1, Vec::new()),
         DiscoverRecord::new(0, "output-0".to_string(), Some(-10.0), -10.0, vec![2.0]),
@@ -116,6 +119,12 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         // rather than folding the constant source into a `setBias` coordinated candidate (Issue #178).
         DiscoverRecord::new(1, "input-0".to_string(), None, arctan_1 * 0.9, Vec::new()),
         DiscoverRecord::new(1, "output-0".to_string(), Some(10.0), 10.0, vec![-1.0]),
+        DiscoverRecord::new(2, "input-0".to_string(), None, arctan_1 * 1.1, Vec::new()),
+        DiscoverRecord::new(2, "output-0".to_string(), Some(-5.0), -5.0, vec![1.5]),
+        DiscoverRecord::new(3, "input-0".to_string(), None, arctan_1 * 0.8, Vec::new()),
+        DiscoverRecord::new(3, "output-0".to_string(), Some(-8.0), -8.0, vec![1.8]),
+        DiscoverRecord::new(4, "input-0".to_string(), None, arctan_1 * 1.05, Vec::new()),
+        DiscoverRecord::new(4, "output-0".to_string(), Some(-3.0), -3.0, vec![1.2]),
     ];
 
     write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");

--- a/tests/issue_789_improve_add_synapses_success_rate.rs
+++ b/tests/issue_789_improve_add_synapses_success_rate.rs
@@ -1,0 +1,167 @@
+//! Issue #789: Investigate and improve add-synapses 0% success rate
+//!
+//! Tests for:
+//! 1. Synapse-specific pessimism calibration (more aggressive than both generic and neuron)
+//! 2. Raised MIN_IMPROVED_RATIO threshold for stricter filtering
+
+mod common;
+
+use neat_ai_discovery::analysis::constants::{
+    MIN_IMPROVED_RATIO, NEURON_PESSIMISM_CURVE_EXPONENT, NEURON_PESSIMISM_DISCOUNT_FLOOR,
+    PESSIMISM_CURVE_EXPONENT, PESSIMISM_DISCOUNT_FLOOR, SYNAPSE_PESSIMISM_CURVE_EXPONENT,
+    SYNAPSE_PESSIMISM_DISCOUNT_FLOOR,
+};
+use neat_ai_discovery::analysis::synapse::{
+    apply_pessimism_discount, apply_synapse_pessimism_discount,
+};
+
+// =============================================================================
+// Synapse-specific pessimism constants (Issue #789)
+// =============================================================================
+
+/// Issue #789: Synapse-specific pessimism floor should be lower than the generic
+/// floor, applying more aggressive base discounting given the 0% success rate.
+#[test]
+fn synapse_pessimism_floor_more_aggressive_than_generic() {
+    const {
+        assert!(SYNAPSE_PESSIMISM_DISCOUNT_FLOOR < PESSIMISM_DISCOUNT_FLOOR);
+    }
+}
+
+/// Issue #789: Synapse-specific pessimism floor should be lower than or equal to
+/// the neuron floor, since synapses have a worse success rate (0% vs 15%).
+#[test]
+fn synapse_pessimism_floor_at_least_as_aggressive_as_neuron() {
+    const {
+        assert!(SYNAPSE_PESSIMISM_DISCOUNT_FLOOR <= NEURON_PESSIMISM_DISCOUNT_FLOOR);
+    }
+}
+
+/// Issue #789: Synapse-specific pessimism exponent should be higher than the generic
+/// exponent, making the curve less forgiving at moderate ratios.
+#[test]
+fn synapse_pessimism_exponent_less_forgiving_than_generic() {
+    const {
+        assert!(SYNAPSE_PESSIMISM_CURVE_EXPONENT > PESSIMISM_CURVE_EXPONENT);
+    }
+}
+
+/// Issue #789: Synapse-specific pessimism exponent should be higher than or equal to
+/// the neuron exponent, since synapses have a worse success rate.
+#[test]
+fn synapse_pessimism_exponent_at_least_as_strict_as_neuron() {
+    const {
+        assert!(SYNAPSE_PESSIMISM_CURVE_EXPONENT >= NEURON_PESSIMISM_CURVE_EXPONENT);
+    }
+}
+
+/// Issue #789: Both synapse pessimism constants should be within valid ranges.
+#[test]
+fn synapse_pessimism_constants_in_valid_ranges() {
+    const {
+        assert!(SYNAPSE_PESSIMISM_DISCOUNT_FLOOR > 0.0);
+        assert!(SYNAPSE_PESSIMISM_DISCOUNT_FLOOR < 0.5);
+        assert!(SYNAPSE_PESSIMISM_CURVE_EXPONENT > 0.0);
+        assert!(SYNAPSE_PESSIMISM_CURVE_EXPONENT <= 1.0);
+    }
+}
+
+// =============================================================================
+// Synapse-specific pessimism discount function (Issue #789)
+// =============================================================================
+
+/// Issue #789: Synapse pessimism discount should be more aggressive than generic
+/// pessimism at all improved ratios between 0% and 100% (exclusive).
+#[test]
+fn synapse_pessimism_more_aggressive_at_all_moderate_ratios() {
+    let gain = 0.10;
+
+    // Test at various ratios from 5% to 95%
+    for improved in (5..=95).step_by(5) {
+        let generic_result = apply_pessimism_discount(gain, improved, 100);
+        let synapse_result = apply_synapse_pessimism_discount(gain, improved, 100);
+
+        assert!(
+            synapse_result <= generic_result,
+            "Issue #789: Synapse pessimism at {improved}% should be <= generic pessimism. \
+             Synapse={synapse_result:.6}, Generic={generic_result:.6}"
+        );
+    }
+}
+
+/// Issue #789: Synapse pessimism discount should still give full gain at 100% ratio.
+#[test]
+fn synapse_pessimism_full_ratio_gives_full_gain() {
+    let gain = 0.10;
+    let result = apply_synapse_pessimism_discount(gain, 100, 100);
+    assert!(
+        (result - gain).abs() < 1e-6,
+        "Issue #789: All samples improved should give full gain: expected {gain}, got {result}"
+    );
+}
+
+/// Issue #789: Synapse pessimism should be monotonically non-decreasing.
+#[test]
+fn synapse_pessimism_monotonically_increasing() {
+    let gain = 0.10;
+    let mut prev = apply_synapse_pessimism_discount(gain, 0, 100);
+    for improved in (5..=100).step_by(5) {
+        let current = apply_synapse_pessimism_discount(gain, improved, 100);
+        assert!(
+            current >= prev - 1e-7,
+            "Issue #789: Synapse discount should be monotonically non-decreasing: \
+             at {improved}/100, got {current:.6} < previous {prev:.6}"
+        );
+        prev = current;
+    }
+}
+
+/// Issue #789: Zero total should give floor discount.
+#[test]
+fn synapse_pessimism_zero_total_gives_floor() {
+    let gain = 0.10;
+    let result = apply_synapse_pessimism_discount(gain, 0, 0);
+    let expected = gain * SYNAPSE_PESSIMISM_DISCOUNT_FLOOR;
+    assert!(
+        (result - expected).abs() < 1e-6,
+        "Issue #789: Zero total should give floor discount: expected {expected}, got {result}"
+    );
+}
+
+/// Issue #789: Typical synapse candidate at 60% ratio should get a lower
+/// score with synapse-specific pessimism than with generic pessimism.
+#[test]
+fn synapse_pessimism_practical_difference() {
+    let gain = 0.02; // Typical small synapse gain
+
+    let generic_discounted = apply_pessimism_discount(gain, 60, 100);
+    let synapse_discounted = apply_synapse_pessimism_discount(gain, 60, 100);
+
+    assert!(
+        synapse_discounted < generic_discounted,
+        "Issue #789: Synapse-specific discount at 60% ratio should be lower. \
+         Synapse={synapse_discounted:.6}, Generic={generic_discounted:.6}"
+    );
+
+    // The difference should be meaningful (at least 5%)
+    let reduction_pct = (generic_discounted - synapse_discounted) / generic_discounted * 100.0;
+    assert!(
+        reduction_pct > 5.0,
+        "Issue #789: Synapse discount reduction should be at least 5%. Got {reduction_pct:.1}%"
+    );
+}
+
+// =============================================================================
+// MIN_IMPROVED_RATIO threshold (Issue #789)
+// =============================================================================
+
+/// Issue #789: MIN_IMPROVED_RATIO should be raised above 0.5 to filter out
+/// marginal candidates that consistently fail ablation testing, but not
+/// be too strict (still <= 0.75).
+#[test]
+fn min_improved_ratio_in_range() {
+    const {
+        assert!(MIN_IMPROVED_RATIO > 0.5);
+        assert!(MIN_IMPROVED_RATIO <= 0.75);
+    }
+}

--- a/tests/synapse_candidate_indices.rs
+++ b/tests/synapse_candidate_indices.rs
@@ -41,6 +41,8 @@ fn synapse_candidates_populate_from_and_to_indices() {
     // Records designed so input-1 correlates positively with output error:
     // - When error is positive (output should be higher), input-1 is high.
     // - When error is negative (output should be lower), input-1 is low.
+    // Issue #789: Use enough positive-error samples so the improved ratio exceeds
+    // the raised MIN_IMPROVED_RATIO threshold of 0.6.
     let mut records = Vec::new();
     let patterns: &[(f32, f32)] = &[
         (1.0, 1.0),
@@ -51,6 +53,10 @@ fn synapse_candidates_populate_from_and_to_indices() {
         (0.6, 0.85),
         (-0.7, 0.05),
         (-0.9, 0.0),
+        (0.5, 0.7),
+        (0.4, 0.65),
+        (0.9, 0.92),
+        (0.7, 0.88),
     ];
 
     for (obs_index, (error, input_1_activation)) in patterns.iter().copied().enumerate() {


### PR DESCRIPTION
## Summary

Improve add-synapses success rate by adding synapse-specific pessimism discounting and raising the MIN_IMPROVED_RATIO threshold. Closes #789.

### Root Cause Analysis

GRQ-sampler discovery cache (Issue #787) showed add-synapses had a **0% success rate** (0/31 candidates). Investigation revealed two contributing factors:

1. **Generic pessimism discount too generous**: Synapse candidates used the same generic pessimism parameters (floor=0.15, exponent=0.6) as the overall pool, despite having the worst success rate. Neuron candidates already received more aggressive discounting (floor=0.10, exponent=0.75) via Issue #791, but synapses still used generic parameters.

2. **MIN_IMPROVED_RATIO threshold too low**: All 31 candidates passed the 0.5 threshold but still failed ablation. The multi-weight search (9 weight variants) creates selection bias — picking the best weight for sample data that does not generalise to full evaluation.

### Changes

- **Added synapse-specific pessimism constants** (`SYNAPSE_PESSIMISM_DISCOUNT_FLOOR = 0.05`, `SYNAPSE_PESSIMISM_CURVE_EXPONENT = 0.85`) — the most aggressive of all candidate types
- **Added `apply_synapse_pessimism_discount()`** function using the synapse-calibrated parameters
- **Raised `MIN_IMPROVED_RATIO`** from 0.5 to 0.6 — requires 60% of samples to improve before a synapse candidate is accepted
- **Updated synapse post-processing** to use `apply_synapse_pessimism_discount()` instead of generic `apply_pessimism_discount()` for both helpful and harmful candidates
- **Updated two existing tests** to provide sufficient sample data for the raised threshold

### Discount Comparison

| Ratio | Generic (0.15/0.6) | Neuron (0.10/0.75) | **Synapse (0.05/0.85)** |
|-------|--------------------|--------------------|------------------------|
| 0.1   | 0.363              | 0.260              | **0.184**              |
| 0.4   | 0.639              | 0.555              | **0.480**              |
| 0.6   | 0.766              | 0.688              | **0.659**              |
| 0.7   | 0.832              | 0.770              | **0.754**              |
| 1.0   | 1.000              | 1.000              | **1.000**              |

## Evidence

- 11 new tests verify synapse pessimism constants, function behaviour, and MIN_IMPROVED_RATIO threshold
- All existing tests pass with the raised threshold (2 tests updated with additional sample data)
- `quality.sh` passes cleanly

## Test Plan

- Added `tests/issue_789_improve_add_synapses_success_rate.rs` with 11 tests:
  - Synapse pessimism floor more aggressive than generic and neuron
  - Synapse pessimism exponent less forgiving than generic and neuron
  - Constants within valid ranges
  - Discount more aggressive at all moderate ratios (5%–95%)
  - Full ratio gives full gain
  - Monotonically non-decreasing
  - Zero total gives floor discount
  - Practical difference at 60% ratio
  - MIN_IMPROVED_RATIO in valid range (> 0.5, <= 0.75)
- Updated `tests/issue_134_direction_flip.rs` — added 3 more observations for robust improved ratio
- Updated `tests/synapse_candidate_indices.rs` — added 4 more sample patterns for robust improved ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)