### PR TITLE
feat: generate fan-in candidates (multiple inputs converging to one hidden neuron)

### DIFF
--- a/docs/pr-summary-908.md
+++ b/docs/pr-summary-908.md
@@ -1,0 +1,41 @@
+## Summary
+
+Add fan-in candidate generation that detects pairs of inputs whose activations
+jointly predict a target's error and creates coordinated structural candidates
+with a shared non-linear hidden neuron. Closes #908.
+
+The new `fan_in` module in `src/analysis/recommendation/` detects complementary
+input pairs via correlation analysis and two-variable least-squares regression,
+then emits `CoordinatedStructuralCandidateJson` candidates containing:
+- `AddNeuron` (hidden, TANH activation) to capture interaction effects
+- `AddSynapse` per input to the hidden neuron (with optimised weights)
+- `AddSynapse` from hidden neuron to target
+
+Key design decisions:
+- Non-linear activations only (TANH/GELU) — IDENTITY is never used for fan-in
+  since it reduces to a linear combination that cannot capture interactions
+- Inputs must have low mutual correlation (< 0.8) to ensure complementarity
+- Combined regression improvement must exceed best individual by 5% ratio
+- Conservative 0.01× scaling on estimated improvement (multi-operation discount)
+- Deterministic UUID generation via FNV-1a hash of sorted input + target UUIDs
+
+## Evidence
+
+All 13 unit tests pass, plus the updated module count test (45 → 46).
+
+## Test Plan
+
+- `tests/recommendation/issue_908_fan_in_candidates.rs` — 13 tests:
+  1. Detects fan-in candidates for correlated inputs
+  2. No candidates for uncorrelated inputs
+  3. Non-linear activations enforced (not IDENTITY)
+  4. Valid coordinated structural operations produced
+  5. Deterministic UUID generation
+  6. Empty records produce no candidates
+  7. Insufficient samples produce no candidates
+  8. Single input cannot form fan-in pair
+  9. Candidates sorted by estimated improvement
+  10. Redundant (highly correlated) inputs filtered out
+  11. Fan-in targets hidden neurons as well as outputs
+  12. Estimated improvement always positive
+  13. Conversion requires at least 2 inputs

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -323,11 +323,11 @@ mod tests {
 
         let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
 
-        // We expect exactly 45 modules across all four spec groups.
+        // We expect exactly 46 modules across all four spec groups.
         assert_eq!(
             specs.len(),
-            45,
-            "Expected 45 discovery module specs, got {}",
+            46,
+            "Expected 46 discovery module specs, got {}",
             specs.len()
         );
 

--- a/src/analysis/module_dispatch_specs/structural_specs.rs
+++ b/src/analysis/module_dispatch_specs/structural_specs.rs
@@ -1,8 +1,8 @@
 //! Structural discovery module dispatch specs.
 //!
 //! Covers: multi-hop candidate analysis, topology structure analysis,
-//! topology diversification, skip-connection discovery, and correlated
-//! error detection.
+//! topology diversification, skip-connection discovery, correlated
+//! error detection, and fan-in candidate generation.
 
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ use super::super::detection::{
     correlated_error, hard_sample_cluster, output_conflict, skip_connection, topology,
     topology_cache::CreatureTopologyCache, topology_diversification,
 };
-use super::super::recommendation::multi_hop;
+use super::super::recommendation::{fan_in, multi_hop};
 use super::super::{cache, discovery_dispatch};
 
 /// Append structural discovery module specs to the provided vector.
@@ -112,6 +112,14 @@ pub(crate) fn append_structural_specs(
                 candidates,
             })
         },
+    );
+
+    // Issue #908: Fan-in candidate generation (multiple inputs converging to one hidden neuron)
+    discovery_spec!(modules, "fan-in candidate generation", "fan_in_candidate_generation",
+        cache = shared_cache, creature = creature =>
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| fan_in::detect_fan_in_candidates(&creature, &records),
+        convert: |detected| fan_in::fan_in_to_coordinated_candidates(&detected, &creature),
     );
 
     // Issue #642: Hard sample cluster detection (cross-network high-error observations)

--- a/src/analysis/recommendation/fan_in.rs
+++ b/src/analysis/recommendation/fan_in.rs
@@ -1,0 +1,575 @@
+//! Fan-in candidate generation module (Issue #908).
+//!
+//! Generates "fan-in" candidates where multiple inputs converge to a single
+//! hidden neuron. When correlated input pairs are detected — i.e. inputs
+//! whose activations jointly predict a target's error — a fan-in candidate
+//! is emitted:
+//!
+//! ```text
+//! input-A --+
+//!           +--> [hidden (non-linear)] --> target
+//! input-B --+
+//! ```
+//!
+//! Non-linear activations (TANH, GELU) are preferred because IDENTITY would
+//! reduce the fan-in to a linear combination, missing interaction effects.
+//!
+//! ## Detection Method
+//!
+//! 1. Identify target neurons (output, hidden) with error records.
+//! 2. For each target, find input neurons whose activation correlates with
+//!    the target error.
+//! 3. For each pair of correlated inputs, check whether they have
+//!    complementary activation patterns (low mutual correlation) — this
+//!    indicates an interaction effect.
+//! 4. Estimate combined improvement from the input pair via least-squares
+//!    regression on the target error.
+//! 5. Emit a `CoordinatedStructuralCandidateJson` with `AddNeuron` + two
+//!    `AddSynapse` (inputs → hidden) + one `AddSynapse` (hidden → target).
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts for neural network computation (Issue #873)
+#![allow(clippy::cast_possible_truncation)] // f64→f32 regression results are intentionally truncated
+
+use std::collections::{HashMap, HashSet};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+use crate::analysis::detection::stats::pearson_correlation;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Minimum absolute correlation between an input's activation and a target's
+/// error to consider that input as a fan-in contributor.
+const INPUT_ERROR_CORRELATION_THRESHOLD: f32 = 0.3;
+
+/// Maximum absolute correlation between two inputs for them to be considered
+/// complementary (low redundancy).
+const MAX_INPUT_MUTUAL_CORRELATION: f32 = 0.8;
+
+/// Minimum combined improvement ratio vs the best single-input improvement
+/// to justify a fan-in candidate over a simple single-input path.
+const MIN_COMBINED_BENEFIT_RATIO: f32 = 1.05;
+
+/// Maximum fan-in candidates returned per analysis run.
+const MAX_FAN_IN_CANDIDATES: usize = 30;
+
+/// Maximum number of input contributors to evaluate per target.
+const MAX_INPUTS_PER_TARGET: usize = 15;
+
+/// Non-linear activations preferred for fan-in neurons (interaction capture).
+const FAN_IN_ACTIVATIONS: &[&str] = &["TANH", "GELU"];
+
+/// A detected fan-in opportunity where multiple inputs converge to one target.
+#[derive(Debug, Clone)]
+pub struct FanInCandidate {
+    /// UUIDs of the input neurons that converge.
+    pub input_uuids: Vec<String>,
+    /// UUID of the target neuron (output or hidden).
+    pub target_uuid: String,
+    /// Optimal weights from each input to the fan-in hidden neuron.
+    pub input_weights: Vec<f32>,
+    /// Weight from the fan-in hidden neuron to the target.
+    pub output_weight: f32,
+    /// Activation function for the fan-in hidden neuron.
+    pub activation: String,
+    /// Estimated creature score improvement.
+    pub estimated_improvement: f32,
+    /// Mean correlation between each input and the target error.
+    pub mean_input_error_correlation: f32,
+    /// Mutual correlation between the inputs (lower = more complementary).
+    pub input_mutual_correlation: f32,
+    /// Number of shared samples used for estimation.
+    pub sample_count: usize,
+    /// Descriptive reason for this candidate.
+    pub reason: String,
+}
+
+/// Detect fan-in candidates by finding pairs of inputs whose activations
+/// jointly predict a target neuron's error.
+///
+/// # Arguments
+/// * `creature` - Network topology.
+/// * `neuron_records` - Recorded activations and errors per neuron.
+///
+/// # Returns
+/// Fan-in candidates sorted by estimated improvement (best first).
+pub fn detect_fan_in_candidates(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<FanInCandidate> {
+    if neuron_records.is_empty() {
+        return Vec::new();
+    }
+
+    // Build record lookup by neuron UUID.
+    let record_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, recs)| (uuid.as_str(), recs))
+        .collect();
+
+    // Classify neurons.
+    let neuron_types: HashMap<&str, &str> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.neuron_type.as_str()))
+        .collect();
+
+    // Build existing synapse set for deduplication.
+    let existing_synapses: HashSet<(&str, &str)> = creature
+        .synapses
+        .iter()
+        .map(|s| (s.from_uuid.as_str(), s.to_uuid.as_str()))
+        .collect();
+
+    // Identify input neurons.
+    let input_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "input")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    // Identify target neurons (output and hidden) with sufficient error records.
+    let target_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output" || n.neuron_type == "hidden")
+        .filter(|n| {
+            record_map.get(n.uuid.as_str()).is_some_and(|recs| {
+                recs.len() >= MIN_DISCOVERY_SAMPLE_COUNT
+                    && recs.iter().any(|r| !r.errors.is_empty())
+            })
+        })
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for &target_uuid in &target_uuids {
+        let target_records = match record_map.get(target_uuid) {
+            Some(r) => *r,
+            None => continue,
+        };
+
+        // Build target error map: obs_index → first error value.
+        let target_errors: HashMap<u32, f32> = target_records
+            .iter()
+            .filter(|r| !r.errors.is_empty())
+            .map(|r| (r.obs_index, r.errors[0]))
+            .collect();
+
+        if target_errors.len() < MIN_DISCOVERY_SAMPLE_COUNT {
+            continue;
+        }
+
+        // Score each input by correlation with target error.
+        let mut input_scores: Vec<(&str, f32, HashMap<u32, f32>)> = Vec::new();
+
+        for &input_uuid in &input_uuids {
+            let input_records = match record_map.get(input_uuid) {
+                Some(r) => *r,
+                None => continue,
+            };
+
+            // Build input activation map.
+            let input_activations: HashMap<u32, f32> = input_records
+                .iter()
+                .map(|r| (r.obs_index, r.activation))
+                .collect();
+
+            // Find shared observation indices.
+            let shared_indices: Vec<u32> = target_errors
+                .keys()
+                .copied()
+                .filter(|idx| input_activations.contains_key(idx))
+                .collect();
+
+            if shared_indices.len() < MIN_DISCOVERY_SAMPLE_COUNT {
+                continue;
+            }
+
+            // Compute correlation between input activation and target error.
+            let acts: Vec<f32> = shared_indices
+                .iter()
+                .map(|idx| input_activations[idx])
+                .collect();
+            let errs: Vec<f32> = shared_indices
+                .iter()
+                .map(|idx| target_errors[idx])
+                .collect();
+
+            let corr = pearson_correlation(&acts, &errs);
+            if corr.abs() < INPUT_ERROR_CORRELATION_THRESHOLD {
+                continue;
+            }
+
+            input_scores.push((input_uuid, corr, input_activations));
+        }
+
+        // Sort by absolute correlation strength and take top candidates.
+        input_scores.sort_by(|a, b| {
+            b.1.abs()
+                .partial_cmp(&a.1.abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        input_scores.truncate(MAX_INPUTS_PER_TARGET);
+
+        // Evaluate all pairs for fan-in opportunity.
+        for i in 0..input_scores.len() {
+            for j in (i + 1)..input_scores.len() {
+                let (input_a_uuid, corr_a, ref acts_a) = input_scores[i];
+                let (input_b_uuid, corr_b, ref acts_b) = input_scores[j];
+
+                if let Some(candidate) = evaluate_fan_in_pair(
+                    input_a_uuid,
+                    input_b_uuid,
+                    corr_a,
+                    corr_b,
+                    acts_a,
+                    acts_b,
+                    target_uuid,
+                    &target_errors,
+                    &existing_synapses,
+                    &neuron_types,
+                ) {
+                    candidates.push(candidate);
+                }
+            }
+        }
+    }
+
+    // Sort by estimated improvement (best first) and truncate.
+    candidates.sort_by(|a, b| {
+        b.estimated_improvement
+            .partial_cmp(&a.estimated_improvement)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    candidates.truncate(MAX_FAN_IN_CANDIDATES);
+
+    candidates
+}
+
+/// Evaluate a pair of inputs for a fan-in candidate targeting a specific neuron.
+#[allow(clippy::too_many_arguments)]
+fn evaluate_fan_in_pair(
+    input_a_uuid: &str,
+    input_b_uuid: &str,
+    corr_a: f32,
+    corr_b: f32,
+    acts_a: &HashMap<u32, f32>,
+    acts_b: &HashMap<u32, f32>,
+    target_uuid: &str,
+    target_errors: &HashMap<u32, f32>,
+    existing_synapses: &HashSet<(&str, &str)>,
+    neuron_types: &HashMap<&str, &str>,
+) -> Option<FanInCandidate> {
+    // Find shared observation indices across all three neurons.
+    let shared_indices: Vec<u32> = target_errors
+        .keys()
+        .copied()
+        .filter(|idx| acts_a.contains_key(idx) && acts_b.contains_key(idx))
+        .collect();
+
+    if shared_indices.len() < MIN_DISCOVERY_SAMPLE_COUNT {
+        return None;
+    }
+
+    // Check mutual correlation between the two inputs — we want complementary patterns.
+    let a_vals: Vec<f32> = shared_indices.iter().map(|idx| acts_a[idx]).collect();
+    let b_vals: Vec<f32> = shared_indices.iter().map(|idx| acts_b[idx]).collect();
+    let mutual_corr = pearson_correlation(&a_vals, &b_vals);
+
+    if mutual_corr.abs() > MAX_INPUT_MUTUAL_CORRELATION {
+        return None; // Too similar; a single-input path would suffice.
+    }
+
+    let err_vals: Vec<f32> = shared_indices
+        .iter()
+        .map(|idx| target_errors[idx])
+        .collect();
+
+    // Compute individual improvements via least-squares: w = Σ(act × err) / Σ(act²).
+    let individual_a = compute_least_squares_improvement(&a_vals, &err_vals);
+    let individual_b = compute_least_squares_improvement(&b_vals, &err_vals);
+
+    // Compute combined improvement: two-variable regression.
+    let (weight_a, weight_b, combined_improvement) =
+        compute_two_input_regression(&a_vals, &b_vals, &err_vals)?;
+
+    // The combined improvement should exceed the best individual by a ratio.
+    let best_individual = individual_a.max(individual_b);
+    if best_individual <= 0.0 {
+        return None;
+    }
+    if combined_improvement < best_individual * MIN_COMBINED_BENEFIT_RATIO {
+        return None;
+    }
+
+    // Compute the target impact discount based on neuron type.
+    let target_impact = match neuron_types.get(target_uuid) {
+        Some(&"output") => 1.0_f32,
+        _ => 0.5_f32, // Hidden neurons have discounted impact.
+    };
+
+    // Apply conservative scaling: fan-in adds multiple operations.
+    let scaled_improvement = combined_improvement * target_impact * 0.01;
+
+    if scaled_improvement <= 0.0 {
+        return None;
+    }
+
+    // Choose activation: prefer TANH as default non-linear activation.
+    let activation =
+        select_fan_in_activation(existing_synapses, input_a_uuid, input_b_uuid, target_uuid);
+
+    let mean_corr = (corr_a.abs() + corr_b.abs()) / 2.0;
+
+    Some(FanInCandidate {
+        input_uuids: vec![input_a_uuid.to_string(), input_b_uuid.to_string()],
+        target_uuid: target_uuid.to_string(),
+        input_weights: vec![weight_a, weight_b],
+        output_weight: 0.1,
+        activation: activation.to_string(),
+        estimated_improvement: scaled_improvement,
+        mean_input_error_correlation: mean_corr,
+        input_mutual_correlation: mutual_corr.abs(),
+        sample_count: shared_indices.len(),
+        reason: format!(
+            "Fan-in: {} and {} converge to {} via {} (corr {:.2}/{:.2}, mutual {:.2}, combined improvement {:.4})",
+            input_a_uuid,
+            input_b_uuid,
+            target_uuid,
+            activation,
+            corr_a,
+            corr_b,
+            mutual_corr.abs(),
+            scaled_improvement,
+        ),
+    })
+}
+
+/// Compute least-squares improvement for a single-input predictor:
+/// minimise Σ(error - w × activation)² → w = Σ(act × err) / Σ(act²),
+/// improvement = Σ(err²) - Σ(err - w × act)².
+fn compute_least_squares_improvement(activations: &[f32], errors: &[f32]) -> f32 {
+    let n = activations.len().min(errors.len());
+    if n < 2 {
+        return 0.0;
+    }
+
+    let sum_act_sq: f32 = activations[..n].iter().map(|a| a * a).sum();
+    if sum_act_sq < 1e-10 {
+        return 0.0;
+    }
+
+    let sum_act_err: f32 = activations[..n]
+        .iter()
+        .zip(errors[..n].iter())
+        .map(|(a, e)| a * e)
+        .sum();
+
+    let w = sum_act_err / sum_act_sq;
+
+    let original_sse: f32 = errors[..n].iter().map(|e| e * e).sum();
+    let residual_sse: f32 = activations[..n]
+        .iter()
+        .zip(errors[..n].iter())
+        .map(|(a, e)| {
+            let residual = e - w * a;
+            residual * residual
+        })
+        .sum();
+
+    (original_sse - residual_sse).max(0.0)
+}
+
+/// Two-input least-squares regression: minimise Σ(err - `w_a` × `act_a` - `w_b` × `act_b`)².
+/// Returns (`weight_a`, `weight_b`, improvement) or `None` if underdetermined.
+fn compute_two_input_regression(
+    acts_a: &[f32],
+    acts_b: &[f32],
+    errors: &[f32],
+) -> Option<(f32, f32, f32)> {
+    let n = acts_a.len().min(acts_b.len()).min(errors.len());
+    if n < 3 {
+        return None; // Need at least 3 samples for 2-variable regression.
+    }
+
+    // Normal equations: [a'a, a'b; b'a, b'b] [wa; wb] = [a'e; b'e]
+    let mut aa = 0.0_f64;
+    let mut ab = 0.0_f64;
+    let mut bb = 0.0_f64;
+    let mut ae = 0.0_f64;
+    let mut be = 0.0_f64;
+    let mut ee = 0.0_f64;
+
+    for i in 0..n {
+        let a = f64::from(acts_a[i]);
+        let b = f64::from(acts_b[i]);
+        let e = f64::from(errors[i]);
+        aa += a * a;
+        ab += a * b;
+        bb += b * b;
+        ae += a * e;
+        be += b * e;
+        ee += e * e;
+    }
+
+    // Solve 2x2 system via Cramer's rule.
+    let det = aa * bb - ab * ab;
+    if det.abs() < 1e-12 {
+        return None; // Singular or near-singular (inputs perfectly correlated).
+    }
+
+    let wa = (bb * ae - ab * be) / det;
+    let wb = (aa * be - ab * ae) / det;
+
+    // Compute residual SSE.
+    let mut residual_sse = 0.0_f64;
+    for i in 0..n {
+        let a = f64::from(acts_a[i]);
+        let b = f64::from(acts_b[i]);
+        let e = f64::from(errors[i]);
+        let residual = e - wa * a - wb * b;
+        residual_sse += residual * residual;
+    }
+
+    let improvement = (ee - residual_sse).max(0.0);
+
+    Some((wa as f32, wb as f32, improvement as f32))
+}
+
+/// Select the activation function for a fan-in hidden neuron.
+/// Prefers non-linear activations; IDENTITY is never used for fan-in.
+fn select_fan_in_activation(
+    _existing_synapses: &HashSet<(&str, &str)>,
+    _input_a: &str,
+    _input_b: &str,
+    _target: &str,
+) -> &'static str {
+    // Default to TANH — the most common non-linear activation for
+    // capturing interaction effects between inputs.
+    FAN_IN_ACTIVATIONS[0]
+}
+
+/// Convert detected fan-in candidates into coordinated structural candidates
+/// that can be applied atomically to the creature.
+///
+/// Each fan-in candidate generates:
+/// - `AddNeuron` — a new hidden neuron with non-linear activation
+/// - `AddSynapse` × N — one synapse per input to the hidden neuron
+/// - `AddSynapse` × 1 — hidden neuron to target
+pub fn fan_in_to_coordinated_candidates(
+    candidates: &[FanInCandidate],
+    creature: &CreatureJson,
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    candidates
+        .iter()
+        .filter_map(|c| fan_in_to_single_coordinated(c, creature))
+        .collect()
+}
+
+/// Convert a single fan-in candidate to a coordinated structural candidate.
+fn fan_in_to_single_coordinated(
+    candidate: &FanInCandidate,
+    creature: &CreatureJson,
+) -> Option<CoordinatedStructuralCandidateJson> {
+    if candidate.input_uuids.len() < 2 {
+        return None;
+    }
+
+    // Generate deterministic UUID for the new hidden neuron from the
+    // input UUIDs and target UUID (FNV-1a hash).
+    let neuron_uuid = generate_fan_in_uuid(&candidate.input_uuids, &candidate.target_uuid);
+
+    // Determine insertion point: place hidden neuron before the target.
+    let insert_before = find_insert_position(creature, &candidate.target_uuid);
+
+    let mut operations = Vec::new();
+
+    // 1. Add the fan-in hidden neuron.
+    operations.push(CoordinatedStructuralOpJson::AddNeuron {
+        neuron_uuid: neuron_uuid.clone(),
+        neuron_type: "hidden".to_string(),
+        squash: candidate.activation.clone(),
+        bias: 0.0,
+        insert_before_neuron_uuid: insert_before,
+    });
+
+    // 2. Add synapses from each input to the hidden neuron.
+    for (i, input_uuid) in candidate.input_uuids.iter().enumerate() {
+        let weight = candidate.input_weights.get(i).copied().unwrap_or(0.5);
+        operations.push(CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: input_uuid.clone(),
+            to_neuron_uuid: neuron_uuid.clone(),
+            weight,
+        });
+    }
+
+    // 3. Add synapse from hidden neuron to target.
+    operations.push(CoordinatedStructuralOpJson::AddSynapse {
+        from_neuron_uuid: neuron_uuid,
+        to_neuron_uuid: candidate.target_uuid.clone(),
+        weight: candidate.output_weight,
+    });
+
+    Some(CoordinatedStructuralCandidateJson {
+        operations,
+        expected_creature_score_gain: candidate.estimated_improvement,
+        comment: Some(candidate.reason.clone()),
+    })
+}
+
+/// Generate a deterministic UUID for a fan-in hidden neuron using FNV-1a
+/// hash of the sorted input UUIDs and target UUID.
+fn generate_fan_in_uuid(input_uuids: &[String], target_uuid: &str) -> String {
+    let mut sorted_inputs: Vec<&str> = input_uuids.iter().map(String::as_str).collect();
+    sorted_inputs.sort();
+
+    // FNV-1a 64-bit hash.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let fnv_prime: u64 = 0x0100_0000_01b3;
+
+    for byte in b"fan-in:" {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(fnv_prime);
+    }
+    for input in &sorted_inputs {
+        for byte in input.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(fnv_prime);
+        }
+        // Separator between inputs.
+        hash ^= u64::from(b'+');
+        hash = hash.wrapping_mul(fnv_prime);
+    }
+    for byte in b"->" {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(fnv_prime);
+    }
+    for byte in target_uuid.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(fnv_prime);
+    }
+
+    format!("fan-in-{hash:016x}")
+}
+
+/// Find the neuron UUID before which the new hidden neuron should be inserted
+/// to maintain forward-only evaluation order.
+fn find_insert_position(creature: &CreatureJson, target_uuid: &str) -> Option<String> {
+    // Insert before the target neuron.
+    creature
+        .neurons
+        .iter()
+        .find(|n| n.uuid == target_uuid)
+        .map(|n| n.uuid.clone())
+}
+
+/// Compute the mean absolute error from a set of error values.
+fn _compute_mean_abs_error(errors: &[f32]) -> f32 {
+    if errors.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = errors.iter().map(|e| e.abs()).sum();
+    sum / errors.len() as f32
+}

--- a/src/analysis/recommendation/mod.rs
+++ b/src/analysis/recommendation/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod activation_recommendation;
 pub mod epistatic;
+pub mod fan_in;
 pub mod gradient_discovery;
 pub mod multi_hop;
 pub mod output_bias_drift;

--- a/tests/recommendation/issue_908_fan_in_candidates.rs
+++ b/tests/recommendation/issue_908_fan_in_candidates.rs
@@ -1,0 +1,633 @@
+//! Tests for Issue #908: Fan-in candidate generation (multiple inputs converging
+//! to one hidden neuron).
+//!
+//! ## TDD Plan
+//! 1. Verify fan-in candidates are detected when correlated input pairs exist
+//! 2. Verify no candidates for uncorrelated inputs
+//! 3. Verify non-linear activations are used (not IDENTITY)
+//! 4. Verify coordinated structural operations are valid
+//! 5. Verify deterministic UUID generation
+//! 6. Verify edge cases (empty records, insufficient samples, single input)
+//! 7. Verify candidates are sorted by estimated improvement
+//! 8. Verify redundant (highly correlated) inputs are filtered out
+
+use neat_ai_discovery::analysis::recommendation::fan_in::{
+    FanInCandidate, detect_fan_in_candidates, fan_in_to_coordinated_candidates,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+/// Helper: create a `DiscoverRecord`.
+fn record(neuron_uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: neuron_uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+/// Helper: build a minimal creature.
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+/// Helper: build a `NeuronJson`.
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+/// Helper: build a `SynapseJson`.
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Build a network with two inputs and one output where both inputs' activations
+/// correlate with the output error but have complementary patterns (low mutual
+/// correlation). The error depends equally on both inputs so the combined
+/// regression is significantly better than either individual.
+fn make_fan_in_network_and_records() -> (CreatureJson, Vec<(String, Vec<DiscoverRecord>)>) {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "output-1", 0.1),
+            synapse("input-b", "output-1", 0.1),
+        ],
+    );
+
+    let n = 100_u32;
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // input-a: varies based on first/second half (uncorrelated with input-b).
+    records.push((
+        "input-a".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i < n / 2 { 0.9 } else { 0.1 };
+                record("input-a", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-b: varies based on even/odd index (uncorrelated with input-a).
+    records.push((
+        "input-b".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i % 2 == 0 { 0.9 } else { 0.1 };
+                record("input-b", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // output-1: error depends equally on both inputs so neither alone is sufficient.
+    // error ≈ 0.5 * act_a + 0.5 * act_b - 0.5 (centred around zero).
+    records.push((
+        "output-1".to_string(),
+        (0..n)
+            .map(|i| {
+                let act_a = if i < n / 2 { 0.9 } else { 0.1 };
+                let act_b = if i % 2 == 0 { 0.9 } else { 0.1 };
+                let error = 0.5 * act_a + 0.5 * act_b - 0.5;
+                record("output-1", i, 0.5, vec![error])
+            })
+            .collect(),
+    ));
+
+    (creature, records)
+}
+
+/// Test 1: Fan-in candidates are detected when correlated input pairs exist.
+#[test]
+fn test_detects_fan_in_candidates_for_correlated_inputs() {
+    let (creature, records) = make_fan_in_network_and_records();
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    assert!(
+        !candidates.is_empty(),
+        "Should detect at least one fan-in candidate"
+    );
+
+    let c = &candidates[0];
+    assert_eq!(
+        c.input_uuids.len(),
+        2,
+        "Fan-in candidate should have exactly 2 inputs"
+    );
+    assert!(
+        c.input_uuids.contains(&"input-a".to_string()),
+        "Should include input-a"
+    );
+    assert!(
+        c.input_uuids.contains(&"input-b".to_string()),
+        "Should include input-b"
+    );
+    assert_eq!(c.target_uuid, "output-1");
+}
+
+/// Test 2: No candidates when inputs are uncorrelated with target error.
+#[test]
+fn test_no_candidates_for_uncorrelated_inputs() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "output-1", 0.1),
+            synapse("input-b", "output-1", 0.1),
+        ],
+    );
+
+    let n = 100_u32;
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Both inputs: random-like constant activations — no correlation with error.
+    records.push((
+        "input-a".to_string(),
+        (0..n).map(|i| record("input-a", i, 0.5, vec![])).collect(),
+    ));
+    records.push((
+        "input-b".to_string(),
+        (0..n).map(|i| record("input-b", i, 0.5, vec![])).collect(),
+    ));
+
+    // Output: error with a pattern unrelated to inputs.
+    records.push((
+        "output-1".to_string(),
+        (0..n)
+            .map(|i| {
+                let error = if i % 3 == 0 { 0.5 } else { -0.2 };
+                record("output-1", i, 0.5, vec![error])
+            })
+            .collect(),
+    ));
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    assert!(
+        candidates.is_empty(),
+        "Should not detect fan-in candidates for uncorrelated inputs"
+    );
+}
+
+/// Test 3: Fan-in neurons use non-linear activations (not IDENTITY).
+#[test]
+fn test_fan_in_uses_non_linear_activation() {
+    let (creature, records) = make_fan_in_network_and_records();
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    assert!(!candidates.is_empty());
+
+    for c in &candidates {
+        assert_ne!(
+            c.activation, "IDENTITY",
+            "Fan-in neurons should not use IDENTITY activation"
+        );
+        assert!(
+            c.activation == "TANH" || c.activation == "GELU",
+            "Fan-in neurons should use TANH or GELU, got {}",
+            c.activation
+        );
+    }
+}
+
+/// Test 4: Coordinated structural operations are valid.
+#[test]
+fn test_fan_in_produces_valid_coordinated_operations() {
+    let (creature, records) = make_fan_in_network_and_records();
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    assert!(!candidates.is_empty());
+
+    let coordinated = fan_in_to_coordinated_candidates(&candidates, &creature);
+
+    assert!(
+        !coordinated.is_empty(),
+        "Should produce coordinated candidates"
+    );
+
+    let c = &coordinated[0];
+    assert!(
+        c.expected_creature_score_gain > 0.0,
+        "Expected improvement should be positive"
+    );
+    assert!(c.comment.is_some(), "Should have a descriptive comment");
+
+    // Check operations: should have AddNeuron + 2 AddSynapse (inputs) + 1 AddSynapse (output).
+    let ops_json = serde_json::to_string(&c.operations).unwrap();
+    assert!(
+        ops_json.contains("addNeuron"),
+        "Should include addNeuron operation: {ops_json}"
+    );
+    assert!(
+        ops_json.contains("addSynapse"),
+        "Should include addSynapse operations: {ops_json}"
+    );
+
+    // Verify operation count: 1 AddNeuron + 3 AddSynapse = 4 operations.
+    assert_eq!(
+        c.operations.len(),
+        4,
+        "Fan-in candidate should have 4 operations (1 AddNeuron + 3 AddSynapse)"
+    );
+}
+
+/// Test 5: Deterministic UUID generation — same inputs produce same UUID.
+#[test]
+fn test_fan_in_deterministic_uuid() {
+    let (creature, records) = make_fan_in_network_and_records();
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    assert!(!candidates.is_empty());
+
+    let coord_1 = fan_in_to_coordinated_candidates(&candidates, &creature);
+    let coord_2 = fan_in_to_coordinated_candidates(&candidates, &creature);
+
+    let json_1 = serde_json::to_string(&coord_1).unwrap();
+    let json_2 = serde_json::to_string(&coord_2).unwrap();
+    assert_eq!(
+        json_1, json_2,
+        "Coordinated candidates should be deterministic"
+    );
+}
+
+/// Test 6: Empty records produce no candidates.
+#[test]
+fn test_fan_in_empty_records() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-a", "output-1", 0.5)],
+    );
+
+    let candidates = detect_fan_in_candidates(&creature, &[]);
+    assert!(
+        candidates.is_empty(),
+        "Empty records should produce no candidates"
+    );
+}
+
+/// Test 7: Insufficient samples produce no candidates.
+#[test]
+fn test_fan_in_insufficient_samples() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "output-1", 0.1),
+            synapse("input-b", "output-1", 0.1),
+        ],
+    );
+
+    // Only 5 samples — below MIN_DISCOVERY_SAMPLE_COUNT.
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "input-a".to_string(),
+            (0..5).map(|i| record("input-a", i, 0.8, vec![])).collect(),
+        ),
+        (
+            "input-b".to_string(),
+            (0..5).map(|i| record("input-b", i, 0.3, vec![])).collect(),
+        ),
+        (
+            "output-1".to_string(),
+            (0..5)
+                .map(|i| record("output-1", i, 0.5, vec![0.3]))
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+    assert!(
+        candidates.is_empty(),
+        "Insufficient samples should produce no candidates"
+    );
+}
+
+/// Test 8: Single input neuron — cannot form fan-in pair.
+#[test]
+fn test_fan_in_single_input_no_candidates() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-a", "output-1", 0.5)],
+    );
+
+    let n = 100_u32;
+    let records: Vec<(String, Vec<DiscoverRecord>)> = vec![
+        (
+            "input-a".to_string(),
+            (0..n)
+                .map(|i| {
+                    let act = if i < 50 { 0.9 } else { 0.1 };
+                    record("input-a", i, act, vec![])
+                })
+                .collect(),
+        ),
+        (
+            "output-1".to_string(),
+            (0..n)
+                .map(|i| {
+                    let error = if i < 50 { 0.5 } else { -0.2 };
+                    record("output-1", i, 0.5, vec![error])
+                })
+                .collect(),
+        ),
+    ];
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+    assert!(
+        candidates.is_empty(),
+        "Single input cannot form fan-in pair"
+    );
+}
+
+/// Test 9: Candidates are sorted by estimated improvement (best first).
+#[test]
+fn test_fan_in_candidates_sorted_by_improvement() {
+    // Three inputs with varying correlation strength.
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("input-c", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "output-1", 0.1),
+            synapse("input-b", "output-1", 0.1),
+            synapse("input-c", "output-1", 0.1),
+        ],
+    );
+
+    let n = 100_u32;
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // input-a: strong correlation with error.
+    records.push((
+        "input-a".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i < n / 2 { 0.95 } else { 0.05 };
+                record("input-a", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-b: moderate correlation, complementary to input-a.
+    records.push((
+        "input-b".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i % 3 == 0 { 0.8 } else { 0.2 };
+                record("input-b", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // input-c: weaker correlation, complementary pattern.
+    records.push((
+        "input-c".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i % 5 == 0 { 0.7 } else { 0.3 };
+                record("input-c", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // Output error correlates with inputs.
+    records.push((
+        "output-1".to_string(),
+        (0..n)
+            .map(|i| {
+                let from_a = if i < n / 2 { 0.5 } else { -0.1 };
+                let from_b = if i % 3 == 0 { 0.15 } else { -0.05 };
+                let from_c = if i % 5 == 0 { 0.1 } else { -0.02 };
+                record("output-1", i, 0.5, vec![from_a + from_b + from_c])
+            })
+            .collect(),
+    ));
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    // Verify sorting: each candidate's improvement >= the next.
+    for window in candidates.windows(2) {
+        assert!(
+            window[0].estimated_improvement >= window[1].estimated_improvement,
+            "Candidates should be sorted by improvement (descending): {} >= {}",
+            window[0].estimated_improvement,
+            window[1].estimated_improvement,
+        );
+    }
+}
+
+/// Test 10: Highly correlated (redundant) inputs are filtered out.
+#[test]
+fn test_fan_in_filters_redundant_inputs() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "output-1", 0.1),
+            synapse("input-b", "output-1", 0.1),
+        ],
+    );
+
+    let n = 100_u32;
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    // Both inputs have nearly identical activation patterns (high mutual correlation).
+    records.push((
+        "input-a".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i < n / 2 { 0.9 } else { 0.1 };
+                record("input-a", i, act, vec![])
+            })
+            .collect(),
+    ));
+    records.push((
+        "input-b".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i < n / 2 { 0.88 } else { 0.12 };
+                record("input-b", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    records.push((
+        "output-1".to_string(),
+        (0..n)
+            .map(|i| {
+                let error = if i < n / 2 { 0.5 } else { -0.2 };
+                record("output-1", i, 0.5, vec![error])
+            })
+            .collect(),
+    ));
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    // Redundant inputs should be filtered — high mutual correlation means
+    // a single-input path would suffice.
+    assert!(
+        candidates.is_empty(),
+        "Highly correlated (redundant) inputs should be filtered out"
+    );
+}
+
+/// Test 11: Fan-in candidates target hidden neurons as well as outputs.
+#[test]
+fn test_fan_in_targets_hidden_neurons() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "TANH"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-a", "hidden-1", 0.1),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+    );
+
+    let n = 100_u32;
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+
+    records.push((
+        "input-a".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i < n / 2 { 0.9 } else { 0.1 };
+                record("input-a", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    records.push((
+        "input-b".to_string(),
+        (0..n)
+            .map(|i| {
+                let act = if i % 2 == 0 { 0.9 } else { 0.1 };
+                record("input-b", i, act, vec![])
+            })
+            .collect(),
+    ));
+
+    // hidden-1 has error records — can be a fan-in target.
+    // Error depends equally on both inputs.
+    records.push((
+        "hidden-1".to_string(),
+        (0..n)
+            .map(|i| {
+                let act_a = if i < n / 2 { 0.9 } else { 0.1 };
+                let act_b = if i % 2 == 0 { 0.9 } else { 0.1 };
+                let error = 0.5 * act_a + 0.5 * act_b - 0.5;
+                record("hidden-1", i, 0.5, vec![error])
+            })
+            .collect(),
+    ));
+
+    records.push((
+        "output-1".to_string(),
+        (0..n)
+            .map(|i| record("output-1", i, 0.5, vec![0.1]))
+            .collect(),
+    ));
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    // Should find candidates targeting hidden-1.
+    let hidden_targets: Vec<_> = candidates
+        .iter()
+        .filter(|c| c.target_uuid == "hidden-1")
+        .collect();
+
+    assert!(
+        !hidden_targets.is_empty(),
+        "Should detect fan-in candidates targeting hidden neurons"
+    );
+}
+
+/// Test 12: Estimated improvement is always positive for detected candidates.
+#[test]
+fn test_fan_in_improvement_positive() {
+    let (creature, records) = make_fan_in_network_and_records();
+    let candidates = detect_fan_in_candidates(&creature, &records);
+
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement > 0.0,
+            "Estimated improvement should be positive, got {}",
+            c.estimated_improvement
+        );
+    }
+}
+
+/// Test 13: Fan-in candidate conversion with fewer than 2 inputs produces nothing.
+#[test]
+fn test_fan_in_conversion_requires_two_inputs() {
+    let creature = make_creature(
+        vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![synapse("input-a", "output-1", 0.5)],
+    );
+
+    // Manually create a degenerate candidate with only 1 input.
+    let bad_candidate = FanInCandidate {
+        input_uuids: vec!["input-a".to_string()],
+        target_uuid: "output-1".to_string(),
+        input_weights: vec![0.5],
+        output_weight: 0.1,
+        activation: "TANH".to_string(),
+        estimated_improvement: 0.01,
+        mean_input_error_correlation: 0.5,
+        input_mutual_correlation: 0.0,
+        sample_count: 100,
+        reason: "test".to_string(),
+    };
+
+    let coordinated = fan_in_to_coordinated_candidates(&[bad_candidate], &creature);
+    assert!(
+        coordinated.is_empty(),
+        "Should not produce coordinated candidate with fewer than 2 inputs"
+    );
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -19,3 +19,4 @@ mod issue_550_weight_magnitude_reset;
 mod issue_551_bias_perturbation_regime_shift;
 mod issue_570_skip_connection_discovery;
 mod issue_788_high_error_squash_exploration;
+mod issue_908_fan_in_candidates;


### PR DESCRIPTION
## Summary

Add fan-in candidate generation that detects pairs of inputs whose activations jointly predict a target's error and creates coordinated structural candidates with a shared non-linear hidden neuron. Closes #908.

The new `fan_in` module in `src/analysis/recommendation/` detects complementary input pairs via correlation analysis and two-variable least-squares regression, then emits `CoordinatedStructuralCandidateJson` candidates containing:
- `AddNeuron` (hidden, TANH activation) to capture interaction effects
- `AddSynapse` per input to the hidden neuron (with optimised weights)
- `AddSynapse` from hidden neuron to target

Key design decisions:
- Non-linear activations only (TANH/GELU) — IDENTITY is never used for fan-in since it reduces to a linear combination that cannot capture interactions
- Inputs must have low mutual correlation (< 0.8) to ensure complementarity
- Combined regression improvement must exceed best individual by 5% ratio
- Conservative 0.01× scaling on estimated improvement (multi-operation discount)
- Deterministic UUID generation via FNV-1a hash of sorted input + target UUIDs

## Test plan

- `tests/recommendation/issue_908_fan_in_candidates.rs` — 13 tests:
  - Detects fan-in candidates for correlated inputs
  - No candidates for uncorrelated inputs
  - Non-linear activations enforced (not IDENTITY)
  - Valid coordinated structural operations produced
  - Deterministic UUID generation
  - Empty records produce no candidates
  - Insufficient samples produce no candidates
  - Single input cannot form fan-in pair
  - Candidates sorted by estimated improvement
  - Redundant (highly correlated) inputs filtered out
  - Fan-in targets hidden neurons as well as outputs
  - Estimated improvement always positive
  - Conversion requires at least 2 inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)