### PR TITLE
refactor: replace Arc<Mutex<bool>> with AtomicBool in neuron evaluation (#803)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.55.1"
+version = "0.55.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.55.0"
+version = "0.55.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-803.md
+++ b/docs/pr-summary-803.md
@@ -1,0 +1,36 @@
+## Summary
+
+Replace `Arc<Mutex<bool>>` with `Arc<AtomicBool>` for the `analysis_timed_out` flag in
+the neuron evaluation module, aligning it with the lock-free pattern already used in the
+synapse module. This eliminates unnecessary mutex contention on a simple boolean flag
+during parallel neuron evaluation. Closes #803.
+
+Regarding `Arc<Mutex<HashMap>>` for `helpful_map`: during the parallel evaluation loop
+all accesses are writes (via `upsert_candidate`), with the single read happening after
+the loop completes. Since the access pattern is write-heavy during parallelism, switching
+to `RwLock` would not provide a benefit and the `Mutex` is retained.
+
+## Changes
+
+- `src/analysis/neuron/evaluation.rs` — changed `analysis_timed_out` parameter from
+  `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with `.store(true, Ordering::Relaxed)`
+- `src/analysis/neuron/post_processing.rs` — changed `NeuronResultParams.analysis_timed_out`
+  from `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with `.load(Ordering::Relaxed)`
+- `src/analysis/neuron/preparation.rs` — changed `load_source_records` parameter from
+  `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with atomic operations,
+  removed unused `Mutex` and `lock_or_bail` imports
+- `src/analysis/neuron/mod.rs` — changed `analysis_timed_out` from `Arc::new(Mutex::new(false))`
+  to `Arc::new(AtomicBool::new(false))`, updated all call sites to use atomic operations,
+  removed unused `lock_or_bail` import
+
+## Evidence
+
+- All existing tests pass (verified via `quality.sh`)
+- The synapse module already uses the identical `AtomicBool` pattern (`synapse/orchestration.rs` line 76)
+- `Ordering::Relaxed` is sufficient because the flag is monotonic (false -> true only) and
+  does not guard any other shared data
+
+## Test Plan
+
+- All existing tests pass unchanged — this is a pure internal refactor with no behavioural change
+- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -6,6 +6,7 @@
 use crate::CandidateNeuronJson;
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -50,12 +51,12 @@ pub(crate) fn evaluate_neuron_candidates(
     target_uuid: &str,
     ctx: &NeuronEvalContext<'_>,
     deadline: &Option<SystemTime>,
-    analysis_timed_out: &Arc<Mutex<bool>>,
+    analysis_timed_out: &Arc<AtomicBool>,
 ) -> Result<()> {
     for result in work_results {
         // Check deadline before each evaluation batch
         if deadline_passed(deadline) {
-            *lock_or_bail(analysis_timed_out, "analysis_timed_out")? = true;
+            analysis_timed_out.store(true, Ordering::Relaxed);
             break;
         }
 

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -23,8 +23,7 @@ use crate::analysis::shared::{AnalyzeNeuronsResult, TimingScope};
 
 // Import utilities
 use crate::analysis::utils::{
-    build_deadline, deadline_passed, lock_or_bail, log_analysis_start, shuffle_slice,
-    verbose_enabled,
+    build_deadline, deadline_passed, log_analysis_start, shuffle_slice, verbose_enabled,
 };
 
 // Import diagnostics and rejection tracking (Issue #271)
@@ -44,6 +43,7 @@ use super::synapse::{
 
 use rayon::prelude::*;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 /// Analyze neurons for a given input.
@@ -99,7 +99,7 @@ pub(crate) fn analyze_neurons_with_cache(
         "Discovery logic called without GPU - check_gpu_available should have prevented this"
     );
     let gpu_used = true;
-    let analysis_timed_out = Arc::new(Mutex::new(false));
+    let analysis_timed_out = Arc::new(AtomicBool::new(false));
 
     // Mark skipped neurons in diagnostics so they appear with the correct reason
     // instead of misleading reasons like NoEligibleSources.
@@ -161,8 +161,8 @@ pub(crate) fn analyze_neurons_with_cache(
     focus_order_arc
         .par_iter()
         .try_for_each(|target_uuid| -> Result<()> {
-            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? || deadline_passed(&deadline) {
-                *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? = true;
+            if analysis_timed_out.load(Ordering::Relaxed) || deadline_passed(&deadline) {
+                analysis_timed_out.store(true, Ordering::Relaxed);
                 return Ok(());
             }
 
@@ -244,7 +244,7 @@ pub(crate) fn analyze_neurons_with_cache(
             )?;
 
             // Check if timed out during pre-filtering
-            if *lock_or_bail(&analysis_timed_out, "analysis_timed_out")? {
+            if analysis_timed_out.load(Ordering::Relaxed) {
                 return Ok(());
             }
 

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -6,6 +6,7 @@
 use crate::{AnalyzeNeuronsInput, CandidateNeuronJson};
 use anyhow::Result;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::analysis::cache::RecordCache;
@@ -19,7 +20,7 @@ use crate::analysis::utils::{
 
 /// Parameters for building the final neuron analysis result.
 pub(crate) struct NeuronResultParams<'a> {
-    pub analysis_timed_out: &'a Arc<Mutex<bool>>,
+    pub analysis_timed_out: &'a Arc<AtomicBool>,
     pub helpful_map: &'a Arc<Mutex<HashMap<u64, CandidateNeuronJson>>>,
     pub completed_count: &'a Arc<std::sync::atomic::AtomicUsize>,
     pub total_focus_count: usize,
@@ -41,7 +42,7 @@ pub(crate) struct NeuronResultParams<'a> {
 pub(crate) fn build_neuron_results(
     params: &NeuronResultParams<'_>,
 ) -> Result<AnalyzeNeuronsResult> {
-    let analysis_timed_out = *lock_or_bail(params.analysis_timed_out, "analysis_timed_out")?;
+    let analysis_timed_out = params.analysis_timed_out.load(Ordering::Relaxed);
     let helpful_map = lock_or_bail(params.helpful_map, "helpful_map")?.clone();
 
     // Log timeout with completion stats (always visible, not just verbose)

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -7,7 +7,8 @@ use crate::AnalyzeNeuronsInput;
 use crate::types::DiscoverRecord;
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 
 use crate::analysis::cache::RecordCache;
@@ -20,8 +21,7 @@ use crate::analysis::shared::{
     AnalyzeNeuronsResult, NeuronNoCandidateReason, NeuronNoCandidateSummary,
 };
 use crate::analysis::utils::{
-    OrderedNeuron, deadline_passed, lock_or_bail, order_eligible_sources, parse_input_index,
-    verbose_enabled,
+    OrderedNeuron, deadline_passed, order_eligible_sources, parse_input_index, verbose_enabled,
 };
 
 /// Result of the preparation phase, containing all maps and filtered targets
@@ -163,7 +163,7 @@ pub(crate) fn load_source_records<'a>(
     used_inputs_arc: &Arc<HashSet<String>>,
     cache: &Arc<RecordCache>,
     deadline: &Option<SystemTime>,
-    analysis_timed_out: &Arc<Mutex<bool>>,
+    analysis_timed_out: &Arc<AtomicBool>,
     diagnostics: &Arc<NeuronDiagnostics>,
 ) -> Result<Vec<(&'a OrderedNeuron, Arc<Vec<DiscoverRecord>>)>> {
     let mut eligible_sources: Vec<&OrderedNeuron> = ordered_neurons_arc
@@ -204,7 +204,7 @@ pub(crate) fn load_source_records<'a>(
 
     for source in &eligible_sources {
         if deadline_passed(deadline) {
-            *lock_or_bail(analysis_timed_out, "analysis_timed_out")? = true;
+            analysis_timed_out.store(true, Ordering::Relaxed);
             break;
         }
         let source_uuid = source.uuid.as_str();
@@ -238,7 +238,7 @@ pub(crate) fn load_source_records<'a>(
     // Log summary of source loading results for debugging
     let sources_checked =
         sources_to_process.len() + empty_record_sources.len() + load_failure_count as usize;
-    let timed_out_during_loading = *lock_or_bail(analysis_timed_out, "analysis_timed_out")?;
+    let timed_out_during_loading = analysis_timed_out.load(Ordering::Relaxed);
     if verbose_enabled()
         && (sources_to_process.is_empty()
             || load_failure_count > 0


### PR DESCRIPTION
## Summary

Replace `Arc<Mutex<bool>>` with `Arc<AtomicBool>` for the `analysis_timed_out` flag in
the neuron evaluation module, aligning it with the lock-free pattern already used in the
synapse module. This eliminates unnecessary mutex contention on a simple boolean flag
during parallel neuron evaluation. Closes #803.

Regarding `Arc<Mutex<HashMap>>` for `helpful_map`: during the parallel evaluation loop
all accesses are writes (via `upsert_candidate`), with the single read happening after
the loop completes. Since the access pattern is write-heavy during parallelism, switching
to `RwLock` would not provide a benefit and the `Mutex` is retained.

## Changes

- `src/analysis/neuron/evaluation.rs` — changed `analysis_timed_out` parameter from
  `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with `.store(true, Ordering::Relaxed)`
- `src/analysis/neuron/post_processing.rs` — changed `NeuronResultParams.analysis_timed_out`
  from `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with `.load(Ordering::Relaxed)`
- `src/analysis/neuron/preparation.rs` — changed `load_source_records` parameter from
  `Arc<Mutex<bool>>` to `Arc<AtomicBool>`, replaced `lock_or_bail` with atomic operations,
  removed unused `Mutex` and `lock_or_bail` imports
- `src/analysis/neuron/mod.rs` — changed `analysis_timed_out` from `Arc::new(Mutex::new(false))`
  to `Arc::new(AtomicBool::new(false))`, updated all call sites to use atomic operations,
  removed unused `lock_or_bail` import

## Evidence

- All existing tests pass (verified via `quality.sh`)
- The synapse module already uses the identical `AtomicBool` pattern (`synapse/orchestration.rs` line 76)
- `Ordering::Relaxed` is sufficient because the flag is monotonic (false -> true only) and
  does not guard any other shared data

## Test Plan

- All existing tests pass unchanged — this is a pure internal refactor with no behavioural change
- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

---

## Automated Fix Details
This PR addresses issue #803: **Replace Arc<Mutex<bool>> with AtomicBool in neuron evaluation**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #803