### PR TITLE
fix: make weight constraints activation-aware (#905)

### DIFF
--- a/docs/pr-summary-905.md
+++ b/docs/pr-summary-905.md
@@ -1,0 +1,44 @@
+## Summary
+
+Make weight constraints activation-aware so that non-linear activation candidates
+(TANH, GELU, ReLU, etc.) are not systematically rejected by constraints calibrated
+on IDENTITY-dominated success data. Closes #905.
+
+The tightened constraints from Issue #888 (`MAX_OUTGOING_WEIGHT = 0.01`,
+`MIN_WEIGHT_RATIO = 50.0`) were over-fitted to IDENTITY candidates. Non-linear
+activations compress their output range and operate in different weight regimes,
+requiring relaxed constraints:
+
+- **`MAX_OUTGOING_WEIGHT_NON_LINEAR = 0.03`** (3x the IDENTITY ceiling of 0.01)
+- **`MIN_WEIGHT_RATIO_NON_LINEAR = 10.0`** (5x more permissive than IDENTITY's 50.0)
+
+New public functions `max_outgoing_weight_for_activation()` and
+`min_weight_ratio_for_activation()` select the appropriate constraint based on
+the activation name. `calculate_activation_aware_outgoing_weight()` wraps the
+core least-squares weight calculation with activation-aware constraints.
+
+All non-IDENTITY callers in the activation evaluation pipeline now use the
+activation-aware function. IDENTITY candidates are unchanged (no regression).
+
+## Evidence
+
+- 13 new unit tests verify activation-aware behaviour
+- All existing tests pass (including GPU shader tests)
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Added `tests/scoring/issue_905_activation_aware_weight_constraints.rs` (13 tests):
+  - `test_identity_gets_tight_max_outgoing_weight` — IDENTITY uses 0.01 ceiling
+  - `test_tanh_gets_relaxed_max_outgoing_weight` — TANH gets relaxed ceiling
+  - `test_gelu_gets_relaxed_max_outgoing_weight` — GELU gets relaxed ceiling
+  - `test_relu_gets_relaxed_max_outgoing_weight` — ReLU gets relaxed ceiling
+  - `test_identity_gets_tight_min_weight_ratio` — IDENTITY uses 50.0 ratio
+  - `test_non_linear_gets_relaxed_min_weight_ratio` — Non-linear activations use relaxed ratio
+  - `test_activation_aware_identity_matches_default` — IDENTITY path matches default function
+  - `test_activation_aware_tanh_allows_larger_weight` — TANH weight not clamped to 0.01
+  - `test_activation_aware_non_linear_passes_ratio_with_smaller_incoming` — Hidden-source passes
+  - `test_activation_aware_still_rejects_invalid_weights` — Invalid inputs still rejected
+  - `test_activation_aware_no_regression_for_identity` — No regression for IDENTITY
+  - `test_tanh_candidate_not_systematically_rejected` — TANH with small incoming passes
+  - `test_gelu_candidate_with_moderate_weight_accepted` — GELU keeps unclamped weight

--- a/src/analysis/scoring/weights/calculation.rs
+++ b/src/analysis/scoring/weights/calculation.rs
@@ -11,7 +11,10 @@ use crate::analysis::activation::{activation_name_to_gpu_id, get_bias_range, get
 use crate::analysis::gpu::GpuAnalyzer;
 use crate::analysis::samples::{EPSILON, HelpfulSample};
 
-use super::{MAX_OUTGOING_WEIGHT, MIN_WEIGHT_RATIO};
+use super::{
+    MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT_NON_LINEAR, MIN_WEIGHT_RATIO,
+    MIN_WEIGHT_RATIO_NON_LINEAR,
+};
 
 // MIN_NEURON_SAMPLE_COUNT moved to constants.rs (Issue #424)
 use crate::analysis::constants::MIN_NEURON_SAMPLE_COUNT;
@@ -46,6 +49,78 @@ pub fn calculate_optimal_outgoing_weight(
     sum_activation_sq: f32,
     incoming_weight: f32,
 ) -> Option<f32> {
+    compute_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        MAX_OUTGOING_WEIGHT,
+        MIN_WEIGHT_RATIO,
+    )
+}
+
+/// Return activation-aware maximum outgoing weight.
+///
+/// Issue #905: IDENTITY candidates use the tight ceiling from Issue #888,
+/// while non-linear activations (TANH, GELU, `ReLU`, etc.) use a relaxed
+/// ceiling because they compress their output range.
+pub fn max_outgoing_weight_for_activation(activation_name: &str) -> f32 {
+    if activation_name.eq_ignore_ascii_case("IDENTITY") {
+        MAX_OUTGOING_WEIGHT
+    } else {
+        MAX_OUTGOING_WEIGHT_NON_LINEAR
+    }
+}
+
+/// Return activation-aware minimum weight ratio.
+///
+/// Issue #905: IDENTITY candidates use the tight ratio from Issue #888,
+/// while non-linear activations use a relaxed ratio because they operate
+/// in different weight regimes.
+pub fn min_weight_ratio_for_activation(activation_name: &str) -> f32 {
+    if activation_name.eq_ignore_ascii_case("IDENTITY") {
+        MIN_WEIGHT_RATIO
+    } else {
+        MIN_WEIGHT_RATIO_NON_LINEAR
+    }
+}
+
+/// Calculate optimal outgoing weight with activation-aware constraints.
+///
+/// Issue #905: This function applies relaxed `MAX_OUTGOING_WEIGHT` and
+/// `MIN_WEIGHT_RATIO` for non-linear activations to avoid systematic
+/// rejection of valid non-IDENTITY and hidden-source candidates.
+///
+/// For IDENTITY, this produces identical results to
+/// [`calculate_optimal_outgoing_weight`].
+pub fn calculate_activation_aware_outgoing_weight(
+    sum_error_activation: f32,
+    sum_activation_sq: f32,
+    incoming_weight: f32,
+    activation_name: &str,
+) -> Option<f32> {
+    let max_outgoing = max_outgoing_weight_for_activation(activation_name);
+    let min_ratio = min_weight_ratio_for_activation(activation_name);
+    compute_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        max_outgoing,
+        min_ratio,
+    )
+}
+
+/// Core outgoing weight calculation with configurable constraints.
+///
+/// Shared implementation for both `calculate_optimal_outgoing_weight` (IDENTITY
+/// defaults) and `calculate_activation_aware_outgoing_weight` (activation-aware
+/// constraints).
+fn compute_outgoing_weight(
+    sum_error_activation: f32,
+    sum_activation_sq: f32,
+    incoming_weight: f32,
+    max_outgoing: f32,
+    min_ratio: f32,
+) -> Option<f32> {
     // Need sufficient activation energy to compute meaningful weight
     if sum_activation_sq <= EPSILON {
         return None;
@@ -59,16 +134,13 @@ pub fn calculate_optimal_outgoing_weight(
         return None;
     }
 
-    // Clamp to tight range based on successful discovery analysis
-    let clamped = raw_weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+    // Clamp to range based on activation-aware constraints
+    let clamped = raw_weight.clamp(-max_outgoing, max_outgoing);
 
     // For add-neuron candidates with non-trivial incoming weights, validate ratio
-    // This catches cases where the computed weight is too large relative to incoming
     if incoming_weight.abs() > 1.0 {
         let ratio = incoming_weight.abs() / (clamped.abs() + EPSILON);
-        if ratio < MIN_WEIGHT_RATIO {
-            // Weight ratio too small - this configuration is unreliable
-            // Skip rather than returning a weight that's likely to fail
+        if ratio < min_ratio {
             return None;
         }
     }

--- a/src/analysis/scoring/weights/mod.rs
+++ b/src/analysis/scoring/weights/mod.rs
@@ -12,9 +12,10 @@
 //!
 //! ## Design Notes
 //!
-//! - Outgoing weights are clamped to [-0.01, 0.01] (tightened in Issue #888)
-//! - Weight ratio validation ensures incoming/outgoing ratio >= 50 for reliable
-//!   predictions (based on successful discovery analysis)
+//! - IDENTITY outgoing weights are clamped to [-0.01, 0.01] (tightened in Issue #888)
+//! - Non-linear activations use relaxed ceiling [-0.05, 0.05] (Issue #905)
+//! - Weight ratio validation is activation-aware: IDENTITY requires ratio >= 50,
+//!   non-linear activations require ratio >= 10 (Issue #905)
 //! - Bias-aware calculation recomputes weights after bias optimisation
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
@@ -26,7 +27,7 @@ pub mod normalisation;
 // Constants
 // =============================================================================
 
-/// Maximum allowed outgoing weight for add-neuron and add-synapse candidates.
+/// Maximum allowed outgoing weight for IDENTITY add-neuron and add-synapse candidates.
 ///
 /// Issue #888: Tightened from 0.1 to 0.01 based on GRQ-sampler discovery cache:
 /// - Successful candidates: outgoing weights 0.001–0.005 (exponent e-3)
@@ -36,9 +37,22 @@ pub mod normalisation;
 ///
 /// Using 0.01 provides margin above the 0.005 success peak while filtering
 /// the 0.01–0.1 range that almost always fails.
+///
+/// Issue #905: This value is now specific to IDENTITY candidates. Non-linear
+/// activations use `MAX_OUTGOING_WEIGHT_NON_LINEAR` via the activation-aware
+/// helpers.
 pub const MAX_OUTGOING_WEIGHT: f32 = 0.01;
 
-/// Minimum incoming/outgoing weight ratio for reliable predictions.
+/// Maximum allowed outgoing weight for non-linear activation candidates.
+///
+/// Issue #905: Non-linear activations (TANH, GELU, `ReLU`, etc.) compress their
+/// output range, requiring a larger outgoing weight to achieve the same
+/// correction magnitude. The IDENTITY-calibrated ceiling of 0.01 systematically
+/// rejects valid non-linear candidates whose optimal weight is in the 0.01–0.03
+/// range.
+pub const MAX_OUTGOING_WEIGHT_NON_LINEAR: f32 = 0.03;
+
+/// Minimum incoming/outgoing weight ratio for IDENTITY predictions.
 ///
 /// Based on successful discovery analysis:
 /// - Successful discoveries have ratio 71x to 104,000x
@@ -46,6 +60,13 @@ pub const MAX_OUTGOING_WEIGHT: f32 = 0.01;
 ///
 /// We require ratio >= 50 when incoming weight > 1.0.
 pub(crate) const MIN_WEIGHT_RATIO: f32 = 50.0;
+
+/// Minimum incoming/outgoing weight ratio for non-linear activation predictions.
+///
+/// Issue #905: Non-linear activations operate in different weight regimes than
+/// IDENTITY. Hidden-source candidates with smaller incoming weights and
+/// non-linear activations are valid at lower ratios.
+pub(crate) const MIN_WEIGHT_RATIO_NON_LINEAR: f32 = 10.0;
 
 // DEFAULT_SENTINEL_TOLERANCE uses SENTINEL_TOLERANCE from constants.rs (Issue #424)
 pub use crate::analysis::constants::SENTINEL_TOLERANCE as DEFAULT_SENTINEL_TOLERANCE;
@@ -56,8 +77,9 @@ pub use crate::analysis::constants::SENTINEL_TOLERANCE as DEFAULT_SENTINEL_TOLER
 
 pub use adjustment::{clamp_weight_update_delta, coordinated_structural_activation_delta};
 pub use calculation::{
-    calculate_optimal_bias, calculate_optimal_identity_outgoing_and_bias,
-    calculate_optimal_outgoing_weight,
+    calculate_activation_aware_outgoing_weight, calculate_optimal_bias,
+    calculate_optimal_identity_outgoing_and_bias, calculate_optimal_outgoing_weight,
+    max_outgoing_weight_for_activation, min_weight_ratio_for_activation,
 };
 pub use normalisation::{calculate_range_aware_weight, compute_range_aware_sums};
 

--- a/src/analysis/synapse/activation_evaluation.rs
+++ b/src/analysis/synapse/activation_evaluation.rs
@@ -14,8 +14,8 @@ use crate::analysis::gpu::GpuEvaluator;
 use crate::analysis::samples::{EPSILON, HelpfulSample, NeuronStats};
 use crate::analysis::scoring::confidence::compute_confidence_metrics;
 use crate::analysis::scoring::weights::{
-    MAX_OUTGOING_WEIGHT, calculate_optimal_bias, calculate_optimal_identity_outgoing_and_bias,
-    calculate_optimal_outgoing_weight,
+    calculate_activation_aware_outgoing_weight, calculate_optimal_bias,
+    calculate_optimal_identity_outgoing_and_bias, max_outgoing_weight_for_activation,
 };
 use anyhow::Result;
 
@@ -205,11 +205,12 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
 
                     (outgoing_weight, optimal_bias, improvement, improved_count)
                 } else if target_activation_fn.is_some() {
-                    // Use shared weight calculation with validation.
-                    let base_weight = match calculate_optimal_outgoing_weight(
+                    // Issue #905: Use activation-aware weight calculation
+                    let base_weight = match calculate_activation_aware_outgoing_weight(
                         sum_error_activation,
                         sum_activation_sq,
                         incoming_weight,
+                        spec.name,
                     ) {
                         Some(w) => w,
                         None => continue,
@@ -247,9 +248,9 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                         let mut best_bias = 0.0f32;
                         let mut best_train_improvement = f32::NEG_INFINITY;
 
+                        let max_out = max_outgoing_weight_for_activation(spec.name);
                         for &weight in &weight_candidates {
-                            let clamped_weight =
-                                weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                            let clamped_weight = weight.clamp(-max_out, max_out);
                             if clamped_weight.abs() <= EPSILON {
                                 continue;
                             }
@@ -304,9 +305,9 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                         let mut best_improvement = f32::NEG_INFINITY;
                         let mut best_improved_count = 0u32;
 
+                        let max_out_fb = max_outgoing_weight_for_activation(spec.name);
                         for &weight in &weight_candidates {
-                            let clamped_weight =
-                                weight.clamp(-MAX_OUTGOING_WEIGHT, MAX_OUTGOING_WEIGHT);
+                            let clamped_weight = weight.clamp(-max_out_fb, max_out_fb);
                             if clamped_weight.abs() <= EPSILON {
                                 continue;
                             }
@@ -348,11 +349,12 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                         )
                     }
                 } else {
-                    // For linear targets or when target data unavailable, use the base weight.
-                    let base_weight = match calculate_optimal_outgoing_weight(
+                    // Issue #905: Use activation-aware weight calculation
+                    let base_weight = match calculate_activation_aware_outgoing_weight(
                         sum_error_activation,
                         sum_activation_sq,
                         incoming_weight,
+                        spec.name,
                     ) {
                         Some(w) => w,
                         None => continue,
@@ -379,11 +381,12 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                             sum_error_activation_with_bias += output * sample.avg_error;
                         }
                     }
-                    // Use shared function for bias-adjusted weight calculation
-                    let outgoing_weight = calculate_optimal_outgoing_weight(
+                    // Issue #905: Use activation-aware function for bias-adjusted weight
+                    let outgoing_weight = calculate_activation_aware_outgoing_weight(
                         sum_error_activation_with_bias,
                         sum_activation_sq_with_bias,
                         incoming_weight,
+                        spec.name,
                     )
                     .unwrap_or(base_weight);
 

--- a/src/analysis/synapse/activation_subset_evaluation.rs
+++ b/src/analysis/synapse/activation_subset_evaluation.rs
@@ -12,8 +12,8 @@ use crate::analysis::gpu::GpuEvaluator;
 use crate::analysis::samples::{HelpfulSample, NeuronStats};
 use crate::analysis::scoring::confidence::compute_confidence_metrics;
 use crate::analysis::scoring::weights::{
-    calculate_optimal_bias, calculate_optimal_identity_outgoing_and_bias,
-    calculate_optimal_outgoing_weight,
+    calculate_activation_aware_outgoing_weight, calculate_optimal_bias,
+    calculate_optimal_identity_outgoing_and_bias,
 };
 use anyhow::Result;
 
@@ -96,11 +96,13 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
                     None => continue,
                 }
             } else {
-                // Use shared weight calculation with ratio validation
-                let outgoing_weight = match calculate_optimal_outgoing_weight(
+                // Issue #905: Use activation-aware weight calculation to avoid
+                // systematically rejecting non-linear candidates
+                let outgoing_weight = match calculate_activation_aware_outgoing_weight(
                     sum_error_activation,
                     sum_activation_sq,
                     incoming_weight,
+                    spec.name,
                 ) {
                     Some(w) => w,
                     None => continue, // Skip if weight is invalid or ratio too small

--- a/src/analysis/synapse/gpu_evaluation.rs
+++ b/src/analysis/synapse/gpu_evaluation.rs
@@ -22,8 +22,8 @@ use crate::analysis::gpu::GpuEvaluator;
 use crate::analysis::samples::{EPSILON, HelpfulSample, NeuronStats};
 use crate::analysis::scoring::confidence::compute_confidence_metrics;
 use crate::analysis::scoring::weights::{
-    calculate_optimal_bias, calculate_optimal_identity_outgoing_and_bias,
-    calculate_optimal_outgoing_weight,
+    calculate_activation_aware_outgoing_weight, calculate_optimal_bias,
+    calculate_optimal_identity_outgoing_and_bias,
 };
 use anyhow::Result;
 
@@ -115,10 +115,13 @@ pub(crate) fn evaluate_all_activation_specs_batched<G: GpuEvaluator>(
                 None => continue,
             }
         } else {
-            let outgoing_weight = match calculate_optimal_outgoing_weight(
+            // Issue #905: Use activation-aware weight calculation to avoid
+            // systematically rejecting non-linear candidates
+            let outgoing_weight = match calculate_activation_aware_outgoing_weight(
                 sum_error_activation,
                 sum_activation_sq,
                 incoming_weight,
+                spec.name,
             ) {
                 Some(w) => w,
                 None => continue,

--- a/tests/scoring/issue_905_activation_aware_weight_constraints.rs
+++ b/tests/scoring/issue_905_activation_aware_weight_constraints.rs
@@ -1,0 +1,250 @@
+//! Tests for Issue #905: Weight constraints must not systematically reject
+//! non-IDENTITY and hidden-source candidates.
+//!
+//! The tightened constraints from Issue #888 (`MAX_OUTGOING_WEIGHT = 0.01`,
+//! `MIN_WEIGHT_RATIO = 50.0`) were calibrated on IDENTITY-dominated success
+//! data. Non-linear activations (TANH, GELU, etc.) operate in different weight
+//! regimes and need relaxed constraints to avoid systematic rejection.
+//!
+//! ## Key Behaviours Verified
+//!
+//! - `calculate_activation_aware_outgoing_weight` uses relaxed constraints for
+//!   non-linear activations
+//! - Non-linear candidates with valid weights are not rejected
+//! - IDENTITY candidates still use tight constraints (no regression)
+//! - Hidden-source candidates with smaller incoming weights pass validation
+
+use neat_ai_discovery::analysis::scoring::weights::{
+    MAX_OUTGOING_WEIGHT, calculate_activation_aware_outgoing_weight,
+    calculate_optimal_outgoing_weight, max_outgoing_weight_for_activation,
+    min_weight_ratio_for_activation,
+};
+
+// =============================================================================
+// Activation-Aware Constraint Functions
+// =============================================================================
+
+#[test]
+fn test_identity_gets_tight_max_outgoing_weight() {
+    let max_out = max_outgoing_weight_for_activation("IDENTITY");
+    assert!(
+        (max_out - MAX_OUTGOING_WEIGHT).abs() < 1e-6,
+        "IDENTITY should use the tight MAX_OUTGOING_WEIGHT ({MAX_OUTGOING_WEIGHT}), got {max_out}"
+    );
+}
+
+#[test]
+fn test_tanh_gets_relaxed_max_outgoing_weight() {
+    let max_out = max_outgoing_weight_for_activation("TANH");
+    assert!(
+        max_out > MAX_OUTGOING_WEIGHT,
+        "TANH should have a larger max outgoing weight than IDENTITY ({MAX_OUTGOING_WEIGHT}), got {max_out}"
+    );
+}
+
+#[test]
+fn test_gelu_gets_relaxed_max_outgoing_weight() {
+    let max_out = max_outgoing_weight_for_activation("GELU");
+    assert!(
+        max_out > MAX_OUTGOING_WEIGHT,
+        "GELU should have a larger max outgoing weight than IDENTITY ({MAX_OUTGOING_WEIGHT}), got {max_out}"
+    );
+}
+
+#[test]
+fn test_relu_gets_relaxed_max_outgoing_weight() {
+    let max_out = max_outgoing_weight_for_activation("ReLU");
+    assert!(
+        max_out > MAX_OUTGOING_WEIGHT,
+        "ReLU should have a larger max outgoing weight than IDENTITY ({MAX_OUTGOING_WEIGHT}), got {max_out}"
+    );
+}
+
+#[test]
+fn test_identity_gets_tight_min_weight_ratio() {
+    let min_ratio = min_weight_ratio_for_activation("IDENTITY");
+    assert!(
+        (min_ratio - 50.0).abs() < 1e-6,
+        "IDENTITY should use the tight MIN_WEIGHT_RATIO (50.0), got {min_ratio}"
+    );
+}
+
+#[test]
+fn test_non_linear_gets_relaxed_min_weight_ratio() {
+    for activation in &["TANH", "GELU", "ReLU", "HARD_TANH", "CLIPPED"] {
+        let min_ratio = min_weight_ratio_for_activation(activation);
+        assert!(
+            min_ratio < 50.0,
+            "{activation} should have a lower min weight ratio than IDENTITY (50.0), got {min_ratio}"
+        );
+        assert!(
+            min_ratio > 0.0,
+            "{activation} min weight ratio should be positive, got {min_ratio}"
+        );
+    }
+}
+
+// =============================================================================
+// Activation-Aware Weight Calculation
+// =============================================================================
+
+#[test]
+fn test_activation_aware_identity_matches_default() {
+    // IDENTITY should produce the same result as the default function
+    let default_result = calculate_optimal_outgoing_weight(1.0, 1.0, 2.0);
+    let aware_result = calculate_activation_aware_outgoing_weight(1.0, 1.0, 2.0, "IDENTITY");
+    assert_eq!(
+        default_result, aware_result,
+        "IDENTITY activation-aware result should match default"
+    );
+}
+
+#[test]
+fn test_activation_aware_tanh_allows_larger_weight() {
+    // With a raw weight of 0.03, IDENTITY would clamp to 0.01,
+    // but TANH should allow the larger weight
+    let sum_error_activation = 0.3;
+    let sum_activation_sq = 10.0; // raw_weight = 0.3/10 = 0.03
+    let incoming_weight = 1.0;
+
+    let identity_result =
+        calculate_optimal_outgoing_weight(sum_error_activation, sum_activation_sq, incoming_weight);
+    let tanh_result = calculate_activation_aware_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        "TANH",
+    );
+
+    assert!(identity_result.is_some());
+    assert!(tanh_result.is_some());
+
+    let identity_weight = identity_result.unwrap();
+    let tanh_weight = tanh_result.unwrap();
+
+    assert!(
+        (identity_weight - MAX_OUTGOING_WEIGHT).abs() < 1e-6,
+        "IDENTITY weight should be clamped to {MAX_OUTGOING_WEIGHT}, got {identity_weight}"
+    );
+    assert!(
+        tanh_weight > identity_weight,
+        "TANH weight ({tanh_weight}) should be larger than clamped IDENTITY weight ({identity_weight})"
+    );
+    assert!(
+        (tanh_weight - 0.03).abs() < 0.001,
+        "TANH weight should be ~0.03 (unclamped), got {tanh_weight}"
+    );
+}
+
+#[test]
+fn test_activation_aware_non_linear_passes_ratio_with_smaller_incoming() {
+    // Hidden-source candidate: incoming_weight=1.5, raw outgoing ~0.03
+    // IDENTITY: clamped to 0.01, ratio=150, passes (but weight was distorted)
+    // TANH: not clamped, ratio=50 with relaxed threshold, passes
+    let sum_error_activation = 0.3;
+    let sum_activation_sq = 10.0; // raw_weight = 0.03
+    let incoming_weight = 1.5;
+
+    let tanh_result = calculate_activation_aware_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        "TANH",
+    );
+    assert!(
+        tanh_result.is_some(),
+        "TANH candidate with incoming=1.5 should pass activation-aware validation"
+    );
+}
+
+#[test]
+fn test_activation_aware_still_rejects_invalid_weights() {
+    // Even with relaxed constraints, invalid weights should still be rejected
+    let result = calculate_activation_aware_outgoing_weight(f32::NAN, 1.0, 1.0, "TANH");
+    assert!(result.is_none(), "NaN input should still be rejected");
+
+    let result = calculate_activation_aware_outgoing_weight(1.0, 0.0, 1.0, "TANH");
+    assert!(
+        result.is_none(),
+        "Zero activation_sq should still be rejected"
+    );
+
+    let result = calculate_activation_aware_outgoing_weight(f32::INFINITY, 1.0, 1.0, "GELU");
+    assert!(result.is_none(), "Infinite input should still be rejected");
+}
+
+#[test]
+fn test_activation_aware_no_regression_for_identity() {
+    // Ensure IDENTITY candidates work exactly as before
+    // incoming=2, raw_weight=10 -> clamped to 0.01, ratio=200 -> passes
+    let result = calculate_activation_aware_outgoing_weight(10.0, 1.0, 2.0, "IDENTITY");
+    assert!(result.is_some());
+    let weight = result.unwrap();
+    assert!(
+        (weight - MAX_OUTGOING_WEIGHT).abs() < 1e-6,
+        "IDENTITY weight should be clamped to MAX_OUTGOING_WEIGHT"
+    );
+
+    // incoming=1.0, ratio check skipped -> passes
+    let result = calculate_activation_aware_outgoing_weight(10.0, 1.0, 1.0, "IDENTITY");
+    assert!(
+        result.is_some(),
+        "IDENTITY with incoming=1.0 should skip ratio check"
+    );
+}
+
+// =============================================================================
+// Non-Linear Candidate Acceptance
+// =============================================================================
+
+#[test]
+fn test_tanh_candidate_not_systematically_rejected() {
+    // TANH neuron with incoming_weight=0.5 (hidden source), raw outgoing ~0.005
+    // This should pass: small weight, no ratio check (incoming <= 1.0)
+    let sum_error_activation = 0.05;
+    let sum_activation_sq = 10.0; // raw_weight = 0.005
+    let incoming_weight = 0.5;
+
+    let result = calculate_activation_aware_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        "TANH",
+    );
+    assert!(
+        result.is_some(),
+        "TANH candidate with small incoming weight should not be rejected"
+    );
+}
+
+#[test]
+fn test_gelu_candidate_with_moderate_weight_accepted() {
+    // GELU neuron with incoming_weight=2.0, raw outgoing ~0.02
+    // IDENTITY would clamp to 0.01; GELU should keep 0.02
+    let sum_error_activation = 0.2;
+    let sum_activation_sq = 10.0; // raw_weight = 0.02
+    let incoming_weight = 2.0;
+
+    let identity_result =
+        calculate_optimal_outgoing_weight(sum_error_activation, sum_activation_sq, incoming_weight);
+    let gelu_result = calculate_activation_aware_outgoing_weight(
+        sum_error_activation,
+        sum_activation_sq,
+        incoming_weight,
+        "GELU",
+    );
+
+    // IDENTITY clamps to 0.01
+    assert!(identity_result.is_some());
+    assert!(
+        (identity_result.unwrap() - MAX_OUTGOING_WEIGHT).abs() < 1e-6,
+        "IDENTITY should clamp to MAX_OUTGOING_WEIGHT"
+    );
+
+    // GELU should keep the unclamped weight
+    assert!(gelu_result.is_some());
+    assert!(
+        gelu_result.unwrap() > MAX_OUTGOING_WEIGHT,
+        "GELU should allow weight > MAX_OUTGOING_WEIGHT"
+    );
+}

--- a/tests/scoring/main.rs
+++ b/tests/scoring/main.rs
@@ -21,3 +21,4 @@ mod issue_805_numeric_safety;
 mod issue_887_activation_neuron_boost;
 mod issue_888_weight_constraints;
 mod issue_891_prediction_calibration;
+mod issue_905_activation_aware_weight_constraints;


### PR DESCRIPTION
## Summary

Make weight constraints activation-aware so that non-linear activation candidates
(TANH, GELU, ReLU, etc.) are not systematically rejected by constraints calibrated
on IDENTITY-dominated success data. Closes #905.

The tightened constraints from Issue #888 (`MAX_OUTGOING_WEIGHT = 0.01`,
`MIN_WEIGHT_RATIO = 50.0`) were over-fitted to IDENTITY candidates. Non-linear
activations compress their output range and operate in different weight regimes,
requiring relaxed constraints:

- **`MAX_OUTGOING_WEIGHT_NON_LINEAR = 0.03`** (3x the IDENTITY ceiling of 0.01)
- **`MIN_WEIGHT_RATIO_NON_LINEAR = 10.0`** (5x more permissive than IDENTITY's 50.0)

New public functions `max_outgoing_weight_for_activation()` and
`min_weight_ratio_for_activation()` select the appropriate constraint based on
the activation name. `calculate_activation_aware_outgoing_weight()` wraps the
core least-squares weight calculation with activation-aware constraints.

All non-IDENTITY callers in the activation evaluation pipeline now use the
activation-aware function. IDENTITY candidates are unchanged (no regression).

## Evidence

- 13 new unit tests verify activation-aware behaviour
- All existing tests pass (including GPU shader tests)
- `quality.sh` passes cleanly

## Test Plan

- Added `tests/scoring/issue_905_activation_aware_weight_constraints.rs` (13 tests):
  - `test_identity_gets_tight_max_outgoing_weight` — IDENTITY uses 0.01 ceiling
  - `test_tanh_gets_relaxed_max_outgoing_weight` — TANH gets relaxed ceiling
  - `test_gelu_gets_relaxed_max_outgoing_weight` — GELU gets relaxed ceiling
  - `test_relu_gets_relaxed_max_outgoing_weight` — ReLU gets relaxed ceiling
  - `test_identity_gets_tight_min_weight_ratio` — IDENTITY uses 50.0 ratio
  - `test_non_linear_gets_relaxed_min_weight_ratio` — Non-linear activations use relaxed ratio
  - `test_activation_aware_identity_matches_default` — IDENTITY path matches default function
  - `test_activation_aware_tanh_allows_larger_weight` — TANH weight not clamped to 0.01
  - `test_activation_aware_non_linear_passes_ratio_with_smaller_incoming` — Hidden-source passes
  - `test_activation_aware_still_rejects_invalid_weights` — Invalid inputs still rejected
  - `test_activation_aware_no_regression_for_identity` — No regression for IDENTITY
  - `test_tanh_candidate_not_systematically_rejected` — TANH with small incoming passes
  - `test_gelu_candidate_with_moderate_weight_accepted` — GELU keeps unclamped weight

---

## Automated Fix Details
This PR addresses issue #905: **fix: weight constraints (MAX_OUTGOING_WEIGHT/MIN_WEIGHT_RATIO) systematically reject non-IDENTITY and hidden-source candidates**

## Milestone
This PR is part of the **Fan In** milestone and targets the `milestone/fan-in` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #905
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-905 -->