### PR TITLE
fix: reduce String cloning in synapse preparation and candidate generation (#808)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,10 @@ harness = false
 name = "weight_coherence_cache"
 harness = false
 
+[[bench]]
+name = "synapse_preparation"
+harness = false
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/benches/synapse_preparation.rs
+++ b/benches/synapse_preparation.rs
@@ -1,0 +1,185 @@
+//! Benchmark for Issue #808: String cloning in synapse preparation and candidate generation.
+//!
+//! Measures the cost of building creature lookup maps and per-target UUID patterns,
+//! which are hot paths in the synapse analysis pipeline. These benchmarks simulate
+//! the same patterns used in `preparation.rs` and `candidate_generation.rs`.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::collections::{HashMap, HashSet};
+
+/// Create a creature with a given number of hidden neurons and synapses.
+fn create_test_creature(hidden_count: usize) -> CreatureJson {
+    let input_count = hidden_count;
+    let mut neurons = Vec::with_capacity(hidden_count + 1);
+    let mut synapses = Vec::with_capacity(hidden_count * 2);
+
+    for h in 0..hidden_count {
+        neurons.push(NeuronJson {
+            uuid: format!("hidden-{h}"),
+            neuron_type: "hidden".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.1 * h as f32,
+        });
+        synapses.push(SynapseJson {
+            from_uuid: format!("input-{h}"),
+            to_uuid: format!("hidden-{h}"),
+            weight: 0.5,
+            synapse_type: None,
+        });
+    }
+
+    neurons.push(NeuronJson {
+        uuid: "output-0".to_string(),
+        neuron_type: "output".to_string(),
+        squash: "IDENTITY".to_string(),
+        bias: 0.0,
+    });
+    for h in 0..hidden_count {
+        synapses.push(SynapseJson {
+            from_uuid: format!("hidden-{h}"),
+            to_uuid: "output-0".to_string(),
+            weight: 0.3,
+            synapse_type: None,
+        });
+    }
+
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: 1,
+    }
+}
+
+/// Simulate the String-cloning preparation pattern (baseline).
+/// This mirrors what `build_creature_lookups` does with owned String keys.
+#[allow(clippy::type_complexity)]
+fn build_lookup_maps_owned(creature: &CreatureJson) {
+    let neuron_squash_map: HashMap<String, String> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.squash.clone()))
+        .collect();
+    black_box(&neuron_squash_map);
+
+    let used_inputs: HashSet<String> = creature
+        .synapses
+        .iter()
+        .filter(|s| s.from_uuid.starts_with("input-"))
+        .map(|s| s.from_uuid.clone())
+        .collect();
+    black_box(&used_inputs);
+
+    let neuron_bias_map: HashMap<String, f32> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.clone(), n.bias))
+        .collect();
+    black_box(&neuron_bias_map);
+}
+
+/// Simulate the borrowed-reference preparation pattern (optimised).
+/// This mirrors the optimised `build_creature_lookups` with &str keys.
+fn build_lookup_maps_borrowed(creature: &CreatureJson) {
+    let neuron_squash_map: HashMap<&str, &str> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
+        .collect();
+    black_box(&neuron_squash_map);
+
+    let used_inputs: HashSet<&str> = creature
+        .synapses
+        .iter()
+        .filter(|s| s.from_uuid.starts_with("input-"))
+        .map(|s| s.from_uuid.as_str())
+        .collect();
+    black_box(&used_inputs);
+
+    let neuron_bias_map: HashMap<&str, f32> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.bias))
+        .collect();
+    black_box(&neuron_bias_map);
+}
+
+/// Simulate per-target UUID cloning in sample building (baseline).
+fn simulate_per_target_uuid_cloning(creature: &CreatureJson, target_count: usize) {
+    for _target in 0..target_count {
+        for neuron in &creature.neurons {
+            // Simulates the double-clone pattern:
+            // 1. build_samples_for_locality_group clones uuid
+            let source_uuid: String = neuron.uuid.clone();
+            // 2. Consumer clones again for HelpfulWork
+            let _work_uuid: String = source_uuid.clone();
+            black_box(&_work_uuid);
+        }
+    }
+}
+
+/// Simulate per-target UUID borrowing in sample building (optimised).
+fn simulate_per_target_uuid_borrowing(creature: &CreatureJson, target_count: usize) {
+    for _target in 0..target_count {
+        for neuron in &creature.neurons {
+            // Optimised: borrow from source, only allocate once for HelpfulWork
+            let source_uuid: &str = neuron.uuid.as_str();
+            let _work_uuid: String = source_uuid.to_string();
+            black_box(&_work_uuid);
+        }
+    }
+}
+
+fn bench_lookup_map_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synapse_preparation_lookup_maps");
+
+    for neuron_count in [50, 200, 500] {
+        let creature = create_test_creature(neuron_count);
+
+        group.bench_function(format!("owned_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_lookup_maps_owned(black_box(&creature)));
+        });
+
+        group.bench_function(format!("borrowed_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_lookup_maps_borrowed(black_box(&creature)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_per_target_uuid_patterns(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synapse_candidate_uuid_cloning");
+
+    for (neuron_count, target_count) in [(50, 20), (200, 50), (500, 100)] {
+        let creature = create_test_creature(neuron_count);
+
+        group.bench_function(
+            format!("double_clone_{neuron_count}n_{target_count}t"),
+            |b| {
+                b.iter(|| {
+                    simulate_per_target_uuid_cloning(black_box(&creature), target_count);
+                });
+            },
+        );
+
+        group.bench_function(
+            format!("borrow_then_clone_{neuron_count}n_{target_count}t"),
+            |b| {
+                b.iter(|| {
+                    simulate_per_target_uuid_borrowing(black_box(&creature), target_count);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_lookup_map_construction,
+    bench_per_target_uuid_patterns,
+);
+criterion_main!(benches);

--- a/docs/pr-summary-808.md
+++ b/docs/pr-summary-808.md
@@ -1,0 +1,59 @@
+## Summary
+
+Reduce String cloning in synapse preparation and candidate generation hot paths
+by replacing owned `String` values with `&str` references tied to input lifetimes.
+Addresses #808.
+
+### Changes
+
+**Hot path optimisations (per target, per source):**
+- `build_samples_for_locality_group` now returns `&str` references instead of
+  cloned `String` UUIDs, eliminating one allocation per source per target
+- `SourceWorkResult.source_uuid` changed from `String` to `&str`, avoiding
+  the double-clone pattern (clone in locality group + clone for HelpfulWork)
+- `PreparedHarmfulWork` uses `&str` for `from_uuid`/`to_uuid` instead of
+  cloning from `SynapseJson`
+- `NeuronWorkResult.source_uuid` changed from `String` to `&str` in the
+  neuron analysis path
+- Eliminated intermediate `diagnostics_updates: Vec<(String, String, ...)>`
+  allocation by updating diagnostics inline
+
+**One-time setup optimisations (per analysis call):**
+- `CreatureLookups.neuron_squash_map` changed from `HashMap<String, String>`
+  to `HashMap<&str, &str>`, borrowing directly from `NeuronJson` fields
+- `CreatureLookups.neuron_bias_map` changed from `HashMap<String, f32>` to
+  `HashMap<&str, f32>`
+- `CreatureLookups.used_inputs` changed from `HashSet<String>` to `HashSet<&str>`
+- `order_eligible_sources` made generic over hash set key type to support
+  both `HashSet<String>` (neuron module) and `HashSet<&str>` (synapse module)
+
+## Evidence
+
+Benchmark results from `cargo bench --bench synapse_preparation`:
+
+### Lookup map construction (one-time setup)
+
+| Neurons | Owned (before) | Borrowed (after) | Improvement |
+|---------|---------------|------------------|-------------|
+| 50      | 4.72 us       | 2.36 us          | ~50% faster |
+| 200     | 18.5 us       | 9.21 us          | ~50% faster |
+| 500     | 50.6 us       | 27.5 us          | ~46% faster |
+
+### Per-target UUID cloning (hot path)
+
+| Size          | Double clone (before) | Borrow+clone (after) | Improvement |
+|---------------|----------------------|---------------------|-------------|
+| 50n x 20t     | 19.8 us              | 10.8 us             | ~45% faster |
+| 200n x 50t    | 200.6 us             | 104.5 us            | ~48% faster |
+| 500n x 100t   | 987.8 us             | 523.0 us            | ~47% faster |
+
+The hot path improvement eliminates one String allocation per source neuron
+per target neuron. For a 500-neuron creature with 100 focus targets, this
+saves ~50,000 String allocations per analysis call.
+
+## Test Plan
+
+- All existing tests pass (verified via `quality.sh`)
+- Added `synapse_preparation` benchmark suite (`benches/synapse_preparation.rs`)
+- Updated `EXPECTED_BENCHMARKS` in `tests/issue_576_benchmark_regression_tracking.rs`
+- Updated test turbofish annotations for generic `order_eligible_sources`

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -25,8 +25,12 @@ use crate::analysis::synapse::{
 
 /// Work result from sample building phase, containing samples for a single
 /// source neuron.
-pub(crate) struct NeuronWorkResult {
-    pub source_uuid: String,
+///
+/// Uses `&str` for `source_uuid` to avoid cloning UUIDs in the hot path
+/// (Issue #808). The reference points to `OrderedNeuron.uuid` from the
+/// locality group's borrowed source neurons.
+pub(crate) struct NeuronWorkResult<'a> {
+    pub source_uuid: &'a str,
     pub samples: Vec<HelpfulSample>,
 }
 
@@ -47,7 +51,7 @@ pub(crate) struct NeuronEvalContext<'a> {
 /// This handles both ReLU split evaluation and batched activation spec
 /// evaluation, applying source variance discounting.
 pub(crate) fn evaluate_neuron_candidates(
-    work_results: &[NeuronWorkResult],
+    work_results: &[NeuronWorkResult<'_>],
     target_uuid: &str,
     ctx: &NeuronEvalContext<'_>,
     deadline: &Option<SystemTime>,
@@ -80,7 +84,7 @@ pub(crate) fn evaluate_neuron_candidates(
 
         // ReLU evaluation: split by TARGET neuron's error sign.
         evaluate_relu_split(
-            &result.source_uuid,
+            result.source_uuid,
             target_uuid,
             &result.samples,
             target_squash,
@@ -90,7 +94,7 @@ pub(crate) fn evaluate_neuron_candidates(
 
         // Issue #201: Evaluate all activation specs in a single batched GPU call
         evaluate_activation_specs(
-            &result.source_uuid,
+            result.source_uuid,
             target_uuid,
             &result.samples,
             target_squash,

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -253,7 +253,7 @@ pub(crate) fn analyze_neurons_with_cache(
             let target_map_ref = &target_map;
 
             // Issue #221: Sample Locality Optimisation
-            let work_results: Vec<evaluation::NeuronWorkResult> = {
+            let work_results: Vec<evaluation::NeuronWorkResult<'_>> = {
                 let _timing = TimingScope::sample_building(&timing_collector);
 
                 let locality_groups = group_sources_by_locality(&sources_to_process);
@@ -295,7 +295,7 @@ pub(crate) fn analyze_neurons_with_cache(
             for result in &work_results {
                 diagnostics.record_candidate_attempt(target_uuid, !result.samples.is_empty());
                 if result.samples.is_empty() {
-                    diagnostics.record_no_samples(target_uuid, &result.source_uuid);
+                    diagnostics.record_no_samples(target_uuid, result.source_uuid);
                 }
             }
 

--- a/src/analysis/synapse/candidate_generation.rs
+++ b/src/analysis/synapse/candidate_generation.rs
@@ -130,15 +130,18 @@ pub(crate) fn group_sources_by_locality<'a>(
 ///
 /// This uses `TargetMap::build_samples_for_group` to build samples for all
 /// sources in a single pass through the target data.
-pub(crate) fn build_samples_for_locality_group(
-    group: &SampleLocalityGroup<'_>,
+///
+/// Returns `&str` references to source UUIDs from the locality group,
+/// avoiding per-source String allocations in the hot path (Issue #808).
+pub(crate) fn build_samples_for_locality_group<'a>(
+    group: &SampleLocalityGroup<'a>,
     target_map: &TargetMap,
-) -> Vec<(String, Vec<HelpfulSample>, usize)> {
+) -> Vec<(&'a str, Vec<HelpfulSample>, usize)> {
     if group.sources.len() == 1 {
         // Single source - use standard path (no overhead)
         let (source, records) = &group.sources[0];
         let samples = target_map.build_samples_from(records);
-        return vec![(source.uuid.clone(), samples, records.len())];
+        return vec![(source.uuid.as_str(), samples, records.len())];
     }
 
     // Multiple sources - use batched sample building
@@ -154,7 +157,7 @@ pub(crate) fn build_samples_for_locality_group(
         .sources
         .iter()
         .zip(samples_batch)
-        .map(|((source, records), samples)| (source.uuid.clone(), samples, records.len()))
+        .map(|((source, records), samples)| (source.uuid.as_str(), samples, records.len()))
         .collect()
 }
 

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -19,25 +19,29 @@ use crate::analysis::utils::OrderedNeuron;
 ///
 /// Built once at the start of synapse analysis and shared (via `Arc`)
 /// across the per-target parallel loop.
-pub(crate) struct CreatureLookups {
+///
+/// Maps that only reference `NeuronJson` or `SynapseJson` fields use `&str`
+/// to avoid cloning UUID and squash strings from the input (Issue #808).
+/// Maps that require `format!("input-{i}")` keys retain owned `String`s.
+pub(crate) struct CreatureLookups<'a> {
     pub ordered_neurons: Vec<OrderedNeuron>,
     pub order_map: HashMap<String, usize>,
     pub neuron_index: NeuronIndex,
     pub existing_synapses: HashSet<(u32, u32)>,
     pub existing_synapse_weights: HashMap<(u32, u32), f32>,
     pub synapses_by_target: HashMap<u32, Vec<SynapseJson>>,
-    pub neuron_squash_map: HashMap<String, String>,
+    pub neuron_squash_map: HashMap<&'a str, &'a str>,
     pub neuron_type_map: HashMap<String, String>,
     pub input_neuron_uuids: HashSet<String>,
-    pub used_inputs: HashSet<String>,
-    pub neuron_bias_map: HashMap<String, f32>,
+    pub used_inputs: HashSet<&'a str>,
+    pub neuron_bias_map: HashMap<&'a str, f32>,
 }
 
 /// Build all creature lookup maps from the analysis input.
 ///
 /// This includes ordered neurons, interned neuron indices, existing synapse
 /// sets, squash/type/bias maps, and input neuron tracking structures.
-pub(crate) fn build_creature_lookups(input: &AnalyzeSynapsesInput) -> CreatureLookups {
+pub(crate) fn build_creature_lookups<'a>(input: &'a AnalyzeSynapsesInput) -> CreatureLookups<'a> {
     let ordered_neurons = build_ordered_neurons(&input.creature);
     let order_map: HashMap<String, usize> = ordered_neurons
         .iter()
@@ -94,11 +98,11 @@ pub(crate) fn build_creature_lookups(input: &AnalyzeSynapsesInput) -> CreatureLo
             acc
         });
 
-    let neuron_squash_map: HashMap<String, String> = input
+    let neuron_squash_map: HashMap<&str, &str> = input
         .creature
         .neurons
         .iter()
-        .map(|n| (n.uuid.clone(), n.squash.clone()))
+        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
         .collect();
 
     // Build comprehensive neuron type map
@@ -114,21 +118,21 @@ pub(crate) fn build_creature_lookups(input: &AnalyzeSynapsesInput) -> CreatureLo
         .map(|i| format!("input-{i}"))
         .collect();
 
-    // Issue #182: Build used inputs set
-    let used_inputs: HashSet<String> = input
+    // Issue #182: Build used inputs set (Issue #808: borrow from input)
+    let used_inputs: HashSet<&str> = input
         .creature
         .synapses
         .iter()
         .filter(|s| crate::analysis::utils::parse_input_index(&s.from_uuid).is_some())
-        .map(|s| s.from_uuid.clone())
+        .map(|s| s.from_uuid.as_str())
         .collect();
 
-    // Neuron bias map for constant-source folding
-    let neuron_bias_map: HashMap<String, f32> = input
+    // Neuron bias map for constant-source folding (Issue #808: borrow from input)
+    let neuron_bias_map: HashMap<&str, f32> = input
         .creature
         .neurons
         .iter()
-        .map(|n| (n.uuid.clone(), n.bias))
+        .map(|n| (n.uuid.as_str(), n.bias))
         .collect();
 
     CreatureLookups {
@@ -259,12 +263,9 @@ mod tests {
         let input = make_test_input();
         let lookups = build_creature_lookups(&input);
 
-        // Squash map should have hidden + output neurons
+        // Squash map should have hidden + output neurons (Issue #808: borrowed keys/values)
         assert_eq!(lookups.neuron_squash_map.len(), 2);
-        assert_eq!(
-            lookups.neuron_squash_map.get("hidden-1"),
-            Some(&"TANH".to_string())
-        );
+        assert_eq!(lookups.neuron_squash_map.get("hidden-1"), Some(&"TANH"));
 
         // Type map should have inputs + neurons
         assert_eq!(lookups.neuron_type_map.len(), 4);

--- a/src/analysis/synapse/structural_patterns.rs
+++ b/src/analysis/synapse/structural_patterns.rs
@@ -34,7 +34,7 @@ pub(crate) fn detect_noisy_vs_trusted(
     synapses_by_target: &[SynapseJson],
     cache: &RecordCache,
     target_map: &TargetMap,
-    neuron_squash_map: &HashMap<String, String>,
+    neuron_squash_map: &HashMap<&str, &str>,
 ) -> Option<CoordinatedStructuralCandidateJson> {
     fn activation_mean_and_variance(records: &[DiscoverRecord]) -> Option<(f32, f32)> {
         let mut n = 0.0f32;
@@ -104,9 +104,7 @@ pub(crate) fn detect_noisy_vs_trusted(
     const MEAN_EPS: f32 = 1e-3;
     const MIN_VAR_RATIO: f32 = 10.0;
 
-    let target_squash = neuron_squash_map
-        .get(target_uuid)
-        .map(std::string::String::as_str);
+    let target_squash = neuron_squash_map.get(target_uuid).copied();
 
     let mut best: Option<(IncomingInput<'_>, IncomingInput<'_>, f32)> = None; // (noisy, trusted, gain)
 

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -107,8 +107,8 @@ pub(crate) fn collect_and_process_helpful_results(
 
             let target_squash = ctx
                 .neuron_squash_map
-                .get(&work.target_uuid)
-                .map(std::string::String::as_str);
+                .get(work.target_uuid.as_str())
+                .copied();
 
             if get_target_simulation_fn(&work.samples, target_squash).is_some() {
                 results.saturation_aware_used = true;
@@ -269,7 +269,7 @@ pub(crate) fn collect_and_process_helpful_results(
                         {
                             let old_bias = ctx
                                 .neuron_bias_map
-                                .get(&work.target_uuid)
+                                .get(work.target_uuid.as_str())
                                 .copied()
                                 .unwrap_or(0.0);
                             let new_bias = old_bias + (applied_weight * mean_activation);
@@ -354,7 +354,7 @@ pub(crate) fn collect_and_process_helpful_results(
 /// Issue #568: Process pre-built harmful samples via GPU evaluation.
 pub(crate) fn process_harmful_batch_from_prepared(
     target_uuid: &str,
-    harmful_work: &[PreparedHarmfulWork],
+    harmful_work: &[PreparedHarmfulWork<'_>],
     gpu: &GpuWorkQueue,
     ctx: &TargetAnalysisContext,
     cache: &RecordCache,
@@ -393,8 +393,8 @@ pub(crate) fn process_harmful_batch_from_prepared(
         let confidence_metrics =
             compute_confidence_metrics(&work.samples, neuron_error_improvement, None);
         harmful_candidates.push(CandidateSynapseJson {
-            from_neuron_uuid: work.from_uuid.clone(),
-            to_neuron_uuid: work.to_uuid.clone(),
+            from_neuron_uuid: work.from_uuid.to_string(),
+            to_neuron_uuid: work.to_uuid.to_string(),
             from_neuron_index: None,
             to_neuron_index: None,
             weight: work.weight,

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -37,18 +37,21 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 /// Shared context for per-target analysis, built once in the main pipeline.
-pub(crate) struct TargetAnalysisContext {
+///
+/// Maps that reference input data use `&str` to avoid cloning (Issue #808).
+/// The lifetime `'a` is tied to the `AnalyzeSynapsesInput` reference.
+pub(crate) struct TargetAnalysisContext<'a> {
     pub ordered_neurons: Arc<Vec<OrderedNeuron>>,
     pub order_map: Arc<HashMap<String, usize>>,
     pub neuron_index: Arc<NeuronIndex>,
     pub existing_synapses: Arc<HashSet<(u32, u32)>>,
     pub existing_synapse_weights: Arc<HashMap<(u32, u32), f32>>,
     pub synapses_by_target: Arc<HashMap<u32, Vec<SynapseJson>>>,
-    pub neuron_squash_map: Arc<HashMap<String, String>>,
+    pub neuron_squash_map: Arc<HashMap<&'a str, &'a str>>,
     pub neuron_type_map: Arc<HashMap<String, String>>,
     pub input_neuron_uuids: Arc<HashSet<String>>,
-    pub used_inputs: Arc<HashSet<String>>,
-    pub neuron_bias_map: Arc<HashMap<String, f32>>,
+    pub used_inputs: Arc<HashSet<&'a str>>,
+    pub neuron_bias_map: Arc<HashMap<&'a str, f32>>,
     pub constant_source_effect_threshold: Option<f32>,
     pub diagnostics: Arc<crate::analysis::diagnostics::TargetDiagnostics>,
     pub timing_collector: Arc<crate::analysis::shared::TimingCollector>,
@@ -88,10 +91,14 @@ struct HelpfulWork {
 }
 
 /// Tracking result from sample building for a single source neuron.
-struct SourceWorkResult {
+///
+/// Uses `&str` for `source_uuid` to avoid cloning UUIDs in the hot path
+/// (Issue #808). The reference points to `OrderedNeuron.uuid` which lives
+/// in `ctx.ordered_neurons` (Arc'd) for the duration of analysis.
+struct SourceWorkResult<'a> {
     work: Option<HelpfulWork>,
     had_samples: bool,
-    source_uuid: String,
+    source_uuid: &'a str,
     record_count: usize,
 }
 

--- a/src/analysis/synapse/target_analysis/statistics.rs
+++ b/src/analysis/synapse/target_analysis/statistics.rs
@@ -161,7 +161,7 @@ pub(crate) fn build_helpful_work_items(
     target_map_ref: &TargetMap,
     ctx: &TargetAnalysisContext,
 ) -> Vec<HelpfulWork> {
-    let source_results: Vec<SourceWorkResult> = {
+    let source_results: Vec<SourceWorkResult<'_>> = {
         let _timing = TimingScope::sample_building(&ctx.timing_collector);
 
         let locality_groups = group_sources_by_locality(sources_to_process);
@@ -194,7 +194,7 @@ pub(crate) fn build_helpful_work_items(
                         let had_samples = !samples.is_empty();
                         let work = if had_samples {
                             Some(HelpfulWork {
-                                source_uuid: source_uuid.clone(),
+                                source_uuid: source_uuid.to_string(),
                                 target_uuid: target_uuid.to_string(),
                                 samples,
                                 existing_weight: None,
@@ -214,28 +214,19 @@ pub(crate) fn build_helpful_work_items(
             .collect()
     };
 
-    // Extract work batch and batch diagnostics updates
+    // Extract work batch and update diagnostics directly (Issue #808:
+    // use &str source_uuid to avoid intermediate String allocations)
     let mut helpful_work_batch: Vec<HelpfulWork> = Vec::new();
-    let mut diagnostics_updates: Vec<(String, String, bool, usize)> = Vec::new();
 
     for result in source_results {
+        ctx.diagnostics
+            .record_candidate_attempt(target_uuid, result.had_samples);
+        if !result.had_samples {
+            ctx.diagnostics
+                .record_no_samples(target_uuid, result.source_uuid, result.record_count);
+        }
         if let Some(work) = result.work {
             helpful_work_batch.push(work);
-        }
-        diagnostics_updates.push((
-            target_uuid.to_string(),
-            result.source_uuid,
-            result.had_samples,
-            result.record_count,
-        ));
-    }
-
-    for (target, source, had_samples, record_count) in diagnostics_updates {
-        ctx.diagnostics
-            .record_candidate_attempt(&target, had_samples);
-        if !had_samples {
-            ctx.diagnostics
-                .record_no_samples(&target, &source, record_count);
         }
     }
 
@@ -285,11 +276,11 @@ pub(crate) fn build_existing_edge_work(
 /// This function loads records from cache and builds samples, which is pure CPU work.
 /// It is called while the helpful GPU batch is being processed, overlapping CPU and GPU.
 /// (Issue #568)
-pub(crate) fn prepare_harmful_samples(
-    existing_synapses: &[SynapseJson],
+pub(crate) fn prepare_harmful_samples<'a>(
+    existing_synapses: &'a [SynapseJson],
     cache: &RecordCache,
     target_map_ref: &TargetMap,
-) -> Vec<PreparedHarmfulWork> {
+) -> Vec<PreparedHarmfulWork<'a>> {
     let mut harmful_work = Vec::with_capacity(existing_synapses.len());
 
     for synapse in existing_synapses {
@@ -307,8 +298,8 @@ pub(crate) fn prepare_harmful_samples(
         }
 
         harmful_work.push(PreparedHarmfulWork {
-            from_uuid: synapse.from_uuid.clone(),
-            to_uuid: synapse.to_uuid.clone(),
+            from_uuid: synapse.from_uuid.as_str(),
+            to_uuid: synapse.to_uuid.as_str(),
             weight: synapse.weight,
             samples,
         });
@@ -318,9 +309,12 @@ pub(crate) fn prepare_harmful_samples(
 }
 
 /// Pre-built harmful synapse work item for CPU/GPU overlap (Issue #568).
-pub(crate) struct PreparedHarmfulWork {
-    pub from_uuid: String,
-    pub to_uuid: String,
+///
+/// Uses `&str` references to synapse UUIDs from `ctx.synapses_by_target`
+/// to avoid cloning in the per-target hot path (Issue #808).
+pub(crate) struct PreparedHarmfulWork<'a> {
+    pub from_uuid: &'a str,
+    pub to_uuid: &'a str,
     pub weight: f32,
     pub samples: Vec<HelpfulSample>,
 }

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -393,12 +393,12 @@ pub struct OrderedNeuron {
 /// - If `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1` is set, input neurons with NO
 ///   existing outgoing synapses are prioritised (moved to the front) before any other
 ///   ordering is applied (Issue #182).
-pub fn order_eligible_sources(
+pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq>(
     eligible_sources: &mut Vec<&OrderedNeuron>,
     seed: Option<u64>,
     context: &str,
     creature_input_count: usize,
-    used_inputs: Option<&HashSet<String>>,
+    used_inputs: Option<&HashSet<S>>,
 ) {
     if eligible_sources.len() <= 1 {
         return;
@@ -413,7 +413,7 @@ pub fn order_eligible_sources(
         // Partition: unused inputs first, then used inputs, then non-inputs
         let (mut unused_inputs, mut others): (Vec<_>, Vec<_>) = eligible_sources
             .drain(..)
-            .partition(|n| parse_input_index(&n.uuid).is_some() && !used.contains(&n.uuid));
+            .partition(|n| parse_input_index(&n.uuid).is_some() && !used.contains(n.uuid.as_str()));
 
         // Issue #467: Within "others", still put used inputs before hidden neurons
         let (mut used_inputs_vec, mut non_inputs): (Vec<_>, Vec<_>) = others

--- a/src/analysis/utils/deadline_tests.rs
+++ b/src/analysis/utils/deadline_tests.rs
@@ -549,8 +549,8 @@ fn order_eligible_sources_shuffles_deterministically_with_seed() {
     let mut sources1: Vec<&OrderedNeuron> = neurons.iter().collect();
     let mut sources2: Vec<&OrderedNeuron> = neurons.iter().collect();
 
-    order_eligible_sources(&mut sources1, Some(12345), "test", 0, None);
-    order_eligible_sources(&mut sources2, Some(12345), "test", 0, None);
+    order_eligible_sources::<String>(&mut sources1, Some(12345), "test", 0, None);
+    order_eligible_sources::<String>(&mut sources2, Some(12345), "test", 0, None);
 
     let uuids1: Vec<&str> = sources1.iter().map(|n| n.uuid.as_str()).collect();
     let uuids2: Vec<&str> = sources2.iter().map(|n| n.uuid.as_str()).collect();
@@ -568,7 +568,7 @@ fn order_eligible_sources_preserves_all_elements() {
         .collect();
 
     let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
-    order_eligible_sources(&mut sources, Some(42), "test", 0, None);
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 0, None);
 
     let mut uuids: Vec<&str> = sources.iter().map(|n| n.uuid.as_str()).collect();
     uuids.sort();
@@ -583,7 +583,7 @@ fn order_eligible_sources_no_op_for_single_element() {
         index: 0,
     }];
     let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
-    order_eligible_sources(&mut sources, Some(42), "test", 0, None);
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 0, None);
     assert_eq!(sources.len(), 1);
     assert_eq!(sources[0].uuid, "single");
 }

--- a/tests/issue_467_source_type_prioritisation.rs
+++ b/tests/issue_467_source_type_prioritisation.rs
@@ -54,7 +54,7 @@ fn order_eligible_sources_places_input_neurons_before_hidden() {
     let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
 
     // Use a fixed seed for determinism
-    order_eligible_sources(&mut sources, Some(42), "test", 3, None);
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 3, None);
 
     // All input neurons (input-0, input-1, input-2) should appear before any hidden neuron
     let first_hidden_pos = sources
@@ -100,7 +100,7 @@ fn order_eligible_sources_input_first_with_different_seeds() {
 
     for seed in [0u64, 1, 42, 100, 999] {
         let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
-        order_eligible_sources(&mut sources, Some(seed), "test-seeds", 4, None);
+        order_eligible_sources::<String>(&mut sources, Some(seed), "test-seeds", 4, None);
 
         // Input neurons should always be at the front
         let input_count = sources
@@ -144,7 +144,7 @@ fn order_eligible_sources_preserves_all_neurons_with_prioritisation() {
     ];
 
     let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
-    order_eligible_sources(&mut sources, Some(42), "test-preserve", 2, None);
+    order_eligible_sources::<String>(&mut sources, Some(42), "test-preserve", 2, None);
 
     assert_eq!(
         sources.len(),

--- a/tests/issue_576_benchmark_regression_tracking.rs
+++ b/tests/issue_576_benchmark_regression_tracking.rs
@@ -30,6 +30,7 @@ const EXPECTED_BENCHMARKS: &[&str] = &[
     "bfs_allocation",
     "synapse_lookup",
     "weight_coherence_cache",
+    "synapse_preparation",
 ];
 
 #[test]


### PR DESCRIPTION
## Summary

Reduce String cloning in synapse preparation and candidate generation hot paths
by replacing owned `String` values with `&str` references tied to input lifetimes.
Addresses #808.

### Changes

**Hot path optimisations (per target, per source):**
- `build_samples_for_locality_group` now returns `&str` references instead of
  cloned `String` UUIDs, eliminating one allocation per source per target
- `SourceWorkResult.source_uuid` changed from `String` to `&str`, avoiding
  the double-clone pattern (clone in locality group + clone for HelpfulWork)
- `PreparedHarmfulWork` uses `&str` for `from_uuid`/`to_uuid` instead of
  cloning from `SynapseJson`
- `NeuronWorkResult.source_uuid` changed from `String` to `&str` in the
  neuron analysis path
- Eliminated intermediate `diagnostics_updates: Vec<(String, String, ...)>`
  allocation by updating diagnostics inline

**One-time setup optimisations (per analysis call):**
- `CreatureLookups.neuron_squash_map` changed from `HashMap<String, String>`
  to `HashMap<&str, &str>`, borrowing directly from `NeuronJson` fields
- `CreatureLookups.neuron_bias_map` changed from `HashMap<String, f32>` to
  `HashMap<&str, f32>`
- `CreatureLookups.used_inputs` changed from `HashSet<String>` to `HashSet<&str>`
- `order_eligible_sources` made generic over hash set key type to support
  both `HashSet<String>` (neuron module) and `HashSet<&str>` (synapse module)

## Evidence

Benchmark results from `cargo bench --bench synapse_preparation`:

### Lookup map construction (one-time setup)

| Neurons | Owned (before) | Borrowed (after) | Improvement |
|---------|---------------|------------------|-------------|
| 50      | 4.72 us       | 2.36 us          | ~50% faster |
| 200     | 18.5 us       | 9.21 us          | ~50% faster |
| 500     | 50.6 us       | 27.5 us          | ~46% faster |

### Per-target UUID cloning (hot path)

| Size          | Double clone (before) | Borrow+clone (after) | Improvement |
|---------------|----------------------|---------------------|-------------|
| 50n x 20t     | 19.8 us              | 10.8 us             | ~45% faster |
| 200n x 50t    | 200.6 us             | 104.5 us            | ~48% faster |
| 500n x 100t   | 987.8 us             | 523.0 us            | ~47% faster |

The hot path improvement eliminates one String allocation per source neuron
per target neuron. For a 500-neuron creature with 100 focus targets, this
saves ~50,000 String allocations per analysis call.

## Test Plan

- All existing tests pass (verified via `quality.sh`)
- Added `synapse_preparation` benchmark suite (`benches/synapse_preparation.rs`)
- Updated `EXPECTED_BENCHMARKS` in `tests/issue_576_benchmark_regression_tracking.rs`
- Updated test turbofish annotations for generic `order_eligible_sources`

---

## Automated Fix Details
This PR addresses issue #808: **Reduce String cloning in synapse preparation and candidate generation hot paths**

## Milestone
This PR is part of the **14-mar-2026** milestone and targets the `milestone/14-mar-2026` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Addresses #808
---

🤖 Processed by: stservice