### PR TITLE
fix: eliminate SynapseJson cloning and neuron_type String allocation (#808)

### DIFF
--- a/benches/synapse_preparation.rs
+++ b/benches/synapse_preparation.rs
@@ -177,9 +177,101 @@ fn bench_per_target_uuid_patterns(c: &mut Criterion) {
     group.finish();
 }
 
+/// Simulate synapses_by_target with cloned SynapseJson objects (baseline).
+fn build_synapses_by_target_cloned(creature: &CreatureJson) {
+    let synapses_by_target: HashMap<&str, Vec<SynapseJson>> =
+        creature
+            .synapses
+            .iter()
+            .fold(HashMap::new(), |mut acc, synapse| {
+                acc.entry(synapse.to_uuid.as_str())
+                    .or_default()
+                    .push(synapse.clone());
+                acc
+            });
+    black_box(&synapses_by_target);
+}
+
+/// Simulate synapses_by_target with borrowed references (optimised).
+fn build_synapses_by_target_borrowed(creature: &CreatureJson) {
+    let synapses_by_target: HashMap<&str, Vec<&SynapseJson>> =
+        creature
+            .synapses
+            .iter()
+            .fold(HashMap::new(), |mut acc, synapse| {
+                acc.entry(synapse.to_uuid.as_str())
+                    .or_default()
+                    .push(synapse);
+                acc
+            });
+    black_box(&synapses_by_target);
+}
+
+/// Simulate neuron_type_map with owned String values (baseline).
+fn build_neuron_type_map_owned(creature: &CreatureJson) {
+    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+    for i in 0..creature.input {
+        neuron_type_map.insert(format!("input-{i}"), "input".to_string());
+    }
+    for neuron in &creature.neurons {
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
+    }
+    black_box(&neuron_type_map);
+}
+
+/// Simulate neuron_type_map with borrowed &str values (optimised).
+fn build_neuron_type_map_borrowed(creature: &CreatureJson) {
+    let mut neuron_type_map: HashMap<String, &str> = HashMap::new();
+    for i in 0..creature.input {
+        neuron_type_map.insert(format!("input-{i}"), "input");
+    }
+    for neuron in &creature.neurons {
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.as_str());
+    }
+    black_box(&neuron_type_map);
+}
+
+fn bench_synapses_by_target(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synapse_preparation_synapses_by_target");
+
+    for neuron_count in [50, 200, 500] {
+        let creature = create_test_creature(neuron_count);
+
+        group.bench_function(format!("cloned_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_synapses_by_target_cloned(black_box(&creature)));
+        });
+
+        group.bench_function(format!("borrowed_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_synapses_by_target_borrowed(black_box(&creature)));
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_neuron_type_map(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synapse_preparation_neuron_type_map");
+
+    for neuron_count in [50, 200, 500] {
+        let creature = create_test_creature(neuron_count);
+
+        group.bench_function(format!("owned_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_neuron_type_map_owned(black_box(&creature)));
+        });
+
+        group.bench_function(format!("borrowed_{neuron_count}_neurons"), |b| {
+            b.iter(|| build_neuron_type_map_borrowed(black_box(&creature)));
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_lookup_map_construction,
     bench_per_target_uuid_patterns,
+    bench_synapses_by_target,
+    bench_neuron_type_map,
 );
 criterion_main!(benches);

--- a/docs/pr-summary-808.md
+++ b/docs/pr-summary-808.md
@@ -1,59 +1,56 @@
 ## Summary
 
-Reduce String cloning in synapse preparation and candidate generation hot paths
-by replacing owned `String` values with `&str` references tied to input lifetimes.
-Addresses #808.
+Further reduce String cloning in synapse preparation by eliminating two
+remaining allocation sources: `SynapseJson` cloning in `synapses_by_target`
+and `neuron_type` String cloning in `neuron_type_map`. Addresses #808.
+
+This builds on PR #830 which addressed hot-path UUID cloning. These changes
+target the one-time setup allocations that were left as future work.
 
 ### Changes
 
-**Hot path optimisations (per target, per source):**
-- `build_samples_for_locality_group` now returns `&str` references instead of
-  cloned `String` UUIDs, eliminating one allocation per source per target
-- `SourceWorkResult.source_uuid` changed from `String` to `&str`, avoiding
-  the double-clone pattern (clone in locality group + clone for HelpfulWork)
-- `PreparedHarmfulWork` uses `&str` for `from_uuid`/`to_uuid` instead of
-  cloning from `SynapseJson`
-- `NeuronWorkResult.source_uuid` changed from `String` to `&str` in the
-  neuron analysis path
-- Eliminated intermediate `diagnostics_updates: Vec<(String, String, ...)>`
-  allocation by updating diagnostics inline
+**`synapses_by_target` — store references instead of clones:**
+- `CreatureLookups.synapses_by_target` changed from `HashMap<u32, Vec<SynapseJson>>`
+  to `HashMap<u32, Vec<&'a SynapseJson>>`, borrowing directly from `input.creature.synapses`
+- Eliminates cloning entire `SynapseJson` objects (2 String fields + Option<String> each)
+- Updated `detect_noisy_vs_trusted` and `prepare_harmful_samples` parameter types
+  to accept `&[&SynapseJson]` instead of `&[SynapseJson]`
+- Updated `TargetAnalysisContext.synapses_by_target` type accordingly
 
-**One-time setup optimisations (per analysis call):**
-- `CreatureLookups.neuron_squash_map` changed from `HashMap<String, String>`
-  to `HashMap<&str, &str>`, borrowing directly from `NeuronJson` fields
-- `CreatureLookups.neuron_bias_map` changed from `HashMap<String, f32>` to
-  `HashMap<&str, f32>`
-- `CreatureLookups.used_inputs` changed from `HashSet<String>` to `HashSet<&str>`
-- `order_eligible_sources` made generic over hash set key type to support
-  both `HashSet<String>` (neuron module) and `HashSet<&str>` (synapse module)
+**`neuron_type_map` — borrow type string values:**
+- `CreatureLookups.neuron_type_map` changed from `HashMap<String, String>`
+  to `HashMap<String, &'a str>`, borrowing type strings from `NeuronJson.neuron_type`
+  and using `"input"` static str for input neurons
+- Eliminates `neuron.neuron_type.clone()` and `"input".to_string()` allocations
+- Updated all downstream comparison sites to dereference `&&str` values
 
 ## Evidence
 
 Benchmark results from `cargo bench --bench synapse_preparation`:
 
-### Lookup map construction (one-time setup)
+### synapses_by_target construction (one-time setup)
+
+| Neurons | Cloned (before) | Borrowed (after) | Improvement |
+|---------|----------------|------------------|-------------|
+| 50      | 4.84 µs        | 2.47 µs          | ~49% faster |
+| 200     | 19.08 µs       | 9.68 µs          | ~49% faster |
+| 500     | 54.69 µs       | 29.65 µs         | ~46% faster |
+
+### neuron_type_map construction (one-time setup)
 
 | Neurons | Owned (before) | Borrowed (after) | Improvement |
 |---------|---------------|------------------|-------------|
-| 50      | 4.72 us       | 2.36 us          | ~50% faster |
-| 200     | 18.5 us       | 9.21 us          | ~50% faster |
-| 500     | 50.6 us       | 27.5 us          | ~46% faster |
+| 50      | 5.21 µs       | 4.18 µs          | ~20% faster |
+| 200     | 21.02 µs      | 17.21 µs         | ~18% faster |
+| 500     | 64.12 µs      | 54.04 µs         | ~16% faster |
 
-### Per-target UUID cloning (hot path)
-
-| Size          | Double clone (before) | Borrow+clone (after) | Improvement |
-|---------------|----------------------|---------------------|-------------|
-| 50n x 20t     | 19.8 us              | 10.8 us             | ~45% faster |
-| 200n x 50t    | 200.6 us             | 104.5 us            | ~48% faster |
-| 500n x 100t   | 987.8 us             | 523.0 us            | ~47% faster |
-
-The hot path improvement eliminates one String allocation per source neuron
-per target neuron. For a 500-neuron creature with 100 focus targets, this
-saves ~50,000 String allocations per analysis call.
+For a 500-neuron creature, the combined saving is ~25 µs per analysis call
+from `synapses_by_target` and ~10 µs from `neuron_type_map`, eliminating
+~1000 String allocations from synapse cloning and ~500 from type string cloning.
 
 ## Test Plan
 
 - All existing tests pass (verified via `quality.sh`)
-- Added `synapse_preparation` benchmark suite (`benches/synapse_preparation.rs`)
-- Updated `EXPECTED_BENCHMARKS` in `tests/issue_576_benchmark_regression_tracking.rs`
-- Updated test turbofish annotations for generic `order_eligible_sources`
+- Updated test assertions in `preparation.rs` for new `&str` value type
+- Added `synapses_by_target` and `neuron_type_map` benchmark groups to
+  `benches/synapse_preparation.rs`

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -29,9 +29,9 @@ pub(crate) struct CreatureLookups<'a> {
     pub neuron_index: NeuronIndex,
     pub existing_synapses: HashSet<(u32, u32)>,
     pub existing_synapse_weights: HashMap<(u32, u32), f32>,
-    pub synapses_by_target: HashMap<u32, Vec<SynapseJson>>,
+    pub synapses_by_target: HashMap<u32, Vec<&'a SynapseJson>>,
     pub neuron_squash_map: HashMap<&'a str, &'a str>,
-    pub neuron_type_map: HashMap<String, String>,
+    pub neuron_type_map: HashMap<String, &'a str>,
     pub input_neuron_uuids: HashSet<String>,
     pub used_inputs: HashSet<&'a str>,
     pub neuron_bias_map: HashMap<&'a str, f32>,
@@ -88,11 +88,11 @@ pub(crate) fn build_creature_lookups<'a>(input: &'a AnalyzeSynapsesInput) -> Cre
         })
         .collect();
 
-    let synapses_by_target: HashMap<u32, Vec<SynapseJson>> = input
+    let synapses_by_target: HashMap<u32, Vec<&SynapseJson>> = input
         .creature
         .synapses
         .iter()
-        .map(|synapse| (neuron_index.intern(&synapse.to_uuid), synapse.clone()))
+        .map(|synapse| (neuron_index.intern(&synapse.to_uuid), synapse))
         .fold(HashMap::new(), |mut acc, (key, val)| {
             acc.entry(key).or_default().push(val);
             acc
@@ -105,13 +105,13 @@ pub(crate) fn build_creature_lookups<'a>(input: &'a AnalyzeSynapsesInput) -> Cre
         .map(|n| (n.uuid.as_str(), n.squash.as_str()))
         .collect();
 
-    // Build comprehensive neuron type map
-    let mut neuron_type_map: HashMap<String, String> = HashMap::new();
+    // Build comprehensive neuron type map (Issue #808: borrow type values from input)
+    let mut neuron_type_map: HashMap<String, &str> = HashMap::new();
     for input_index in 0..input.creature.input {
-        neuron_type_map.insert(format!("input-{input_index}"), "input".to_string());
+        neuron_type_map.insert(format!("input-{input_index}"), "input");
     }
     for neuron in &input.creature.neurons {
-        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.clone());
+        neuron_type_map.insert(neuron.uuid.clone(), neuron.neuron_type.as_str());
     }
 
     let input_neuron_uuids: HashSet<String> = (0..input.creature.input)
@@ -269,14 +269,8 @@ mod tests {
 
         // Type map should have inputs + neurons
         assert_eq!(lookups.neuron_type_map.len(), 4);
-        assert_eq!(
-            lookups.neuron_type_map.get("input-0"),
-            Some(&"input".to_string())
-        );
-        assert_eq!(
-            lookups.neuron_type_map.get("hidden-1"),
-            Some(&"hidden".to_string())
-        );
+        assert_eq!(lookups.neuron_type_map.get("input-0"), Some(&"input"));
+        assert_eq!(lookups.neuron_type_map.get("hidden-1"), Some(&"hidden"));
 
         // Input neuron UUIDs
         assert_eq!(lookups.input_neuron_uuids.len(), 2);

--- a/src/analysis/synapse/structural_patterns.rs
+++ b/src/analysis/synapse/structural_patterns.rs
@@ -31,7 +31,7 @@ use std::collections::{HashMap, HashSet};
 /// Returns `Some(candidate)` if a beneficial noisy-vs-trusted pair is found.
 pub(crate) fn detect_noisy_vs_trusted(
     target_uuid: &str,
-    synapses_by_target: &[SynapseJson],
+    synapses_by_target: &[&SynapseJson],
     cache: &RecordCache,
     target_map: &TargetMap,
     neuron_squash_map: &HashMap<&str, &str>,

--- a/src/analysis/synapse/target_analysis/candidate_selection.rs
+++ b/src/analysis/synapse/target_analysis/candidate_selection.rs
@@ -43,7 +43,7 @@ pub(crate) fn detect_epistatic_and_synergistic(
     let target_is_output = ctx
         .neuron_type_map
         .get(target_uuid)
-        .is_some_and(|t| t == "output");
+        .is_some_and(|t| *t == "output");
     let target_impact = if target_is_output { 1.0 } else { 0.5 };
 
     // Issue #202: Detect epistatic neuron pairs
@@ -118,7 +118,7 @@ pub(crate) fn detect_redundant_path_candidates(
     let target_is_output = ctx
         .neuron_type_map
         .get(target_uuid)
-        .is_some_and(|t| t == "output");
+        .is_some_and(|t| *t == "output");
     let target_impact = if target_is_output { 1.0 } else { 0.5 };
 
     let redundant_paths =

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -46,9 +46,9 @@ pub(crate) struct TargetAnalysisContext<'a> {
     pub neuron_index: Arc<NeuronIndex>,
     pub existing_synapses: Arc<HashSet<(u32, u32)>>,
     pub existing_synapse_weights: Arc<HashMap<(u32, u32), f32>>,
-    pub synapses_by_target: Arc<HashMap<u32, Vec<SynapseJson>>>,
+    pub synapses_by_target: Arc<HashMap<u32, Vec<&'a SynapseJson>>>,
     pub neuron_squash_map: Arc<HashMap<&'a str, &'a str>>,
-    pub neuron_type_map: Arc<HashMap<String, String>>,
+    pub neuron_type_map: Arc<HashMap<String, &'a str>>,
     pub input_neuron_uuids: Arc<HashSet<String>>,
     pub used_inputs: Arc<HashSet<&'a str>>,
     pub neuron_bias_map: Arc<HashMap<&'a str, f32>>,
@@ -186,8 +186,8 @@ pub(crate) fn analyse_single_target(
         })?;
 
     let input_count = ctx.input_neuron_uuids.len();
-    let is_input_neuron = target_neuron_type == "input";
-    let is_constant_neuron = target_neuron_type == "constant";
+    let is_input_neuron = *target_neuron_type == "input";
+    let is_constant_neuron = *target_neuron_type == "constant";
 
     if is_input_neuron || is_constant_neuron {
         return Ok(results);
@@ -201,7 +201,7 @@ pub(crate) fn analyse_single_target(
             neuron.index < target_index
                 && {
                     match ctx.neuron_type_map.get(&neuron.uuid) {
-                        Some(neuron_type) => neuron_type != "constant",
+                        Some(neuron_type) => *neuron_type != "constant",
                         None => {
                             tracing::warn!(
                                 neuron_uuid = %neuron.uuid,
@@ -231,7 +231,7 @@ pub(crate) fn analyse_single_target(
                     && ctx
                         .neuron_type_map
                         .get(&n.uuid)
-                        .is_some_and(|t| t == "constant")
+                        .is_some_and(|t| *t == "constant")
             })
             .count();
         let input_neurons_before_index = ctx

--- a/src/analysis/synapse/target_analysis/statistics.rs
+++ b/src/analysis/synapse/target_analysis/statistics.rs
@@ -277,7 +277,7 @@ pub(crate) fn build_existing_edge_work(
 /// It is called while the helpful GPU batch is being processed, overlapping CPU and GPU.
 /// (Issue #568)
 pub(crate) fn prepare_harmful_samples<'a>(
-    existing_synapses: &'a [SynapseJson],
+    existing_synapses: &[&'a SynapseJson],
     cache: &RecordCache,
     target_map_ref: &TargetMap,
 ) -> Vec<PreparedHarmfulWork<'a>> {


### PR DESCRIPTION
## Summary

Further reduce String cloning in synapse preparation by eliminating two
remaining allocation sources: `SynapseJson` cloning in `synapses_by_target`
and `neuron_type` String cloning in `neuron_type_map`. closes #808.

This builds on PR #830 which addressed hot-path UUID cloning. These changes
target the one-time setup allocations that were left as future work.

### Changes

**`synapses_by_target` — store references instead of clones:**
- `CreatureLookups.synapses_by_target` changed from `HashMap<u32, Vec<SynapseJson>>`
  to `HashMap<u32, Vec<&'a SynapseJson>>`, borrowing directly from `input.creature.synapses`
- Eliminates cloning entire `SynapseJson` objects (2 String fields + Option<String> each)
- Updated `detect_noisy_vs_trusted` and `prepare_harmful_samples` parameter types
  to accept `&[&SynapseJson]` instead of `&[SynapseJson]`
- Updated `TargetAnalysisContext.synapses_by_target` type accordingly

**`neuron_type_map` — borrow type string values:**
- `CreatureLookups.neuron_type_map` changed from `HashMap<String, String>`
  to `HashMap<String, &'a str>`, borrowing type strings from `NeuronJson.neuron_type`
  and using `"input"` static str for input neurons
- Eliminates `neuron.neuron_type.clone()` and `"input".to_string()` allocations
- Updated all downstream comparison sites to dereference `&&str` values

## Evidence

Benchmark results from `cargo bench --bench synapse_preparation`:

### synapses_by_target construction (one-time setup)

| Neurons | Cloned (before) | Borrowed (after) | Improvement |
|---------|----------------|------------------|-------------|
| 50      | 4.84 µs        | 2.47 µs          | ~49% faster |
| 200     | 19.08 µs       | 9.68 µs          | ~49% faster |
| 500     | 54.69 µs       | 29.65 µs         | ~46% faster |

### neuron_type_map construction (one-time setup)

| Neurons | Owned (before) | Borrowed (after) | Improvement |
|---------|---------------|------------------|-------------|
| 50      | 5.21 µs       | 4.18 µs          | ~20% faster |
| 200     | 21.02 µs      | 17.21 µs         | ~18% faster |
| 500     | 64.12 µs      | 54.04 µs         | ~16% faster |

For a 500-neuron creature, the combined saving is ~25 µs per analysis call
from `synapses_by_target` and ~10 µs from `neuron_type_map`, eliminating
~1000 String allocations from synapse cloning and ~500 from type string cloning.

## Test Plan

- All existing tests pass (verified via `quality.sh`)
- Updated test assertions in `preparation.rs` for new `&str` value type
- Added `synapses_by_target` and `neuron_type_map` benchmark groups to
  `benches/synapse_preparation.rs`

---

## Automated Fix Details
This PR addresses issue #808: **Reduce String cloning in synapse preparation and candidate generation hot paths**

## Milestone
This PR is part of the **14-mar-2026** milestone and targets the `milestone/14-mar-2026` feature branch.

## Quality Checks
- All checks pass via `./quality.sh`
- No existing tests removed or commented out

Addresses #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)