### PR TITLE
fix: interleave hidden sources to ensure hidden-to-hidden candidate evaluation

### DIFF
--- a/docs/pr-summary-907.md
+++ b/docs/pr-summary-907.md
@@ -1,0 +1,43 @@
+## Summary
+
+Interleave hidden sources among input sources during source ordering so that
+hidden-to-hidden synapse candidates are evaluated even under deadline constraints.
+Closes #907.
+
+Previously, `order_eligible_sources()` always placed all input neurons before all
+hidden neurons. Under tight deadlines, analysis time would run out before reaching
+hidden sources, meaning hidden-to-hidden candidates were rarely or never evaluated.
+
+This change introduces `interleave_sources()` which inserts one hidden source after
+every `HIDDEN_SOURCE_INTERLEAVE_INTERVAL` (3) input sources. This gives hidden
+sources approximately 25% of evaluation slots while still prioritising input sources
+(which have a higher historical success rate).
+
+### Changes
+
+- **`src/analysis/constants.rs`**: Added `HIDDEN_SOURCE_INTERLEAVE_INTERVAL = 3`
+  constant controlling how often hidden sources are inserted among input sources.
+- **`src/analysis/utils/deadline.rs`**: Added `interleave_sources()` helper function
+  and updated all three code paths in `order_eligible_sources()` (no-bias, weighted
+  bias, and focus-unused-observations) to interleave rather than append hidden sources.
+  Added diagnostic logging for input/hidden source ratios.
+- **`tests/analysis/issue_907_hidden_source_interleaving.rs`**: 8 integration tests
+  verifying interleaving behaviour, determinism, element preservation, and edge cases.
+
+## Evidence
+
+All existing tests pass (including the 11 issue #467 source-type prioritisation tests),
+confirming no regression in input-source candidate quality. The new tests verify that
+hidden sources appear in the first half of the evaluation order under various conditions.
+
+## Test Plan
+
+- `hidden_sources_are_interleaved_among_inputs` — hidden neurons appear in first half
+- `all_elements_preserved_after_interleaving` — no neurons lost during reordering
+- `interleaving_is_deterministic_with_seed` — same seed produces same order
+- `hidden_sources_evaluated_under_simulated_deadline_pressure` — hidden sources present in first N evaluated
+- `only_inputs_no_hidden_neurons_still_works` — edge case: no hidden neurons
+- `only_hidden_no_input_neurons_still_works` — edge case: no input neurons
+- `interleaving_consistent_across_seeds` — works across multiple seeds
+- `focus_unused_observations_also_interleaves_hidden` — interleaving works with focus-unused path
+- Compile-time assertions validate `HIDDEN_SOURCE_INTERLEAVE_INTERVAL` is in range [2, 5]

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -124,6 +124,21 @@ pub const DIVERSIFY_TOP_K: usize = 64;
 /// Must be > 1.0 (boost) and <= 3.0 (avoid over-biasing).
 pub const INPUT_SOURCE_BOOST: f64 = 1.5;
 
+/// Interleave interval for hidden sources during source ordering (Issue #907).
+///
+/// After every `HIDDEN_SOURCE_INTERLEAVE_INTERVAL` input sources, one hidden
+/// source is inserted into the evaluation order. This ensures hidden-to-hidden
+/// synapse candidates are evaluated even under tight deadline constraints.
+///
+/// With an interval of 3, approximately 25% of evaluation slots go to hidden
+/// sources — enough to discover hidden-to-hidden connections without starving
+/// the higher-success-rate input sources.
+///
+/// ## Valid Range
+/// Must be >= 2 (to still prioritise inputs) and <= 5 (to ensure hidden
+/// sources get meaningful evaluation time).
+pub const HIDDEN_SOURCE_INTERLEAVE_INTERVAL: usize = 3;
+
 /// Minimum number of recorded outcomes before applying source-type boost.
 ///
 /// Below this threshold, the Bayesian estimate is too noisy to use for

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -382,13 +382,81 @@ pub struct OrderedNeuron {
     pub index: usize,
 }
 
+/// Interleave hidden sources among input sources (Issue #907).
+///
+/// Instead of appending all hidden sources after all input sources, this
+/// function inserts one hidden source after every
+/// [`crate::analysis::constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL`] input
+/// sources. This ensures hidden-to-hidden synapse candidates are evaluated
+/// even under tight deadline constraints.
+///
+/// Input sources are still prioritised (they occupy the majority of slots),
+/// but hidden sources get regular evaluation opportunities throughout the
+/// ordering rather than being starved at the end.
+fn interleave_sources<'a>(
+    eligible_sources: &mut Vec<&'a OrderedNeuron>,
+    inputs: Vec<&'a OrderedNeuron>,
+    hidden: Vec<&'a OrderedNeuron>,
+) {
+    use crate::analysis::constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL;
+
+    if hidden.is_empty() {
+        eligible_sources.extend(inputs);
+        return;
+    }
+    if inputs.is_empty() {
+        eligible_sources.extend(hidden);
+        return;
+    }
+
+    let interval = HIDDEN_SOURCE_INTERLEAVE_INTERVAL;
+    let input_iter = inputs.into_iter();
+    let mut hidden_iter = hidden.into_iter().peekable();
+
+    let mut input_count_since_hidden = 0usize;
+
+    for inp in input_iter {
+        eligible_sources.push(inp);
+        input_count_since_hidden += 1;
+
+        // After every `interval` inputs, insert one hidden source
+        if input_count_since_hidden >= interval {
+            if let Some(hid) = hidden_iter.next() {
+                eligible_sources.push(hid);
+            }
+            input_count_since_hidden = 0;
+        }
+    }
+
+    // Append any remaining hidden sources
+    eligible_sources.extend(hidden_iter);
+
+    if verbose_enabled() {
+        let total = eligible_sources.len();
+        let hidden_count = eligible_sources
+            .iter()
+            .filter(|n| parse_input_index(&n.uuid).is_none())
+            .count();
+        let input_count = total - hidden_count;
+        tracing::debug!(
+            input_sources = input_count,
+            hidden_sources = hidden_count,
+            total_sources = total,
+            interleave_interval = interval,
+            "Issue #907: interleaved hidden sources among input sources"
+        );
+    }
+}
+
 /// Order eligible sources for evaluation.
 ///
 /// - Always respects forward-only candidate constraints (caller must filter by index).
-/// - **Issue #467**: Input neurons are always evaluated before hidden neurons. Within
-///   each group, neurons are randomly shuffled. This ensures that under deadline
-///   constraints, input-neuron sources (36.2% success rate) are tried before hidden
-///   neurons (2.8–3.3% success rate).
+/// - **Issue #467**: Input neurons are prioritised over hidden neurons. Within
+///   each group, neurons are randomly shuffled.
+/// - **Issue #907**: Hidden sources are interleaved among input sources at regular
+///   intervals (every [`crate::analysis::constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL`]
+///   inputs) so they are evaluated even under deadline pressure, rather than being
+///   appended at the end where they would be skipped.
 /// - If `NEAT_AI_DISCOVERY_SOURCE_INPUT_INDEX_BIAS` is set, input sources are further
 ///   ordered by a weighted random permutation favouring higher input indices.
 /// - If `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS=1` is set, input neurons with NO
@@ -431,7 +499,7 @@ pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq
             );
         }
 
-        // Shuffle each partition separately, then concatenate
+        // Shuffle each partition separately, then interleave (Issue #907)
         shuffle_slice(&mut unused_inputs, seed, &format!("{context}:unused"));
         shuffle_slice(
             &mut used_inputs_vec,
@@ -440,9 +508,11 @@ pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq
         );
         shuffle_slice(&mut non_inputs, seed, &format!("{context}:non_inputs"));
 
-        eligible_sources.extend(unused_inputs);
-        eligible_sources.extend(used_inputs_vec);
-        eligible_sources.extend(non_inputs);
+        // Combine unused and used inputs in priority order, then interleave
+        // hidden sources among them so they are evaluated under deadline pressure.
+        let mut all_inputs = unused_inputs;
+        all_inputs.extend(used_inputs_vec);
+        interleave_sources(eligible_sources, all_inputs, non_inputs);
         return;
     }
 
@@ -454,11 +524,10 @@ pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq
         .partition(|n| parse_input_index(&n.uuid).is_some());
 
     let Some(bias) = source_input_index_bias_from_env() else {
-        // No index bias: shuffle each partition independently, inputs first
+        // No index bias: shuffle each partition independently, then interleave (Issue #907)
         shuffle_slice(&mut inputs, seed, &format!("{context}:inputs"));
         shuffle_slice(&mut non_inputs, seed, &format!("{context}:non_inputs"));
-        eligible_sources.extend(inputs);
-        eligible_sources.extend(non_inputs);
+        interleave_sources(eligible_sources, inputs, non_inputs);
         return;
     };
 
@@ -498,11 +567,11 @@ pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq
     }
 
     keyed.sort_by(|a, b| a.0.total_cmp(&b.0));
-    eligible_sources.extend(keyed.into_iter().map(|(_, n)| n));
+    let sorted_inputs: Vec<&OrderedNeuron> = keyed.into_iter().map(|(_, n)| n).collect();
 
-    // Append non-input neurons after all input neurons
+    // Issue #907: Interleave hidden sources among weighted input sources
     shuffle_slice(&mut non_inputs, seed, &format!("{context}:non_inputs"));
-    eligible_sources.extend(non_inputs);
+    interleave_sources(eligible_sources, sorted_inputs, non_inputs);
 }
 
 // =============================================================================

--- a/tests/analysis/issue_907_hidden_source_interleaving.rs
+++ b/tests/analysis/issue_907_hidden_source_interleaving.rs
@@ -1,0 +1,231 @@
+//! Tests for Issue #907: Interleave hidden sources with input sources
+//! during source ordering to ensure hidden-to-hidden synapse candidates
+//! are evaluated even under deadline constraints.
+//!
+//! Previously, `order_eligible_sources()` always placed all input neurons
+//! before all hidden neurons. Under tight deadlines, hidden sources were
+//! rarely or never evaluated. This change interleaves hidden sources at
+//! regular intervals so a meaningful proportion are always evaluated.
+
+#![allow(clippy::cast_possible_truncation)]
+use neat_ai_discovery::analysis::constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL;
+use neat_ai_discovery::analysis::utils::{
+    OrderedNeuron, order_eligible_sources, parse_input_index,
+};
+use std::collections::HashSet;
+
+// =============================================================================
+// Hidden source interleaving
+// =============================================================================
+
+/// Helper to create a mixed set of input and hidden neurons.
+fn make_mixed_neurons(input_count: usize, hidden_count: usize) -> Vec<OrderedNeuron> {
+    let mut neurons = Vec::with_capacity(input_count + hidden_count);
+    for i in 0..input_count {
+        neurons.push(OrderedNeuron {
+            uuid: format!("input-{i}"),
+            index: i,
+        });
+    }
+    for i in 0..hidden_count {
+        neurons.push(OrderedNeuron {
+            uuid: format!("hidden-uuid-{i}"),
+            index: input_count + i,
+        });
+    }
+    neurons
+}
+
+#[test]
+fn hidden_sources_are_interleaved_among_inputs() {
+    // With 9 inputs and 6 hidden neurons, hidden neurons should appear
+    // interleaved among inputs, not all at the end.
+    let neurons = make_mixed_neurons(9, 6);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 9, None);
+
+    // Check that at least one hidden neuron appears in the first half
+    let half = sources.len() / 2;
+    let hidden_in_first_half = sources[..half]
+        .iter()
+        .filter(|n| parse_input_index(&n.uuid).is_none())
+        .count();
+
+    assert!(
+        hidden_in_first_half > 0,
+        "At least one hidden neuron should appear in the first half of the ordering. \
+         Order: {:?}",
+        sources.iter().map(|n| &n.uuid).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn all_elements_preserved_after_interleaving() {
+    let neurons = make_mixed_neurons(6, 4);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 6, None);
+
+    assert_eq!(sources.len(), 10, "All 10 neurons should be preserved");
+
+    let input_count = sources
+        .iter()
+        .filter(|n| parse_input_index(&n.uuid).is_some())
+        .count();
+    let hidden_count = sources
+        .iter()
+        .filter(|n| parse_input_index(&n.uuid).is_none())
+        .count();
+
+    assert_eq!(input_count, 6, "All 6 input neurons should be preserved");
+    assert_eq!(hidden_count, 4, "All 4 hidden neurons should be preserved");
+}
+
+#[test]
+fn interleaving_is_deterministic_with_seed() {
+    let neurons = make_mixed_neurons(6, 4);
+
+    let mut sources1: Vec<&OrderedNeuron> = neurons.iter().collect();
+    let mut sources2: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources1, Some(99), "test", 6, None);
+    order_eligible_sources::<String>(&mut sources2, Some(99), "test", 6, None);
+
+    let uuids1: Vec<&str> = sources1.iter().map(|n| n.uuid.as_str()).collect();
+    let uuids2: Vec<&str> = sources2.iter().map(|n| n.uuid.as_str()).collect();
+
+    assert_eq!(uuids1, uuids2, "Same seed should produce same ordering");
+}
+
+#[test]
+fn hidden_sources_evaluated_under_simulated_deadline_pressure() {
+    // Simulate deadline pressure by only looking at the first N sources
+    // (representing what gets evaluated before deadline expires).
+    // With interleaving, hidden sources should be present in the first N.
+    let neurons = make_mixed_neurons(12, 6);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 12, None);
+
+    // Only the first 6 sources would be evaluated under tight deadlines
+    let evaluated_count = 6;
+    let hidden_in_evaluated = sources[..evaluated_count]
+        .iter()
+        .filter(|n| parse_input_index(&n.uuid).is_none())
+        .count();
+
+    assert!(
+        hidden_in_evaluated > 0,
+        "Hidden sources should be present among the first {evaluated_count} sources \
+         evaluated under deadline pressure. Order: {:?}",
+        sources
+            .iter()
+            .take(evaluated_count)
+            .map(|n| &n.uuid)
+            .collect::<Vec<_>>()
+    );
+}
+
+// Compile-time validation that the interleave interval is within a reasonable range
+const _: () = assert!(HIDDEN_SOURCE_INTERLEAVE_INTERVAL >= 2);
+const _: () = assert!(HIDDEN_SOURCE_INTERLEAVE_INTERVAL <= 5);
+
+#[test]
+fn only_inputs_no_hidden_neurons_still_works() {
+    let neurons = make_mixed_neurons(5, 0);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 5, None);
+
+    assert_eq!(sources.len(), 5);
+    for n in &sources {
+        assert!(
+            parse_input_index(&n.uuid).is_some(),
+            "All should be input neurons"
+        );
+    }
+}
+
+#[test]
+fn only_hidden_no_input_neurons_still_works() {
+    let neurons = make_mixed_neurons(0, 5);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    order_eligible_sources::<String>(&mut sources, Some(42), "test", 0, None);
+
+    assert_eq!(sources.len(), 5);
+    for n in &sources {
+        assert!(
+            parse_input_index(&n.uuid).is_none(),
+            "All should be hidden neurons"
+        );
+    }
+}
+
+#[test]
+fn interleaving_consistent_across_seeds() {
+    // Verify that hidden sources are interleaved regardless of seed
+    let neurons = make_mixed_neurons(9, 6);
+
+    for seed in [0u64, 1, 42, 100, 999, 12345] {
+        let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+        order_eligible_sources::<String>(&mut sources, Some(seed), "test", 9, None);
+
+        // With 9 inputs and 6 hidden, the first 6 sources should contain
+        // at least one hidden neuron due to interleaving
+        let hidden_in_first_6 = sources[..6]
+            .iter()
+            .filter(|n| parse_input_index(&n.uuid).is_none())
+            .count();
+
+        assert!(
+            hidden_in_first_6 > 0,
+            "Seed {seed}: hidden sources should be interleaved in the first 6 positions. \
+             Order: {:?}",
+            sources.iter().map(|n| &n.uuid).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn focus_unused_observations_also_interleaves_hidden() {
+    // When FOCUS_UNUSED_OBSERVATIONS is active and used_inputs is provided,
+    // hidden neurons should still be interleaved (not all at the end)
+    let neurons = make_mixed_neurons(6, 4);
+    let used_inputs: HashSet<String> = ["input-0".to_string(), "input-1".to_string()].into();
+
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+    order_eligible_sources(&mut sources, Some(42), "test", 6, Some(&used_inputs));
+
+    // All elements should be preserved
+    assert_eq!(sources.len(), 10);
+
+    // Hidden neurons should appear among the sources, not just at the very end
+    let last_three = &sources[sources.len() - 3..];
+    let all_hidden_at_end = last_three
+        .iter()
+        .all(|n| parse_input_index(&n.uuid).is_none());
+
+    // It's acceptable for some hidden neurons to be at the end, but not ALL
+    // hidden neurons should be at the very end if interleaving is working.
+    // With 4 hidden neurons, at most 3 can be at the last 3 positions.
+    let hidden_count = sources
+        .iter()
+        .filter(|n| parse_input_index(&n.uuid).is_none())
+        .count();
+
+    if hidden_count > 3 && all_hidden_at_end {
+        // Check if ALL hidden neurons are at the end
+        let hidden_at_end = sources[sources.len() - hidden_count..]
+            .iter()
+            .filter(|n| parse_input_index(&n.uuid).is_none())
+            .count();
+        assert!(
+            hidden_at_end < hidden_count,
+            "Not all hidden neurons should be pushed to the end. \
+             Order: {:?}",
+            sources.iter().map(|n| &n.uuid).collect::<Vec<_>>()
+        );
+    }
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -42,6 +42,7 @@ mod issue_733_add_neurons_pessimism_tuning;
 mod issue_791_improve_add_neurons_prediction;
 mod issue_792_adaptive_module_wiring;
 mod issue_806_dry_variant_generation;
+mod issue_907_hidden_source_interleaving;
 mod split_error_all_activations;
 mod split_error_fallback_candidates;
 mod target_map_optimization;


### PR DESCRIPTION
## Summary

Interleave hidden sources among input sources during source ordering so that
hidden-to-hidden synapse candidates are evaluated even under deadline constraints.
Closes #907.

Previously, `order_eligible_sources()` always placed all input neurons before all
hidden neurons. Under tight deadlines, analysis time would run out before reaching
hidden sources, meaning hidden-to-hidden candidates were rarely or never evaluated.

This change introduces `interleave_sources()` which inserts one hidden source after
every `HIDDEN_SOURCE_INTERLEAVE_INTERVAL` (3) input sources. This gives hidden
sources approximately 25% of evaluation slots while still prioritising input sources
(which have a higher historical success rate).

### Changes

- **`src/analysis/constants.rs`**: Added `HIDDEN_SOURCE_INTERLEAVE_INTERVAL = 3`
  constant controlling how often hidden sources are inserted among input sources.
- **`src/analysis/utils/deadline.rs`**: Added `interleave_sources()` helper function
  and updated all three code paths in `order_eligible_sources()` (no-bias, weighted
  bias, and focus-unused-observations) to interleave rather than append hidden sources.
  Added diagnostic logging for input/hidden source ratios.
- **`tests/analysis/issue_907_hidden_source_interleaving.rs`**: 8 integration tests
  verifying interleaving behaviour, determinism, element preservation, and edge cases.

## Evidence

All existing tests pass (including the 11 issue #467 source-type prioritisation tests),
confirming no regression in input-source candidate quality. The new tests verify that
hidden sources appear in the first half of the evaluation order under various conditions.

## Test Plan

- `hidden_sources_are_interleaved_among_inputs` — hidden neurons appear in first half
- `all_elements_preserved_after_interleaving` — no neurons lost during reordering
- `interleaving_is_deterministic_with_seed` — same seed produces same order
- `hidden_sources_evaluated_under_simulated_deadline_pressure` — hidden sources present in first N evaluated
- `only_inputs_no_hidden_neurons_still_works` — edge case: no hidden neurons
- `only_hidden_no_input_neurons_still_works` — edge case: no input neurons
- `interleaving_consistent_across_seeds` — works across multiple seeds
- `focus_unused_observations_also_interleaves_hidden` — interleaving works with focus-unused path
- Compile-time assertions validate `HIDDEN_SOURCE_INTERLEAVE_INTERVAL` is in range [2, 5]

---

## Automated Fix Details
This PR addresses issue #907: **fix: deadline-constrained source ordering prevents hidden-to-hidden candidate evaluation**

## Milestone
This PR is part of the **Fan In** milestone and targets the `milestone/fan-in` feature branch.

## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #907
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-907 -->