### PR TITLE
feat: add compound bias+weight degradation detection (#929)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.65.5"
+version = "0.65.6"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.65.4"
+version = "0.65.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-929.md
+++ b/docs/pr-summary-929.md
@@ -1,0 +1,55 @@
+## Summary
+
+Add compound bias+weight degradation detection to the coordinated structural
+discovery pipeline. This enables the discovery engine to identify cases where
+multiple parameters (neuron bias and synapse weight) are both degraded and
+need simultaneous correction — neither fix alone fully restores performance.
+
+The new detection module (`compound_degradation.rs`) analyses hidden neurons
+for consistent error (suggesting bias drift) and synapses for
+activation-error correlation (suggesting weight degradation), then combines
+related corrections on the same forward path into atomic coordinated
+candidates with `setBias` + `setWeight` operations.
+
+Closes #929.
+
+## Changes
+
+- **New file: `src/analysis/detection/compound_degradation.rs`** — Detection
+  module for compound bias+weight degradations. Uses error gradient analysis
+  to compute optimal bias corrections and least-squares regression for
+  weight corrections, combining related pairs into coordinated candidates.
+- **`src/analysis/detection/mod.rs`** — Register the new module.
+- **`src/analysis/module_dispatch_specs/structural_specs.rs`** — Wire the
+  new detector into the parallel dispatch pipeline.
+- **`src/analysis/module_dispatch_specs/mod.rs`** — Update expected module
+  count in tests (46 → 47).
+- **New file: `tests/synapse/issue_929_coordinated_structural_compound_degradation.rs`**
+  — End-to-end scenario test verifying coordinated discovery for the
+  compound degradation scenario from the issue.
+- **`tests/synapse/main.rs`** — Register the new test module.
+
+## Evidence
+
+All 4 new tests pass on GPU:
+- `issue_929_discovers_compound_bias_weight_degradation` — Finds compound
+  candidate with 2 operations (setBias + setWeight), scoreGain=0.118
+- `issue_929_set_bias_targets_correct_neuron` — setBias(hidden-A) bias=0.226
+  (target ~0.3)
+- `issue_929_set_weight_targets_correct_synapse` — setWeight(hidden-B ->
+  hidden-C) weight=0.969 (target ~0.8)
+- `issue_929_all_candidates_have_positive_improvement` — All candidates have
+  positive expected score gain
+
+Full quality gate passes: 158 tests, 0 failures, clippy clean, docs build.
+
+## Test Plan
+
+- Added `tests/synapse/issue_929_coordinated_structural_compound_degradation.rs`
+  with 4 test cases:
+  1. Discovery produces a coordinated-structural candidate with both setBias
+     and setWeight operations
+  2. The setBias operation targets the correct neuron with reasonable bias
+  3. The setWeight operation targets the correct synapse with reasonable weight
+  4. All returned candidates have positive expected improvement
+- Existing 154 synapse tests continue to pass (no regressions)

--- a/src/analysis/detection/compound_degradation.rs
+++ b/src/analysis/detection/compound_degradation.rs
@@ -1,0 +1,487 @@
+//! Compound parameter degradation detection (Issue #929).
+//!
+//! Detects coordinated degradations where multiple parameters (bias + weight)
+//! need simultaneous correction. Neither fix alone fully explains the
+//! performance loss — both must be restored together.
+//!
+//! ## Detection Criteria
+//!
+//! A compound degradation is detected when:
+//! 1. A hidden neuron has consistent, non-zero mean error suggesting bias drift.
+//! 2. A synapse has error correlated with its source activation, suggesting
+//!    the weight is wrong.
+//! 3. Both corrections are on the same forward path to an output neuron.
+//! 4. The combined correction is predicted to improve the creature's score.
+//!
+//! ## Recommended Actions
+//!
+//! - `setBias` — correct the neuron's operating point.
+//! - `setWeight` — correct the synapse's contribution.
+//! - Both applied atomically as a coordinated-structural candidate.
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
+
+use super::helpers::build_record_map;
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+use std::collections::{HashMap, HashSet};
+
+/// Minimum mean absolute error to consider a neuron for bias correction.
+const MIN_BIAS_ERROR: f32 = 0.02;
+
+/// Minimum absolute bias delta to emit a correction.
+const MIN_BIAS_DELTA: f32 = 0.05;
+
+/// Minimum absolute weight delta to consider a synapse degraded.
+const MIN_WEIGHT_DELTA: f32 = 0.05;
+
+/// A detected bias correction for a hidden neuron.
+#[derive(Debug, Clone)]
+struct BiasCorrection {
+    neuron_uuid: String,
+    recommended_bias: f32,
+    estimated_improvement: f32,
+}
+
+/// A detected weight correction for a synapse.
+#[derive(Debug, Clone)]
+struct WeightCorrection {
+    from_neuron_uuid: String,
+    to_neuron_uuid: String,
+    recommended_weight: f32,
+    estimated_improvement: f32,
+}
+
+/// Approximate the squash function derivative at a given pre-activation value.
+///
+/// Used to convert error signals back to pre-activation deltas for bias
+/// correction estimation.
+fn squash_derivative(squash: &str, pre_activation: f32) -> f32 {
+    match squash {
+        "TANH" | "HARD_TANH" => {
+            let t = pre_activation.tanh();
+            1.0 - t * t
+        }
+        "ReLU" | "RELU" => {
+            if pre_activation > 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        "LOGISTIC" => {
+            let s = 1.0 / (1.0 + (-pre_activation).exp());
+            s * (1.0 - s)
+        }
+        "IDENTITY" => 1.0,
+        "GELU" => {
+            // Approximate GELU derivative
+            let cdf = 0.5
+                * (1.0 + (0.7978846 * (pre_activation + 0.044715 * pre_activation.powi(3))).tanh());
+            let pdf = (-0.5 * pre_activation * pre_activation).exp()
+                / (2.0 * std::f32::consts::PI).sqrt();
+            cdf + pre_activation * pdf
+        }
+        _ => 1.0, // Default: assume identity-like
+    }
+}
+
+/// Detect compound bias+weight degradations across the network.
+///
+/// Analyses hidden neurons for consistent error (bias drift) and synapses
+/// for activation-error correlation (weight degradation). When both a bias
+/// and weight correction lie on the same forward path and improve the
+/// network, emits a coordinated candidate with `setBias` + `setWeight`.
+///
+/// # Arguments
+/// * `creature` - The creature topology.
+/// * `neuron_records` - Slice of `(uuid, records)` pairs with observation data.
+///
+/// # Returns
+/// Vector of compound degradation candidates, sorted by estimated improvement.
+pub fn detect_compound_bias_weight_degradations(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+) -> Vec<CompoundDegradationCandidate> {
+    let records_map = build_record_map(neuron_records);
+
+    // Build neuron lookup maps
+    let neuron_squash: HashMap<&str, &str> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
+        .collect();
+    let neuron_bias: HashMap<&str, f32> = creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.bias))
+        .collect();
+
+    // Build connectivity: which neurons are downstream of which
+    let mut downstream_of: HashMap<&str, HashSet<&str>> = HashMap::new();
+    for syn in &creature.synapses {
+        downstream_of
+            .entry(syn.from_uuid.as_str())
+            .or_default()
+            .insert(syn.to_uuid.as_str());
+    }
+
+    // Phase 1: Detect bias corrections for hidden neurons
+    let bias_corrections =
+        detect_bias_corrections(creature, &records_map, &neuron_squash, &neuron_bias);
+
+    // Phase 2: Detect weight corrections for synapses
+    let weight_corrections = detect_weight_corrections(creature, &records_map);
+
+    // Phase 3: Combine related corrections
+    combine_corrections(
+        &bias_corrections,
+        &weight_corrections,
+        &downstream_of,
+        creature,
+    )
+}
+
+/// Detect hidden neurons with consistent error suggesting bias drift.
+fn detect_bias_corrections(
+    creature: &CreatureJson,
+    records_map: &HashMap<&str, &Vec<DiscoverRecord>>,
+    neuron_squash: &HashMap<&str, &str>,
+    neuron_bias: &HashMap<&str, f32>,
+) -> Vec<BiasCorrection> {
+    let mut corrections = Vec::new();
+
+    for neuron in &creature.neurons {
+        if neuron.neuron_type != "hidden" {
+            continue;
+        }
+
+        let Some(records) = records_map.get(neuron.uuid.as_str()) else {
+            continue;
+        };
+        if records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Compute mean error (signed — a consistent offset indicates bias drift)
+        let n = records.len() as f32;
+        let mean_error: f32 = records
+            .iter()
+            .map(|r| r.errors.first().copied().unwrap_or(0.0))
+            .sum::<f32>()
+            / n;
+
+        if mean_error.abs() < MIN_BIAS_ERROR {
+            continue;
+        }
+
+        // Compute mean pre-activation for derivative estimation
+        let mean_pre_act: f32 = records.iter().filter_map(|r| r.value).sum::<f32>()
+            / records.iter().filter(|r| r.value.is_some()).count().max(1) as f32;
+
+        let squash = neuron_squash
+            .get(neuron.uuid.as_str())
+            .copied()
+            .unwrap_or("IDENTITY");
+        let deriv = squash_derivative(squash, mean_pre_act);
+
+        // Skip if derivative is near zero (saturated region)
+        if deriv.abs() < 1e-4 {
+            continue;
+        }
+
+        // Bias correction: error ≈ f'(pre_act) × Δbias → Δbias ≈ error / f'(pre_act)
+        let bias_delta = mean_error / deriv;
+        let old_bias = neuron_bias
+            .get(neuron.uuid.as_str())
+            .copied()
+            .unwrap_or(0.0);
+        let new_bias = old_bias + bias_delta;
+
+        if bias_delta.abs() < MIN_BIAS_DELTA || !new_bias.is_finite() {
+            continue;
+        }
+
+        // Estimated improvement: proportional to error corrected
+        let estimated_improvement = mean_error.abs() * 0.3;
+
+        corrections.push(BiasCorrection {
+            neuron_uuid: neuron.uuid.clone(),
+            recommended_bias: new_bias,
+            estimated_improvement,
+        });
+    }
+
+    corrections
+}
+
+/// Detect synapses with error correlated to source activation (weight degradation).
+fn detect_weight_corrections(
+    creature: &CreatureJson,
+    records_map: &HashMap<&str, &Vec<DiscoverRecord>>,
+) -> Vec<WeightCorrection> {
+    let mut corrections = Vec::new();
+
+    for syn in &creature.synapses {
+        let Some(source_records) = records_map.get(syn.from_uuid.as_str()) else {
+            continue;
+        };
+        let Some(target_records) = records_map.get(syn.to_uuid.as_str()) else {
+            continue;
+        };
+
+        if source_records.len() < MIN_SAMPLES || target_records.len() < MIN_SAMPLES {
+            continue;
+        }
+
+        // Build per-observation maps
+        let source_map: HashMap<u32, f32> = source_records
+            .iter()
+            .filter(|r| r.activation.is_finite())
+            .map(|r| (r.obs_index, r.activation))
+            .collect();
+
+        let target_error_map: HashMap<u32, f32> = target_records
+            .iter()
+            .filter(|r| r.errors.first().copied().unwrap_or(0.0).is_finite())
+            .map(|r| (r.obs_index, r.errors.first().copied().unwrap_or(0.0)))
+            .collect();
+
+        // Compute correlation between source activation and target error
+        // Optimal weight delta via least squares: Δw = Σ(act × err) / Σ(act²)
+        let mut sum_act_sq = 0.0f32;
+        let mut sum_act_err = 0.0f32;
+        let mut count = 0u32;
+
+        for (obs, src_act) in &source_map {
+            if let Some(tgt_err) = target_error_map.get(obs) {
+                sum_act_sq += src_act * src_act;
+                sum_act_err += src_act * tgt_err;
+                count += 1;
+            }
+        }
+
+        if (count as usize) < MIN_SAMPLES || sum_act_sq < 1e-8 {
+            continue;
+        }
+
+        let weight_delta = sum_act_err / sum_act_sq;
+        let new_weight = syn.weight + weight_delta;
+
+        if weight_delta.abs() < MIN_WEIGHT_DELTA || !new_weight.is_finite() {
+            continue;
+        }
+
+        // Estimated improvement from weight correction
+        let baseline_error_sq: f32 = target_error_map.values().map(|e| e * e).sum::<f32>();
+        let corrected_error_sq: f32 = source_map
+            .iter()
+            .filter_map(|(obs, act)| {
+                target_error_map.get(obs).map(|err| {
+                    let corrected = err - weight_delta * act;
+                    corrected * corrected
+                })
+            })
+            .sum();
+
+        let improvement = (baseline_error_sq - corrected_error_sq) / count as f32;
+        if improvement <= 0.0 {
+            continue;
+        }
+
+        corrections.push(WeightCorrection {
+            from_neuron_uuid: syn.from_uuid.clone(),
+            to_neuron_uuid: syn.to_uuid.clone(),
+            recommended_weight: new_weight,
+            estimated_improvement: improvement,
+        });
+    }
+
+    corrections
+}
+
+/// Combine bias and weight corrections on the same forward path into
+/// coordinated candidates.
+fn combine_corrections(
+    bias_corrections: &[BiasCorrection],
+    weight_corrections: &[WeightCorrection],
+    downstream_of: &HashMap<&str, HashSet<&str>>,
+    creature: &CreatureJson,
+) -> Vec<CompoundDegradationCandidate> {
+    let mut candidates = Vec::new();
+
+    // Build a set of output neuron UUIDs for path validation
+    let output_uuids: HashSet<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    for bias_corr in bias_corrections {
+        for weight_corr in weight_corrections {
+            // Skip if bias and weight target the same neuron (not a compound case)
+            if bias_corr.neuron_uuid == weight_corr.to_neuron_uuid
+                && bias_corr.neuron_uuid == weight_corr.from_neuron_uuid
+            {
+                continue;
+            }
+
+            // Check if both corrections are on connected forward paths.
+            // Either: bias neuron feeds into weight target, or weight target
+            // feeds downstream from bias neuron, or both feed to same output.
+            let on_same_path = are_on_connected_path(
+                &bias_corr.neuron_uuid,
+                &weight_corr.from_neuron_uuid,
+                &weight_corr.to_neuron_uuid,
+                downstream_of,
+                &output_uuids,
+            );
+
+            if !on_same_path {
+                continue;
+            }
+
+            // Combined improvement: conservative estimate
+            let combined_improvement =
+                bias_corr.estimated_improvement + weight_corr.estimated_improvement * 0.7;
+
+            if combined_improvement <= 0.0 {
+                continue;
+            }
+
+            candidates.push(CompoundDegradationCandidate {
+                bias_neuron_uuid: bias_corr.neuron_uuid.clone(),
+                recommended_bias: bias_corr.recommended_bias,
+                weight_from_uuid: weight_corr.from_neuron_uuid.clone(),
+                weight_to_uuid: weight_corr.to_neuron_uuid.clone(),
+                recommended_weight: weight_corr.recommended_weight,
+                estimated_improvement: combined_improvement,
+            });
+        }
+    }
+
+    // Sort by estimated improvement descending
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
+}
+
+/// Check whether two corrections are on a connected forward path.
+///
+/// Returns true if:
+/// - The bias neuron feeds (directly or indirectly) into the weight target neuron
+/// - The weight synapse feeds from or into the bias neuron's downstream
+/// - Both corrections affect neurons that share a downstream output
+fn are_on_connected_path(
+    bias_neuron: &str,
+    weight_from: &str,
+    weight_to: &str,
+    downstream_of: &HashMap<&str, HashSet<&str>>,
+    output_uuids: &HashSet<&str>,
+) -> bool {
+    // Direct connection: bias neuron feeds into weight target
+    if let Some(downs) = downstream_of.get(bias_neuron)
+        && (downs.contains(weight_to) || downs.contains(weight_from))
+    {
+        return true;
+    }
+
+    // Weight target feeds from bias neuron's downstream
+    if let Some(downs) = downstream_of.get(weight_from)
+        && downs.contains(bias_neuron)
+    {
+        return true;
+    }
+
+    // Both on path to same output: check if bias neuron and weight target
+    // share a common downstream output (BFS depth 1-2)
+    let bias_reaches = reachable_outputs(bias_neuron, downstream_of, output_uuids, 3);
+    let weight_reaches = reachable_outputs(weight_to, downstream_of, output_uuids, 3);
+
+    // If both reach the same output, they're on connected paths
+    bias_reaches.intersection(&weight_reaches).next().is_some()
+}
+
+/// Find output neurons reachable within `max_depth` hops from a starting neuron.
+fn reachable_outputs<'a>(
+    start: &str,
+    downstream_of: &HashMap<&str, HashSet<&'a str>>,
+    output_uuids: &HashSet<&str>,
+    max_depth: usize,
+) -> HashSet<&'a str> {
+    let mut reached = HashSet::new();
+    let mut frontier: Vec<&str> = vec![start];
+
+    for _depth in 0..max_depth {
+        let mut next_frontier = Vec::new();
+        for node in &frontier {
+            if let Some(downs) = downstream_of.get(*node) {
+                for &down in downs {
+                    if output_uuids.contains(down) {
+                        reached.insert(down);
+                    }
+                    next_frontier.push(down);
+                }
+            }
+        }
+        frontier = next_frontier;
+        if frontier.is_empty() {
+            break;
+        }
+    }
+
+    reached
+}
+
+/// A detected compound degradation requiring both bias and weight correction.
+#[derive(Debug, Clone)]
+pub struct CompoundDegradationCandidate {
+    /// UUID of the neuron needing bias correction.
+    pub bias_neuron_uuid: String,
+    /// Recommended bias value.
+    pub recommended_bias: f32,
+    /// UUID of the source neuron for the degraded synapse.
+    pub weight_from_uuid: String,
+    /// UUID of the target neuron for the degraded synapse.
+    pub weight_to_uuid: String,
+    /// Recommended synapse weight.
+    pub recommended_weight: f32,
+    /// Estimated combined improvement.
+    pub estimated_improvement: f32,
+}
+
+/// Convert compound degradation candidates to coordinated structural candidates.
+///
+/// Each compound candidate generates a two-operation coordinated group with
+/// `setBias` and `setWeight` applied atomically.
+pub fn compound_degradations_to_coordinated_candidates(
+    candidates: &[CompoundDegradationCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    candidates
+        .iter()
+        .map(|c| CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::SetBias {
+                    neuron_uuid: c.bias_neuron_uuid.clone(),
+                    bias: c.recommended_bias,
+                },
+                CoordinatedStructuralOpJson::SetWeight {
+                    from_neuron_uuid: c.weight_from_uuid.clone(),
+                    to_neuron_uuid: c.weight_to_uuid.clone(),
+                    weight: c.recommended_weight,
+                },
+            ],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Compound degradation: setBias({}) {:.3} and setWeight({} → {}) {:.3}. \
+                 Neither fix alone fully restores performance. (Issue #929)",
+                c.bias_neuron_uuid,
+                c.recommended_bias,
+                c.weight_from_uuid,
+                c.weight_to_uuid,
+                c.recommended_weight,
+            )),
+        })
+        .collect()
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -11,6 +11,7 @@ pub mod bimodal_neuron;
 pub mod bottleneck;
 pub mod bounded_range;
 pub mod co_adaptation;
+pub mod compound_degradation;
 pub mod correlated_error;
 pub mod dead_neuron;
 pub mod dormant_synapse;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -323,11 +323,11 @@ mod tests {
 
         let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
 
-        // We expect exactly 46 modules across all four spec groups.
+        // We expect exactly 47 modules across all four spec groups.
         assert_eq!(
             specs.len(),
-            46,
-            "Expected 46 discovery module specs, got {}",
+            47,
+            "Expected 47 discovery module specs, got {}",
             specs.len()
         );
 

--- a/src/analysis/module_dispatch_specs/structural_specs.rs
+++ b/src/analysis/module_dispatch_specs/structural_specs.rs
@@ -7,8 +7,8 @@
 use std::sync::Arc;
 
 use super::super::detection::{
-    correlated_error, hard_sample_cluster, output_conflict, skip_connection, topology,
-    topology_cache::CreatureTopologyCache, topology_diversification,
+    compound_degradation, correlated_error, hard_sample_cluster, output_conflict, skip_connection,
+    topology, topology_cache::CreatureTopologyCache, topology_diversification,
 };
 use super::super::recommendation::{fan_in, multi_hop};
 use super::super::{cache, discovery_dispatch};
@@ -131,5 +131,14 @@ pub(crate) fn append_structural_specs(
             hard_sample_cluster::detect_hard_sample_clusters(&creature, &records, &config)
         },
         convert: |detected| hard_sample_cluster::hard_sample_clusters_to_coordinated_candidates(&detected, &creature),
+    );
+
+    // Issue #929: Compound bias+weight degradation detection
+    discovery_spec!(modules, "compound bias weight degradation detection", "compound_bias_weight_degradation_detection",
+        cache = shared_cache, hidden = hidden_neurons, creature = creature =>
+        guard: hidden,
+        records: cache.load_records_for_all_neurons(&creature),
+        detect: |records| compound_degradation::detect_compound_bias_weight_degradations(&creature, &records),
+        convert: |detected| compound_degradation::compound_degradations_to_coordinated_candidates(&detected),
     );
 }

--- a/tests/synapse/issue_929_coordinated_structural_compound_degradation.rs
+++ b/tests/synapse/issue_929_coordinated_structural_compound_degradation.rs
@@ -1,0 +1,447 @@
+//! Scenario test: coordinated-structural discovery for compound degradations (Issue #929).
+//!
+//! Topology (whole creature):
+//! ```text
+//! input-0 ──(1.0)──▶ hidden-A (TANH, bias 0.3) ──(1.0)──▶ hidden-C (RELU)
+//! input-1 ──(1.0)──▶ hidden-B (RELU, bias -0.1) ──(0.8)──▶ hidden-C
+//! hidden-C ──(1.0)──▶ output-0 (IDENTITY)
+//! ```
+//!
+//! Crippled creature (coordinated degradation):
+//! - hidden-A bias changed: 0.3 → 0.0
+//! - hidden-B → hidden-C weight changed: 0.8 → 0.05 (nearly disabled)
+//!
+//! Same topology, degraded parameters.
+//!
+//! Discovery should produce a coordinated-structural candidate with both
+//! `setBias` and `setWeight` operations restoring the degraded parameters.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson, analyze_parallel_internal};
+
+/// Build the crippled creature with both degradations applied.
+fn crippled_creature() -> CreatureJson {
+    CreatureJson {
+        input: 2,
+        output: 1,
+        neurons: vec![
+            NeuronJson {
+                uuid: "hidden-A".into(),
+                neuron_type: "hidden".into(),
+                squash: "TANH".into(),
+                bias: 0.0, // Degraded: should be 0.3
+            },
+            NeuronJson {
+                uuid: "hidden-B".into(),
+                neuron_type: "hidden".into(),
+                squash: "ReLU".into(),
+                bias: -0.1,
+            },
+            NeuronJson {
+                uuid: "hidden-C".into(),
+                neuron_type: "hidden".into(),
+                squash: "ReLU".into(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".into(),
+                neuron_type: "output".into(),
+                squash: "IDENTITY".into(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".into(),
+                to_uuid: "hidden-A".into(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-1".into(),
+                to_uuid: "hidden-B".into(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-A".into(),
+                to_uuid: "hidden-C".into(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-B".into(),
+                to_uuid: "hidden-C".into(),
+                weight: 0.05, // Degraded: should be 0.8
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-C".into(),
+                to_uuid: "output-0".into(),
+                weight: 1.0,
+                synapse_type: None,
+            },
+        ],
+    }
+}
+
+/// Generate discovery records from the crippled creature with error signals
+/// derived from the whole (undegraded) creature's expected output.
+fn generate_records(num_observations: u32) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+
+    for obs in 0..num_observations {
+        let t = obs as f32 / num_observations as f32;
+        let x0 = t * 2.0 - 1.0; // [-1, 1]
+        let x1 = (t * 3.7).sin() * 0.8; // Varied pattern in [-0.8, 0.8]
+
+        // --- hidden-A: TANH(input-0 * 1.0 + bias) ---
+        let ha_pre_whole = x0 * 1.0 + 0.3; // Whole: bias = 0.3
+        let ha_act_whole = ha_pre_whole.tanh();
+        let ha_pre_crippled = x0 * 1.0 + 0.0; // Crippled: bias = 0.0
+        let ha_act_crippled = ha_pre_crippled.tanh();
+
+        // --- hidden-B: ReLU(input-1 * 1.0 + bias) ---
+        let hb_pre = x1 * 1.0 + (-0.1); // Same in both
+        let hb_act = hb_pre.max(0.0);
+
+        // --- hidden-C: ReLU(hidden-A * 1.0 + hidden-B * weight) ---
+        let hc_pre_whole = ha_act_whole * 1.0 + hb_act * 0.8; // Whole: weight = 0.8
+        let hc_act_whole = hc_pre_whole.max(0.0);
+        let hc_pre_crippled = ha_act_crippled * 1.0 + hb_act * 0.05; // Crippled: weight = 0.05
+        let hc_act_crippled = hc_pre_crippled.max(0.0);
+
+        // --- output-0: IDENTITY(hidden-C * 1.0) ---
+        let out_whole = hc_act_whole * 1.0;
+        let out_crippled = hc_act_crippled * 1.0;
+
+        // Error = whole - crippled (what's missing due to degradation)
+        let out_err = out_whole - out_crippled;
+        let hc_err = hc_act_whole - hc_act_crippled;
+        let ha_err = ha_act_whole - ha_act_crippled;
+        // hidden-B itself is correct; small propagated error
+        let hb_err = out_err * 0.05;
+
+        records.push(DiscoverRecord::new(
+            obs,
+            "hidden-A".into(),
+            Some(ha_pre_crippled),
+            ha_act_crippled,
+            vec![ha_err],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "hidden-B".into(),
+            Some(hb_pre),
+            hb_act,
+            vec![hb_err],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "hidden-C".into(),
+            Some(hc_pre_crippled),
+            hc_act_crippled,
+            vec![hc_err],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "output-0".into(),
+            Some(out_crippled),
+            out_crippled,
+            vec![out_err],
+        ));
+    }
+    records
+}
+
+/// Run the full discovery pipeline and return parsed JSON output.
+fn run_analysis(creature: &CreatureJson, records: &[DiscoverRecord]) -> serde_json::Value {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let parquet_file = temp_dir
+        .path()
+        .join("records.parquet")
+        .to_str()
+        .expect("valid UTF-8 path")
+        .to_string();
+
+    write_records_to_parquet(&parquet_file, records).expect("write parquet");
+
+    let input_json = serde_json::json!({
+        "parquetFile": parquet_file,
+        "creature": creature,
+        "focusNeurons": ["output-0", "hidden-C", "hidden-A"],
+        "maxSynapseCandidates": 64,
+        "maxNeuronCandidates": 32,
+        "randomSeed": 42
+    })
+    .to_string();
+
+    let output_json = analyze_parallel_internal(&input_json).expect("analysis should return JSON");
+    let output: serde_json::Value =
+        serde_json::from_str(&output_json).expect("output should be valid JSON");
+
+    assert_eq!(
+        output["success"],
+        true,
+        "Analysis failed: {}",
+        output["error"].as_str().unwrap_or("unknown")
+    );
+
+    output
+}
+
+/// Check whether any coordinated structural candidate contains both a setBias
+/// operation for `neuron_uuid` and a setWeight operation for (from, to).
+fn find_compound_candidate(
+    coordinated: &[serde_json::Value],
+    bias_neuron: &str,
+    weight_from: &str,
+    weight_to: &str,
+) -> Option<serde_json::Value> {
+    for group in coordinated {
+        let Some(ops) = group["operations"].as_array() else {
+            continue;
+        };
+
+        let has_set_bias = ops.iter().any(|op| {
+            op["type"].as_str() == Some("setBias") && op["neuronUuid"].as_str() == Some(bias_neuron)
+        });
+
+        let has_set_weight = ops.iter().any(|op| {
+            op["type"].as_str() == Some("setWeight")
+                && op["fromNeuronUuid"].as_str() == Some(weight_from)
+                && op["toNeuronUuid"].as_str() == Some(weight_to)
+        });
+
+        if has_set_bias && has_set_weight {
+            return Some(group.clone());
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Test: Discovery produces a coordinated-structural candidate with setBias + setWeight
+// ---------------------------------------------------------------------------
+
+/// The discovery engine should identify both degraded parameters (hidden-A bias
+/// and hidden-B→hidden-C weight) and produce a coordinated-structural candidate
+/// containing both setBias and setWeight operations.
+#[test]
+fn issue_929_discovers_compound_bias_weight_degradation() {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping: no GPU available");
+        return;
+    }
+
+    let creature = crippled_creature();
+    let records = generate_records(128);
+    let output = run_analysis(&creature, &records);
+
+    let empty = vec![];
+    let coordinated = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .unwrap_or(&empty);
+
+    let compound = find_compound_candidate(coordinated, "hidden-A", "hidden-B", "hidden-C");
+
+    assert!(
+        compound.is_some(),
+        "Expected a coordinated-structural candidate with both setBias(hidden-A) \
+         and setWeight(hidden-B → hidden-C). \
+         coordinatedStructuralCandidates count: {}, \
+         candidates: {:#?}",
+        coordinated.len(),
+        coordinated
+    );
+
+    let group = compound.unwrap();
+    let ops = group["operations"].as_array().expect("operations array");
+
+    // Verify the candidate has exactly 2 operations
+    assert_eq!(
+        ops.len(),
+        2,
+        "Expected exactly 2 operations (setBias + setWeight), got {}: {ops:#?}",
+        ops.len()
+    );
+
+    // Verify positive expected score gain
+    let score_gain = group["expectedCreatureScoreGain"]
+        .as_f64()
+        .expect("expectedCreatureScoreGain should be a number");
+    assert!(
+        score_gain > 0.0,
+        "Expected positive expectedCreatureScoreGain, got {score_gain}"
+    );
+
+    eprintln!(
+        "Issue #929 PASS: compound candidate found with {ops_count} operations, \
+         scoreGain={score_gain:.6}",
+        ops_count = ops.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test: The setBias operation targets the correct neuron with reasonable bias
+// ---------------------------------------------------------------------------
+
+/// Verify that the setBias operation in the compound candidate correctly
+/// identifies hidden-A and recommends a bias approximately restoring 0.3.
+#[test]
+fn issue_929_set_bias_targets_correct_neuron() {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping: no GPU available");
+        return;
+    }
+
+    let creature = crippled_creature();
+    let records = generate_records(128);
+    let output = run_analysis(&creature, &records);
+
+    let empty = vec![];
+    let coordinated = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .unwrap_or(&empty);
+
+    let compound = find_compound_candidate(coordinated, "hidden-A", "hidden-B", "hidden-C");
+
+    assert!(
+        compound.is_some(),
+        "Expected compound candidate with setBias(hidden-A) + setWeight(hidden-B → hidden-C)"
+    );
+
+    let group = compound.unwrap();
+    let ops = group["operations"].as_array().unwrap();
+
+    let bias_op = ops
+        .iter()
+        .find(|op| {
+            op["type"].as_str() == Some("setBias") && op["neuronUuid"].as_str() == Some("hidden-A")
+        })
+        .expect("setBias operation for hidden-A");
+
+    let bias = bias_op["bias"].as_f64().expect("bias should be a number");
+
+    // The recommended bias should be positive (moving toward 0.3 from 0.0)
+    assert!(
+        bias > 0.0,
+        "Expected positive bias correction for hidden-A (toward 0.3), got {bias}"
+    );
+
+    eprintln!("Issue #929: setBias(hidden-A) bias={bias:.4} (target ≈ 0.3)");
+}
+
+// ---------------------------------------------------------------------------
+// Test: The setWeight operation targets the correct synapse with reasonable weight
+// ---------------------------------------------------------------------------
+
+/// Verify that the setWeight operation in the compound candidate correctly
+/// identifies the hidden-B → hidden-C synapse and recommends a weight
+/// significantly higher than the degraded 0.05.
+#[test]
+fn issue_929_set_weight_targets_correct_synapse() {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping: no GPU available");
+        return;
+    }
+
+    let creature = crippled_creature();
+    let records = generate_records(128);
+    let output = run_analysis(&creature, &records);
+
+    let empty = vec![];
+    let coordinated = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .unwrap_or(&empty);
+
+    let compound = find_compound_candidate(coordinated, "hidden-A", "hidden-B", "hidden-C");
+
+    assert!(
+        compound.is_some(),
+        "Expected compound candidate with setBias(hidden-A) + setWeight(hidden-B → hidden-C)"
+    );
+
+    let group = compound.unwrap();
+    let ops = group["operations"].as_array().unwrap();
+
+    let weight_op = ops
+        .iter()
+        .find(|op| {
+            op["type"].as_str() == Some("setWeight")
+                && op["fromNeuronUuid"].as_str() == Some("hidden-B")
+                && op["toNeuronUuid"].as_str() == Some("hidden-C")
+        })
+        .expect("setWeight operation for hidden-B → hidden-C");
+
+    let weight = weight_op["weight"]
+        .as_f64()
+        .expect("weight should be a number");
+
+    // The recommended weight should be significantly higher than 0.05
+    // (the degraded value), moving toward the original 0.8.
+    assert!(
+        weight > 0.1,
+        "Expected weight significantly above degraded 0.05 (toward 0.8), got {weight}"
+    );
+
+    eprintln!("Issue #929: setWeight(hidden-B → hidden-C) weight={weight:.4} (target ≈ 0.8)");
+}
+
+// ---------------------------------------------------------------------------
+// Test: All returned candidates have positive expected improvement
+// ---------------------------------------------------------------------------
+
+/// Verify that all candidates returned by the pipeline have positive expected
+/// score gain.
+#[test]
+fn issue_929_all_candidates_have_positive_improvement() {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping: no GPU available");
+        return;
+    }
+
+    let creature = crippled_creature();
+    let records = generate_records(128);
+    let output = run_analysis(&creature, &records);
+
+    let empty = vec![];
+
+    // Check coordinated structural candidates
+    let coordinated = output["coordinatedStructuralCandidates"]
+        .as_array()
+        .unwrap_or(&empty);
+    for (i, group) in coordinated.iter().enumerate() {
+        if let Some(gain) = group["expectedCreatureScoreGain"].as_f64() {
+            assert!(
+                gain > 0.0,
+                "coordinatedStructural[{i}] expected positive gain, got {gain}"
+            );
+        }
+    }
+
+    // Check helpful synapses
+    if let Some(helpful) = output["helpfulSynapses"].as_array() {
+        for (i, c) in helpful.iter().enumerate() {
+            if let Some(gain) = c["expectedCreatureScoreGain"].as_f64() {
+                assert!(
+                    gain > 0.0,
+                    "helpfulSynapses[{i}] expected positive score gain, got {gain}"
+                );
+            }
+        }
+    }
+
+    eprintln!(
+        "Issue #929: all candidates have positive improvement \
+         (coordinated={}, helpful={})",
+        coordinated.len(),
+        output["helpfulSynapses"]
+            .as_array()
+            .map_or(0, std::vec::Vec::len),
+    );
+}

--- a/tests/synapse/main.rs
+++ b/tests/synapse/main.rs
@@ -25,6 +25,7 @@ mod issue_893_holdout_validation;
 mod issue_897_saturation_aware_coordinated_estimation;
 mod issue_906_saturation_aware_fallback_nonlinear;
 mod issue_927_remove_harmful_synapse;
+mod issue_929_coordinated_structural_compound_degradation;
 mod sample_matching;
 mod sensible_range_filtering;
 mod source_variance_discounting;


### PR DESCRIPTION
## Summary

Add compound bias+weight degradation detection to the coordinated structural
discovery pipeline. This enables the discovery engine to identify cases where
multiple parameters (neuron bias and synapse weight) are both degraded and
need simultaneous correction — neither fix alone fully restores performance.

The new detection module (`compound_degradation.rs`) analyses hidden neurons
for consistent error (suggesting bias drift) and synapses for
activation-error correlation (suggesting weight degradation), then combines
related corrections on the same forward path into atomic coordinated
candidates with `setBias` + `setWeight` operations.

Closes #929.

## Changes

- **New file: `src/analysis/detection/compound_degradation.rs`** — Detection
  module for compound bias+weight degradations. Uses error gradient analysis
  to compute optimal bias corrections and least-squares regression for
  weight corrections, combining related pairs into coordinated candidates.
- **`src/analysis/detection/mod.rs`** — Register the new module.
- **`src/analysis/module_dispatch_specs/structural_specs.rs`** — Wire the
  new detector into the parallel dispatch pipeline.
- **`src/analysis/module_dispatch_specs/mod.rs`** — Update expected module
  count in tests (46 → 47).
- **New file: `tests/synapse/issue_929_coordinated_structural_compound_degradation.rs`**
  — End-to-end scenario test verifying coordinated discovery for the
  compound degradation scenario from the issue.
- **`tests/synapse/main.rs`** — Register the new test module.

## Evidence

All 4 new tests pass on GPU:
- `issue_929_discovers_compound_bias_weight_degradation` — Finds compound
  candidate with 2 operations (setBias + setWeight), scoreGain=0.118
- `issue_929_set_bias_targets_correct_neuron` — setBias(hidden-A) bias=0.226
  (target ~0.3)
- `issue_929_set_weight_targets_correct_synapse` — setWeight(hidden-B ->
  hidden-C) weight=0.969 (target ~0.8)
- `issue_929_all_candidates_have_positive_improvement` — All candidates have
  positive expected score gain

Full quality gate passes: 158 tests, 0 failures, clippy clean, docs build.

## Test Plan

- Added `tests/synapse/issue_929_coordinated_structural_compound_degradation.rs`
  with 4 test cases:
  1. Discovery produces a coordinated-structural candidate with both setBias
     and setWeight operations
  2. The setBias operation targets the correct neuron with reasonable bias
  3. The setWeight operation targets the correct synapse with reasonable weight
  4. All returned candidates have positive expected improvement
- Existing 154 synapse tests continue to pass (no regressions)

---

## Automated Fix Details
This PR addresses issue #929: **Verify: coordinated-structural discovery for compound degradations (NEAT-AI scenario test)**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #929
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-929 -->