### PR TITLE
feat: add hold-out validation for synapse multi-weight search (#893)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.59.0"
+version = "0.59.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.59.1"
+version = "0.60.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-893.md
+++ b/docs/pr-summary-893.md
@@ -1,0 +1,40 @@
+## Summary
+
+Add hold-out validation for synapse multi-weight search to combat overfitting. The 9-variant multi-weight search in synapse candidate evaluation picks the best-looking weight from 9 options, creating selection bias that contributes to 0% success rate in practice. This change splits samples into train/validate sets (70/30), selects the best weight using only training data, and reports improvement using only held-out validation data. Closes #893.
+
+## Changes
+
+- **`src/analysis/synapse/holdout_validation.rs`** (new): Deterministic train/validate splitting module using FNV-1a hash of (source_uuid, target_uuid) as split seed for reproducibility.
+- **`src/analysis/synapse/target_analysis/evaluation.rs`**: Apply hold-out validation to the 9-weight search for new synapse candidates. Weight selection uses training samples; improvement and counts are reported from validation samples.
+- **`src/analysis/synapse/activation_evaluation.rs`**: Apply hold-out validation to the 9-weight search for non-ReLU activation candidates with non-linear targets.
+- **`src/analysis/constants.rs`**: Add `HOLDOUT_MIN_SAMPLE_COUNT` (20) and `HOLDOUT_VALIDATION_FRACTION` (0.3) constants.
+- **`src/analysis/synapse/mod.rs`**: Register the new `holdout_validation` module.
+
+## Design Decisions
+
+- **Minimum sample threshold**: Below `HOLDOUT_MIN_SAMPLE_COUNT` (20), falls back to the current full-sample approach with existing pessimism discounting, since splitting would leave too few samples for reliable results.
+- **Consistent total_count**: When hold-out validation is used, `total_count` is set to the validation sample count (not the full sample count) to keep `MIN_IMPROVED_RATIO` checks consistent.
+- **Deterministic splitting**: Uses FNV-1a hash of (source_uuid, target_uuid) as the split seed, ensuring the same synapse candidate always gets the same split across evaluations.
+
+## Evidence
+
+- All 348 existing tests continue to pass (including GPU-dependent tests)
+- `quality.sh` passes cleanly (clippy, fmt, tests, docs, release build)
+
+## Test Plan
+
+- Unit tests in `src/analysis/synapse/holdout_validation.rs`:
+  - `test_split_returns_none_below_threshold` — verifies fallback below minimum sample count
+  - `test_split_produces_correct_partition_sizes` — verifies 70/30 split
+  - `test_split_is_deterministic` — verifies same UUIDs produce identical splits
+  - `test_different_uuids_produce_different_splits` — verifies different UUIDs produce different splits
+  - `test_no_sample_in_both_partitions` — verifies partitions are disjoint
+  - `test_baseline_error_sq_computation` — verifies baseline error calculation
+  - `test_collect_samples_roundtrip` — verifies sample collection helper
+- Integration tests in `tests/synapse/issue_893_holdout_validation.rs`:
+  - Constant validation: `HOLDOUT_MIN_SAMPLE_COUNT >= MIN_DISCOVERY_SAMPLE_COUNT`
+  - Fraction in valid range: `HOLDOUT_VALIDATION_FRACTION` in (0.1, 0.5)
+  - Training partition has at least `MIN_NEURON_SAMPLE_COUNT` samples
+  - Validation partition has at least 3 samples
+  - 70/30 split produces expected partition sizes
+  - Threshold-edge split produces non-empty partitions

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -290,6 +290,34 @@ pub const ACTIVATION_BOOST_BIPOLAR: f64 = 0.95;
 /// Penalty multiplier for `HARD_TANH` activation (7.2% raw, Bayesian-smoothed 0.80×).
 pub const ACTIVATION_BOOST_HARD_TANH: f64 = 0.80;
 
+// =============================================================================
+// Hold-Out Validation for Multi-Weight Search (Issue #893)
+// =============================================================================
+
+/// Minimum number of samples required to use hold-out validation.
+///
+/// Below this threshold, splitting into train/validate sets would leave
+/// too few samples in each partition for reliable results. When the total
+/// sample count is below this value, the current approach (full-sample
+/// evaluation with pessimism discounting) is used as a fallback.
+///
+/// ## Valid Range
+/// Must be >= `MIN_DISCOVERY_SAMPLE_COUNT`. Values below 20 produce
+/// unreliable splits.
+pub const HOLDOUT_MIN_SAMPLE_COUNT: usize = 20;
+
+/// Fraction of samples reserved for the validation (hold-out) set.
+///
+/// The remaining samples (1 - this fraction) are used for training
+/// (weight selection). A 70/30 split balances having enough training
+/// data for reliable weight fitting while retaining a meaningful
+/// validation set.
+///
+/// ## Valid Range
+/// Must be in (0.1, 0.5). Values below 0.1 leave too few validation
+/// samples. Values above 0.5 leave too few training samples.
+pub const HOLDOUT_VALIDATION_FRACTION: f32 = 0.3;
+
 /// Returns the activation-function-aware boost/penalty multiplier for add-neuron
 /// candidate scoring (Issue #887).
 ///

--- a/src/analysis/synapse/activation_evaluation.rs
+++ b/src/analysis/synapse/activation_evaluation.rs
@@ -228,54 +228,125 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                         -base_weight,
                     ];
 
-                    let mut best_weight = base_weight;
-                    let mut best_bias = 0.0f32;
-                    let mut best_improvement = f32::NEG_INFINITY;
-                    let mut best_improved_count = 0u32;
+                    // Issue #893: Hold-out validation to combat overfitting from the
+                    // 9-variant search. Select weight on training samples, report
+                    // improvement on held-out validation samples.
+                    use crate::analysis::synapse::holdout_validation::{
+                        baseline_error_sq as compute_baseline, collect_samples,
+                        split_samples_holdout,
+                    };
 
-                    for &weight in &weight_candidates {
-                        // Clamp scaled weights to ensure they stay within bounds
-                        let clamped_weight =
-                            weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
-                        if clamped_weight.abs() <= EPSILON {
-                            continue;
+                    if let Some(split) =
+                        split_samples_holdout(samples, params.source_uuid, params.target_uuid)
+                    {
+                        // Phase 1: Select best weight+bias using training samples only
+                        let train_samples = collect_samples(&split.train);
+                        let train_baseline = compute_baseline(&split.train);
+
+                        let mut best_weight = base_weight;
+                        let mut best_bias = 0.0f32;
+                        let mut best_train_improvement = f32::NEG_INFINITY;
+
+                        for &weight in &weight_candidates {
+                            let clamped_weight =
+                                weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                            if clamped_weight.abs() <= EPSILON {
+                                continue;
+                            }
+
+                            let bias = calculate_optimal_bias(
+                                &train_samples,
+                                incoming_weight,
+                                clamped_weight,
+                                spec.activation,
+                                spec.name,
+                                None,
+                                params.target_squash,
+                            );
+
+                            let (improvement, _, _) = compute_activation_improvement_and_count(
+                                &train_samples,
+                                incoming_weight,
+                                clamped_weight,
+                                bias,
+                                spec.activation,
+                                train_baseline,
+                                target_activation_fn,
+                            );
+
+                            if improvement > best_train_improvement {
+                                best_train_improvement = improvement;
+                                best_weight = clamped_weight;
+                                best_bias = bias;
+                            }
                         }
 
-                        let bias = calculate_optimal_bias(
-                            samples,
-                            incoming_weight,
-                            clamped_weight,
-                            spec.activation,
-                            spec.name,
-                            None,
-                            params.target_squash,
-                        );
+                        // Phase 2: Report improvement on validation samples only
+                        let validate_samples = collect_samples(&split.validate);
+                        let validate_baseline = compute_baseline(&split.validate);
 
-                        // Single pass for improvement and count with target simulation
-                        let (improvement, improved, _) = compute_activation_improvement_and_count(
-                            samples,
-                            incoming_weight,
-                            clamped_weight,
-                            bias,
-                            spec.activation,
-                            baseline_sq,
-                            target_activation_fn,
-                        );
+                        let (val_improvement, val_improved, _) =
+                            compute_activation_improvement_and_count(
+                                &validate_samples,
+                                incoming_weight,
+                                best_weight,
+                                best_bias,
+                                spec.activation,
+                                validate_baseline,
+                                target_activation_fn,
+                            );
 
-                        if improvement > best_improvement {
-                            best_improvement = improvement;
-                            best_weight = clamped_weight;
-                            best_bias = bias;
-                            best_improved_count = improved;
+                        (best_weight, best_bias, val_improvement, val_improved)
+                    } else {
+                        // Fallback: below hold-out threshold, use all samples
+                        let mut best_weight = base_weight;
+                        let mut best_bias = 0.0f32;
+                        let mut best_improvement = f32::NEG_INFINITY;
+                        let mut best_improved_count = 0u32;
+
+                        for &weight in &weight_candidates {
+                            let clamped_weight =
+                                weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                            if clamped_weight.abs() <= EPSILON {
+                                continue;
+                            }
+
+                            let bias = calculate_optimal_bias(
+                                samples,
+                                incoming_weight,
+                                clamped_weight,
+                                spec.activation,
+                                spec.name,
+                                None,
+                                params.target_squash,
+                            );
+
+                            let (improvement, improved, _) =
+                                compute_activation_improvement_and_count(
+                                    samples,
+                                    incoming_weight,
+                                    clamped_weight,
+                                    bias,
+                                    spec.activation,
+                                    baseline_sq,
+                                    target_activation_fn,
+                                );
+
+                            if improvement > best_improvement {
+                                best_improvement = improvement;
+                                best_weight = clamped_weight;
+                                best_bias = bias;
+                                best_improved_count = improved;
+                            }
                         }
+
+                        (
+                            best_weight,
+                            best_bias,
+                            best_improvement,
+                            best_improved_count,
+                        )
                     }
-
-                    (
-                        best_weight,
-                        best_bias,
-                        best_improvement,
-                        best_improved_count,
-                    )
                 } else {
                     // For linear targets or when target data unavailable, use the base weight.
                     let base_weight = match calculate_optimal_outgoing_weight(

--- a/src/analysis/synapse/holdout_validation.rs
+++ b/src/analysis/synapse/holdout_validation.rs
@@ -1,0 +1,244 @@
+//! Hold-out validation for multi-weight search (Issue #893).
+//!
+//! The 9-variant multi-weight search picks the best-looking weight from 9
+//! options, creating selection bias that causes overfitting. This module
+//! provides deterministic train/validate splitting so that weights are
+//! selected on training data and improvement is reported on held-out
+//! validation data.
+
+use crate::analysis::constants::{HOLDOUT_MIN_SAMPLE_COUNT, HOLDOUT_VALIDATION_FRACTION};
+use crate::analysis::samples::HelpfulSample;
+
+/// Result of a hold-out split.
+pub(crate) struct HoldoutSplit<'a> {
+    /// Training samples used for weight selection.
+    pub train: Vec<&'a HelpfulSample>,
+    /// Validation samples used for improvement reporting.
+    pub validate: Vec<&'a HelpfulSample>,
+}
+
+/// Deterministically split samples into train and validate sets.
+///
+/// Uses a hash of (`source_uuid`, `target_uuid`) as the split seed to ensure
+/// reproducibility across evaluations of the same synapse candidate.
+///
+/// Returns `None` if the sample count is below `HOLDOUT_MIN_SAMPLE_COUNT`,
+/// signalling that the caller should fall back to full-sample evaluation.
+pub(crate) fn split_samples_holdout<'a>(
+    samples: &'a [HelpfulSample],
+    source_uuid: &str,
+    target_uuid: &str,
+) -> Option<HoldoutSplit<'a>> {
+    if samples.len() < HOLDOUT_MIN_SAMPLE_COUNT {
+        return None;
+    }
+
+    let seed = deterministic_seed(source_uuid, target_uuid);
+    // Compute validation count: fraction of total, at least 1.
+    // Sample counts are bounded by practical sizes (well under 2^52).
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
+    let validate_count = {
+        let frac = (samples.len() as f64 * f64::from(HOLDOUT_VALIDATION_FRACTION)).round();
+        frac.max(1.0) as usize
+    };
+
+    // Assign each sample to train or validate based on a deterministic hash
+    // of its index combined with the seed.
+    let mut train = Vec::with_capacity(samples.len() - validate_count);
+    let mut validate = Vec::with_capacity(validate_count);
+
+    for (i, sample) in samples.iter().enumerate() {
+        if is_validation_sample(seed, i, samples.len(), validate_count) {
+            validate.push(sample);
+        } else {
+            train.push(sample);
+        }
+    }
+
+    // Safety: ensure both partitions are non-empty
+    if train.is_empty() || validate.is_empty() {
+        return None;
+    }
+
+    Some(HoldoutSplit { train, validate })
+}
+
+/// Compute a deterministic seed from source and target UUIDs using FNV-1a.
+fn deterministic_seed(source_uuid: &str, target_uuid: &str) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325; // FNV-1a offset basis
+    for b in source_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash ^= 0xFF;
+    hash = hash.wrapping_mul(0x100000001b3);
+    for b in target_uuid.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+/// Determine whether a sample at the given index belongs to the validation set.
+///
+/// Uses a stride-based selection seeded by the deterministic hash to ensure
+/// even distribution across the sample range.
+fn is_validation_sample(seed: u64, index: usize, total: usize, validate_count: usize) -> bool {
+    // Use the seed to pick a deterministic offset, then select evenly-spaced
+    // indices for the validation set.
+    // total is from samples.len() which fits in u64; modulo guarantees result < total,
+    // so the truncation to usize is safe.
+    let offset = usize::try_from(seed % (total as u64)).unwrap_or(0);
+    let shifted = (index + offset) % total;
+    // Select the first `validate_count` positions in the shifted order
+    shifted < validate_count
+}
+
+/// Collect owned samples from references.
+pub(crate) fn collect_samples(refs: &[&HelpfulSample]) -> Vec<HelpfulSample> {
+    refs.iter().copied().copied().collect()
+}
+
+/// Compute baseline error squared for a set of sample references.
+pub(crate) fn baseline_error_sq(samples: &[&HelpfulSample]) -> f32 {
+    let mut total = 0.0f32;
+    for sample in samples {
+        if sample.avg_error.is_finite() {
+            total += sample.avg_error * sample.avg_error;
+        }
+    }
+    total
+}
+
+// =============================================================================
+// Unit Tests
+// =============================================================================
+
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss)] // Intentional for test data generation
+mod tests {
+    use super::*;
+
+    fn make_samples(count: usize) -> Vec<HelpfulSample> {
+        (0..count)
+            .map(|i| HelpfulSample {
+                activation: i as f32 * 0.1,
+                avg_error: (i as f32 - count as f32 / 2.0) * 0.01,
+                target_value: None,
+                target_activation: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_split_returns_none_below_threshold() {
+        let samples = make_samples(10);
+        let result = split_samples_holdout(&samples, "source-1", "target-1");
+        assert!(
+            result.is_none(),
+            "Should return None below HOLDOUT_MIN_SAMPLE_COUNT"
+        );
+    }
+
+    #[test]
+    fn test_split_produces_correct_partition_sizes() {
+        let samples = make_samples(100);
+        let split = split_samples_holdout(&samples, "source-1", "target-1").unwrap();
+        // 30% of 100 = 30 validation samples
+        assert_eq!(split.validate.len(), 30);
+        assert_eq!(split.train.len(), 70);
+        // All samples accounted for
+        assert_eq!(split.train.len() + split.validate.len(), 100);
+    }
+
+    #[test]
+    fn test_split_is_deterministic() {
+        let samples = make_samples(50);
+        let split1 = split_samples_holdout(&samples, "source-a", "target-b").unwrap();
+        let split2 = split_samples_holdout(&samples, "source-a", "target-b").unwrap();
+
+        // Same UUIDs must produce the same split
+        assert_eq!(split1.train.len(), split2.train.len());
+        assert_eq!(split1.validate.len(), split2.validate.len());
+
+        for (a, b) in split1.train.iter().zip(split2.train.iter()) {
+            assert_eq!(a.activation, b.activation);
+            assert_eq!(a.avg_error, b.avg_error);
+        }
+    }
+
+    #[test]
+    fn test_different_uuids_produce_different_splits() {
+        let samples = make_samples(50);
+        let split1 = split_samples_holdout(&samples, "source-a", "target-b").unwrap();
+        let split2 = split_samples_holdout(&samples, "source-c", "target-d").unwrap();
+
+        // Different UUIDs should (almost certainly) produce different validation sets.
+        // Compare the activations of the first validation sample.
+        let v1_activations: Vec<f32> = split1.validate.iter().map(|s| s.activation).collect();
+        let v2_activations: Vec<f32> = split2.validate.iter().map(|s| s.activation).collect();
+        assert_ne!(
+            v1_activations, v2_activations,
+            "Different UUID pairs should produce different splits"
+        );
+    }
+
+    #[test]
+    fn test_no_sample_in_both_partitions() {
+        let samples = make_samples(50);
+        let split = split_samples_holdout(&samples, "source-1", "target-1").unwrap();
+
+        // Collect all activation values (unique in our test data)
+        let train_acts: std::collections::HashSet<u32> =
+            split.train.iter().map(|s| s.activation.to_bits()).collect();
+        let validate_acts: std::collections::HashSet<u32> = split
+            .validate
+            .iter()
+            .map(|s| s.activation.to_bits())
+            .collect();
+
+        let overlap: Vec<_> = train_acts.intersection(&validate_acts).collect();
+        assert!(
+            overlap.is_empty(),
+            "No sample should appear in both train and validate"
+        );
+    }
+
+    #[test]
+    fn test_baseline_error_sq_computation() {
+        let samples = [
+            HelpfulSample {
+                activation: 1.0,
+                avg_error: 3.0,
+                target_value: None,
+                target_activation: None,
+            },
+            HelpfulSample {
+                activation: 2.0,
+                avg_error: 4.0,
+                target_value: None,
+                target_activation: None,
+            },
+        ];
+        let refs: Vec<&HelpfulSample> = samples.iter().collect();
+        let result = baseline_error_sq(&refs);
+        // 3^2 + 4^2 = 9 + 16 = 25
+        assert!((result - 25.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_collect_samples_roundtrip() {
+        let samples = make_samples(10);
+        let refs: Vec<&HelpfulSample> = samples.iter().collect();
+        let collected = collect_samples(&refs);
+        assert_eq!(collected.len(), 10);
+        for (orig, coll) in samples.iter().zip(collected.iter()) {
+            assert_eq!(orig.activation, coll.activation);
+            assert_eq!(orig.avg_error, coll.avg_error);
+        }
+    }
+}

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -38,6 +38,7 @@ mod activation_subset_evaluation;
 mod candidate_generation;
 mod filtering;
 mod gpu_evaluation;
+pub(crate) mod holdout_validation;
 mod metadata;
 mod orchestration;
 pub mod post_processing;

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -92,8 +92,8 @@ pub(crate) fn collect_and_process_helpful_results(
                 continue;
             }
 
-            let total_count = work.samples.len() as u32;
-            if total_count == 0 {
+            let full_total_count = work.samples.len() as u32;
+            if full_total_count == 0 {
                 continue;
             }
 
@@ -117,38 +117,100 @@ pub(crate) fn collect_and_process_helpful_results(
 
             let baseline_error_sq = stats.error_sq_sum;
 
-            let (applied_weight, neuron_error_improvement, improved_count, worsened_count) =
-                if let Some(old_weight) = work.existing_weight {
-                    let Some((_new_weight, delta_weight)) =
-                        clamp_weight_update_delta(old_weight, weight)
-                    else {
-                        continue;
-                    };
-                    let (improvement, improved, worsened, _) =
-                        compute_synapse_improvement_and_count(
-                            &work.samples,
-                            delta_weight,
-                            baseline_error_sq,
+            // Issue #893: total_count is updated to the validation sample count
+            // when hold-out validation is used, so ratio checks remain consistent.
+            let (
+                applied_weight,
+                neuron_error_improvement,
+                improved_count,
+                worsened_count,
+                total_count,
+            ) = if let Some(old_weight) = work.existing_weight {
+                let Some((_new_weight, delta_weight)) =
+                    clamp_weight_update_delta(old_weight, weight)
+                else {
+                    continue;
+                };
+                let (improvement, improved, worsened, _) = compute_synapse_improvement_and_count(
+                    &work.samples,
+                    delta_weight,
+                    baseline_error_sq,
+                    target_squash,
+                );
+                (
+                    delta_weight,
+                    improvement,
+                    improved,
+                    worsened,
+                    full_total_count,
+                )
+            } else {
+                // Issue #730: Multi-weight search for ALL new synapse candidates.
+                // Previously only saturating targets used weight search (Issue #413).
+                // Production data showed 0% success rate because a single computed
+                // weight often overshoots, especially with noisy samples.
+                //
+                // Issue #893: Hold-out validation to combat overfitting from the
+                // 9-variant search. Select weight on training samples, report
+                // improvement on held-out validation samples.
+                use crate::analysis::synapse::holdout_validation::{
+                    baseline_error_sq as compute_baseline, collect_samples, split_samples_holdout,
+                };
+
+                let weight_candidates: [f32; 9] = [
+                    weight * 0.1,
+                    weight * 0.25,
+                    weight * 0.5,
+                    weight * 0.75,
+                    weight,
+                    weight * 1.5,
+                    weight * 2.0,
+                    -weight * 0.5,
+                    -weight,
+                ];
+
+                if let Some(split) =
+                    split_samples_holdout(&work.samples, &work.source_uuid, &work.target_uuid)
+                {
+                    // Phase 1: Select best weight using training samples only
+                    let train_samples = collect_samples(&split.train);
+                    let train_baseline = compute_baseline(&split.train);
+
+                    let mut best_weight = weight;
+                    let mut best_train_improvement = f32::NEG_INFINITY;
+
+                    for &w in &weight_candidates {
+                        let clamped = w.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                        if clamped.abs() <= EPSILON {
+                            continue;
+                        }
+                        let (imp, _, _, _) = compute_synapse_improvement_and_count(
+                            &train_samples,
+                            clamped,
+                            train_baseline,
                             target_squash,
                         );
-                    (delta_weight, improvement, improved, worsened)
-                } else {
-                    // Issue #730: Multi-weight search for ALL new synapse candidates.
-                    // Previously only saturating targets used weight search (Issue #413).
-                    // Production data showed 0% success rate because a single computed
-                    // weight often overshoots, especially with noisy samples.
-                    let weight_candidates: [f32; 9] = [
-                        weight * 0.1,
-                        weight * 0.25,
-                        weight * 0.5,
-                        weight * 0.75,
-                        weight,
-                        weight * 1.5,
-                        weight * 2.0,
-                        -weight * 0.5,
-                        -weight,
-                    ];
+                        if imp > best_train_improvement {
+                            best_train_improvement = imp;
+                            best_weight = clamped;
+                        }
+                    }
 
+                    // Phase 2: Report improvement on validation samples only
+                    let validate_samples = collect_samples(&split.validate);
+                    let validate_baseline = compute_baseline(&split.validate);
+                    let val_total = validate_samples.len() as u32;
+
+                    let (val_imp, val_improved, val_worsened, _) =
+                        compute_synapse_improvement_and_count(
+                            &validate_samples,
+                            best_weight,
+                            validate_baseline,
+                            target_squash,
+                        );
+                    (best_weight, val_imp, val_improved, val_worsened, val_total)
+                } else {
+                    // Fallback: below hold-out threshold, use all samples
                     let mut best_weight = weight;
                     let mut best_improvement = f32::NEG_INFINITY;
                     let mut best_improved = 0u32;
@@ -172,8 +234,15 @@ pub(crate) fn collect_and_process_helpful_results(
                             best_worsened = worsened;
                         }
                     }
-                    (best_weight, best_improvement, best_improved, best_worsened)
-                };
+                    (
+                        best_weight,
+                        best_improvement,
+                        best_improved,
+                        best_worsened,
+                        full_total_count,
+                    )
+                }
+            };
 
             // Issue #202: Track source contribution for epistatic pair detection
             if work.existing_weight.is_none() {

--- a/tests/synapse/issue_893_holdout_validation.rs
+++ b/tests/synapse/issue_893_holdout_validation.rs
@@ -1,0 +1,109 @@
+//! Issue #893: Hold-out validation for synapse multi-weight search
+//!
+//! Tests for:
+//! 1. Hold-out validation constants are in valid ranges
+//! 2. Constants maintain correct relationships with other thresholds
+//! 3. The validation fraction produces meaningful split sizes
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // Intentional numeric casts for test arithmetic (Issue #873)
+
+use neat_ai_discovery::analysis::constants::{
+    HOLDOUT_MIN_SAMPLE_COUNT, HOLDOUT_VALIDATION_FRACTION, MIN_DISCOVERY_SAMPLE_COUNT,
+    MIN_NEURON_SAMPLE_COUNT,
+};
+
+// =============================================================================
+// Hold-out constant validation (Issue #893)
+// =============================================================================
+
+/// Issue #893: Hold-out minimum sample count must be >= `MIN_DISCOVERY_SAMPLE_COUNT`.
+#[test]
+fn holdout_min_sample_count_at_least_min_discovery() {
+    const {
+        assert!(HOLDOUT_MIN_SAMPLE_COUNT >= MIN_DISCOVERY_SAMPLE_COUNT);
+    }
+}
+
+/// Issue #893: Hold-out validation fraction must be in (0.1, 0.5).
+#[test]
+fn holdout_validation_fraction_in_valid_range() {
+    const {
+        assert!(HOLDOUT_VALIDATION_FRACTION > 0.1);
+        assert!(HOLDOUT_VALIDATION_FRACTION < 0.5);
+    }
+}
+
+/// Issue #893: Hold-out minimum sample count must be >= 20.
+#[test]
+fn holdout_min_sample_count_reasonable() {
+    const {
+        assert!(HOLDOUT_MIN_SAMPLE_COUNT >= 20);
+    }
+}
+
+/// Issue #893: The training partition from the split must have at least
+/// `MIN_NEURON_SAMPLE_COUNT` samples to ensure reliable weight fitting.
+#[test]
+fn holdout_training_partition_has_enough_samples() {
+    // At the minimum sample count, the training partition should have
+    // at least MIN_NEURON_SAMPLE_COUNT samples.
+    let train_count = HOLDOUT_MIN_SAMPLE_COUNT as f32 * (1.0 - HOLDOUT_VALIDATION_FRACTION);
+    assert!(
+        train_count >= MIN_NEURON_SAMPLE_COUNT as f32,
+        "Issue #893: Training partition at minimum split size ({train_count:.0}) \
+         must be >= MIN_NEURON_SAMPLE_COUNT ({MIN_NEURON_SAMPLE_COUNT})"
+    );
+}
+
+/// Issue #893: The validation partition from the split must have at least 3 samples
+/// to produce a meaningful improvement estimate.
+#[test]
+fn holdout_validation_partition_has_enough_samples() {
+    let validate_count =
+        (HOLDOUT_MIN_SAMPLE_COUNT as f32 * HOLDOUT_VALIDATION_FRACTION).round() as usize;
+    assert!(
+        validate_count >= 3,
+        "Issue #893: Validation partition at minimum split size ({validate_count}) \
+         must be >= 3"
+    );
+}
+
+/// Issue #893: 70/30 split means roughly 70% training and 30% validation.
+#[test]
+fn holdout_split_produces_expected_partition_sizes() {
+    let total = 100;
+    let validate = (total as f32 * HOLDOUT_VALIDATION_FRACTION).round() as usize;
+    let train = total - validate;
+
+    assert_eq!(
+        validate, 30,
+        "Issue #893: 30% of 100 should be 30 validation samples"
+    );
+    assert_eq!(
+        train, 70,
+        "Issue #893: 70% of 100 should be 70 training samples"
+    );
+}
+
+/// Issue #893: For sample counts just at the threshold, both partitions are non-empty.
+#[test]
+fn holdout_split_at_threshold_produces_non_empty_partitions() {
+    let total = HOLDOUT_MIN_SAMPLE_COUNT;
+    let validate = (total as f32 * HOLDOUT_VALIDATION_FRACTION)
+        .round()
+        .max(1.0) as usize;
+    let train = total - validate;
+
+    assert!(
+        validate >= 1,
+        "Issue #893: Validation partition must be non-empty"
+    );
+    assert!(
+        train >= 1,
+        "Issue #893: Training partition must be non-empty"
+    );
+}

--- a/tests/synapse/main.rs
+++ b/tests/synapse/main.rs
@@ -21,6 +21,7 @@ mod issue_731_combo_successful_filtering;
 mod issue_732_coordinated_structural_success_rate;
 mod issue_789_improve_add_synapses_success_rate;
 mod issue_790_reduce_coordinated_structural_false_positives;
+mod issue_893_holdout_validation;
 mod sample_matching;
 mod sensible_range_filtering;
 mod source_variance_discounting;


### PR DESCRIPTION
## Summary

Add hold-out validation for synapse multi-weight search to combat overfitting. The 9-variant multi-weight search in synapse candidate evaluation picks the best-looking weight from 9 options, creating selection bias that contributes to 0% success rate in practice. This change splits samples into train/validate sets (70/30), selects the best weight using only training data, and reports improvement using only held-out validation data. Closes #893.

## Changes

- **`src/analysis/synapse/holdout_validation.rs`** (new): Deterministic train/validate splitting module using FNV-1a hash of (source_uuid, target_uuid) as split seed for reproducibility.
- **`src/analysis/synapse/target_analysis/evaluation.rs`**: Apply hold-out validation to the 9-weight search for new synapse candidates. Weight selection uses training samples; improvement and counts are reported from validation samples.
- **`src/analysis/synapse/activation_evaluation.rs`**: Apply hold-out validation to the 9-weight search for non-ReLU activation candidates with non-linear targets.
- **`src/analysis/constants.rs`**: Add `HOLDOUT_MIN_SAMPLE_COUNT` (20) and `HOLDOUT_VALIDATION_FRACTION` (0.3) constants.
- **`src/analysis/synapse/mod.rs`**: Register the new `holdout_validation` module.

## Design Decisions

- **Minimum sample threshold**: Below `HOLDOUT_MIN_SAMPLE_COUNT` (20), falls back to the current full-sample approach with existing pessimism discounting, since splitting would leave too few samples for reliable results.
- **Consistent total_count**: When hold-out validation is used, `total_count` is set to the validation sample count (not the full sample count) to keep `MIN_IMPROVED_RATIO` checks consistent.
- **Deterministic splitting**: Uses FNV-1a hash of (source_uuid, target_uuid) as the split seed, ensuring the same synapse candidate always gets the same split across evaluations.

## Evidence

- All 348 existing tests continue to pass (including GPU-dependent tests)
- `quality.sh` passes cleanly (clippy, fmt, tests, docs, release build)

## Test Plan

- Unit tests in `src/analysis/synapse/holdout_validation.rs`:
  - `test_split_returns_none_below_threshold` — verifies fallback below minimum sample count
  - `test_split_produces_correct_partition_sizes` — verifies 70/30 split
  - `test_split_is_deterministic` — verifies same UUIDs produce identical splits
  - `test_different_uuids_produce_different_splits` — verifies different UUIDs produce different splits
  - `test_no_sample_in_both_partitions` — verifies partitions are disjoint
  - `test_baseline_error_sq_computation` — verifies baseline error calculation
  - `test_collect_samples_roundtrip` — verifies sample collection helper
- Integration tests in `tests/synapse/issue_893_holdout_validation.rs`:
  - Constant validation: `HOLDOUT_MIN_SAMPLE_COUNT >= MIN_DISCOVERY_SAMPLE_COUNT`
  - Fraction in valid range: `HOLDOUT_VALIDATION_FRACTION` in (0.1, 0.5)
  - Training partition has at least `MIN_NEURON_SAMPLE_COUNT` samples
  - Validation partition has at least 3 samples
  - 70/30 split produces expected partition sizes
  - Threshold-edge split produces non-empty partitions

---

## Automated Fix Details
This PR addresses issue #893: **feat: add hold-out validation for synapse multi-weight search to combat overfitting**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #893
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-893 -->