### PR TITLE
feat: add lock contention tracing for diagnosing concurrent stalls (#837)

### DIFF
--- a/docs/pr-summary-837.md
+++ b/docs/pr-summary-837.md
@@ -1,0 +1,31 @@
+## Summary
+
+Add optional lock contention tracing for diagnosing concurrent stalls in hot-path lock acquisitions. When `NEAT_AI_DISCOVERY_VERBOSE=1` is set, lock acquisitions exceeding a 100ms threshold emit a `tracing::warn` with the lock name and wait duration. In non-verbose mode, tracing is completely bypassed with zero overhead. Closes #837.
+
+## Changes
+
+- **New module `src/analysis/utils/lock_contention.rs`**: Provides `traced_lock` and `traced_lock_default` functions that wrap `parking_lot::Mutex::lock()` with optional timing when verbose mode is enabled
+- **`src/analysis/shared.rs`**: Instrumented `shader_timings` Mutex in `TimingCollector::record_shader()` and `finalize()` with contention tracing
+- **`src/analysis/utils/mod.rs`**: Updated `lock_or_bail` helper (used by neuron analysis `helpful_map` and other hot paths) to route through contention tracing
+
+Note: Two of the three originally identified hot-path locks have already been eliminated:
+- `error_values_for_distribution` was replaced with Rayon fold/reduce (#834)
+- `shared_cache` in impact calculation was replaced with DashMap (#835)
+
+The remaining `helpful_map` Mutex in neuron analysis and `shader_timings` in `TimingCollector` are now instrumented.
+
+## Evidence
+
+All 7 integration tests pass, plus all existing tests (124+ tests). `quality.sh` passes cleanly including clippy, fmt, doc build, and release build.
+
+## Test Plan
+
+- Added `tests/infrastructure/issue_837_lock_contention_tracing.rs` with 7 tests:
+  - `traced_lock_acquires_mutex_and_returns_correct_value` — basic acquisition
+  - `traced_lock_default_uses_100ms_threshold` — default threshold verification
+  - `traced_lock_allows_mutation_through_guard` — mutation through guard
+  - `traced_lock_with_custom_threshold` — custom threshold support
+  - `traced_lock_concurrent_access_does_not_deadlock` — 4-thread concurrent stress test
+  - `traced_lock_guard_drops_correctly` — guard release verification
+  - `lock_or_bail_uses_contention_tracing` — integration with existing helper
+- Unit tests in `src/analysis/utils/lock_contention.rs` (5 tests)

--- a/src/analysis/shared.rs
+++ b/src/analysis/shared.rs
@@ -122,7 +122,10 @@ impl TimingCollector {
         if !self.enabled {
             return;
         }
-        let mut timings = self.shader_timings.lock();
+        let mut timings = super::utils::lock_contention::traced_lock_default(
+            &self.shader_timings,
+            "shader_timings",
+        );
         let entry = timings.entry(shader_name.to_string()).or_insert((0, 0));
         entry.0 += 1;
         entry.1 += duration_ns;
@@ -165,7 +168,10 @@ impl TimingCollector {
 
         let total_analysis_ms = self.start_time.elapsed().as_secs_f64() * 1000.0;
 
-        let shader_timings_lock = self.shader_timings.lock();
+        let shader_timings_lock = super::utils::lock_contention::traced_lock_default(
+            &self.shader_timings,
+            "shader_timings_finalize",
+        );
         let mut shader_timings = HashMap::new();
         let mut total_shader_ns: u64 = 0;
 

--- a/src/analysis/utils/lock_contention.rs
+++ b/src/analysis/utils/lock_contention.rs
@@ -1,0 +1,111 @@
+//! Lock contention tracing for diagnosing concurrent stalls (Issue #837).
+//!
+//! Provides utilities to trace lock acquisition times on hot-path Mutex locks.
+//! When verbose mode is enabled (`NEAT_AI_DISCOVERY_VERBOSE=1`), lock acquisitions
+//! that exceed a configurable threshold emit a warning via `tracing`.
+//!
+//! In non-verbose mode, the tracing is completely bypassed — there is no
+//! overhead from `Instant::now()` calls or threshold checks.
+
+use parking_lot::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+/// Default lock wait threshold: 100ms.
+///
+/// Lock acquisitions exceeding this duration trigger a warning when verbose
+/// mode is enabled.
+pub const DEFAULT_LOCK_WAIT_THRESHOLD: Duration = Duration::from_millis(100);
+
+/// Acquire a `parking_lot::Mutex` lock with optional contention tracing.
+///
+/// When `NEAT_AI_DISCOVERY_VERBOSE=1` is set, this function measures the time
+/// spent waiting for the lock. If the wait exceeds `threshold`, a warning is
+/// emitted via `tracing` identifying the lock by `lock_name`.
+///
+/// When verbose mode is disabled, this is equivalent to a plain `.lock()` call
+/// with zero overhead.
+///
+/// # Arguments
+/// * `mutex` — The mutex to lock
+/// * `lock_name` — Human-readable label for diagnostics (e.g. `"helpful_map"`)
+/// * `threshold` — Duration above which a warning is emitted
+#[inline]
+pub fn traced_lock<'a, T>(
+    mutex: &'a Mutex<T>,
+    lock_name: &str,
+    threshold: Duration,
+) -> MutexGuard<'a, T> {
+    if !crate::config::verbose() {
+        return mutex.lock();
+    }
+
+    let start = Instant::now();
+    let guard = mutex.lock();
+    let elapsed = start.elapsed();
+
+    if elapsed >= threshold {
+        tracing::warn!(
+            lock = lock_name,
+            wait_ms = elapsed.as_millis() as u64,
+            threshold_ms = threshold.as_millis() as u64,
+            "Lock contention detected: waited {elapsed:?} for lock \"{lock_name}\""
+        );
+    } else {
+        tracing::trace!(
+            lock = lock_name,
+            wait_ms = elapsed.as_millis() as u64,
+            "Lock acquired"
+        );
+    }
+
+    guard
+}
+
+/// Convenience wrapper using the default 100ms threshold.
+#[inline]
+pub fn traced_lock_default<'a, T>(mutex: &'a Mutex<T>, lock_name: &str) -> MutexGuard<'a, T> {
+    traced_lock(mutex, lock_name, DEFAULT_LOCK_WAIT_THRESHOLD)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn traced_lock_acquires_and_returns_guard() {
+        let mutex = Mutex::new(42_i32);
+        let guard = traced_lock(&mutex, "test_lock", Duration::from_millis(100));
+        assert_eq!(*guard, 42);
+    }
+
+    #[test]
+    fn traced_lock_default_acquires_lock() {
+        let mutex = Mutex::new(String::from("hello"));
+        let guard = traced_lock_default(&mutex, "test_default");
+        assert_eq!(*guard, "hello");
+    }
+
+    #[test]
+    fn traced_lock_allows_mutation() {
+        let mutex = Mutex::new(vec![1, 2, 3]);
+        {
+            let mut guard = traced_lock_default(&mutex, "test_mutation");
+            guard.push(4);
+        }
+        let guard = mutex.lock();
+        assert_eq!(*guard, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn traced_lock_works_with_arc() {
+        let mutex = Arc::new(Mutex::new(0_u64));
+        let guard = traced_lock_default(&mutex, "arc_lock");
+        assert_eq!(*guard, 0);
+    }
+
+    #[test]
+    fn default_threshold_is_100ms() {
+        assert_eq!(DEFAULT_LOCK_WAIT_THRESHOLD, Duration::from_millis(100));
+    }
+}

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -11,6 +11,7 @@
 //! - `variant_generation` - Parameterised candidate variant generation (Issue #806)
 
 pub mod deadline;
+pub mod lock_contention;
 pub mod memory;
 pub mod platform;
 pub mod variant_generation;
@@ -24,13 +25,13 @@ use parking_lot::Mutex;
 /// Lock a mutex, returning the guard wrapped in `Ok`.
 ///
 /// `parking_lot::Mutex` does not poison on thread panic, so this helper always
-/// succeeds. The `_context` parameter is retained for API compatibility with
-/// call sites that pass a diagnostic label.
+/// succeeds. The `context` parameter is used as a diagnostic label for lock
+/// contention tracing when verbose mode is enabled (Issue #837).
 pub fn lock_or_bail<'a, T>(
     mutex: &'a Mutex<T>,
-    _context: &str,
+    context: &str,
 ) -> anyhow::Result<parking_lot::MutexGuard<'a, T>> {
-    Ok(mutex.lock())
+    Ok(lock_contention::traced_lock_default(mutex, context))
 }
 
 /// Consume a mutex and return its inner value.
@@ -65,6 +66,9 @@ pub use deadline::{
 // Re-export deadline override for tests
 #[cfg(test)]
 pub use deadline::deadline_override;
+
+// Re-export lock contention tracing functions (Issue #837)
+pub use lock_contention::{DEFAULT_LOCK_WAIT_THRESHOLD, traced_lock, traced_lock_default};
 
 // Re-export variant generation functions for backward compatibility (Issue #806)
 pub(crate) use variant_generation::sensible_bias_abs_max_for_squash;

--- a/tests/infrastructure/issue_837_lock_contention_tracing.rs
+++ b/tests/infrastructure/issue_837_lock_contention_tracing.rs
@@ -1,0 +1,101 @@
+//! Integration tests for lock contention tracing (Issue #837).
+//!
+//! Verifies that the lock contention tracing infrastructure works correctly:
+//! - `traced_lock` acquires the mutex and returns the correct guard
+//! - `traced_lock_default` uses the default 100ms threshold
+//! - Contention tracing does not interfere with correct mutex behaviour
+//! - Multiple threads can use traced locks concurrently without deadlock
+
+use neat_ai_discovery::analysis::utils::lock_contention::{
+    DEFAULT_LOCK_WAIT_THRESHOLD, traced_lock, traced_lock_default,
+};
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[test]
+fn traced_lock_acquires_mutex_and_returns_correct_value() {
+    let mutex = Mutex::new(42_i32);
+    let guard = traced_lock(&mutex, "test_value", Duration::from_millis(100));
+    assert_eq!(*guard, 42);
+}
+
+#[test]
+fn traced_lock_default_uses_100ms_threshold() {
+    assert_eq!(DEFAULT_LOCK_WAIT_THRESHOLD, Duration::from_millis(100));
+    let mutex = Mutex::new("contention_test");
+    let guard = traced_lock_default(&mutex, "default_threshold");
+    assert_eq!(*guard, "contention_test");
+}
+
+#[test]
+fn traced_lock_allows_mutation_through_guard() {
+    let mutex = Mutex::new(vec![1_u32, 2, 3]);
+    {
+        let mut guard = traced_lock_default(&mutex, "mutation_test");
+        guard.push(4);
+        guard.push(5);
+    }
+    // After guard is dropped, verify the mutation persisted
+    let final_value = mutex.lock();
+    assert_eq!(*final_value, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn traced_lock_with_custom_threshold() {
+    let mutex = Mutex::new(String::from("custom"));
+    // Very short threshold — should still acquire without issues
+    let guard = traced_lock(&mutex, "custom_threshold", Duration::from_nanos(1));
+    assert_eq!(*guard, "custom");
+}
+
+#[test]
+fn traced_lock_concurrent_access_does_not_deadlock() {
+    let mutex = Arc::new(Mutex::new(0_u64));
+    let iterations = 100;
+    let thread_count = 4;
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let m = Arc::clone(&mutex);
+            std::thread::spawn(move || {
+                for _ in 0..iterations {
+                    let mut guard = traced_lock_default(&m, "concurrent_test");
+                    *guard += 1;
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().expect("Thread should not panic");
+    }
+
+    let final_value = *mutex.lock();
+    assert_eq!(
+        final_value,
+        thread_count * iterations,
+        "All increments should be accounted for"
+    );
+}
+
+#[test]
+fn traced_lock_guard_drops_correctly() {
+    let mutex = Mutex::new(());
+    // Acquire and immediately drop
+    {
+        let _guard = traced_lock_default(&mutex, "drop_test");
+    }
+    // Should be able to acquire again without blocking
+    let _guard2 = traced_lock_default(&mutex, "drop_test_reacquire");
+}
+
+#[test]
+fn lock_or_bail_uses_contention_tracing() {
+    // Verify that the lock_or_bail helper (used throughout the codebase)
+    // integrates with contention tracing.
+    let mutex = Mutex::new(99_i32);
+    let result = neat_ai_discovery::analysis::utils::lock_or_bail(&mutex, "bail_test");
+    assert!(result.is_ok());
+    assert_eq!(*result.unwrap(), 99);
+}

--- a/tests/infrastructure/main.rs
+++ b/tests/infrastructure/main.rs
@@ -17,4 +17,5 @@ mod issue_754_topology_cache;
 mod issue_769_zero_alloc_synapse_lookup;
 mod issue_776_hashset_hashmap_iteration;
 mod issue_836_deadlock_abort;
+mod issue_837_lock_contention_tracing;
 mod observability;


### PR DESCRIPTION
## Summary

Add optional lock contention tracing for diagnosing concurrent stalls in hot-path lock acquisitions. When `NEAT_AI_DISCOVERY_VERBOSE=1` is set, lock acquisitions exceeding a 100ms threshold emit a `tracing::warn` with the lock name and wait duration. In non-verbose mode, tracing is completely bypassed with zero overhead. Closes #837.

## Changes

- **New module `src/analysis/utils/lock_contention.rs`**: Provides `traced_lock` and `traced_lock_default` functions that wrap `parking_lot::Mutex::lock()` with optional timing when verbose mode is enabled
- **`src/analysis/shared.rs`**: Instrumented `shader_timings` Mutex in `TimingCollector::record_shader()` and `finalize()` with contention tracing
- **`src/analysis/utils/mod.rs`**: Updated `lock_or_bail` helper (used by neuron analysis `helpful_map` and other hot paths) to route through contention tracing

Note: Two of the three originally identified hot-path locks have already been eliminated:
- `error_values_for_distribution` was replaced with Rayon fold/reduce (#834)
- `shared_cache` in impact calculation was replaced with DashMap (#835)

The remaining `helpful_map` Mutex in neuron analysis and `shader_timings` in `TimingCollector` are now instrumented.

## Evidence

All 7 integration tests pass, plus all existing tests (124+ tests). `quality.sh` passes cleanly including clippy, fmt, doc build, and release build.

## Test Plan

- Added `tests/infrastructure/issue_837_lock_contention_tracing.rs` with 7 tests:
  - `traced_lock_acquires_mutex_and_returns_correct_value` — basic acquisition
  - `traced_lock_default_uses_100ms_threshold` — default threshold verification
  - `traced_lock_allows_mutation_through_guard` — mutation through guard
  - `traced_lock_with_custom_threshold` — custom threshold support
  - `traced_lock_concurrent_access_does_not_deadlock` — 4-thread concurrent stress test
  - `traced_lock_guard_drops_correctly` — guard release verification
  - `lock_or_bail_uses_contention_tracing` — integration with existing helper
- Unit tests in `src/analysis/utils/lock_contention.rs` (5 tests)

---

## Automated Fix Details
This PR addresses issue #837: **Add lock contention tracing for diagnosing concurrent stalls**

## Milestone
This PR is part of the **14-mar-2026** milestone and targets the `milestone/14-mar-2026` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #837
---

🤖 Processed by: nleck