### PR TITLE
docs: unify and de-duplicate documentation with README.md as hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,27 +7,9 @@ repository. For user-facing documentation, see [README.md](README.md).
 
 ## 1. Project Overview
 
-**NEAT-AI-Discovery** is a high-performance Rust companion library for
-[stSoftwareAU/NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI). It records
-neuron activations and errors during discovery runs, then analyses the captured
-samples to recommend **mutation candidates** (add/remove/modify) that are likely
-to improve the creature's score.
-
-### Sole Mission
-
-> **Discover changes that improve the creature's score — as fast as possible.**
-
-1. **Improve the creature's score.** Only return candidates with a positive
-   expected improvement.
-2. **Discover improvements as fast as possible.** Leverage GPU compute shaders
-   and SIMD so large creatures can be analysed in seconds.
-3. **Minimise changes to NEAT-AI.** Reuse existing candidate types whenever
-   possible (see [Candidate Types](#11-candidate-types) below).
-
-This library does **not** directly "fix" a creature. NEAT-AI validates each
-candidate by cloning the creature, applying the mutation, and re-scoring against
-the full training set. Only candidates that measurably improve the score are
-admitted back into the population.
+For the full project description, mission statement, and user-facing
+documentation, see [README.md](README.md). The sections below cover
+agent-specific conventions and invariants.
 
 ---
 
@@ -455,54 +437,22 @@ This script:
 
 ## 7. FFI Contract
 
-The library exposes a Deno FFI-friendly symbol set. The authoritative list of
-exported symbols lives in `src/lib.rs` as `#[no_mangle] pub extern "C"`
-functions.
+For the full FFI API reference, exported symbols, JSON interface specification,
+and streaming recording API, see [docs/FFI_API.md](docs/FFI_API.md).
 
-### Key Symbols
-
-| Category | Symbols |
-|----------|---------|
-| **GPU probe** | `check_gpu_available()` |
-| **Version probe** | `get_library_version()` |
-| **Recording (streaming)** | `start_discovery_session`, `append_discovery_records`, `finish_discovery_session`, `cancel_discovery_session` |
-| **Recording (single-call)** | `record_discovery` (avoid for large runs) |
-| **Analysis** | `rank_focus_neurons`, `analyze_parallel` |
-| **Utilities** | `merge_discovery_parquet`, `read_discovery_records_ffi`, `export_visualisation_snapshot` |
-| **Memory management** | `free_discovery_result` |
-
-### Memory Management
+### Key Invariant — Memory Management
 
 Every FFI call returning a `char*` **must** be freed with
 `free_discovery_result()`. Failure to do so will leak memory.
-
-### JSON Interface
-
-All FFI functions accept and return JSON strings. See
-[README.md — JSON Interface](README.md#json-interface) for the full input/output
-format specification.
 
 ---
 
 ## 8. GPU Requirement
 
-**This library requires a GPU.** There is no CPU fallback.
-
-- **macOS**: Metal (should always be available)
-- **Linux**: Vulkan only (no OpenGL/EGL probe to avoid panics)
-
-### Minimum System Requirements
-
-| Requirement | Minimum | Reason |
-|-------------|---------|--------|
-| **Total RAM** | 4 GB | GPU operations require staging buffers |
-| **Available RAM** | 1 GB | Prevents hangs from memory pressure |
-| **GPU** | Metal (macOS) or Vulkan (Linux) | Required for compute shaders |
-
-If no compatible GPU is available, discovery is simply skipped — NEAT-AI
-continues training without the discovery phase. See
-[README.md — GPU Requirement](README.md#gpu-requirement) for full details
-including memory checks and streaming parquet loading.
+**This library requires a GPU.** There is no CPU fallback. See
+[README.md — GPU Requirement](README.md#gpu-requirement) for system requirements
+and [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) for performance tuning and
+troubleshooting.
 
 ---
 
@@ -617,7 +567,5 @@ cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_fo
 
 ## 13. Further Reading
 
-- [README.md](README.md) — User-facing documentation, FFI API, troubleshooting
-- [docs/DISCOVERY_TYPES.md](docs/DISCOVERY_TYPES.md) — Discovery type reference
-- [docs/IMPACT_CALCULATION.md](docs/IMPACT_CALCULATION.md) — Impact scoring algorithm
-- [CHANGELOG.md](CHANGELOG.md) — Version-by-version history
+See the [Additional Documentation](README.md#additional-documentation) table in
+README.md for a comprehensive index of all project documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,127 +73,27 @@ We follow strict TDD:
 ### Quality Gate
 
 **Always run `./quality.sh` before committing.** CI treats warnings as errors.
-
-`./quality.sh` performs these checks in order:
-
-1. Bash syntax check (all `.sh` files)
-2. `cargo build` (debug, quick feedback)
-3. `cargo fmt --all` (auto-formatting)
-4. `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args`
-5. `cargo check --all-targets --all-features`
-6. `cargo test --lib --tests --all-features -- --test-threads=2`
-7. `cargo build --release --lib`
-
-If any step fails, fix the issue and re-run. Do **not** commit code that fails
-`./quality.sh`.
-
-### CI Pipeline
-
-GitHub Actions runs on every pull request to `Develop`:
-
-- `auto-format` — applies `rustfmt` and commits fixes
-- `version-increment` — auto-bumps patch version when `src/` changes
-- `quality` — fmt check, Clippy, cargo check, tests, build
-- `shell-checks` — validates bash script syntax
-- `spell-check` — runs codespell on the codebase
-- `validation` — checks required files and `Cargo.toml`
-- `security` — runs security audit workflow
+For the full list of checks performed by `./quality.sh` and details of the CI
+pipeline, see [AGENTS.md — Quality Gate](AGENTS.md#5-quality-gate).
 
 **GPU tests are skipped in CI** (no GPU available). For full coverage, run
 `./quality.sh` locally before pushing.
-
-**Do NOT modify `.github/workflows/ci.yml` without explicit approval.**
 
 ---
 
 ## Code Style
 
-### Australian English
-
-Use Australian English throughout all code, comments, and documentation:
-
-- colour, behaviour, organisation, favour, metre, centre, analyse, minimise,
-  optimise, serialise, initialise, utilise, recognise, emphasise, prioritise,
-  licence (noun), defence, modelling, travelling
-
-### Formatting and Linting
-
-- **Formatting**: `cargo fmt --all` (applied automatically by `./quality.sh`)
-- **Linting**: `cargo clippy --all-targets --all-features -- -D warnings -D clippy::uninlined_format_args`
-
-### Coding Principles
-
-- **KISS** — Favour simplicity; avoid unnecessary complexity.
-- **DRY** — Avoid duplication; maintain a single source of truth.
-- **Boy Scout Rule** — Leave the code cleaner than you found it.
-- **Prefer smaller files** — Favour many smaller, focused source files over
-  large monolithic ones (Single Responsibility Principle).
-- **Avoid over-engineering** — Only make changes that are directly requested or
-  clearly necessary. Do not add features, refactoring, or "improvements" beyond
-  what was asked.
-
-### Rust Best Practices
-
-- Follow standard Rust idioms (`Result`, `Option`, pattern matching).
-- Use `anyhow` for error handling in application code.
-- Prefer Rust standard library features over external crates when possible.
-- All dependencies must be Apache-2.0 compatible (see
-  [AGENTS.md](AGENTS.md#rust-best-practices) for the full list of allowed
-  licences).
+For the full coding conventions — Australian English requirements, formatting,
+linting, coding principles, and Rust best practices — see
+[AGENTS.md — Coding Conventions](AGENTS.md#3-coding-conventions).
 
 ---
 
 ## Testing Guidelines
 
-### Unit Tests vs Benchmarks
-
-| Concern | Unit Tests | Benchmarks |
-|---------|-----------|------------|
-| **Purpose** | Verify correctness | Measure performance |
-| **Location** | `tests/` (integration) or `src/` with `#[cfg(test)]` | `benches/` |
-| **Run with** | `cargo test` | `cargo bench --bench <name>` |
-| **Should not** | Measure performance or print timing | Verify correctness |
-
-**Never reduce iteration counts to make "performance tests" faster in unit
-tests.** If you need to confirm performance, create proper benchmarks.
-
-### Test Organisation
-
-- **Prefer `tests/` directory** (integration tests) over inline unit tests.
-- Only place tests under `src/` when the behaviour cannot be exercised cleanly
-  via the public API.
-- If unit tests in `src/` grow large, extract them into a dedicated `tests.rs`
-  module file.
-- Do not make APIs public just for testing.
-- Group related tests by concern (e.g., all weight tests in one file).
-
-### Test Outcomes, Not Implementation
-
-Tests verify **what** the system does, not **how** it does it. The same test
-should pass regardless of whether we use GPU, CPU, or TPU internally.
-
-```rust
-// GOOD: Tests the outcome
-#[test]
-fn test_low_impact_neurons_are_detected() {
-    let creature = create_test_creature();
-    let impacts = compute_impacts(&creature);
-    assert!(impacts["far-from-output"] < 0.1);
-    assert!(impacts["close-to-output"] > 0.9);
-}
-
-// BAD: Tests implementation details
-#[test]
-fn test_gpu_kernel_computes_impacts() {
-    // Don't test HOW we compute, test WHAT we compute
-}
-```
-
-### Test Change Significance
-
-- **New test file** — generally good (more coverage).
-- **Modified test** — requires justification (did requirements change?).
-- **Removed/skipped test** — red flag; must be justified.
+For the full testing philosophy — TDD workflow, unit tests vs benchmarks, test
+organisation, and test outcomes vs implementation — see
+[AGENTS.md — Testing Philosophy](AGENTS.md#4-testing-philosophy).
 
 ---
 
@@ -232,52 +132,12 @@ worker has loaded.
 
 ## Project Structure
 
-```
-src/
-├── lib.rs                    # FFI entry points (no_mangle extern "C")
-├── types.rs                  # Core type definitions
-├── activations.rs            # Activation function calculations
-├── record.rs                 # Discovery data recording
-├── streaming.rs              # Streaming session management
-├── parquet_format.rs         # Parquet I/O
-├── export.rs                 # Data export utilities
-├── discovery_history.rs      # Historical tracking
-├── debug.rs                  # Debugging utilities
-├── observability.rs          # Observability / logging
-├── intern.rs                 # Neuron UUID interning
-├── watchdog.rs               # Signal handling (SIGUSR1)
-├── focus.rs                  # Focus neuron selection
-│
-├── analysis/                 # Core analysis engine
-│   ├── mod.rs                # Module organisation
-│   ├── shared.rs             # Common types, results, diagnostics
-│   ├── synapse.rs            # Synapse analysis
-│   ├── neuron.rs             # Neuron analysis
-│   ├── activation.rs         # Activation function analysis
-│   ├── samples.rs            # Sample data structures
-│   ├── gpu/                  # GPU infrastructure
-│   └── utils/                # Utilities (memory, deadline, platform)
-│
-└── shaders/                  # WGSL compute shaders
-```
-
-| Directory | Purpose |
-|-----------|---------|
-| `tests/` | Integration tests |
-| `benches/` | Criterion benchmarks |
-| `examples/` | Standalone examples |
-| `scripts/` | Build and install helpers |
-| `docs/` | Supplementary documentation and PR summaries |
-
-For the full source layout with all files, see
-[AGENTS.md — Source Layout](AGENTS.md#source-layout).
+For the full source layout with all files and directory descriptions, see
+[AGENTS.md — Architecture](AGENTS.md#2-architecture).
 
 ---
 
 ## Further Reading
 
-- [README.md](README.md) — User-facing documentation, FFI API, troubleshooting
-- [AGENTS.md](AGENTS.md) — Detailed coding conventions for AI agents
-- [docs/DISCOVERY_TYPES.md](docs/DISCOVERY_TYPES.md) — Discovery type reference
-- [docs/IMPACT_CALCULATION.md](docs/IMPACT_CALCULATION.md) — Impact scoring algorithm
-- [CHANGELOG.md](CHANGELOG.md) — Version-by-version history
+See the [Additional Documentation](README.md#additional-documentation) table in
+README.md for a comprehensive index of all project documentation.

--- a/README.md
+++ b/README.md
@@ -469,12 +469,13 @@ All dependencies build automatically on remote, unattended machines.
 | [docs/discoveries/](docs/discoveries/README.md) | Visual discovery scenario guides with diagrams and examples |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Development guidelines for contributors |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version history of changes |
-| [AGENTS.md](AGENTS.md) | Coding guidelines for AI agents |
+| [AGENTS.md](AGENTS.md) | Coding guidelines and invariants for AI agents |
 | [docs/DISCOVERY_TYPES.md](docs/DISCOVERY_TYPES.md) | All discovery types with success/failure rates |
 | [docs/IMPACT_CALCULATION.md](docs/IMPACT_CALCULATION.md) | Neuron impact calculation details |
 | [docs/ANALYSIS_DEEP_DIVE.md](docs/ANALYSIS_DEEP_DIVE.md) | Detailed analysis workflow and detection algorithms |
 | [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) | GPU performance tuning, troubleshooting, and debugging |
 | [docs/FFI_API.md](docs/FFI_API.md) | Full FFI API reference and JSON interface |
+| [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Benchmark regression tracking and comparison workflow |
 | [CodeWiki](https://codewiki.google/github.com/stsoftwareau/neat-ai-discovery) | AI-powered documentation and code exploration |
 
 ## License

--- a/docs/pr-summary-841.md
+++ b/docs/pr-summary-841.md
@@ -1,0 +1,45 @@
+## Summary
+
+Unified and de-duplicated user documentation with README.md as the central hub.
+Closes #841.
+
+### Changes
+
+- **AGENTS.md**: Replaced duplicated Project Overview/Sole Mission (§1), FFI
+  Contract/Key Symbols (§7), and GPU Requirement/System Requirements (§8) with
+  concise references to README.md and docs/FFI_API.md. Replaced Further Reading
+  list with reference to README.md's comprehensive documentation table.
+- **CONTRIBUTING.md**: Replaced duplicated Quality Gate steps, CI Pipeline list,
+  Code Style/Coding Principles, Testing Guidelines (including code examples),
+  and Project Structure layout with references to the authoritative versions in
+  AGENTS.md. Replaced Further Reading with reference to README.md's
+  documentation table.
+- **README.md**: Added docs/BENCHMARKS.md to the Additional Documentation table
+  so every documentation file is now reachable from README.md.
+
+### Content ownership after this change
+
+| Content | Authoritative location |
+|---------|----------------------|
+| Project overview and mission | README.md |
+| FFI API reference | docs/FFI_API.md |
+| GPU requirements and tuning | README.md + docs/GPU_GUIDE.md |
+| Quality gate and CI pipeline | AGENTS.md §5 |
+| Coding conventions and style | AGENTS.md §3 |
+| Testing philosophy | AGENTS.md §4 |
+| Source layout / architecture | AGENTS.md §2 |
+| Discovery types reference | docs/DISCOVERY_TYPES.md |
+| Benchmark tracking | docs/BENCHMARKS.md |
+
+## Evidence
+
+- No content is duplicated across documentation files
+- README.md links (directly or transitively) to every documentation file
+- All cross-references verified accurate
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Documentation-only change — no code or tests modified
+- Verified all markdown cross-reference anchors resolve to existing headings
+- Ran `./quality.sh` — all checks passed


### PR DESCRIPTION
## Summary

Unified and de-duplicated user documentation with README.md as the central hub. Closes #841.

### Changes

- **AGENTS.md**: Replaced duplicated Project Overview/Sole Mission (§1), FFI Contract/Key Symbols (§7), and GPU Requirement/System Requirements (§8) with concise references to README.md and docs/FFI_API.md. Replaced Further Reading list with reference to README.md's comprehensive documentation table.
- **CONTRIBUTING.md**: Replaced duplicated Quality Gate steps, CI Pipeline list, Code Style/Coding Principles, Testing Guidelines (including code examples), and Project Structure layout with references to the authoritative versions in AGENTS.md. Replaced Further Reading with reference to README.md's documentation table.
- **README.md**: Added docs/BENCHMARKS.md to the Additional Documentation table so every documentation file is now reachable from README.md.

### Content ownership after this change

| Content | Authoritative location |
|---------|----------------------|
| Project overview and mission | README.md |
| FFI API reference | docs/FFI_API.md |
| GPU requirements and tuning | README.md + docs/GPU_GUIDE.md |
| Quality gate and CI pipeline | AGENTS.md §5 |
| Coding conventions and style | AGENTS.md §3 |
| Testing philosophy | AGENTS.md §4 |
| Source layout / architecture | AGENTS.md §2 |
| Discovery types reference | docs/DISCOVERY_TYPES.md |
| Benchmark tracking | docs/BENCHMARKS.md |

## Evidence

- No content is duplicated across documentation files
- README.md links (directly or transitively) to every documentation file
- All cross-references verified accurate
- `quality.sh` passes cleanly

## Test plan

- Documentation-only change — no code or tests modified
- Verified all markdown cross-reference anchors resolve to existing headings
- Ran `./quality.sh` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)