### PR TITLE
feat: add low-impact neuron detection to expand remove-low-impact candidates (#793)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.54.2"
+version = "0.54.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.54.3"
+version = "0.54.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-793.md
+++ b/docs/pr-summary-793.md
@@ -1,0 +1,30 @@
+## Summary
+
+Add a new low-impact neuron detection module that expands remove-low-impact candidate generation by catching neurons in the activation range between the dead threshold (1e-6) and a new low-impact ceiling (1e-3). Closes #793.
+
+The existing dead neuron detector uses a very tight threshold (1e-6). Neurons with activations slightly above this (e.g. 1e-5 to 1e-4) still have negligible impact on the network but were previously missed. The new module uses a tiered confidence approach based on activation magnitude, variance consistency, and sample count to identify these low-impact neurons as removal candidates.
+
+## Changes
+
+- **New module**: `src/analysis/detection/low_impact_neuron.rs` — detects hidden neurons with mean absolute activation between 1e-6 and 1e-3 with low variance, converts them to `RemoveNeuron` coordinated structural candidates
+- **Dispatch wiring**: Added to `neuron_specs.rs` as a new discovery module spec (`low_impact_neuron_detection`)
+- **Module count**: Updated from 44 to 45 discovery modules
+
+## Evidence
+
+- All 10 new unit tests pass covering: detection of low-impact neurons, exclusion of dead/active/input/output neurons, confidence scaling with sample count and activation magnitude, coordinated candidate conversion, insufficient samples, and high-variance exclusion
+- `quality.sh` passes cleanly (fmt, clippy, check, tests, docs, release build)
+
+## Test Plan
+
+- Added `tests/issue_793_low_impact_neuron_detection.rs` with 10 tests:
+  1. Detects neuron with activation in low-impact range (1e-5)
+  2. Does not detect truly dead neurons (below 1e-6)
+  3. Does not detect active neurons (above 1e-3)
+  4. Confidence increases with more samples
+  5. Confidence increases with lower activation
+  6. Output and input neurons excluded
+  7. Candidates produce coordinated RemoveNeuron operations
+  8. Mixed network: only low-impact neurons detected
+  9. Insufficient samples not detected
+  10. Low mean but high variance not detected

--- a/src/analysis/detection/low_impact_neuron.rs
+++ b/src/analysis/detection/low_impact_neuron.rs
@@ -1,0 +1,238 @@
+//! Low-impact neuron detection module (Issue #793).
+//!
+//! Identifies hidden neurons whose activations are consistently near-zero but
+//! above the dead-neuron threshold (1e-6). These neurons have negligible impact
+//! on the network's output and are good candidates for removal.
+//!
+//! This module complements `dead_neuron.rs` (Issue #341) by catching neurons in
+//! the "twilight zone" between truly dead (< 1e-6) and meaningfully active
+//! (> 1e-3). The dead-neuron detector uses a very tight threshold; this module
+//! broadens the removal pool with a tiered confidence approach.
+//!
+//! ## Detection Criteria
+//!
+//! A neuron is "low-impact" if:
+//! 1. **Mean absolute activation** is between the dead threshold (1e-6) and
+//!    the low-impact ceiling (1e-3).
+//! 2. **Low activation variance** — the neuron is consistently near-zero, not
+//!    sporadically spiking.
+//! 3. **Only hidden neurons** — output and input neurons are excluded.
+//! 4. **Sufficient samples** — at least `MIN_DISCOVERY_SAMPLE_COUNT` records.
+//!
+//! ## Confidence Scoring
+//!
+//! Removal confidence is computed from three factors:
+//! - **Activation proximity** — lower mean abs activation = higher confidence
+//! - **Variance consistency** — lower std dev relative to mean = higher confidence
+//! - **Sample sufficiency** — more samples = higher confidence (plateaus at 500)
+
+use std::collections::HashMap;
+
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+use super::topology_cache::CreatureTopologyCache;
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+
+/// Lower bound: activations at or below this are handled by `dead_neuron.rs`.
+const DEAD_THRESHOLD: f32 = 1e-6;
+
+/// Upper bound: activations above this are considered meaningfully active.
+const LOW_IMPACT_CEILING: f32 = 1e-3;
+
+/// Maximum activation standard deviation relative to mean for low-impact status.
+/// If the neuron's output varies too much, it may still be contributing on some
+/// samples even if the mean is low.
+const MAX_RELATIVE_STD_DEV: f32 = 5.0;
+
+/// Absolute ceiling on standard deviation. Even if the relative std dev is low,
+/// a high absolute std dev suggests the neuron is not consistently near-zero.
+const MAX_ABSOLUTE_STD_DEV: f32 = 1e-3;
+
+/// Base estimated improvement for removing a low-impact neuron.
+/// Lower than dead-neuron removal because there is a small chance the neuron
+/// contributes marginally.
+const BASE_IMPROVEMENT: f32 = 0.002;
+
+/// Result of detecting a low-impact neuron.
+#[derive(Debug, Clone)]
+pub struct LowImpactNeuronCandidate {
+    /// UUID of the low-impact neuron.
+    pub neuron_uuid: String,
+    /// Mean absolute activation across all samples.
+    pub mean_abs_activation: f32,
+    /// Standard deviation of activation across samples.
+    pub activation_std_dev: f32,
+    /// Number of samples analysed.
+    pub sample_count: usize,
+    /// Confidence that removing this neuron is safe (0.0 to 1.0).
+    pub removal_confidence: f32,
+    /// Estimated creature score improvement from removing this neuron.
+    pub estimated_improvement: f32,
+}
+
+/// Detect low-impact neurons from the creature topology and recorded activations.
+///
+/// Low-impact neurons have mean absolute activations between the dead threshold
+/// (1e-6) and the low-impact ceiling (1e-3), with consistently low variance.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_records` - List of `(neuron_uuid, records)` tuples with recorded activations.
+/// * `topo` - Optional pre-computed topology cache (Issue #754).
+///
+/// # Returns
+/// A list of `LowImpactNeuronCandidate` sorted by removal confidence (highest first).
+pub fn detect_low_impact_neurons(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    topo: Option<&CreatureTopologyCache>,
+) -> Vec<LowImpactNeuronCandidate> {
+    let local_cache;
+    let topo = match topo {
+        Some(t) => t,
+        None => {
+            local_cache = CreatureTopologyCache::new(creature);
+            &local_cache
+        }
+    };
+
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::with_capacity(topo.hidden_uuids.len());
+
+    for uuid in &topo.hidden_uuids {
+        let Some(records) = records_map.get(uuid.as_str()) else {
+            continue;
+        };
+
+        if records.len() < MIN_DISCOVERY_SAMPLE_COUNT {
+            continue;
+        }
+
+        let n = records.len() as f32;
+
+        // Compute mean absolute activation
+        let sum_abs_activation: f32 = records.iter().map(|r| r.activation.abs()).sum();
+        let mean_abs_activation = sum_abs_activation / n;
+
+        // Must be above dead threshold and below low-impact ceiling
+        if mean_abs_activation <= DEAD_THRESHOLD || mean_abs_activation >= LOW_IMPACT_CEILING {
+            continue;
+        }
+
+        // Compute activation standard deviation
+        let mean_activation: f32 = records.iter().map(|r| r.activation).sum::<f32>() / n;
+        let variance: f32 = records
+            .iter()
+            .map(|r| {
+                let diff = r.activation - mean_activation;
+                diff * diff
+            })
+            .sum::<f32>()
+            / n;
+        let activation_std_dev = variance.sqrt();
+
+        // Reject if variance is too high (neuron may still be useful on some samples)
+        if activation_std_dev >= MAX_ABSOLUTE_STD_DEV {
+            continue;
+        }
+
+        // Also reject if relative std dev is too high (noisy relative to mean)
+        if mean_abs_activation > 0.0
+            && activation_std_dev / mean_abs_activation > MAX_RELATIVE_STD_DEV
+        {
+            continue;
+        }
+
+        let confidence = compute_low_impact_confidence(mean_abs_activation, activation_std_dev, n);
+
+        let estimated_improvement = BASE_IMPROVEMENT * confidence;
+
+        candidates.push(LowImpactNeuronCandidate {
+            neuron_uuid: uuid.clone(),
+            mean_abs_activation,
+            activation_std_dev,
+            sample_count: records.len(),
+            removal_confidence: confidence,
+            estimated_improvement,
+        });
+    }
+
+    // Sort by removal confidence (highest first)
+    candidates.sort_by(|a, b| b.removal_confidence.total_cmp(&a.removal_confidence));
+
+    candidates
+}
+
+/// Compute removal confidence for a low-impact neuron.
+///
+/// Three factors contribute:
+/// - **Activation proximity** (40%): how close to the dead threshold (lower = safer)
+/// - **Variance consistency** (30%): how consistent the low activation is
+/// - **Sample sufficiency** (30%): how many samples confirm the low impact
+fn compute_low_impact_confidence(
+    mean_abs_activation: f32,
+    activation_std_dev: f32,
+    sample_count: f32,
+) -> f32 {
+    // Activation proximity: log-scale distance from dead threshold to ceiling.
+    // Closer to dead threshold → higher factor.
+    let log_range = (LOW_IMPACT_CEILING / DEAD_THRESHOLD).ln();
+    let log_position = (mean_abs_activation / DEAD_THRESHOLD).ln();
+    let activation_factor = 1.0 - (log_position / log_range).clamp(0.0, 1.0);
+
+    // Variance consistency: lower std dev relative to ceiling → higher factor.
+    let variance_factor = 1.0 - (activation_std_dev / MAX_ABSOLUTE_STD_DEV).clamp(0.0, 1.0);
+
+    // Sample sufficiency: more samples → higher confidence, plateaus at 500.
+    let sample_factor = (sample_count / 500.0).min(1.0);
+
+    // Weighted combination
+    let raw = activation_factor * 0.4 + variance_factor * 0.3 + sample_factor * 0.3;
+
+    // Scale to [0.3, 0.9] range — lower than dead-neuron confidence since
+    // there is more uncertainty when the neuron is not completely dead.
+    0.3 + raw * 0.6
+}
+
+/// Convert low-impact neuron candidates into coordinated structural candidates.
+///
+/// Each low-impact neuron produces a `RemoveNeuron` coordinated candidate.
+/// NEAT-AI validates the removal through ablation testing before applying.
+pub fn low_impact_neurons_to_coordinated_candidates(
+    candidates: &[LowImpactNeuronCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: c.neuron_uuid.clone(),
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "[#793] Low-impact neuron {}: mean abs activation {:.2e}, \
+                 std dev {:.2e}, {} samples, confidence {:.2} \
+                 — remove to reduce wasted computation",
+                c.neuron_uuid,
+                c.mean_abs_activation,
+                c.activation_std_dev,
+                c.sample_count,
+                c.removal_confidence
+            )),
+        });
+    }
+
+    // Sort by expected improvement (best first)
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    results
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -19,6 +19,7 @@ pub mod fanin_polarity_conflict;
 pub mod hard_sample_cluster;
 pub mod high_error_squash_exploration;
 pub mod input_sensitivity;
+pub mod low_impact_neuron;
 pub mod monotonicity;
 pub mod noise_signal;
 pub mod observation_range;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -323,11 +323,11 @@ mod tests {
 
         let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
 
-        // We expect exactly 44 modules across all four spec groups.
+        // We expect exactly 45 modules across all four spec groups.
         assert_eq!(
             specs.len(),
-            44,
-            "Expected 44 discovery module specs, got {}",
+            45,
+            "Expected 45 discovery module specs, got {}",
             specs.len()
         );
 

--- a/src/analysis/module_dispatch_specs/neuron_specs.rs
+++ b/src/analysis/module_dispatch_specs/neuron_specs.rs
@@ -1,7 +1,7 @@
 //! Neuron-focused discovery module dispatch specs.
 //!
-//! Covers: saturated, bottleneck, dead, oscillating, restricted range,
-//! operating point, unbounded capping, noisy neurons, activation
+//! Covers: saturated, bottleneck, dead, low-impact, oscillating, restricted
+//! range, operating point, unbounded capping, noisy neurons, activation
 //! recommendation, activation mismatch, bimodal neuron, bias perturbation,
 //! symmetry breaking, and co-adaptation detection.
 
@@ -9,8 +9,8 @@ use std::sync::Arc;
 
 use super::super::detection::{
     activation_mismatch, bias_perturbation, bimodal_neuron, bottleneck, co_adaptation, dead_neuron,
-    high_error_squash_exploration, monotonicity, noise_signal, operating_point, oscillating_neuron,
-    restricted_range, saturation, squash_weight_rescale, symmetry_breaking,
+    high_error_squash_exploration, low_impact_neuron, monotonicity, noise_signal, operating_point,
+    oscillating_neuron, restricted_range, saturation, squash_weight_rescale, symmetry_breaking,
     topology_cache::CreatureTopologyCache, unbounded_capping,
 };
 use super::super::recommendation::activation_recommendation;
@@ -49,6 +49,15 @@ pub(crate) fn append_neuron_specs(
         records: cache.load_records_for_hidden(&hidden),
         detect: |records| dead_neuron::detect_dead_neurons(&creature, &records, Some(&topo)),
         convert: |detected| dead_neuron::dead_neurons_to_coordinated_candidates(&detected),
+    );
+
+    // Issue #793: Low-impact neuron detection (broader threshold than dead neuron)
+    discovery_spec!(modules, "low impact neuron detection", "low_impact_neuron_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature, topo = topo =>
+        guard: hidden,
+        records: cache.load_records_for_hidden(&hidden),
+        detect: |records| low_impact_neuron::detect_low_impact_neurons(&creature, &records, Some(&topo)),
+        convert: |detected| low_impact_neuron::low_impact_neurons_to_coordinated_candidates(&detected),
     );
 
     // Issue #358: Oscillating neuron detection

--- a/tests/issue_793_low_impact_neuron_detection.rs
+++ b/tests/issue_793_low_impact_neuron_detection.rs
@@ -1,0 +1,381 @@
+//! Tests for Issue #793: Expand remove-low-impact candidate generation.
+//!
+//! Low-impact neurons have activations slightly above the dead-neuron threshold
+//! (1e-6) but still negligible (up to 1e-3). Detecting these neurons and
+//! recommending their removal increases the volume of remove-low-impact
+//! candidates while maintaining a high success rate.
+//!
+//! ## TDD Plan
+//! 1. Neuron with mean abs activation in the low-impact range is detected
+//! 2. Truly dead neurons (below 1e-6) are NOT detected (handled by dead_neuron module)
+//! 3. Active neurons (above the low-impact threshold) are NOT detected
+//! 4. Confidence scales with sample count (more samples = higher confidence)
+//! 5. Confidence scales inversely with activation magnitude (lower = more confident)
+//! 6. Output and input neurons are excluded
+//! 7. Candidates convert to coordinated structural RemoveNeuron operations
+//! 8. Mixed network: only low-impact neurons are detected
+
+mod common;
+
+use common::{make_creature, neuron, record, synapse};
+use neat_ai_discovery::analysis::detection::low_impact_neuron::{
+    LowImpactNeuronCandidate, detect_low_impact_neurons,
+    low_impact_neurons_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+/// Test 1: Neuron with mean abs activation in low-impact range (1e-5) is detected.
+#[test]
+fn test_detects_low_impact_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-low", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-low", "output-1", 0.5)],
+    );
+
+    // Mean abs activation ~1e-5: above dead threshold (1e-6) but below low-impact ceiling (1e-3)
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-low", i, 1e-5, Some(0.01)))
+        .collect();
+
+    let candidates =
+        detect_low_impact_neurons(&creature, &[("hidden-low".to_string(), records)], None);
+
+    assert_eq!(candidates.len(), 1, "Should detect one low-impact neuron");
+    let c = &candidates[0];
+    assert_eq!(c.neuron_uuid, "hidden-low");
+    assert!(
+        c.mean_abs_activation > 1e-6,
+        "Should be above dead threshold"
+    );
+    assert!(
+        c.mean_abs_activation < 1e-3,
+        "Should be below low-impact ceiling"
+    );
+    assert!(
+        c.removal_confidence > 0.0,
+        "Should have positive confidence"
+    );
+}
+
+/// Test 2: Truly dead neuron (below 1e-6) is NOT detected — handled by dead_neuron module.
+#[test]
+fn test_does_not_detect_dead_neurons() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-dead", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-dead", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-dead", i, 0.0, Some(-5.0)))
+        .collect();
+
+    let candidates =
+        detect_low_impact_neurons(&creature, &[("hidden-dead".to_string(), records)], None);
+
+    assert!(
+        candidates.is_empty(),
+        "Dead neurons should not be flagged by low-impact detector"
+    );
+}
+
+/// Test 3: Active neuron (above low-impact ceiling) is NOT detected.
+#[test]
+fn test_does_not_detect_active_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-active", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-active", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = 0.5 + 0.3 * ((i as f32 * 0.1).sin());
+            record("hidden-active", i, activation, Some(0.5))
+        })
+        .collect();
+
+    let candidates =
+        detect_low_impact_neurons(&creature, &[("hidden-active".to_string(), records)], None);
+
+    assert!(
+        candidates.is_empty(),
+        "Active neuron should not be flagged as low-impact"
+    );
+}
+
+/// Test 4: More samples yield higher confidence.
+#[test]
+fn test_confidence_increases_with_sample_count() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-low", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-low", "output-1", 0.5)],
+    );
+
+    let small_records: Vec<DiscoverRecord> = (0..30)
+        .map(|i| record("hidden-low", i, 5e-5, Some(0.01)))
+        .collect();
+
+    let large_records: Vec<DiscoverRecord> = (0..500)
+        .map(|i| record("hidden-low", i, 5e-5, Some(0.01)))
+        .collect();
+
+    let small_candidates = detect_low_impact_neurons(
+        &creature,
+        &[("hidden-low".to_string(), small_records)],
+        None,
+    );
+    let large_candidates = detect_low_impact_neurons(
+        &creature,
+        &[("hidden-low".to_string(), large_records)],
+        None,
+    );
+
+    assert_eq!(small_candidates.len(), 1);
+    assert_eq!(large_candidates.len(), 1);
+    assert!(
+        large_candidates[0].removal_confidence > small_candidates[0].removal_confidence,
+        "More samples should yield higher confidence: {} vs {}",
+        large_candidates[0].removal_confidence,
+        small_candidates[0].removal_confidence
+    );
+}
+
+/// Test 5: Lower activation yields higher confidence.
+#[test]
+fn test_confidence_increases_with_lower_activation() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-a", "hidden", "RELU"),
+            neuron("hidden-b", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("hidden-a", "output-1", 0.5),
+            synapse("hidden-b", "output-1", 0.5),
+        ],
+    );
+
+    // Neuron A: very low impact (5e-6)
+    let records_a: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-a", i, 5e-6, Some(0.01)))
+        .collect();
+
+    // Neuron B: moderate-low impact (5e-4)
+    let records_b: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("hidden-b", i, 5e-4, Some(0.01)))
+        .collect();
+
+    let candidates = detect_low_impact_neurons(
+        &creature,
+        &[
+            ("hidden-a".to_string(), records_a),
+            ("hidden-b".to_string(), records_b),
+        ],
+        None,
+    );
+
+    assert_eq!(candidates.len(), 2, "Both should be detected");
+    let c_a = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "hidden-a")
+        .unwrap();
+    let c_b = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "hidden-b")
+        .unwrap();
+    assert!(
+        c_a.removal_confidence > c_b.removal_confidence,
+        "Lower activation should yield higher confidence: {} vs {}",
+        c_a.removal_confidence,
+        c_b.removal_confidence
+    );
+}
+
+/// Test 6: Output and input neurons are excluded.
+#[test]
+fn test_output_and_input_neurons_excluded() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![],
+    );
+
+    let records_input: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("input-1", i, 5e-5, Some(0.01)))
+        .collect();
+    let records_output: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("output-1", i, 5e-5, Some(0.01)))
+        .collect();
+
+    let candidates = detect_low_impact_neurons(
+        &creature,
+        &[
+            ("input-1".to_string(), records_input),
+            ("output-1".to_string(), records_output),
+        ],
+        None,
+    );
+
+    assert!(
+        candidates.is_empty(),
+        "Input and output neurons should not be flagged"
+    );
+}
+
+/// Test 7: Candidates convert to coordinated structural RemoveNeuron operations.
+#[test]
+fn test_candidates_produce_coordinated_removal_operations() {
+    let candidate = LowImpactNeuronCandidate {
+        neuron_uuid: "hidden-low".to_string(),
+        mean_abs_activation: 5e-5,
+        activation_std_dev: 1e-5,
+        sample_count: 200,
+        removal_confidence: 0.75,
+        estimated_improvement: 0.002,
+    };
+
+    let coordinated = low_impact_neurons_to_coordinated_candidates(&[candidate]);
+
+    assert_eq!(
+        coordinated.len(),
+        1,
+        "Should produce one coordinated candidate"
+    );
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(
+        c.comment.is_some(),
+        "Should have a comment explaining the removal"
+    );
+
+    // Check that operations include a RemoveNeuron
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("removeNeuron"),
+        "Should include removeNeuron operation, got: {ops_json}"
+    );
+}
+
+/// Test 8: Mixed network — only low-impact neurons are detected.
+#[test]
+fn test_mixed_network_only_low_impact_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("dead", "hidden", "RELU"),
+            neuron("low-impact", "hidden", "TANH"),
+            neuron("active", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("dead", "output-1", 0.5),
+            synapse("low-impact", "output-1", 0.3),
+            synapse("active", "output-1", 0.8),
+        ],
+    );
+
+    // Dead neuron: activation 0.0 (below 1e-6) — should NOT be detected here
+    let dead_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("dead", i, 0.0, Some(-3.0)))
+        .collect();
+
+    // Low-impact neuron: activation 1e-4 — should be detected
+    let low_impact_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| record("low-impact", i, 1e-4, Some(1e-5)))
+        .collect();
+
+    // Active neuron: activation ~0.5 — should NOT be detected
+    let active_records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = 0.5 + 0.2 * ((i as f32 * 0.1).sin());
+            record("active", i, activation, Some(1.0))
+        })
+        .collect();
+
+    let candidates = detect_low_impact_neurons(
+        &creature,
+        &[
+            ("dead".to_string(), dead_records),
+            ("low-impact".to_string(), low_impact_records),
+            ("active".to_string(), active_records),
+        ],
+        None,
+    );
+
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Should detect exactly 1 low-impact neuron"
+    );
+    assert_eq!(candidates[0].neuron_uuid, "low-impact");
+}
+
+/// Test 9: Too few samples should not trigger detection.
+#[test]
+fn test_insufficient_samples_not_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-few", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-few", "output-1", 0.5)],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..5)
+        .map(|i| record("hidden-few", i, 5e-5, Some(0.01)))
+        .collect();
+
+    let candidates =
+        detect_low_impact_neurons(&creature, &[("hidden-few".to_string(), records)], None);
+
+    assert!(
+        candidates.is_empty(),
+        "Too few samples should not trigger detection"
+    );
+}
+
+/// Test 10: Neuron with low mean but high variance is NOT low-impact.
+/// If a neuron has sporadic high activations, it may still be useful.
+#[test]
+fn test_low_mean_high_variance_not_detected() {
+    let creature = make_creature(
+        vec![
+            neuron("hidden-sporadic", "hidden", "RELU"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("hidden-sporadic", "output-1", 0.5)],
+    );
+
+    // Most samples are 0, but 10% have activation = 0.1 → mean_abs ≈ 0.01
+    // This is above the low-impact ceiling, so not detected.
+    // But even if mean_abs were in range, high variance means it's not consistently low.
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = if i % 10 == 0 { 0.1 } else { 0.0 };
+            record("hidden-sporadic", i, activation, Some(0.0))
+        })
+        .collect();
+
+    let candidates =
+        detect_low_impact_neurons(&creature, &[("hidden-sporadic".to_string(), records)], None);
+
+    assert!(
+        candidates.is_empty(),
+        "Sporadic high activations should prevent low-impact detection"
+    );
+}


### PR DESCRIPTION
## Summary

Add a new low-impact neuron detection module that expands remove-low-impact candidate generation by catching neurons in the activation range between the dead threshold (1e-6) and a new low-impact ceiling (1e-3). Closes #793.

The existing dead neuron detector uses a very tight threshold (1e-6). Neurons with activations slightly above this (e.g. 1e-5 to 1e-4) still have negligible impact on the network but were previously missed. The new module uses a tiered confidence approach based on activation magnitude, variance consistency, and sample count to identify these low-impact neurons as removal candidates.

## Changes

- **New module**: `src/analysis/detection/low_impact_neuron.rs` — detects hidden neurons with mean absolute activation between 1e-6 and 1e-3 with low variance, converts them to `RemoveNeuron` coordinated structural candidates
- **Dispatch wiring**: Added to `neuron_specs.rs` as a new discovery module spec (`low_impact_neuron_detection`)
- **Module count**: Updated from 44 to 45 discovery modules

## Evidence

- All 10 new unit tests pass covering: detection of low-impact neurons, exclusion of dead/active/input/output neurons, confidence scaling with sample count and activation magnitude, coordinated candidate conversion, insufficient samples, and high-variance exclusion
- quality.sh passes cleanly (fmt, clippy, check, tests, docs, release build)

## Test Plan

- Added `tests/issue_793_low_impact_neuron_detection.rs` with 10 tests:
  1. Detects neuron with activation in low-impact range (1e-5)
  2. Does not detect truly dead neurons (below 1e-6)
  3. Does not detect active neurons (above 1e-3)
  4. Confidence increases with more samples
  5. Confidence increases with lower activation
  6. Output and input neurons excluded
  7. Candidates produce coordinated RemoveNeuron operations
  8. Mixed network: only low-impact neurons detected
  9. Insufficient samples not detected
  10. Low mean but high variance not detected

Generated with Claude Code