### PR TITLE
fix: deduplicate test names across integration test files (#815)

### DIFF
--- a/docs/pr-summary-815.md
+++ b/docs/pr-summary-815.md
@@ -1,0 +1,21 @@
+## Summary
+
+Deduplicate 58 test function names that appeared across multiple integration test files, making CI output ambiguous. Added module-specific prefixes to 182 test functions across 45 files so every test name is unique and self-describing. Closes #815.
+
+For example:
+- `test_empty_records_no_candidates` in `issue_358_oscillating_neuron_detection.rs` became `test_oscillating_neuron_empty_records_no_candidates`
+- `test_insufficient_samples_not_flagged` in `issue_341_dead_neuron_detection.rs` became `test_dead_neuron_insufficient_samples_not_flagged`
+
+No test logic was changed — only function names were updated with module-specific prefixes.
+
+## Evidence
+
+- Zero duplicate test names remain across all integration test files
+- All 1017 integration tests pass
+- `quality.sh` passes cleanly (fmt, clippy, check, tests, docs, release build)
+
+## Test Plan
+
+- No new tests added — this is a pure rename of existing tests
+- Verified no duplicate test function names remain: `grep -rn '#\[test\]' tests/ -A1 | grep 'fn test_' | sed 's/.*fn \(test_[a-zA-Z0-9_]*\).*/\1/' | sort | uniq -c | awk '$1 > 1'` returns empty
+- All existing tests pass with their new names

--- a/tests/issue_230_multi_hop_candidate_analysis.rs
+++ b/tests/issue_230_multi_hop_candidate_analysis.rs
@@ -211,7 +211,7 @@ fn test_no_candidates_when_fully_connected() {
 
 /// Test 3: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_multi_hop_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -248,7 +248,7 @@ fn test_insufficient_samples_no_candidates() {
 
 /// Test 4: Empty records produce no candidates.
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_multi_hop_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -267,7 +267,7 @@ fn test_empty_records_no_candidates() {
 
 /// Test 5: Estimated improvement is positive for detected candidates.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_multi_hop_estimated_improvement_positive() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -348,7 +348,7 @@ fn test_estimated_improvement_positive() {
 /// Test 6: Multi-hop candidates produce valid coordinated structural candidates
 /// with AddNeuron and AddSynapse operations.
 #[test]
-fn test_candidates_produce_coordinated_operations() {
+fn test_multi_hop_candidates_produce_coordinated_operations() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -455,7 +455,7 @@ fn test_candidate_path_depth_bounded() {
 
 /// Test 8: Multi-hop candidates are sorted by estimated improvement.
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_multi_hop_candidates_sorted_by_improvement() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -522,7 +522,7 @@ fn test_candidates_sorted_by_improvement() {
 
 /// Test 9: Network with no hidden neurons produces no multi-hop candidates.
 #[test]
-fn test_no_hidden_neurons_no_candidates() {
+fn test_multi_hop_no_hidden_neurons_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_341_dead_neuron_detection.rs
+++ b/tests/issue_341_dead_neuron_detection.rs
@@ -156,7 +156,7 @@ fn test_constant_tiny_activation_is_dead() {
 
 /// Test 6: Output neurons should never be flagged as dead.
 #[test]
-fn test_output_neurons_not_flagged() {
+fn test_dead_neuron_output_neurons_not_flagged() {
     let creature = make_creature(vec![neuron("output-1", "output", "IDENTITY")], vec![]);
 
     let records: Vec<DiscoverRecord> = (0..100)
@@ -173,7 +173,7 @@ fn test_output_neurons_not_flagged() {
 
 /// Test 7: Too few samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_dead_neuron_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("hidden-few", "hidden", "RELU"),
@@ -242,7 +242,7 @@ fn test_mixed_neurons_only_dead_detected() {
 
 /// Test 9: Dead neuron candidates produce correct coordinated structural operations.
 #[test]
-fn test_candidates_produce_coordinated_removal_operations() {
+fn test_dead_neuron_candidates_produce_coordinated_removal_operations() {
     let candidate = DeadNeuronCandidate {
         neuron_uuid: "hidden-dead".to_string(),
         mean_abs_activation: 1e-8,

--- a/tests/issue_342_saturated_neuron_detection.rs
+++ b/tests/issue_342_saturated_neuron_detection.rs
@@ -207,7 +207,7 @@ fn test_unbounded_activations_not_flagged() {
 
 /// Test 8: Neuron with too few samples should not be flagged.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_saturated_neuron_insufficient_samples_not_flagged() {
     // Only 5 samples — not enough to be confident about saturation
     let records: Vec<DiscoverRecord> = (0..5)
         .map(|i| record("few-samples", i, 0.999, Some(10.0)))
@@ -226,7 +226,7 @@ fn test_insufficient_samples_not_flagged() {
 
 /// Test 9: Candidates produce correct coordinated structural operations.
 #[test]
-fn test_candidates_produce_coordinated_operations() {
+fn test_saturated_neuron_candidates_produce_coordinated_operations() {
     let candidate = SaturatedNeuronCandidate {
         neuron_uuid: "hidden-17".to_string(),
         current_squash: "TANH".to_string(),
@@ -301,7 +301,7 @@ fn test_mixed_neurons_only_saturated_detected() {
 
 /// Test 11: Input neurons should not be flagged (they are not computation nodes).
 #[test]
-fn test_input_neurons_excluded() {
+fn test_saturated_neuron_input_neurons_excluded() {
     // Input neurons are excluded by the caller — they should not be passed to detect.
     // But if they are, IDENTITY squash means they are not bounded so not flagged.
     let records: Vec<DiscoverRecord> = (0..100)

--- a/tests/issue_343_bottleneck_neuron_detection.rs
+++ b/tests/issue_343_bottleneck_neuron_detection.rs
@@ -331,7 +331,7 @@ fn test_does_not_flag_wide_topology() {
 
 /// Test 3: Output neurons are never flagged as bottlenecks (they are natural convergence points).
 #[test]
-fn test_output_neurons_not_flagged() {
+fn test_bottleneck_output_neurons_not_flagged() {
     // Even though output neurons may have high fan-in, they are expected convergence points
     let creature = CreatureJson {
         neurons: vec![
@@ -408,7 +408,7 @@ fn test_output_neurons_not_flagged() {
 
 /// Test 4: Input neurons are never flagged.
 #[test]
-fn test_input_neurons_not_flagged() {
+fn test_bottleneck_input_neurons_not_flagged() {
     let creature = bottleneck_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
@@ -427,7 +427,7 @@ fn test_input_neurons_not_flagged() {
 
 /// Test 5: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_bottleneck_insufficient_samples_not_flagged() {
     let creature = bottleneck_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
@@ -446,7 +446,7 @@ fn test_insufficient_samples_not_flagged() {
 
 /// Test 6: Candidates produce correct coordinated structural operations.
 #[test]
-fn test_candidates_produce_coordinated_operations() {
+fn test_bottleneck_candidates_produce_coordinated_operations() {
     let candidate = BottleneckNeuronCandidate {
         neuron_uuid: "hidden-bottleneck".to_string(),
         fan_in: 5,

--- a/tests/issue_344_correlated_error_detection.rs
+++ b/tests/issue_344_correlated_error_detection.rs
@@ -196,7 +196,7 @@ fn test_single_output_skips() {
 
 /// Test 4: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_correlated_error_insufficient_samples_no_detection() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -229,7 +229,7 @@ fn test_insufficient_samples_no_detection() {
 /// Test 5: Correlated error group produces coordinated structural candidate
 /// with AddNeuron and AddSynapse operations.
 #[test]
-fn test_candidates_produce_coordinated_operations() {
+fn test_correlated_error_candidates_produce_coordinated_operations() {
     let group = CorrelatedErrorGroup {
         output_neuron_uuids: vec![
             "output-1".to_string(),
@@ -504,7 +504,7 @@ fn test_shared_error_sample_count() {
 
 /// Test 10: Estimated improvement is positive for detected groups.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_correlated_error_estimated_improvement_positive() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_356_dormant_synapse_detection.rs
+++ b/tests/issue_356_dormant_synapse_detection.rs
@@ -32,7 +32,7 @@ fn record(neuron_uuid: &str, obs_index: u32, activation: f32) -> DiscoverRecord 
 
 /// Test 1: Synapse with near-zero weight is detected as dormant.
 #[test]
-fn test_detects_near_zero_weight_synapse() {
+fn test_dormant_synapse_356_detects_near_zero_weight_synapse() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -65,7 +65,7 @@ fn test_detects_near_zero_weight_synapse() {
 
 /// Test 2: Synapse with meaningful weight is NOT flagged.
 #[test]
-fn test_active_synapse_not_flagged() {
+fn test_dormant_synapse_356_active_synapse_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -97,7 +97,7 @@ fn test_active_synapse_not_flagged() {
 
 /// Test 3: Sole connection to target is NOT flagged even if dormant.
 #[test]
-fn test_sole_connection_not_flagged() {
+fn test_dormant_synapse_356_sole_connection_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -120,7 +120,7 @@ fn test_sole_connection_not_flagged() {
 
 /// Test 4: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_dormant_synapse_356_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -145,7 +145,7 @@ fn test_insufficient_samples_not_flagged() {
 
 /// Test 5: Dormant synapse candidates produce correct coordinated removal operations.
 #[test]
-fn test_candidates_produce_coordinated_removal_operations() {
+fn test_dormant_synapse_356_candidates_produce_coordinated_removal_operations() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -194,7 +194,7 @@ fn test_candidates_produce_coordinated_removal_operations() {
 
 /// Test 6: Multiple dormant synapses are all detected.
 #[test]
-fn test_multiple_dormant_synapses_detected() {
+fn test_dormant_synapse_356_multiple_dormant_synapses_detected() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -227,7 +227,7 @@ fn test_multiple_dormant_synapses_detected() {
 
 /// Test 7: Other fan-in count is correctly recorded.
 #[test]
-fn test_other_fan_in_count_correct() {
+fn test_dormant_synapse_356_other_fan_in_count_correct() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_356_opposing_synapse_detection.rs
+++ b/tests/issue_356_opposing_synapse_detection.rs
@@ -59,7 +59,7 @@ fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
 
 /// Test 1: Synapse with strong positive contribution–error correlation is detected.
 #[test]
-fn test_detects_opposing_synapse() {
+fn test_opposing_synapse_356_detects_opposing_synapse() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -104,7 +104,7 @@ fn test_detects_opposing_synapse() {
 
 /// Test 2: Helpful synapse (negative contribution–error correlation) is NOT flagged.
 #[test]
-fn test_helpful_synapse_not_flagged() {
+fn test_opposing_synapse_356_helpful_synapse_not_flagged() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -143,7 +143,7 @@ fn test_helpful_synapse_not_flagged() {
 
 /// Test 3: Hidden-to-hidden synapses are not analysed (only output targets).
 #[test]
-fn test_hidden_target_synapses_not_analysed() {
+fn test_opposing_synapse_356_hidden_target_synapses_not_analysed() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input"),
@@ -199,7 +199,7 @@ fn test_hidden_target_synapses_not_analysed() {
 
 /// Test 4: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_opposing_synapse_356_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -228,7 +228,7 @@ fn test_insufficient_samples_not_flagged() {
 
 /// Test 5: Strongly opposing synapse recommends removal.
 #[test]
-fn test_strongly_opposing_recommends_removal() {
+fn test_opposing_synapse_356_strongly_opposing_recommends_removal() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],

--- a/tests/issue_356_oscillating_neuron_detection.rs
+++ b/tests/issue_356_oscillating_neuron_detection.rs
@@ -118,7 +118,7 @@ fn test_low_sign_change_frequency_not_flagged() {
 
 /// Test 5: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_oscillating_neuron_356_insufficient_samples_not_flagged() {
     let neurons = vec![("hidden-few".to_string(), "TANH".to_string(), 0.0)];
 
     let records: Vec<DiscoverRecord> = (0..5)

--- a/tests/issue_356_output_bias_drift_detection.rs
+++ b/tests/issue_356_output_bias_drift_detection.rs
@@ -60,7 +60,7 @@ fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
 
 /// Test 1: Output neuron with predominantly positive errors is detected.
 #[test]
-fn test_detects_positive_bias_drift() {
+fn test_output_bias_drift_356_detects_positive_bias_drift() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -96,7 +96,7 @@ fn test_detects_positive_bias_drift() {
 
 /// Test 2: Output neuron with predominantly negative errors is detected.
 #[test]
-fn test_detects_negative_bias_drift() {
+fn test_output_bias_drift_356_detects_negative_bias_drift() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -127,7 +127,7 @@ fn test_detects_negative_bias_drift() {
 
 /// Test 3: Output neuron with balanced errors is NOT flagged.
 #[test]
-fn test_balanced_errors_not_flagged() {
+fn test_output_bias_drift_356_balanced_errors_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -184,7 +184,7 @@ fn test_hidden_neuron_not_flagged() {
 
 /// Test 5: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_output_bias_drift_356_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -208,7 +208,7 @@ fn test_insufficient_samples_not_flagged() {
 
 /// Test 6: Very small errors (noise) are NOT flagged.
 #[test]
-fn test_noise_level_errors_not_flagged() {
+fn test_output_bias_drift_356_noise_level_errors_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -277,7 +277,7 @@ fn test_candidates_produce_coordinated_set_bias_operations() {
 
 /// Test 8: Multiple output neurons — only biased ones are detected.
 #[test]
-fn test_multiple_outputs_only_biased_detected() {
+fn test_output_bias_drift_356_multiple_outputs_only_biased_detected() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),
@@ -322,7 +322,7 @@ fn test_multiple_outputs_only_biased_detected() {
 
 /// Test 9: Current bias is correctly recorded.
 #[test]
-fn test_current_bias_recorded() {
+fn test_output_bias_drift_356_current_bias_recorded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),

--- a/tests/issue_358_oscillating_neuron_detection.rs
+++ b/tests/issue_358_oscillating_neuron_detection.rs
@@ -126,7 +126,7 @@ fn test_low_sign_change_frequency_excluded() {
 
 /// Test 5: Insufficient samples (below minimum) are NOT detected.
 #[test]
-fn test_insufficient_samples_excluded() {
+fn test_oscillating_neuron_insufficient_samples_excluded() {
     let neurons = vec![("few".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = (0..5)
         .map(|i| {
@@ -204,7 +204,7 @@ fn test_unbalanced_sign_distribution_excluded() {
 
 /// Test 8: Multiple neurons — only oscillating ones detected.
 #[test]
-fn test_mixed_neurons_filters_correctly() {
+fn test_oscillating_neuron_mixed_neurons_filters_correctly() {
     let neurons = vec![
         ("osc-mix".to_string(), "TANH".to_string(), 0.0),
         ("stable-mix".to_string(), "RELU".to_string(), 0.0),
@@ -317,7 +317,7 @@ fn test_bias_adjustment_for_imbalanced_oscillation() {
 
 /// Test 11: Candidates are sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_oscillating_neuron_candidates_sorted_by_improvement() {
     let neurons = vec![
         ("osc-small".to_string(), "TANH".to_string(), 0.0),
         ("osc-large".to_string(), "TANH".to_string(), 0.0),
@@ -392,7 +392,7 @@ fn test_irregular_oscillation_detected() {
 
 /// Test 13: Empty records produce no candidates.
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_oscillating_neuron_empty_records_no_candidates() {
     let neurons = vec![("empty".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = vec![];
 
@@ -406,7 +406,7 @@ fn test_empty_records_no_candidates() {
 
 /// Test 14: Neuron not in records produces no candidate.
 #[test]
-fn test_missing_neuron_records_no_candidate() {
+fn test_oscillating_neuron_missing_neuron_records_no_candidate() {
     let neurons = vec![("missing".to_string(), "TANH".to_string(), 0.0)];
     // No records for this neuron
     let candidates = detect_oscillating_neurons(&neurons, &[]);
@@ -476,7 +476,7 @@ fn test_balanced_oscillation_no_set_bias() {
 
 /// Test 17: Estimated improvement is positive for detected neurons.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_oscillating_neuron_estimated_improvement_positive() {
     let neurons = vec![("osc-imp".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = (0..100)
         .map(|i| {

--- a/tests/issue_359_dormant_synapse_detection.rs
+++ b/tests/issue_359_dormant_synapse_detection.rs
@@ -84,7 +84,7 @@ fn make_records(neuron_uuid: &str, count: u32, activation: f32) -> Vec<DiscoverR
 // Test 1: Synapse with near-zero weight is detected as dormant.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_detects_near_zero_weight_synapse() {
+fn test_dormant_synapse_detects_near_zero_weight_synapse() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -119,7 +119,7 @@ fn test_detects_near_zero_weight_synapse() {
 // Test 2: Active synapse with meaningful weight is NOT flagged.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_active_synapse_not_flagged() {
+fn test_dormant_synapse_active_synapse_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -153,7 +153,7 @@ fn test_active_synapse_not_flagged() {
 // Test 3: Sole connection to target is NOT flagged even if dormant.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_sole_connection_not_flagged() {
+fn test_dormant_synapse_sole_connection_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -178,7 +178,7 @@ fn test_sole_connection_not_flagged() {
 // Test 4: Insufficient samples should not trigger detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_dormant_synapse_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -206,7 +206,7 @@ fn test_insufficient_samples_not_flagged() {
 // Test 5: Dormant synapse candidates produce correct coordinated removal operations.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_candidates_produce_coordinated_removal_operations() {
+fn test_dormant_synapse_candidates_produce_coordinated_removal_operations() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -257,7 +257,7 @@ fn test_candidates_produce_coordinated_removal_operations() {
 // Test 6: Multiple dormant synapses are all detected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_multiple_dormant_synapses_detected() {
+fn test_dormant_synapse_multiple_dormant_synapses_detected() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -292,7 +292,7 @@ fn test_multiple_dormant_synapses_detected() {
 // Test 7: Other fan-in count is correctly recorded.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_other_fan_in_count_correct() {
+fn test_dormant_synapse_other_fan_in_count_correct() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -322,7 +322,7 @@ fn test_other_fan_in_count_correct() {
 // Test 8: Empty synapse list produces no candidates.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_synapses_no_candidates() {
+fn test_dormant_synapse_empty_synapses_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -345,7 +345,7 @@ fn test_empty_synapses_no_candidates() {
 // Test 9: Missing source neuron records are handled gracefully.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_missing_source_records_handled() {
+fn test_dormant_synapse_missing_source_records_handled() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -523,7 +523,7 @@ fn test_low_activation_does_not_make_active_synapse_dormant() {
 // Test 13: Candidates are sorted by estimated improvement (best first).
 // ---------------------------------------------------------------------------
 #[test]
-fn test_candidates_sorted_by_estimated_improvement() {
+fn test_dormant_synapse_candidates_sorted_by_estimated_improvement() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -566,7 +566,7 @@ fn test_candidates_sorted_by_estimated_improvement() {
 // Test 14: All estimated improvements are positive.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_estimated_improvement_always_positive() {
+fn test_dormant_synapse_estimated_improvement_always_positive() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -607,7 +607,7 @@ fn test_estimated_improvement_always_positive() {
 // Test 15: Coordinated candidate comment includes diagnostic information.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_comment_includes_diagnostics() {
+fn test_dormant_synapse_coordinated_candidate_comment_includes_diagnostics() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -704,7 +704,7 @@ fn test_dormant_to_one_target_active_to_another() {
 // Test 17: Exactly minimum sample count (20) is accepted.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_exactly_minimum_samples_accepted() {
+fn test_dormant_synapse_exactly_minimum_samples_accepted() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -781,7 +781,7 @@ fn test_negative_near_zero_weight_detected() {
 // Test 19: Coordinated candidates are sorted by expected score gain.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidates_sorted_by_score_gain() {
+fn test_dormant_synapse_coordinated_candidates_sorted_by_score_gain() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -824,7 +824,7 @@ fn test_coordinated_candidates_sorted_by_score_gain() {
 // Test 20: Nineteen samples (just below minimum) is rejected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_nineteen_samples_below_minimum_rejected() {
+fn test_dormant_synapse_nineteen_samples_below_minimum_rejected() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -859,7 +859,7 @@ fn test_nineteen_samples_below_minimum_rejected() {
 // Test 21: Empty records list produces no candidates.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_dormant_synapse_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -968,7 +968,7 @@ fn test_varying_activations_correct_mean_contribution() {
 // Test 24: Conversion of empty candidates produces empty results.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_candidates_conversion() {
+fn test_dormant_synapse_empty_candidates_conversion() {
     let coordinated = dormant_synapses_to_coordinated_candidates(&[]);
     assert!(
         coordinated.is_empty(),

--- a/tests/issue_360_opposing_synapse_detection.rs
+++ b/tests/issue_360_opposing_synapse_detection.rs
@@ -122,7 +122,7 @@ fn make_opposing_records(
 // Test 1: Synapse with strong positive contribution–error correlation is detected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_detects_opposing_synapse() {
+fn test_opposing_synapse_detects_opposing_synapse() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -154,7 +154,7 @@ fn test_detects_opposing_synapse() {
 // Test 2: Helpful synapse (negative contribution–error correlation) is NOT flagged.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_helpful_synapse_not_flagged() {
+fn test_opposing_synapse_helpful_synapse_not_flagged() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -182,7 +182,7 @@ fn test_helpful_synapse_not_flagged() {
 // Test 3: Hidden-to-hidden synapses are not analysed (only output targets).
 // ---------------------------------------------------------------------------
 #[test]
-fn test_hidden_target_synapses_not_analysed() {
+fn test_opposing_synapse_hidden_target_synapses_not_analysed() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input"),
@@ -237,7 +237,7 @@ fn test_hidden_target_synapses_not_analysed() {
 // Test 4: Insufficient samples should not trigger detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_opposing_synapse_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -269,7 +269,7 @@ fn test_insufficient_samples_not_flagged() {
 // Test 5: Strongly opposing synapse (correlation > 0.5) recommends removal.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_strongly_opposing_recommends_removal() {
+fn test_opposing_synapse_strongly_opposing_recommends_removal() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -363,7 +363,7 @@ fn test_moderately_opposing_recommends_weight_flip() {
 // Test 7: Coordinated candidate conversion produces correct operations.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_conversion() {
+fn test_opposing_synapse_coordinated_candidate_conversion() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -402,7 +402,7 @@ fn test_coordinated_candidate_conversion() {
 // Test 8: Empty synapse list produces no candidates.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_synapses_no_candidates() {
+fn test_opposing_synapse_empty_synapses_no_candidates() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![], // No synapses
@@ -424,7 +424,7 @@ fn test_empty_synapses_no_candidates() {
 // Test 9: Missing source neuron records are handled gracefully.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_missing_source_records_handled() {
+fn test_opposing_synapse_missing_source_records_handled() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -600,7 +600,7 @@ fn test_multiple_opposing_synapses_detected() {
 // Test 14: Candidates are sorted by estimated improvement (best first).
 // ---------------------------------------------------------------------------
 #[test]
-fn test_candidates_sorted_by_estimated_improvement() {
+fn test_opposing_synapse_candidates_sorted_by_estimated_improvement() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input"),
@@ -659,7 +659,7 @@ fn test_candidates_sorted_by_estimated_improvement() {
 // Test 15: All estimated improvements are positive.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_estimated_improvement_always_positive() {
+fn test_opposing_synapse_estimated_improvement_always_positive() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -689,7 +689,7 @@ fn test_estimated_improvement_always_positive() {
 // Test 16: Coordinated candidate comment includes diagnostic information.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_comment_includes_diagnostics() {
+fn test_opposing_synapse_coordinated_candidate_comment_includes_diagnostics() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -736,7 +736,7 @@ fn test_coordinated_candidate_comment_includes_diagnostics() {
 // Test 17: Exactly minimum sample count (20) is accepted.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_exactly_minimum_samples_accepted() {
+fn test_opposing_synapse_exactly_minimum_samples_accepted() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -764,7 +764,7 @@ fn test_exactly_minimum_samples_accepted() {
 // Test 18: Nineteen samples (just below minimum) is rejected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_nineteen_samples_below_minimum_rejected() {
+fn test_opposing_synapse_nineteen_samples_below_minimum_rejected() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -791,7 +791,7 @@ fn test_nineteen_samples_below_minimum_rejected() {
 // Test 19: Empty records list produces no candidates.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_opposing_synapse_empty_records_no_candidates() {
     let creature = make_creature(
         vec![neuron("input-1", "input"), neuron("output-1", "output")],
         vec![synapse("input-1", "output-1", 0.5)],
@@ -809,7 +809,7 @@ fn test_empty_records_no_candidates() {
 // Test 20: Coordinated candidates sorted by expected score gain.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidates_sorted_by_score_gain() {
+fn test_opposing_synapse_coordinated_candidates_sorted_by_score_gain() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input"),
@@ -904,7 +904,7 @@ fn test_negative_weight_opposing_synapse_detected() {
 // Test 22: Each coordinated candidate has exactly one operation.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_each_candidate_has_one_operation() {
+fn test_opposing_synapse_each_candidate_has_one_operation() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input"),
@@ -963,7 +963,7 @@ fn test_each_candidate_has_one_operation() {
 // Test 23: Empty candidates conversion produces empty results.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_candidates_conversion() {
+fn test_opposing_synapse_empty_candidates_conversion() {
     let coordinated = opposing_synapses_to_coordinated_candidates(&[]);
     assert!(
         coordinated.is_empty(),

--- a/tests/issue_361_output_bias_drift_detection.rs
+++ b/tests/issue_361_output_bias_drift_detection.rs
@@ -93,7 +93,7 @@ fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
 // Test 1: Output neuron with predominantly positive errors is detected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_detects_positive_bias_drift() {
+fn test_output_bias_drift_detects_positive_bias_drift() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -127,7 +127,7 @@ fn test_detects_positive_bias_drift() {
 // Test 2: Output neuron with predominantly negative errors is detected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_detects_negative_bias_drift() {
+fn test_output_bias_drift_detects_negative_bias_drift() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -159,7 +159,7 @@ fn test_detects_negative_bias_drift() {
 // Test 3: Output neuron with balanced errors is NOT flagged.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_balanced_errors_not_flagged() {
+fn test_output_bias_drift_balanced_errors_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -241,7 +241,7 @@ fn test_input_neuron_excluded() {
 // Test 6: Insufficient samples should not trigger detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_output_bias_drift_insufficient_samples_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -266,7 +266,7 @@ fn test_insufficient_samples_not_flagged() {
 // Test 7: Very small errors (noise level) are NOT flagged.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_noise_level_errors_not_flagged() {
+fn test_output_bias_drift_noise_level_errors_not_flagged() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -292,7 +292,7 @@ fn test_noise_level_errors_not_flagged() {
 // Test 8: Coordinated candidate conversion produces correct SetBias operations.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_conversion() {
+fn test_output_bias_drift_coordinated_candidate_conversion() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -337,7 +337,7 @@ fn test_coordinated_candidate_conversion() {
 // Test 9: Multiple output neurons — only biased ones are detected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_multiple_outputs_only_biased_detected() {
+fn test_output_bias_drift_multiple_outputs_only_biased_detected() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),
@@ -384,7 +384,7 @@ fn test_multiple_outputs_only_biased_detected() {
 // Test 10: Current bias is correctly recorded in candidate.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_current_bias_recorded() {
+fn test_output_bias_drift_current_bias_recorded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -479,7 +479,7 @@ fn test_positive_error_fraction_computed_correctly() {
 // Test 13: Candidates are sorted by estimated improvement (best first).
 // ---------------------------------------------------------------------------
 #[test]
-fn test_candidates_sorted_by_estimated_improvement() {
+fn test_output_bias_drift_candidates_sorted_by_estimated_improvement() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),
@@ -531,7 +531,7 @@ fn test_candidates_sorted_by_estimated_improvement() {
 // Test 14: Estimated improvement is always positive.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_estimated_improvement_always_positive() {
+fn test_output_bias_drift_estimated_improvement_always_positive() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),
@@ -584,7 +584,7 @@ fn test_estimated_improvement_always_positive() {
 // Test 15: Coordinated candidate comment includes diagnostics.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_comment_includes_diagnostics() {
+fn test_output_bias_drift_coordinated_candidate_comment_includes_diagnostics() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -628,7 +628,7 @@ fn test_coordinated_candidate_comment_includes_diagnostics() {
 // Test 16: Exactly minimum sample count (20) is accepted.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_exactly_minimum_samples_accepted() {
+fn test_output_bias_drift_exactly_minimum_samples_accepted() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -651,7 +651,7 @@ fn test_exactly_minimum_samples_accepted() {
 // Test 17: Nineteen samples (below minimum) is rejected.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_nineteen_samples_below_minimum_rejected() {
+fn test_output_bias_drift_nineteen_samples_below_minimum_rejected() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -778,7 +778,7 @@ fn test_mean_error_at_noise_threshold_boundary() {
 // Test 21: Empty records produce no candidates.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_output_bias_drift_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", 0.0),
@@ -874,7 +874,7 @@ fn test_set_bias_value_is_current_plus_delta() {
 // Test 24: Each coordinated candidate has exactly one operation.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_each_candidate_has_one_operation() {
+fn test_output_bias_drift_each_candidate_has_one_operation() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),
@@ -920,7 +920,7 @@ fn test_each_candidate_has_one_operation() {
 // Test 25: Empty candidates conversion produces empty results.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_empty_candidates_conversion() {
+fn test_output_bias_drift_empty_candidates_conversion() {
     let coordinated = output_bias_drift_to_coordinated_candidates(&[]);
     assert!(
         coordinated.is_empty(),
@@ -932,7 +932,7 @@ fn test_empty_candidates_conversion() {
 // Test 26: Coordinated candidates sorted by expected score gain.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidates_sorted_by_score_gain() {
+fn test_output_bias_drift_coordinated_candidates_sorted_by_score_gain() {
     let creature = CreatureJson {
         neurons: vec![
             neuron("input-1", "input", 0.0),

--- a/tests/issue_395_bounded_range_detection.rs
+++ b/tests/issue_395_bounded_range_detection.rs
@@ -172,7 +172,7 @@ fn test_detects_hidden_neuron_with_boundary_cluster() {
 // Test 5: Insufficient samples → no detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_not_detected() {
+fn test_bounded_range_insufficient_samples_not_detected() {
     let creature = make_creature(
         vec![
             neuron("input-obs", "input", "IDENTITY"),
@@ -255,7 +255,7 @@ fn test_detects_cluster_at_zero_sentinel() {
 // Test 8: Coordinated candidate conversion produces valid operations.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_coordinated_candidate_conversion() {
+fn test_bounded_range_coordinated_candidate_conversion() {
     let candidates = vec![BoundedRangeCandidate {
         neuron_uuid: "input-obs".to_string(),
         boundary_value: -1.0,
@@ -340,7 +340,7 @@ fn test_multiple_neurons_only_boundary_clustered_detected() {
 // Test 10: Output neurons are excluded from bounded range detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_output_neurons_excluded() {
+fn test_bounded_range_output_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_398_observation_range_detection.rs
+++ b/tests/issue_398_observation_range_detection.rs
@@ -174,7 +174,7 @@ fn test_uniform_distribution_full_range_effective() {
 // Test 4: Insufficient samples — no detection.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_observation_range_insufficient_samples_no_detection() {
     let creature = make_creature(
         vec![
             neuron("input-obs", "input", "IDENTITY"),
@@ -240,7 +240,7 @@ fn test_utilisation_ratio_computed_correctly() {
 // Test 6: Output neurons are excluded (only input observations analysed).
 // ---------------------------------------------------------------------------
 #[test]
-fn test_output_neurons_excluded() {
+fn test_observation_range_output_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_399_restricted_range_detection.rs
+++ b/tests/issue_399_restricted_range_detection.rs
@@ -117,7 +117,7 @@ fn test_does_not_flag_neuron_using_full_range() {
 // Test 3: Unbounded activations (IDENTITY, RELU) are excluded.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_unbounded_activations_excluded() {
+fn test_restricted_range_unbounded_activations_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -157,7 +157,7 @@ fn test_unbounded_activations_excluded() {
 // Test 4: Output neurons are excluded.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_output_neurons_excluded() {
+fn test_restricted_range_output_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -183,7 +183,7 @@ fn test_output_neurons_excluded() {
 // Test 5: Insufficient samples are skipped.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_insufficient_samples_skipped() {
+fn test_restricted_range_insufficient_samples_skipped() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -243,7 +243,7 @@ fn test_dead_neurons_excluded() {
 // Test 7: Candidate generation includes changeSquash, setBias, setWeight.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_candidate_generation_includes_expected_operations() {
+fn test_restricted_range_candidate_generation_includes_expected_operations() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -310,7 +310,7 @@ fn test_candidate_generation_includes_expected_operations() {
 // Test 8: Configurable utilisation threshold.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_configurable_utilisation_threshold() {
+fn test_restricted_range_configurable_utilisation_threshold() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_400_sentinel_value_gating.rs
+++ b/tests/issue_400_sentinel_value_gating.rs
@@ -429,7 +429,7 @@ fn test_detects_sentinel_at_zero() {
 // Test 9: Output neurons are excluded from sentinel gating.
 // ---------------------------------------------------------------------------
 #[test]
-fn test_output_neurons_excluded() {
+fn test_sentinel_gating_output_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_401_operating_point_analysis.rs
+++ b/tests/issue_401_operating_point_analysis.rs
@@ -130,7 +130,7 @@ fn test_well_placed_tanh_not_flagged() {
 
 /// Output neurons should be excluded from operating-point analysis.
 #[test]
-fn test_output_neurons_excluded() {
+fn test_operating_point_output_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -155,7 +155,7 @@ fn test_output_neurons_excluded() {
 
 /// Input neurons should be excluded from operating-point analysis.
 #[test]
-fn test_input_neurons_excluded() {
+fn test_operating_point_input_neurons_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "LOGISTIC"),
@@ -180,7 +180,7 @@ fn test_input_neurons_excluded() {
 
 /// Neurons with fewer than min_samples should not be flagged.
 #[test]
-fn test_insufficient_samples_skipped() {
+fn test_operating_point_insufficient_samples_skipped() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -244,7 +244,7 @@ fn test_records_without_value_skipped() {
 /// Unbounded activations (IDENTITY, RELU) have no fixed active zone,
 /// so they should not be flagged by this module.
 #[test]
-fn test_unbounded_activations_excluded() {
+fn test_operating_point_unbounded_activations_excluded() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -352,7 +352,7 @@ fn test_multiple_neurons_only_poorly_placed_detected() {
 
 /// Candidate generation should produce setBias, changeSquash, and setWeight candidates.
 #[test]
-fn test_candidate_generation_includes_expected_operations() {
+fn test_operating_point_candidate_generation_includes_expected_operations() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -420,7 +420,7 @@ fn test_candidate_generation_includes_expected_operations() {
 
 /// Configurable utilisation threshold should work.
 #[test]
-fn test_configurable_utilisation_threshold() {
+fn test_operating_point_configurable_utilisation_threshold() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_421_gradient_based_discovery.rs
+++ b/tests/issue_421_gradient_based_discovery.rs
@@ -325,7 +325,7 @@ fn test_gradient_to_coordinated_candidates() {
 
 /// Empty records should produce no candidates.
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_gradient_discovery_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -345,7 +345,7 @@ fn test_empty_records_no_candidates() {
 
 /// Insufficient samples should produce no candidates.
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_gradient_discovery_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -536,7 +536,7 @@ fn test_improvement_scales_with_gradient() {
 
 /// Candidates should be sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_gradient_discovery_candidates_sorted_by_improvement() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),

--- a/tests/issue_422_topology_aware_discovery.rs
+++ b/tests/issue_422_topology_aware_discovery.rs
@@ -370,7 +370,7 @@ fn test_balanced_topology_no_issues() {
 
 /// Test 4: Output neurons are never flagged as topology issues.
 #[test]
-fn test_output_neurons_not_flagged() {
+fn test_topology_discovery_output_neurons_not_flagged() {
     let creature = deep_chain_creature();
 
     // Only provide records for the output neuron
@@ -388,7 +388,7 @@ fn test_output_neurons_not_flagged() {
 
 /// Test 5: Input neurons are never flagged.
 #[test]
-fn test_input_neurons_not_flagged() {
+fn test_topology_discovery_input_neurons_not_flagged() {
     let creature = deep_chain_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> =
@@ -405,7 +405,7 @@ fn test_input_neurons_not_flagged() {
 
 /// Test 6: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_flagged() {
+fn test_topology_discovery_insufficient_samples_not_flagged() {
     let creature = deep_chain_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -461,7 +461,7 @@ fn test_empty_network_no_candidates() {
 
 /// Test 8: Candidates have positive estimated improvement.
 #[test]
-fn test_candidates_have_positive_improvement() {
+fn test_topology_discovery_candidates_have_positive_improvement() {
     let creature = deep_chain_with_error_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -485,7 +485,7 @@ fn test_candidates_have_positive_improvement() {
 
 /// Test 9: Topology candidates convert to valid coordinated structural candidates.
 #[test]
-fn test_conversion_to_coordinated_candidates() {
+fn test_topology_discovery_conversion_to_coordinated_candidates() {
     let creature = deep_chain_with_error_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -549,7 +549,7 @@ fn test_long_path_suggests_skip_connection() {
 
 /// Test 11: Candidates are sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_topology_discovery_candidates_sorted_by_improvement() {
     let creature = deep_chain_with_error_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -586,7 +586,7 @@ fn test_no_hidden_records_no_candidates() {
 
 /// Test 13: Network with skip connection already present should not suggest duplicate.
 #[test]
-fn test_existing_skip_connection_not_duplicated() {
+fn test_topology_discovery_existing_skip_connection_not_duplicated() {
     // Deep chain with existing skip: input-0 → h0 → h1 → h2 → output-0
     // Plus skip: h0 → output-0 already exists
     let creature = CreatureJson {

--- a/tests/issue_423_sample_weighted_discovery.rs
+++ b/tests/issue_423_sample_weighted_discovery.rs
@@ -187,7 +187,7 @@ fn test_low_error_neurons_not_flagged() {
 
 /// Detection needs a minimum number of samples.
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_sample_weighted_insufficient_samples_returns_empty() {
     let records = vec![(
         "neuron-a".to_string(),
         make_records("neuron-a", &[0.9, 0.8]),
@@ -277,7 +277,7 @@ fn test_stratify_empty_records() {
 /// Detected high-error neurons should convert to valid coordinated candidates
 /// with positive expected improvement and appropriate comments.
 #[test]
-fn test_candidates_have_positive_improvement() {
+fn test_sample_weighted_candidates_have_positive_improvement() {
     let high_error_records = make_records(
         "problem-neuron",
         &[
@@ -319,7 +319,7 @@ fn test_candidates_have_positive_improvement() {
 
 /// Candidates should be sorted by expected improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_sample_weighted_candidates_sorted_by_improvement() {
     // Create multiple neurons with varying error levels
     let records = vec![
         (

--- a/tests/issue_434_noise_signal_ratio_detection.rs
+++ b/tests/issue_434_noise_signal_ratio_detection.rs
@@ -225,7 +225,7 @@ fn test_small_weight_synapse_not_flagged() {
 
 /// Detection requires minimum samples for statistical reliability.
 #[test]
-fn test_minimum_samples_required() {
+fn test_noise_signal_minimum_samples_required() {
     let creature = make_creature(
         vec![
             neuron("hidden-noisy", "hidden", "RELU"),
@@ -581,7 +581,7 @@ fn test_setweight_recommendation_for_noise_reduction() {
 
 /// Candidates include diagnostic comments explaining the detection.
 #[test]
-fn test_candidate_includes_diagnostic_comment() {
+fn test_noise_signal_candidate_includes_diagnostic_comment() {
     let candidate = NoisyNeuronCandidate {
         neuron_uuid: "hidden-noisy".to_string(),
         noise_to_signal_ratio: 3.5,

--- a/tests/issue_435_input_sensitivity_analysis.rs
+++ b/tests/issue_435_input_sensitivity_analysis.rs
@@ -315,7 +315,7 @@ fn test_zero_variance_input_handled() {
 
 /// Detection requires minimum samples for statistical reliability.
 #[test]
-fn test_minimum_samples_required() {
+fn test_input_sensitivity_minimum_samples_required() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -591,7 +591,7 @@ fn test_configurable_sensitivity_threshold() {
 
 /// Candidates should include diagnostic comments explaining the detection.
 #[test]
-fn test_candidate_includes_diagnostic_comment() {
+fn test_input_sensitivity_candidate_includes_diagnostic_comment() {
     let candidate = DominantInputCandidate {
         input_neuron_uuid: "input-dominant".to_string(),
         target_neuron_uuid: "output-1".to_string(),
@@ -734,7 +734,7 @@ fn test_hidden_neurons_excluded_from_dominant_detection() {
 
 /// Empty records should be handled without panicking.
 #[test]
-fn test_empty_records_handled() {
+fn test_input_sensitivity_empty_records_handled() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_437_weight_coherence_validation.rs
+++ b/tests/issue_437_weight_coherence_validation.rs
@@ -386,7 +386,7 @@ fn test_uncorrelated_opposite_weights_not_flagged() {
 
 /// Detection requires minimum samples for statistical reliability.
 #[test]
-fn test_minimum_samples_required() {
+fn test_weight_coherence_minimum_samples_required() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -582,7 +582,7 @@ fn test_configurable_ratio_threshold() {
 
 /// Candidates should include diagnostic comments explaining the detection.
 #[test]
-fn test_candidate_includes_diagnostic_comment() {
+fn test_weight_coherence_candidate_includes_diagnostic_comment() {
     let candidate = IncoherentWeightRatioCandidate {
         neuron_uuid: "hidden-imbalanced".to_string(),
         incoming_weight_sum: 50.0,
@@ -653,7 +653,7 @@ fn test_input_output_excluded_from_ratio_check() {
 
 /// Empty records should be handled without panicking.
 #[test]
-fn test_empty_records_handled() {
+fn test_weight_coherence_empty_records_handled() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_441_unbounded_capping.rs
+++ b/tests/issue_441_unbounded_capping.rs
@@ -187,7 +187,7 @@ fn test_identity_spiking_detected() {
 
 /// Test: Output neurons should NOT be detected (even if spiking)
 #[test]
-fn test_output_neurons_excluded() {
+fn test_unbounded_capping_output_neurons_excluded() {
     let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "RELU")];
 
     let creature = make_creature(neurons, vec![synapse("hidden-1", "output-0", 1.0)]);
@@ -287,7 +287,7 @@ fn test_bounded_activations_excluded() {
 
 /// Test: Conversion to coordinated structural candidates
 #[test]
-fn test_conversion_to_coordinated_candidates() {
+fn test_unbounded_capping_conversion_to_coordinated_candidates() {
     let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "IDENTITY")];
 
     let creature = make_creature(neurons, vec![synapse("hidden-1", "output-0", 1.0)]);
@@ -337,7 +337,7 @@ fn test_conversion_to_coordinated_candidates() {
 
 /// Test: Insufficient samples should not trigger detection
 #[test]
-fn test_insufficient_samples_skipped() {
+fn test_unbounded_capping_insufficient_samples_skipped() {
     let neurons = vec![hidden("hidden-1", "RELU"), output("output-0", "IDENTITY")];
 
     let creature = make_creature(neurons, vec![synapse("hidden-1", "output-0", 1.0)]);

--- a/tests/issue_489_cross_module_deduplication.rs
+++ b/tests/issue_489_cross_module_deduplication.rs
@@ -181,7 +181,7 @@ fn test_empty_input() {
 
 /// Test 6: Single candidate passes through unchanged.
 #[test]
-fn test_single_candidate_passthrough() {
+fn test_cross_module_dedup_single_candidate_passthrough() {
     let candidates = vec![change_squash_candidate(
         "neuron-5",
         "TANH",

--- a/tests/issue_545_error_plateau.rs
+++ b/tests/issue_545_error_plateau.rs
@@ -112,7 +112,7 @@ fn test_no_detection_for_low_error() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_error_plateau_insufficient_samples_returns_empty() {
     let outputs = vec![output_neuron("output-1", "HARD_TANH")];
 
     let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(
@@ -135,7 +135,7 @@ fn test_insufficient_samples_returns_empty() {
 // =============================================================================
 
 #[test]
-fn test_coordinated_candidate_conversion() {
+fn test_error_plateau_coordinated_candidate_conversion() {
     let outputs = vec![output_neuron("output-1", "HARD_TANH")];
 
     let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(

--- a/tests/issue_545_output_squash_mismatch.rs
+++ b/tests/issue_545_output_squash_mismatch.rs
@@ -119,7 +119,7 @@ fn test_tanh_output_with_tanh_targets_no_detection() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_squash_mismatch_insufficient_samples_returns_empty() {
     let outputs = vec![output_neuron("output-1", "HARD_TANH")];
 
     // Only 5 records — below MIN_DISCOVERY_SAMPLE_COUNT (20)
@@ -166,7 +166,7 @@ fn test_hidden_neurons_are_ignored() {
 // =============================================================================
 
 #[test]
-fn test_coordinated_candidate_conversion() {
+fn test_squash_mismatch_coordinated_candidate_conversion() {
     let outputs = vec![output_neuron("output-1", "HARD_TANH")];
 
     let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(

--- a/tests/issue_547_error_plateau_structural.rs
+++ b/tests/issue_547_error_plateau_structural.rs
@@ -248,7 +248,7 @@ fn test_healthy_network_no_candidates() {
 // =============================================================================
 
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_error_plateau_structural_estimated_improvement_positive() {
     let outputs = vec![output_neuron("output-1", "HARD_TANH")];
 
     let records: Vec<(String, Vec<DiscoverRecord>)> = vec![(

--- a/tests/issue_548_squash_weight_rescale.rs
+++ b/tests/issue_548_squash_weight_rescale.rs
@@ -400,7 +400,7 @@ fn test_aggregate_squash_skipped() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_squash_weight_rescale_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             input_neuron("input-1"),

--- a/tests/issue_549_topology_diversification.rs
+++ b/tests/issue_549_topology_diversification.rs
@@ -194,7 +194,7 @@ fn test_no_detection_for_low_error_direct_path() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_topology_diversification_insufficient_samples_returns_empty() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_550_weight_magnitude_reset.rs
+++ b/tests/issue_550_weight_magnitude_reset.rs
@@ -303,7 +303,7 @@ fn test_no_candidates_for_healthy_synapses() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_weight_magnitude_reset_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             input_neuron("input-1"),

--- a/tests/issue_551_bias_perturbation_regime_shift.rs
+++ b/tests/issue_551_bias_perturbation_regime_shift.rs
@@ -266,7 +266,7 @@ fn test_multiple_suboptimal_neurons_produce_candidates() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_bias_perturbation_insufficient_samples_returns_empty() {
     let hidden_neurons = vec![hidden_neuron("h1", "TANH", 5.0)];
 
     // Only 5 samples — below MIN_DISCOVERY_SAMPLE_COUNT

--- a/tests/issue_569_symmetry_breaking.rs
+++ b/tests/issue_569_symmetry_breaking.rs
@@ -231,7 +231,7 @@ fn test_different_squash_prevents_detection() {
 // =============================================================================
 
 #[test]
-fn test_single_hidden_neuron_no_candidates() {
+fn test_symmetry_breaking_single_hidden_neuron_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -266,7 +266,7 @@ fn test_single_hidden_neuron_no_candidates() {
 // =============================================================================
 
 #[test]
-fn test_no_hidden_neurons_no_candidates() {
+fn test_symmetry_breaking_no_hidden_neurons_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -331,7 +331,7 @@ fn test_coordinated_candidates_include_perturbations() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_returns_empty() {
+fn test_symmetry_breaking_insufficient_samples_returns_empty() {
     let creature = symmetric_creature();
 
     // Only 5 samples — below MIN_DISCOVERY_SAMPLE_COUNT

--- a/tests/issue_570_skip_connection_discovery.rs
+++ b/tests/issue_570_skip_connection_discovery.rs
@@ -374,7 +374,7 @@ fn test_candidates_prioritise_largest_depth_gaps() {
 
 /// Test 4: Candidates have positive estimated improvement.
 #[test]
-fn test_candidates_have_positive_improvement() {
+fn test_skip_connection_candidates_have_positive_improvement() {
     let creature = deep_network_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -450,7 +450,7 @@ fn test_coordinated_candidates_use_conservative_weights() {
 
 /// Test 6: Existing skip connections are not duplicated.
 #[test]
-fn test_existing_skip_connection_not_duplicated() {
+fn test_skip_connection_existing_skip_connection_not_duplicated() {
     // Deep chain with an existing skip: input-0 → h0 directly connected
     let mut creature = deep_network_creature();
     // Add an existing skip: input-0 → h4
@@ -486,7 +486,7 @@ fn test_existing_skip_connection_not_duplicated() {
 
 /// Test 7: Empty network (no hidden neurons) produces no candidates.
 #[test]
-fn test_no_hidden_neurons_no_candidates() {
+fn test_skip_connection_no_hidden_neurons_no_candidates() {
     let creature = CreatureJson {
         neurons: vec![
             NeuronJson {
@@ -523,7 +523,7 @@ fn test_no_hidden_neurons_no_candidates() {
 
 /// Test 8: Insufficient samples do not trigger detection.
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_skip_connection_insufficient_samples_no_candidates() {
     let creature = deep_network_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![
@@ -611,7 +611,7 @@ fn test_source_is_shallow_neuron() {
 
 /// Test 12: Candidates are sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_skip_connection_candidates_sorted_by_improvement() {
     let creature = deep_network_creature();
 
     let neuron_records: Vec<(String, Vec<DiscoverRecord>)> = vec![

--- a/tests/issue_571_co_adaptation_detection.rs
+++ b/tests/issue_571_co_adaptation_detection.rs
@@ -214,7 +214,7 @@ fn test_candidates_generated_for_co_adapted_pair() {
 
 /// Neurons with fewer samples than the minimum threshold should be skipped.
 #[test]
-fn test_insufficient_samples_skipped() {
+fn test_co_adaptation_insufficient_samples_skipped() {
     let creature = make_creature(
         vec![
             neuron("in-0", "input", "IDENTITY"),
@@ -246,7 +246,7 @@ fn test_insufficient_samples_skipped() {
 
 /// A network with only one hidden neuron cannot have co-adapted pairs.
 #[test]
-fn test_single_hidden_neuron_no_candidates() {
+fn test_co_adaptation_single_hidden_neuron_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("in-0", "input", "IDENTITY"),

--- a/tests/issue_610_candidate_diversity_enforcement.rs
+++ b/tests/issue_610_candidate_diversity_enforcement.rs
@@ -207,7 +207,7 @@ fn test_empty_candidates_passthrough() {
 
 /// Test 8: Single candidate passes through unchanged.
 #[test]
-fn test_single_candidate_passthrough() {
+fn test_candidate_diversity_single_candidate_passthrough() {
     let candidates = vec![remove_synapse_candidate("input-1", "output-0", 0.10)];
 
     let config = DiversityConfig::default();

--- a/tests/issue_639_output_conflict_detection.rs
+++ b/tests/issue_639_output_conflict_detection.rs
@@ -163,7 +163,7 @@ fn test_only_hidden_neurons_analysed() {
 
 /// Test 4: Insufficient samples produce no detections.
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_output_conflict_insufficient_samples_no_detection() {
     let creature = two_output_creature();
 
     // Only 5 samples — below minimum threshold
@@ -212,7 +212,7 @@ fn test_single_output_no_detection() {
 
 /// Test 6: Produces valid coordinated structural candidates.
 #[test]
-fn test_produces_valid_coordinated_candidates() {
+fn test_output_conflict_produces_valid_coordinated_candidates() {
     let creature = two_output_creature();
 
     let detected = vec![OutputConflictNeuron {
@@ -372,7 +372,7 @@ fn test_results_sorted_by_severity() {
 
 /// Test 10: Empty records produce no detections.
 #[test]
-fn test_empty_records_no_detections() {
+fn test_output_conflict_empty_records_no_detections() {
     let creature = two_output_creature();
 
     let detected = detect_output_conflict_neurons(&creature, &[]);

--- a/tests/issue_640_bimodal_neuron_detection.rs
+++ b/tests/issue_640_bimodal_neuron_detection.rs
@@ -103,7 +103,7 @@ fn test_none_values_skipped() {
 
 /// Test 4: Insufficient samples are excluded.
 #[test]
-fn test_insufficient_samples_excluded() {
+fn test_bimodal_neuron_insufficient_samples_excluded() {
     let neurons = vec![("few".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = (0..5)
         .map(|i| {
@@ -208,7 +208,7 @@ fn test_overlapping_clusters_not_detected() {
 
 /// Test 8: Multiple neurons — only bimodal ones detected.
 #[test]
-fn test_mixed_neurons_filters_correctly() {
+fn test_bimodal_neuron_mixed_neurons_filters_correctly() {
     let neurons = vec![
         ("bimodal-mix".to_string(), "TANH".to_string(), 0.0),
         ("unimodal-mix".to_string(), "RELU".to_string(), 0.0),
@@ -243,7 +243,7 @@ fn test_mixed_neurons_filters_correctly() {
 
 /// Test 9: Candidates are sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_bimodal_neuron_candidates_sorted_by_improvement() {
     let neurons = vec![
         ("bimodal-small".to_string(), "TANH".to_string(), 0.0),
         ("bimodal-large".to_string(), "TANH".to_string(), 0.0),
@@ -288,7 +288,7 @@ fn test_candidates_sorted_by_improvement() {
 
 /// Test 10: Empty records produce no candidates.
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_bimodal_neuron_empty_records_no_candidates() {
     let neurons = vec![("empty".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = vec![];
 
@@ -302,7 +302,7 @@ fn test_empty_records_no_candidates() {
 
 /// Test 11: Missing neuron records produce no candidate.
 #[test]
-fn test_missing_neuron_records_no_candidate() {
+fn test_bimodal_neuron_missing_neuron_records_no_candidate() {
     let neurons = vec![("missing".to_string(), "TANH".to_string(), 0.0)];
     let candidates = detect_bimodal_neurons(&neurons, &[]);
 
@@ -338,7 +338,7 @@ fn test_partial_none_values_still_detects() {
 
 /// Test 13: Estimated improvement is positive for detected neurons.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_bimodal_neuron_estimated_improvement_positive() {
     let neurons = vec![("bimodal-imp".to_string(), "TANH".to_string(), 0.0)];
     let records: Vec<DiscoverRecord> = (0..100)
         .map(|i| {

--- a/tests/issue_641_fanin_polarity_conflict.rs
+++ b/tests/issue_641_fanin_polarity_conflict.rs
@@ -260,7 +260,7 @@ fn test_candidate_proposes_add_neuron_split() {
 // =============================================================================
 
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_fanin_polarity_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("in-0", "input", "IDENTITY"),
@@ -296,7 +296,7 @@ fn test_insufficient_samples_no_candidates() {
 // =============================================================================
 
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_fanin_polarity_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("in-0", "input", "IDENTITY"),

--- a/tests/issue_642_hard_sample_cluster_detection.rs
+++ b/tests/issue_642_hard_sample_cluster_detection.rs
@@ -210,7 +210,7 @@ fn test_uniform_error_no_clusters() {
 
 /// Test 4: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_hard_sample_cluster_insufficient_samples_no_detection() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -392,7 +392,7 @@ fn test_dominant_inputs_identified() {
 
 /// Test 8: Estimated improvement is positive for detected clusters.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_hard_sample_cluster_estimated_improvement_positive() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_643_activation_error_monotonicity.rs
+++ b/tests/issue_643_activation_error_monotonicity.rs
@@ -252,7 +252,7 @@ fn test_input_output_neurons_excluded() {
 
 /// Test 6: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_activation_monotonicity_insufficient_samples_no_detection() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -390,7 +390,7 @@ fn test_multiple_neurons_only_non_monotonic_flagged() {
 
 /// Test 9: Estimated improvement is positive for detected non-monotonic neurons.
 #[test]
-fn test_estimated_improvement_positive() {
+fn test_activation_monotonicity_estimated_improvement_positive() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),
@@ -438,7 +438,7 @@ fn test_estimated_improvement_positive() {
 
 /// Test 10: Empty records produce no detections.
 #[test]
-fn test_empty_records_no_detections() {
+fn test_activation_monotonicity_empty_records_no_detections() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY"),

--- a/tests/issue_644_weight_polarity_flip.rs
+++ b/tests/issue_644_weight_polarity_flip.rs
@@ -348,7 +348,7 @@ fn test_near_zero_weight_not_flagged() {
 
 /// Empty records should produce no candidates.
 #[test]
-fn test_empty_records_no_candidates() {
+fn test_weight_polarity_flip_empty_records_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -368,7 +368,7 @@ fn test_empty_records_no_candidates() {
 
 /// Insufficient samples should produce no candidates.
 #[test]
-fn test_insufficient_samples_no_candidates() {
+fn test_weight_polarity_flip_insufficient_samples_no_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),
@@ -475,7 +475,7 @@ fn test_flip_is_distinct_from_gradient_delta() {
 
 /// Candidates should be sorted by estimated improvement (best first).
 #[test]
-fn test_candidates_sorted_by_improvement() {
+fn test_weight_polarity_flip_candidates_sorted_by_improvement() {
     let creature = make_creature(
         vec![
             neuron("input-0", "input", "IDENTITY"),

--- a/tests/issue_645_output_range_compression.rs
+++ b/tests/issue_645_output_range_compression.rs
@@ -173,7 +173,7 @@ fn test_hidden_neurons_excluded() {
 
 /// Test 4: Insufficient samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_no_detection() {
+fn test_output_range_compression_insufficient_samples_no_detection() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY", 0.0),
@@ -233,7 +233,7 @@ fn test_unbounded_activation_excluded() {
 
 /// Test 6: Produces valid coordinated candidates (setBias+setWeight or changeSquash).
 #[test]
-fn test_produces_valid_coordinated_candidates() {
+fn test_output_range_compression_produces_valid_coordinated_candidates() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY", 0.0),
@@ -427,7 +427,7 @@ fn test_dead_output_excluded() {
 
 /// Test 11: Empty records produce no detections.
 #[test]
-fn test_empty_records_no_detections() {
+fn test_output_range_compression_empty_records_no_detections() {
     let creature = make_creature(
         vec![
             neuron("input-1", "input", "IDENTITY", 0.0),

--- a/tests/issue_793_low_impact_neuron_detection.rs
+++ b/tests/issue_793_low_impact_neuron_detection.rs
@@ -237,7 +237,7 @@ fn test_output_and_input_neurons_excluded() {
 
 /// Test 7: Candidates convert to coordinated structural RemoveNeuron operations.
 #[test]
-fn test_candidates_produce_coordinated_removal_operations() {
+fn test_low_impact_neuron_candidates_produce_coordinated_removal_operations() {
     let candidate = LowImpactNeuronCandidate {
         neuron_uuid: "hidden-low".to_string(),
         mean_abs_activation: 5e-5,
@@ -327,7 +327,7 @@ fn test_mixed_network_only_low_impact_detected() {
 
 /// Test 9: Too few samples should not trigger detection.
 #[test]
-fn test_insufficient_samples_not_detected() {
+fn test_low_impact_neuron_insufficient_samples_not_detected() {
     let creature = make_creature(
         vec![
             neuron("hidden-few", "hidden", "RELU"),


### PR DESCRIPTION
## Summary

Deduplicate 58 test function names that appeared across multiple integration test files, making CI output ambiguous. Added module-specific prefixes to 182 test functions across 45 files so every test name is unique and self-describing. Closes #815.

For example:
- `test_empty_records_no_candidates` in `issue_358_oscillating_neuron_detection.rs` became `test_oscillating_neuron_empty_records_no_candidates`
- `test_insufficient_samples_not_flagged` in `issue_341_dead_neuron_detection.rs` became `test_dead_neuron_insufficient_samples_not_flagged`

No test logic was changed — only function names were updated with module-specific prefixes.

## Evidence

- Zero duplicate test names remain across all integration test files
- All 1017 integration tests pass
- `quality.sh` passes cleanly (fmt, clippy, check, tests, docs, release build)

## Test Plan

- No new tests added — this is a pure rename of existing tests
- Verified no duplicate test function names remain: `grep -rn '#\[test\]' tests/ -A1 | grep 'fn test_' | sed 's/.*fn \(test_[a-zA-Z0-9_]*\).*/\1/' | sort | uniq -c | awk '$1 > 1'` returns empty
- All existing tests pass with their new names

---

## Automated Fix Details
This PR addresses issue #815: **Audit: deduplicate test names across integration test files**

## Milestone
This PR is part of the **14-mar-2026** milestone and targets the `milestone/14-mar-2026` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #815
---

🤖 Processed by: stservice