### PR TITLE
feat: enforce UUID-only FFI discovery contract (#952)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.70.1"
+version = "0.71.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.70.0"
+version = "0.70.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -107,11 +107,15 @@ suitable GPU, controllers must disable discovery entirely.
 
 ### Output Format
 
+All discovery responses include a `schemaVersion` field (Issue #952) so callers can
+reject stale cached payloads instead of guessing compatibility.
+
 Success:
 ```json
 {
   "success": true,
-  "temp_dir": ".discovery/abc123_456789",
+  "schemaVersion": "2",
+  "tempDir": ".discovery/abc123_456789",
   "file": "discovery_data.parquet"
 }
 ```
@@ -120,9 +124,26 @@ Error:
 ```json
 {
   "success": false,
-  "error": "Error message here"
+  "schemaVersion": "2",
+  "error": "Error message here",
+  "errorKind": "data_validation",
+  "retryable": false
 }
 ```
+
+### Neuron Identity Contract (Issue #952)
+
+All neuron and synapse identity fields in FFI JSON payloads must use **stable UUID
+strings**. Purely numeric integer IDs (e.g. `"0"`, `"42"`, `"999999"`) are rejected
+at the FFI boundary with a `data_validation` error.
+
+Accepted formats:
+- RFC 4122 UUIDs: `"550e8400-e29b-41d4-a716-446655440000"`
+- Input neuron identifiers: `"input-0"`, `"input-1"`
+- Descriptive identifiers: `"hidden-layer1-node0"`, `"output-main"`
+
+Numeric integer IDs are an internal optimisation detail and must never cross the
+FFI boundary.
 
 ---
 

--- a/docs/pr-summary-952.md
+++ b/docs/pr-summary-952.md
@@ -1,0 +1,48 @@
+## Summary
+
+Enforce UUID-only FFI discovery contract by rejecting purely numeric integer
+neuron/synapse IDs at the FFI boundary. Internal numeric IDs are an optimisation
+detail that must never leak into JSON, cache files, or cross-library payloads.
+Closes #952.
+
+### Changes
+
+- **UUID validation**: Added `deserialise_neuron_uuid` and `deserialise_synapse_uuid`
+  custom deserialisers to `NeuronJson::uuid`, `SynapseJson::from_uuid`/`to_uuid`,
+  and `NeuronData::neuron_uuid`. These reject purely numeric strings (e.g. `"0"`,
+  `"42"`, `"999999"`) with a `data_validation` error.
+- **Schema version**: Added `schemaVersion` field to `RecordDiscoveryOutput`,
+  `AnalyzeParallelOutput`, `RankFocusNeuronsOutput`, and `GetVersionOutput`.
+  Current schema version is `"2"`. Callers can use this to reject stale cached
+  payloads.
+- **Wire format**: `RecordDiscoveryOutput` now uses `camelCase` field names
+  (`tempDir`, `schemaVersion`, `errorKind`) consistent with other response types.
+- **Documentation**: Updated `FFI_API.md` with the neuron identity contract and
+  schema version field.
+- **Dead code removal**: Removed comments and documentation referencing numeric ID
+  acceptance (Issue #950 compatibility).
+
+## Evidence
+
+All 158 tests pass including:
+- `tests/ffi/issue_952_uuid_only_ffi_contract.rs` — 11 new tests verifying UUID
+  enforcement, numeric ID rejection, and schema version presence
+- `tests/ffi/issue_950_numeric_neuron_ids.rs` — Rewritten to test UUID-format IDs
+  through the full pipeline (deserialisation, recording, reading, interning)
+- Updated existing tests in `tests/integration.rs`,
+  `tests/analysis/issue_337_candidate_type_contract.rs`, and
+  `tests/infrastructure/issue_874_module_split_backward_compat.rs`
+
+## Test Plan
+
+- `reject_creature_with_numeric_neuron_ids` — Verifies numeric neuron UUIDs are rejected
+- `reject_synapse_with_numeric_from_uuid` — Verifies numeric synapse UUIDs are rejected
+- `reject_neuron_data_with_numeric_id` — Verifies numeric `NeuronData` UUIDs are rejected
+- `reject_large_numeric_neuron_ids` — Verifies large numeric strings are rejected
+- `accept_rfc4122_uuids` — Verifies RFC 4122 UUIDs are accepted
+- `accept_input_neuron_format` — Verifies `input-N` format is accepted
+- `accept_neuron_data_with_uuid` — Verifies UUID `NeuronData` is accepted
+- `ffi_record_discovery_rejects_numeric_ids` — Full FFI pipeline rejection test
+- `record_discovery_response_includes_schema_version` — Schema version in responses
+- `get_version_response_includes_schema_version` — Schema version in version output
+- `coordinated_op_serialises_uuid_references` — Coordinated ops use UUID references

--- a/src/ffi/analysis.rs
+++ b/src/ffi/analysis.rs
@@ -47,6 +47,7 @@ pub unsafe extern "C" fn rank_focus_neurons(
                 let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = RankFocusNeuronsOutput {
                     success: false,
+                    schema_version: SCHEMA_VERSION.to_string(),
                     neurons: None,
                     removal_candidates: None,
                     constant_neuron_removals: None,
@@ -115,6 +116,7 @@ pub unsafe extern "C" fn analyze_parallel(
                 let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = AnalyzeParallelOutput {
                     success: false,
+                    schema_version: SCHEMA_VERSION.to_string(),
                     helpful_synapses: None,
                     harmful_synapses: None,
                     synapse_diagnostics: None,

--- a/src/ffi/recording.rs
+++ b/src/ffi/recording.rs
@@ -49,6 +49,7 @@ pub unsafe extern "C" fn record_discovery(
                 let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
                 let output = RecordDiscoveryOutput {
                     success: false,
+                    schema_version: SCHEMA_VERSION.to_string(),
                     temp_dir: None,
                     file: None,
                     error: Some(err_msg),

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -331,6 +331,7 @@ pub extern "C" fn get_library_version() -> *mut std::ffi::c_char {
                 let output = GetVersionOutput {
                     success: false,
                     version: String::new(),
+                    schema_version: SCHEMA_VERSION.to_string(),
                     error: Some(err_msg),
                     error_kind,
                     retryable,

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -17,6 +17,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
             let kind = typed.error_kind();
             let output = AnalyzeParallelOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 helpful_synapses: None,
                 harmful_synapses: None,
                 synapse_diagnostics: None,
@@ -73,6 +74,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
 
             let output = AnalyzeParallelOutput {
                 success: true,
+                schema_version: SCHEMA_VERSION.to_string(),
                 helpful_synapses: synapse.as_ref().map(|s| s.helpful_synapses.clone()),
                 harmful_synapses: synapse.as_ref().map(|s| s.harmful_synapses.clone()),
                 synapse_diagnostics: synapse
@@ -136,6 +138,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
             let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = AnalyzeParallelOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 helpful_synapses: None,
                 harmful_synapses: None,
                 synapse_diagnostics: None,
@@ -189,6 +192,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
             let kind = typed.error_kind();
             let output = RankFocusNeuronsOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 neurons: None,
                 removal_candidates: None,
                 constant_neuron_removals: None,
@@ -241,6 +245,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
             let (error_kind, retryable) = no_error_fields();
             let output = RankFocusNeuronsOutput {
                 success: true,
+                schema_version: SCHEMA_VERSION.to_string(),
                 neurons: Some(neurons),
                 removal_candidates: if removal_candidates.is_empty() {
                     None
@@ -267,6 +272,7 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
             let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = RankFocusNeuronsOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 neurons: None,
                 removal_candidates: None,
                 constant_neuron_removals: None,

--- a/src/ffi_internal/gpu.rs
+++ b/src/ffi_internal/gpu.rs
@@ -42,6 +42,7 @@ pub fn get_library_version_internal() -> Result<String> {
     let output = GetVersionOutput {
         success: true,
         version: crate::LIB_VERSION.to_string(),
+        schema_version: SCHEMA_VERSION.to_string(),
         error: None,
         error_kind,
         retryable,

--- a/src/ffi_internal/mod.rs
+++ b/src/ffi_internal/mod.rs
@@ -94,6 +94,7 @@ mod tests {
             let (error_kind, retryable) = error_fields(error_msg);
             let output = RecordDiscoveryOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 temp_dir: None,
                 file: None,
                 error: Some(error_msg.to_string()),

--- a/src/ffi_internal/recording.rs
+++ b/src/ffi_internal/recording.rs
@@ -22,6 +22,7 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
             let kind = typed.error_kind();
             let output = RecordDiscoveryOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 temp_dir: None,
                 file: None,
                 error: Some(typed.to_string()),
@@ -39,6 +40,7 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
             let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&e);
             let output = RecordDiscoveryOutput {
                 success: false,
+                schema_version: SCHEMA_VERSION.to_string(),
                 temp_dir: None,
                 file: None,
                 error: Some(err_msg),
@@ -53,6 +55,7 @@ pub fn record_discovery_internal(input_json: &str) -> Result<String> {
     let (error_kind, retryable) = no_error_fields();
     let output = RecordDiscoveryOutput {
         success: true,
+        schema_version: SCHEMA_VERSION.to_string(),
         temp_dir: Some(result.temp_dir),
         file: Some(result.file),
         error: None,

--- a/src/ffi_types/mod.rs
+++ b/src/ffi_types/mod.rs
@@ -19,6 +19,62 @@ pub use session::*;
 use serde::{Deserialize, Deserializer, Serialize};
 
 // ============================================================================
+// FFI contract version (Issue #952)
+// ============================================================================
+
+/// Current discovery FFI schema version.
+///
+/// Callers can use this to reject stale cached payloads instead of guessing
+/// compatibility. Bump this when the wire format changes.
+pub const SCHEMA_VERSION: &str = "2";
+
+// ============================================================================
+// UUID validation (Issue #952)
+// ============================================================================
+
+/// Returns `true` if the string is a purely numeric integer (e.g. `"0"`, `"42"`,
+/// `"999999"`). These are runtime integer IDs that must never cross the FFI
+/// boundary.
+fn is_numeric_id(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Deserialise a neuron UUID string, rejecting purely numeric identifiers.
+///
+/// Accepts RFC 4122 UUIDs, `input-N` format, and any other descriptive string
+/// identifier. Rejects stringified integers (Issue #952).
+fn deserialise_neuron_uuid<'de, D>(deserialiser: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserialiser)?;
+    if is_numeric_id(&raw) {
+        return Err(serde::de::Error::custom(format!(
+            "numeric integer neuron ID \"{raw}\" is not permitted in FFI payloads \
+             (Issue #952). Use a stable UUID string instead."
+        )));
+    }
+    Ok(raw)
+}
+
+/// Deserialise a synapse UUID string, rejecting purely numeric identifiers.
+///
+/// Empty strings are allowed (serde default for missing fields).
+fn deserialise_synapse_uuid<'de, D>(deserialiser: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserialiser)?;
+    if is_numeric_id(&raw) {
+        return Err(serde::de::Error::custom(format!(
+            "numeric integer synapse UUID \"{raw}\" is not permitted in FFI payloads \
+             (Issue #952). Use a stable UUID string instead."
+        )));
+    }
+    Ok(raw)
+}
+
+// ============================================================================
 // Creature / Neuron / Synapse representations
 // ============================================================================
 
@@ -33,12 +89,11 @@ pub struct CreatureJson {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NeuronJson {
-    /// Neuron identity string. May be either:
-    /// - An RFC 4122 UUID from creature exports (e.g. `"550e8400-e29b-41d4-…"`), or
-    /// - A stringified integer matching the TypeScript runtime `neuron.id` after
-    ///   normalisation (e.g. `"42"`).
+    /// Stable neuron identity string. Must be a UUID or descriptive identifier
+    /// (e.g. `"550e8400-e29b-41d4-…"`, `"input-0"`).
     ///
-    /// Callers must not assume a single format (Issue #950).
+    /// Purely numeric integer IDs are rejected at the FFI boundary (Issue #952).
+    #[serde(deserialize_with = "deserialise_neuron_uuid")]
     pub uuid: String,
     #[serde(rename = "type")]
     pub neuron_type: String,
@@ -75,13 +130,21 @@ where
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SynapseJson {
-    /// Source neuron identity string. Same format rules as [`NeuronJson::uuid`]:
-    /// may be an RFC 4122 UUID or a stringified integer (Issue #950).
-    #[serde(default, alias = "fromUUID")]
+    /// Source neuron identity string. Must be a UUID or descriptive identifier.
+    /// Purely numeric integer IDs are rejected (Issue #952).
+    #[serde(
+        default,
+        alias = "fromUUID",
+        deserialize_with = "deserialise_synapse_uuid"
+    )]
     pub from_uuid: String,
-    /// Target neuron identity string. Same format rules as [`NeuronJson::uuid`]:
-    /// may be an RFC 4122 UUID or a stringified integer (Issue #950).
-    #[serde(default, alias = "toUUID")]
+    /// Target neuron identity string. Must be a UUID or descriptive identifier.
+    /// Purely numeric integer IDs are rejected (Issue #952).
+    #[serde(
+        default,
+        alias = "toUUID",
+        deserialize_with = "deserialise_synapse_uuid"
+    )]
     pub to_uuid: String,
     #[serde(default)]
     pub weight: f32,
@@ -96,7 +159,8 @@ pub struct SynapseJson {
 #[derive(Debug, Deserialize, Clone)]
 pub struct NeuronData {
     /// Neuron identity string. Must match the corresponding [`NeuronJson::uuid`]
-    /// exactly — may be an RFC 4122 UUID or a stringified integer (Issue #950).
+    /// exactly. Purely numeric integer IDs are rejected (Issue #952).
+    #[serde(deserialize_with = "deserialise_neuron_uuid")]
     pub neuron_uuid: String,
     pub activation: f32,
     #[serde(default)]

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -190,8 +190,9 @@ fn default_top_k() -> Option<usize> {
 #[derive(Debug, Deserialize)]
 pub struct ReadDiscoveryInput {
     pub parquet_file: String,
-    /// Neuron identity string to filter by. May be an RFC 4122 UUID or a
-    /// stringified integer — exact string matching is used (Issue #950).
+    /// Neuron identity string to filter by. Must be a stable UUID or descriptive
+    /// identifier — exact string matching is used. Numeric integer IDs are not
+    /// permitted (Issue #952).
     pub neuron_uuid: String,
 }
 

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -18,6 +18,8 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeParallelOutput {
     pub success: bool,
+    /// FFI schema version so callers can reject stale cached payloads (Issue #952).
+    pub schema_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub helpful_synapses: Option<Vec<CandidateSynapseJson>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/ffi_types/responses/mod.rs
+++ b/src/ffi_types/responses/mod.rs
@@ -27,8 +27,11 @@ use crate::analysis as analysis_mod;
 
 /// JSON output from `record_discovery` function
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RecordDiscoveryOutput {
     pub success: bool,
+    /// FFI schema version so callers can reject stale cached payloads (Issue #952).
+    pub schema_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temp_dir: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,6 +51,8 @@ pub struct RecordDiscoveryOutput {
 pub struct GetVersionOutput {
     pub success: bool,
     pub version: String,
+    /// FFI schema version so callers can reject stale cached payloads (Issue #952).
+    pub schema_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Structured error classification for retry decisions (Issue #651).
@@ -62,6 +67,8 @@ pub struct GetVersionOutput {
 #[serde(rename_all = "camelCase")]
 pub struct RankFocusNeuronsOutput {
     pub success: bool,
+    /// FFI schema version so callers can reject stale cached payloads (Issue #952).
+    pub schema_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub neurons: Option<Vec<RankedNeuronJson>>,
     /// Neurons with high error but very low impact - candidates for removal

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -44,9 +44,9 @@ use std::sync::Arc;
 ///
 /// Maps neuron identity strings to compact `u32` indices, enabling
 /// memory-efficient HashMap/HashSet operations with integer keys instead of
-/// String keys. Identity strings may be RFC 4122 UUIDs or stringified
-/// integers from TypeScript runtime `neuron.id` (Issue #950) — no format
-/// validation is performed.
+/// String keys. Identity strings are stable UUIDs or descriptive identifiers
+/// (e.g. `input-0`, `hidden-abc`). Numeric integer IDs are rejected at the
+/// FFI boundary (Issue #952).
 #[derive(Debug, Clone)]
 pub struct NeuronIndex {
     /// Maps interned UUID strings to their assigned index.

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 pub struct DiscoverRecord {
     /// Observation index (training record index)
     pub obs_index: u32,
-    /// Neuron identity string — may be an RFC 4122 UUID or a stringified
-    /// integer from TypeScript runtime `neuron.id` (Issue #950).
+    /// Stable neuron identity string (RFC 4122 UUID, `input-N`, or other
+    /// descriptive identifier). Numeric integer IDs are not permitted (Issue #952).
     pub neuron_uuid: String,
     /// Neuron value (optional, can be None)
     pub value: Option<f32>,

--- a/tests/analysis/issue_337_candidate_type_contract.rs
+++ b/tests/analysis/issue_337_candidate_type_contract.rs
@@ -299,6 +299,7 @@ fn analyze_parallel_output_contains_all_candidate_fields() {
     // that NEAT-AI's DiscoverResult.ts and DiscoveryCandidates.ts consume.
     let output = neat_ai_discovery::AnalyzeParallelOutput {
         success: true,
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
         helpful_synapses: Some(vec![]),
         harmful_synapses: Some(vec![]),
         synapse_diagnostics: None,
@@ -357,6 +358,7 @@ fn rank_focus_neurons_output_contains_removal_candidate_fields() {
     // including constantNeuronRemovals (Issue #306).
     let output = neat_ai_discovery::RankFocusNeuronsOutput {
         success: true,
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
         neurons: Some(vec![]),
         removal_candidates: Some(vec![]),
         constant_neuron_removals: Some(vec![]),

--- a/tests/ffi/issue_950_numeric_neuron_ids.rs
+++ b/tests/ffi/issue_950_numeric_neuron_ids.rs
@@ -1,145 +1,147 @@
-//! Issue #950 — FFI tests: do not treat runtime neuron id strings as RFC UUIDs.
+//! Issue #950 — FFI tests: neuron identity strings in the FFI pipeline.
 //!
-//! NEAT-AI public creature exports use stable wire-format strings for neuron
-//! identity (`neuron.uuid`, synapse `fromUUID`/`toUUID`). However, TypeScript
-//! bridges (e.g. `creatureToRustFormat`) may stringify **numeric runtime ids**
-//! for the Rust side. These strings are **not** RFC 4122 UUIDs.
+//! Originally these tests verified that stringified-integer neuron IDs were
+//! accepted. Issue #952 tightened the FFI contract to UUID-only: purely
+//! numeric IDs are now rejected at the FFI boundary.
 //!
-//! These tests verify that the FFI boundary, recording pipeline, and neuron
-//! interning all handle stringified-integer neuron identifiers correctly,
-//! without assuming a UUID format.
+//! These tests now verify that:
+//! 1. Valid UUID-format neuron IDs work through the full pipeline.
+//! 2. Neuron interning handles diverse string formats correctly.
+//! 3. `DiscoverRecord` preserves UUID strings without normalisation.
 
 use neat_ai_discovery::{CreatureJson, NeuronData, RecordDiscoveryInput};
 
 // ============================================================================
-// FFI deserialisation: stringified-integer neuron IDs
+// FFI deserialisation: valid neuron ID formats
 // ============================================================================
 
-/// Creature JSON with purely numeric neuron UUIDs must deserialise correctly.
-/// This guards against any future UUID-format validation rejecting runtime ids.
+/// Creature JSON with RFC 4122 UUID neuron identifiers must deserialise correctly.
 #[test]
-fn deserialise_creature_with_numeric_neuron_ids() {
+fn deserialise_creature_with_uuid_neuron_ids() {
     let json = r#"{
         "neurons": [
-            {"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
-            {"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
-            {"uuid": "2", "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
-            {"uuid": "3", "type": "output", "squash": "LOGISTIC", "bias": -0.2}
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+            {"uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
+            {"uuid": "b2c3d4e5-f6a7-4890-bcde-f01234567890", "type": "output", "squash": "LOGISTIC", "bias": -0.2}
         ],
         "synapses": [
-            {"fromUUID": "0", "toUUID": "2", "weight": 0.5},
-            {"fromUUID": "1", "toUUID": "2", "weight": -0.3},
-            {"fromUUID": "2", "toUUID": "3", "weight": 0.8}
+            {"fromUUID": "input-0", "toUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "weight": 0.5},
+            {"fromUUID": "input-1", "toUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "weight": -0.3},
+            {"fromUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "toUUID": "b2c3d4e5-f6a7-4890-bcde-f01234567890", "weight": 0.8}
         ],
         "input": 2,
         "output": 1
     }"#;
 
-    let creature: CreatureJson = serde_json::from_str(json).expect("numeric IDs must deserialise");
+    let creature: CreatureJson = serde_json::from_str(json).expect("UUID IDs must deserialise");
 
     assert_eq!(creature.neurons.len(), 4);
-    assert_eq!(creature.neurons[0].uuid, "0");
-    assert_eq!(creature.neurons[2].uuid, "2");
-    assert_eq!(creature.synapses[0].from_uuid, "0");
-    assert_eq!(creature.synapses[2].to_uuid, "3");
+    assert_eq!(creature.neurons[0].uuid, "input-0");
+    assert_eq!(
+        creature.neurons[2].uuid,
+        "a1b2c3d4-e5f6-4789-abcd-ef0123456789"
+    );
+    assert_eq!(creature.synapses[0].from_uuid, "input-0");
+    assert_eq!(
+        creature.synapses[2].to_uuid,
+        "b2c3d4e5-f6a7-4890-bcde-f01234567890"
+    );
 }
 
-/// Creature JSON mixing RFC 4122 UUIDs with numeric IDs must deserialise.
-/// This is the realistic scenario after `normaliseCreatureExport`: hidden
-/// neurons have RFC UUIDs while TypeScript runtime ids are numeric.
+/// Creature JSON with mixed UUID styles (RFC 4122 + descriptive) must deserialise.
 #[test]
 fn deserialise_creature_with_mixed_uuid_formats() {
     let json = r#"{
         "neurons": [
-            {"uuid": "0", "type": "input", "squash": "IDENTITY"},
-            {"uuid": "1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
             {"uuid": "550e8400-e29b-41d4-a716-446655440000", "type": "hidden", "squash": "RELU", "bias": 0.1},
-            {"uuid": "42", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+            {"uuid": "hidden-output-main", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
         ],
         "synapses": [
-            {"fromUUID": "0", "toUUID": "550e8400-e29b-41d4-a716-446655440000", "weight": 0.5},
-            {"fromUUID": "550e8400-e29b-41d4-a716-446655440000", "toUUID": "42", "weight": 0.8}
+            {"fromUUID": "input-0", "toUUID": "550e8400-e29b-41d4-a716-446655440000", "weight": 0.5},
+            {"fromUUID": "550e8400-e29b-41d4-a716-446655440000", "toUUID": "hidden-output-main", "weight": 0.8}
         ],
         "input": 2,
         "output": 1
     }"#;
 
-    let creature: CreatureJson = serde_json::from_str(json).expect("mixed IDs must deserialise");
+    let creature: CreatureJson = serde_json::from_str(json).expect("mixed UUIDs must deserialise");
 
     assert_eq!(
         creature.neurons[2].uuid,
         "550e8400-e29b-41d4-a716-446655440000"
     );
-    assert_eq!(creature.neurons[3].uuid, "42");
+    assert_eq!(creature.neurons[3].uuid, "hidden-output-main");
     assert_eq!(
         creature.synapses[0].to_uuid,
         "550e8400-e29b-41d4-a716-446655440000"
     );
 }
 
-/// `NeuronData` with numeric `neuron_uuid` must deserialise correctly.
-/// This is the format TypeScript sends for pre-computed activations.
+/// `NeuronData` with UUID `neuron_uuid` must deserialise correctly.
 #[test]
-fn deserialise_neuron_data_with_numeric_ids() {
-    let json = r#"{"neuron_uuid": "7", "activation": 0.85, "errors": [0.01, -0.02]}"#;
+fn deserialise_neuron_data_with_uuid_ids() {
+    let json = r#"{"neuron_uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "activation": 0.85, "errors": [0.01, -0.02]}"#;
 
-    let data: NeuronData =
-        serde_json::from_str(json).expect("numeric neuron_uuid must deserialise");
+    let data: NeuronData = serde_json::from_str(json).expect("UUID neuron_uuid must deserialise");
 
-    assert_eq!(data.neuron_uuid, "7");
+    assert_eq!(data.neuron_uuid, "a1b2c3d4-e5f6-4789-abcd-ef0123456789");
     assert!((data.activation - 0.85).abs() < f32::EPSILON);
 }
 
-/// Large numeric IDs (matching TypeScript's `neuron.id` counter) must work.
-/// Runtime IDs can be arbitrarily large integers stringified.
+/// Descriptive string neuron IDs must work.
 #[test]
-fn deserialise_large_numeric_neuron_ids() {
+fn deserialise_descriptive_string_neuron_ids() {
     let json = r#"{
         "neurons": [
-            {"uuid": "100000", "type": "input", "squash": "IDENTITY"},
-            {"uuid": "100001", "type": "input", "squash": "IDENTITY"},
-            {"uuid": "999999", "type": "hidden", "squash": "TANH", "bias": 0.0},
-            {"uuid": "1000000", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "hidden-layer1-node0", "type": "hidden", "squash": "TANH", "bias": 0.0},
+            {"uuid": "output-main", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
         ],
         "synapses": [
-            {"fromUUID": "100000", "toUUID": "999999", "weight": 1.0},
-            {"fromUUID": "999999", "toUUID": "1000000", "weight": -0.5}
+            {"fromUUID": "input-0", "toUUID": "hidden-layer1-node0", "weight": 1.0},
+            {"fromUUID": "hidden-layer1-node0", "toUUID": "output-main", "weight": -0.5}
         ],
         "input": 2,
         "output": 1
     }"#;
 
     let creature: CreatureJson =
-        serde_json::from_str(json).expect("large numeric IDs must deserialise");
+        serde_json::from_str(json).expect("descriptive string IDs must deserialise");
 
-    assert_eq!(creature.neurons[2].uuid, "999999");
-    assert_eq!(creature.synapses[1].from_uuid, "999999");
+    assert_eq!(creature.neurons[2].uuid, "hidden-layer1-node0");
+    assert_eq!(creature.synapses[1].from_uuid, "hidden-layer1-node0");
 }
 
 // ============================================================================
-// Recording pipeline: numeric neuron IDs through record + read
+// Recording pipeline: UUID neuron IDs through record + read
 // ============================================================================
 
-/// Recording and reading back discovery data with purely numeric neuron IDs
-/// must produce correct, retrievable records. This exercises the full pipeline:
-/// JSON → `RecordDiscoveryInput` → Parquet write → Parquet read.
+/// Recording and reading back discovery data with UUID neuron IDs must
+/// produce correct, retrievable records.
 #[test]
-fn record_and_read_with_numeric_neuron_ids() {
+fn record_and_read_with_uuid_neuron_ids() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let hidden_uuid = "a1b2c3d4-e5f6-4789-abcd-ef0123456789";
+    let output_uuid = "b2c3d4e5-f6a7-4890-bcde-f01234567890";
 
     let input_json = serde_json::json!({
         "creature": {
             "neurons": [
-                {"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
-                {"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
-                {"uuid": "2", "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
-                {"uuid": "3", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+                {"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+                {"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+                {"uuid": hidden_uuid, "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
+                {"uuid": output_uuid, "type": "output", "squash": "LOGISTIC", "bias": 0.0}
             ],
             "synapses": [
-                {"fromUUID": "0", "toUUID": "2", "weight": 0.5},
-                {"fromUUID": "1", "toUUID": "2", "weight": -0.3},
-                {"fromUUID": "2", "toUUID": "3", "weight": 0.8}
+                {"fromUUID": "input-0", "toUUID": hidden_uuid, "weight": 0.5},
+                {"fromUUID": "input-1", "toUUID": hidden_uuid, "weight": -0.3},
+                {"fromUUID": hidden_uuid, "toUUID": output_uuid, "weight": 0.8}
             ],
             "input": 2,
             "output": 1
@@ -149,16 +151,16 @@ fn record_and_read_with_numeric_neuron_ids() {
                 "input": [0.5, 0.3],
                 "output": [0.7],
                 "neuron_data": [
-                    {"neuron_uuid": "2", "activation": 0.6, "errors": [0.01]},
-                    {"neuron_uuid": "3", "activation": 0.7, "errors": [-0.05]}
+                    {"neuron_uuid": hidden_uuid, "activation": 0.6, "errors": [0.01]},
+                    {"neuron_uuid": output_uuid, "activation": 0.7, "errors": [-0.05]}
                 ]
             },
             {
                 "input": [0.1, 0.9],
                 "output": [0.4],
                 "neuron_data": [
-                    {"neuron_uuid": "2", "activation": 0.45, "errors": [0.02]},
-                    {"neuron_uuid": "3", "activation": 0.38, "errors": [0.03]}
+                    {"neuron_uuid": hidden_uuid, "activation": 0.45, "errors": [0.02]},
+                    {"neuron_uuid": output_uuid, "activation": 0.38, "errors": [0.03]}
                 ]
             }
         ],
@@ -174,54 +176,58 @@ fn record_and_read_with_numeric_neuron_ids() {
     let parquet_path = std::path::Path::new(&result.temp_dir).join(&result.file);
     let parquet_str = parquet_path.to_str().unwrap();
 
-    // Read records for numeric neuron ID "2"
-    let records_2 = neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, "2")
-        .expect("reading records for neuron '2' must succeed");
+    // Read records for hidden neuron UUID
+    let records_hidden =
+        neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, hidden_uuid)
+            .expect("reading records for hidden neuron must succeed");
     assert_eq!(
-        records_2.len(),
+        records_hidden.len(),
         2,
-        "neuron '2' should have 2 records (one per training sample)"
+        "hidden neuron should have 2 records (one per training sample)"
     );
-    for r in &records_2 {
-        assert_eq!(r.neuron_uuid, "2");
+    for r in &records_hidden {
+        assert_eq!(r.neuron_uuid, hidden_uuid);
     }
 
-    // Read records for numeric neuron ID "3"
-    let records_3 = neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, "3")
-        .expect("reading records for neuron '3' must succeed");
-    assert_eq!(records_3.len(), 2);
-    for r in &records_3 {
-        assert_eq!(r.neuron_uuid, "3");
+    // Read records for output neuron UUID
+    let records_output =
+        neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, output_uuid)
+            .expect("reading records for output neuron must succeed");
+    assert_eq!(records_output.len(), 2);
+    for r in &records_output {
+        assert_eq!(r.neuron_uuid, output_uuid);
     }
 
-    // Querying a non-existent numeric ID must return empty, not an error
-    let records_99 =
-        neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, "99")
-            .expect("querying non-existent neuron must not error");
-    assert!(records_99.is_empty());
+    // Querying a non-existent UUID must return empty, not an error
+    let records_missing = neat_ai_discovery::parquet_format::read_records_from_parquet(
+        parquet_str,
+        "non-existent-uuid",
+    )
+    .expect("querying non-existent neuron must not error");
+    assert!(records_missing.is_empty());
 }
 
-/// Recording with mixed UUID formats (RFC 4122 + numeric) must correctly
-/// associate each record with its neuron. This is the realistic scenario
-/// after `normaliseCreatureExport`.
+/// Recording with descriptive string IDs must correctly associate each
+/// record with its neuron.
 #[test]
-fn record_and_read_with_mixed_id_formats() {
+fn record_and_read_with_descriptive_id_formats() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let temp_path = temp_dir.path().to_str().unwrap().to_string();
 
     let rfc_uuid = "a1b2c3d4-e5f6-4789-abcd-ef0123456789";
+    let descriptive_id = "output-main";
 
     let input_json = serde_json::json!({
         "creature": {
             "neurons": [
-                {"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
-                {"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+                {"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+                {"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
                 {"uuid": rfc_uuid, "type": "hidden", "squash": "RELU", "bias": 0.0},
-                {"uuid": "42", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+                {"uuid": descriptive_id, "type": "output", "squash": "LOGISTIC", "bias": 0.0}
             ],
             "synapses": [
-                {"fromUUID": "0", "toUUID": rfc_uuid, "weight": 1.0},
-                {"fromUUID": rfc_uuid, "toUUID": "42", "weight": 0.5}
+                {"fromUUID": "input-0", "toUUID": rfc_uuid, "weight": 1.0},
+                {"fromUUID": rfc_uuid, "toUUID": descriptive_id, "weight": 0.5}
             ],
             "input": 2,
             "output": 1
@@ -232,7 +238,7 @@ fn record_and_read_with_mixed_id_formats() {
                 "output": [0.7],
                 "neuron_data": [
                     {"neuron_uuid": rfc_uuid, "activation": 0.6, "errors": [0.01]},
-                    {"neuron_uuid": "42", "activation": 0.7, "errors": [-0.05]}
+                    {"neuron_uuid": descriptive_id, "activation": 0.7, "errors": [-0.05]}
                 ]
             }
         ],
@@ -240,7 +246,7 @@ fn record_and_read_with_mixed_id_formats() {
     });
 
     let input: RecordDiscoveryInput =
-        serde_json::from_value(input_json).expect("mixed-format input must deserialise");
+        serde_json::from_value(input_json).expect("descriptive-format input must deserialise");
 
     let result =
         neat_ai_discovery::record::record_discovery_data(&input).expect("recording must succeed");
@@ -255,12 +261,12 @@ fn record_and_read_with_mixed_id_formats() {
     assert_eq!(records_rfc.len(), 1);
     assert_eq!(records_rfc[0].neuron_uuid, rfc_uuid);
 
-    // Read by numeric ID
-    let records_42 =
-        neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, "42")
-            .expect("reading by numeric ID must succeed");
-    assert_eq!(records_42.len(), 1);
-    assert_eq!(records_42[0].neuron_uuid, "42");
+    // Read by descriptive ID
+    let records_desc =
+        neat_ai_discovery::parquet_format::read_records_from_parquet(parquet_str, descriptive_id)
+            .expect("reading by descriptive ID must succeed");
+    assert_eq!(records_desc.len(), 1);
+    assert_eq!(records_desc[0].neuron_uuid, descriptive_id);
 
     // Grouped read must separate by exact string identity
     let grouped =
@@ -271,92 +277,102 @@ fn record_and_read_with_mixed_id_formats() {
         "grouped records must contain RFC UUID key"
     );
     assert!(
-        grouped.contains_key("42"),
-        "grouped records must contain numeric key '42'"
+        grouped.contains_key(descriptive_id),
+        "grouped records must contain descriptive key"
     );
 }
 
 // ============================================================================
-// Neuron interning: numeric string IDs
+// Neuron interning: diverse string IDs
 // ============================================================================
 
-/// `NeuronIndex` must correctly intern stringified-integer neuron IDs.
-/// These are NOT parsed to integers — they are opaque strings.
+/// `NeuronIndex` must correctly intern UUID-format neuron IDs.
 #[test]
-fn intern_numeric_neuron_ids() {
+fn intern_uuid_neuron_ids() {
     use neat_ai_discovery::intern::NeuronIndex;
 
     let mut index = NeuronIndex::new();
 
-    // Intern purely numeric IDs
-    let idx_0 = index.intern("0");
-    let idx_1 = index.intern("1");
-    let idx_42 = index.intern("42");
-    let idx_999 = index.intern("999999");
+    // Intern UUID-format IDs
+    let idx_input = index.intern("input-0");
+    let idx_hidden = index.intern("a1b2c3d4-e5f6-4789-abcd-ef0123456789");
+    let idx_output = index.intern("output-main");
+    let idx_descriptive = index.intern("hidden-layer1-node0");
 
     // Must assign distinct indices
-    assert_ne!(idx_0, idx_1);
-    assert_ne!(idx_1, idx_42);
-    assert_ne!(idx_42, idx_999);
+    assert_ne!(idx_input, idx_hidden);
+    assert_ne!(idx_hidden, idx_output);
+    assert_ne!(idx_output, idx_descriptive);
 
     // Round-trip must preserve exact string
-    assert_eq!(index.get_uuid(idx_0), Some("0"));
-    assert_eq!(index.get_uuid(idx_42), Some("42"));
-    assert_eq!(index.get_uuid(idx_999), Some("999999"));
+    assert_eq!(index.get_uuid(idx_input), Some("input-0"));
+    assert_eq!(
+        index.get_uuid(idx_hidden),
+        Some("a1b2c3d4-e5f6-4789-abcd-ef0123456789")
+    );
+    assert_eq!(index.get_uuid(idx_output), Some("output-main"));
 
     // Re-interning same string must return same index
-    assert_eq!(index.intern("42"), idx_42);
+    assert_eq!(
+        index.intern("a1b2c3d4-e5f6-4789-abcd-ef0123456789"),
+        idx_hidden
+    );
 }
 
-/// `NeuronIndex` must treat "42" (numeric) and RFC UUIDs as distinct entries.
-/// No implicit format conversion should occur.
+/// `NeuronIndex` must treat different UUID formats as distinct entries.
 #[test]
-fn intern_mixed_format_ids_are_distinct() {
+fn intern_different_uuid_formats_are_distinct() {
     use neat_ai_discovery::intern::NeuronIndex;
 
     let mut index = NeuronIndex::new();
 
-    let idx_numeric = index.intern("42");
     let idx_rfc = index.intern("550e8400-e29b-41d4-a716-446655440000");
-    let idx_prefixed = index.intern("hidden-42");
+    let idx_descriptive = index.intern("hidden-42");
+    let idx_input = index.intern("input-42");
 
     // All three must be distinct
-    assert_ne!(idx_numeric, idx_rfc);
-    assert_ne!(idx_numeric, idx_prefixed);
-    assert_ne!(idx_rfc, idx_prefixed);
+    assert_ne!(idx_rfc, idx_descriptive);
+    assert_ne!(idx_rfc, idx_input);
+    assert_ne!(idx_descriptive, idx_input);
 
     // Each round-trips correctly
-    assert_eq!(index.get_uuid(idx_numeric), Some("42"));
     assert_eq!(
         index.get_uuid(idx_rfc),
         Some("550e8400-e29b-41d4-a716-446655440000")
     );
-    assert_eq!(index.get_uuid(idx_prefixed), Some("hidden-42"));
+    assert_eq!(index.get_uuid(idx_descriptive), Some("hidden-42"));
+    assert_eq!(index.get_uuid(idx_input), Some("input-42"));
 }
 
 // ============================================================================
-// DiscoverRecord: numeric neuron IDs
+// DiscoverRecord: UUID neuron IDs
 // ============================================================================
 
-/// `DiscoverRecord` must accept numeric string neuron UUIDs.
-/// This is the core data type that flows through the pipeline.
+/// `DiscoverRecord` must accept UUID-format neuron identifiers.
 #[test]
-fn discover_record_with_numeric_neuron_id() {
+fn discover_record_with_uuid_neuron_id() {
     use neat_ai_discovery::types::DiscoverRecord;
 
-    let record = DiscoverRecord::new(0, "42".to_string(), Some(0.5), 0.6, vec![0.01]);
+    let record = DiscoverRecord::new(
+        0,
+        "a1b2c3d4-e5f6-4789-abcd-ef0123456789".to_string(),
+        Some(0.5),
+        0.6,
+        vec![0.01],
+    );
 
-    assert_eq!(record.neuron_uuid, "42");
+    assert_eq!(record.neuron_uuid, "a1b2c3d4-e5f6-4789-abcd-ef0123456789");
     assert_eq!(record.obs_index, 0);
 }
 
-/// `DiscoverRecord` must preserve both numeric and RFC UUID strings
+/// `DiscoverRecord` must preserve both RFC UUID and descriptive strings
 /// without any normalisation or conversion.
 #[test]
 fn discover_record_preserves_id_format() {
     use neat_ai_discovery::types::DiscoverRecord;
 
-    let numeric = DiscoverRecord::new(0, "7".to_string(), Some(0.5), 0.6, vec![0.01]);
+    let descriptive =
+        DiscoverRecord::new(0, "hidden-node-7".to_string(), Some(0.5), 0.6, vec![0.01]);
     let rfc = DiscoverRecord::new(
         1,
         "a1b2c3d4-e5f6-4789-abcd-ef0123456789".to_string(),
@@ -366,21 +382,21 @@ fn discover_record_preserves_id_format() {
     );
 
     // Each format is preserved as-is
-    assert_eq!(numeric.neuron_uuid, "7");
+    assert_eq!(descriptive.neuron_uuid, "hidden-node-7");
     assert_eq!(rfc.neuron_uuid, "a1b2c3d4-e5f6-4789-abcd-ef0123456789");
 
     // They are distinct identities
-    assert_ne!(numeric.neuron_uuid, rfc.neuron_uuid);
+    assert_ne!(descriptive.neuron_uuid, rfc.neuron_uuid);
 }
 
 // ============================================================================
-// FFI entry point: record_discovery_internal with numeric IDs
+// FFI entry point: record_discovery_internal with UUID IDs
 // ============================================================================
 
-/// The FFI `record_discovery_internal` entry point must accept numeric neuron
-/// IDs and return `success: true`. This tests the full JSON-in → JSON-out path.
+/// The FFI `record_discovery_internal` entry point must accept UUID neuron
+/// IDs and return `success: true`.
 #[test]
-fn ffi_record_discovery_with_numeric_ids() {
+fn ffi_record_discovery_with_uuid_ids() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let temp_path = temp_dir.path().to_str().unwrap();
 
@@ -388,15 +404,15 @@ fn ffi_record_discovery_with_numeric_ids() {
         r#"{{
             "creature": {{
                 "neurons": [
-                    {{"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
-                    {{"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
-                    {{"uuid": "5", "type": "hidden", "squash": "LOGISTIC", "bias": 0.0}},
-                    {{"uuid": "10", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
+                    {{"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "hidden-a1b2c3", "type": "hidden", "squash": "LOGISTIC", "bias": 0.0}},
+                    {{"uuid": "output-d4e5f6", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
                 ],
                 "synapses": [
-                    {{"fromUUID": "0", "toUUID": "5", "weight": 0.5}},
-                    {{"fromUUID": "1", "toUUID": "5", "weight": -0.3}},
-                    {{"fromUUID": "5", "toUUID": "10", "weight": 0.8}}
+                    {{"fromUUID": "input-0", "toUUID": "hidden-a1b2c3", "weight": 0.5}},
+                    {{"fromUUID": "input-1", "toUUID": "hidden-a1b2c3", "weight": -0.3}},
+                    {{"fromUUID": "hidden-a1b2c3", "toUUID": "output-d4e5f6", "weight": 0.8}}
                 ],
                 "input": 2,
                 "output": 1
@@ -406,8 +422,8 @@ fn ffi_record_discovery_with_numeric_ids() {
                     "input": [0.5, 0.3],
                     "output": [0.7],
                     "neuron_data": [
-                        {{"neuron_uuid": "5", "activation": 0.6, "errors": [0.01]}},
-                        {{"neuron_uuid": "10", "activation": 0.7, "errors": [-0.05]}}
+                        {{"neuron_uuid": "hidden-a1b2c3", "activation": 0.6, "errors": [0.01]}},
+                        {{"neuron_uuid": "output-d4e5f6", "activation": 0.7, "errors": [-0.05]}}
                     ]
                 }}
             ],
@@ -422,29 +438,29 @@ fn ffi_record_discovery_with_numeric_ids() {
         serde_json::from_str(&result).expect("response must be valid JSON");
     assert_eq!(
         parsed["success"], true,
-        "recording with numeric IDs must succeed: {result}"
+        "recording with UUID IDs must succeed: {result}"
     );
 }
 
-/// The FFI `read_discovery_records_internal` entry point must accept a numeric
+/// The FFI `read_discovery_records_internal` entry point must accept a UUID
 /// `neuron_uuid` for querying.
 #[test]
-fn ffi_read_discovery_with_numeric_neuron_id() {
+fn ffi_read_discovery_with_uuid_neuron_id() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
     let temp_path = temp_dir.path().to_str().unwrap();
 
-    // First, record some data with numeric IDs
+    // First, record some data with UUID IDs
     let record_json = format!(
         r#"{{
             "creature": {{
                 "neurons": [
-                    {{"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
-                    {{"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
-                    {{"uuid": "77", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
+                    {{"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "output-abc123", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
                 ],
                 "synapses": [
-                    {{"fromUUID": "0", "toUUID": "77", "weight": 0.5}},
-                    {{"fromUUID": "1", "toUUID": "77", "weight": -0.3}}
+                    {{"fromUUID": "input-0", "toUUID": "output-abc123", "weight": 0.5}},
+                    {{"fromUUID": "input-1", "toUUID": "output-abc123", "weight": -0.3}}
                 ],
                 "input": 2,
                 "output": 1
@@ -454,7 +470,7 @@ fn ffi_read_discovery_with_numeric_neuron_id() {
                     "input": [0.5, 0.3],
                     "output": [0.7],
                     "neuron_data": [
-                        {{"neuron_uuid": "77", "activation": 0.65, "errors": [0.02]}}
+                        {{"neuron_uuid": "output-abc123", "activation": 0.65, "errors": [0.02]}}
                     ]
                 }}
             ],
@@ -467,11 +483,11 @@ fn ffi_read_discovery_with_numeric_neuron_id() {
     let record_parsed: serde_json::Value = serde_json::from_str(&record_result).unwrap();
     assert_eq!(record_parsed["success"], true, "recording must succeed");
 
-    // Now read using numeric neuron ID
+    // Now read using UUID neuron ID
     let parquet_file = format!("{temp_path}/discovery_data.parquet");
     let read_json = serde_json::json!({
         "parquet_file": parquet_file,
-        "neuron_uuid": "77"
+        "neuron_uuid": "output-abc123"
     });
 
     let read_result =
@@ -481,6 +497,6 @@ fn ffi_read_discovery_with_numeric_neuron_id() {
     let read_parsed: serde_json::Value = serde_json::from_str(&read_result).unwrap();
     assert_eq!(
         read_parsed["success"], true,
-        "reading with numeric neuron ID must succeed: {read_result}"
+        "reading with UUID neuron ID must succeed: {read_result}"
     );
 }

--- a/tests/ffi/issue_952_uuid_only_ffi_contract.rs
+++ b/tests/ffi/issue_952_uuid_only_ffi_contract.rs
@@ -1,0 +1,330 @@
+//! Issue #952 — Enforce UUID-only FFI discovery contract.
+//!
+//! The FFI contract requires stable UUID strings for all neuron/synapse
+//! identity fields. Runtime integer IDs (e.g. `"0"`, `"42"`) must be
+//! rejected at the FFI boundary to prevent NaN/dangling-reference
+//! regressions and brittle cache compatibility.
+//!
+//! These tests verify:
+//! 1. Numeric-only neuron IDs are rejected at deserialisation.
+//! 2. Valid UUID formats (RFC 4122, `input-N`, descriptive strings) are accepted.
+//! 3. Discovery responses include a `schemaVersion` field.
+//! 4. Coordinated structural operations use UUID-based references.
+
+use neat_ai_discovery::{CreatureJson, NeuronData};
+
+// ============================================================================
+// Validation: reject purely numeric neuron IDs
+// ============================================================================
+
+/// Creature JSON with purely numeric neuron UUIDs must be rejected.
+/// Numeric IDs are internal-only and must never cross the FFI boundary.
+#[test]
+fn reject_creature_with_numeric_neuron_ids() {
+    let json = r#"{
+        "neurons": [
+            {"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+            {"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0},
+            {"uuid": "2", "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
+            {"uuid": "3", "type": "output", "squash": "LOGISTIC", "bias": -0.2}
+        ],
+        "synapses": [
+            {"fromUUID": "0", "toUUID": "2", "weight": 0.5}
+        ],
+        "input": 2,
+        "output": 1
+    }"#;
+
+    let result = serde_json::from_str::<CreatureJson>(json);
+    assert!(
+        result.is_err(),
+        "purely numeric neuron UUIDs must be rejected at deserialisation"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("numeric") || err_msg.contains("integer"),
+        "error message should mention numeric/integer IDs: {err_msg}"
+    );
+}
+
+/// Synapse JSON with numeric fromUUID/toUUID must be rejected.
+#[test]
+fn reject_synapse_with_numeric_from_uuid() {
+    let json = r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "550e8400-e29b-41d4-a716-446655440000", "type": "output", "squash": "LOGISTIC"}
+        ],
+        "synapses": [
+            {"fromUUID": "42", "toUUID": "550e8400-e29b-41d4-a716-446655440000", "weight": 0.5}
+        ],
+        "input": 2,
+        "output": 1
+    }"#;
+
+    let result = serde_json::from_str::<CreatureJson>(json);
+    assert!(result.is_err(), "numeric synapse fromUUID must be rejected");
+}
+
+/// `NeuronData` with numeric `neuron_uuid` must be rejected.
+#[test]
+fn reject_neuron_data_with_numeric_id() {
+    let json = r#"{"neuron_uuid": "7", "activation": 0.85, "errors": [0.01, -0.02]}"#;
+
+    let result = serde_json::from_str::<NeuronData>(json);
+    assert!(
+        result.is_err(),
+        "numeric neuron_uuid in NeuronData must be rejected"
+    );
+}
+
+/// Large numeric IDs must also be rejected.
+#[test]
+fn reject_large_numeric_neuron_ids() {
+    let json = r#"{
+        "neurons": [
+            {"uuid": "100000", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "100001", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "999999", "type": "hidden", "squash": "TANH", "bias": 0.0},
+            {"uuid": "1000000", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "100000", "toUUID": "999999", "weight": 1.0}
+        ],
+        "input": 2,
+        "output": 1
+    }"#;
+
+    let result = serde_json::from_str::<CreatureJson>(json);
+    assert!(
+        result.is_err(),
+        "large numeric neuron UUIDs must be rejected"
+    );
+}
+
+// ============================================================================
+// Validation: accept valid UUID formats
+// ============================================================================
+
+/// RFC 4122 UUIDs must be accepted.
+#[test]
+fn accept_rfc4122_uuids() {
+    let json = r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "550e8400-e29b-41d4-a716-446655440000", "type": "hidden", "squash": "RELU", "bias": 0.1},
+            {"uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "550e8400-e29b-41d4-a716-446655440000", "weight": 0.5},
+            {"fromUUID": "550e8400-e29b-41d4-a716-446655440000", "toUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "weight": 0.8}
+        ],
+        "input": 2,
+        "output": 1
+    }"#;
+
+    let creature: CreatureJson =
+        serde_json::from_str(json).expect("RFC 4122 UUIDs must be accepted");
+
+    assert_eq!(creature.neurons.len(), 4);
+    assert_eq!(
+        creature.neurons[2].uuid,
+        "550e8400-e29b-41d4-a716-446655440000"
+    );
+}
+
+/// `input-N` format neuron UUIDs must be accepted (used for input neurons).
+#[test]
+fn accept_input_neuron_format() {
+    let json = r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "hidden-abc123", "type": "hidden", "squash": "LOGISTIC", "bias": 0.1},
+            {"uuid": "output-def456", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "hidden-abc123", "weight": 0.5},
+            {"fromUUID": "hidden-abc123", "toUUID": "output-def456", "weight": 0.8}
+        ],
+        "input": 2,
+        "output": 1
+    }"#;
+
+    let creature: CreatureJson =
+        serde_json::from_str(json).expect("input-N format UUIDs must be accepted");
+
+    assert_eq!(creature.neurons[0].uuid, "input-0");
+    assert_eq!(creature.neurons[1].uuid, "input-1");
+}
+
+/// `NeuronData` with RFC UUID must be accepted.
+#[test]
+fn accept_neuron_data_with_uuid() {
+    let json = r#"{"neuron_uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "activation": 0.85, "errors": [0.01]}"#;
+
+    let data: NeuronData =
+        serde_json::from_str(json).expect("RFC UUID in NeuronData must be accepted");
+    assert_eq!(data.neuron_uuid, "a1b2c3d4-e5f6-4789-abcd-ef0123456789");
+}
+
+// ============================================================================
+// FFI record_discovery: numeric IDs rejected
+// ============================================================================
+
+/// The FFI `record_discovery_internal` must reject numeric neuron IDs
+/// and return a structured error response.
+#[test]
+fn ffi_record_discovery_rejects_numeric_ids() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_path = temp_dir.path().to_str().unwrap();
+
+    let input_json = format!(
+        r#"{{
+            "creature": {{
+                "neurons": [
+                    {{"uuid": "0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "5", "type": "hidden", "squash": "LOGISTIC", "bias": 0.0}},
+                    {{"uuid": "10", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
+                ],
+                "synapses": [
+                    {{"fromUUID": "0", "toUUID": "5", "weight": 0.5}},
+                    {{"fromUUID": "5", "toUUID": "10", "weight": 0.8}}
+                ],
+                "input": 2,
+                "output": 1
+            }},
+            "training_data": [
+                {{
+                    "input": [0.5, 0.3],
+                    "output": [0.7],
+                    "neuron_data": [
+                        {{"neuron_uuid": "5", "activation": 0.6, "errors": [0.01]}},
+                        {{"neuron_uuid": "10", "activation": 0.7, "errors": [-0.05]}}
+                    ]
+                }}
+            ],
+            "temp_dir": "{temp_path}"
+        }}"#
+    );
+
+    let result = neat_ai_discovery::record_discovery_internal(&input_json)
+        .expect("internal call must not panic");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result).expect("response must be valid JSON");
+    assert_eq!(
+        parsed["success"], false,
+        "recording with numeric IDs must fail: {result}"
+    );
+}
+
+// ============================================================================
+// Schema version in responses
+// ============================================================================
+
+/// Discovery responses must include a `schemaVersion` field.
+#[test]
+fn record_discovery_response_includes_schema_version() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_path = temp_dir.path().to_str().unwrap();
+
+    let input_json = format!(
+        r#"{{
+            "creature": {{
+                "neurons": [
+                    {{"uuid": "input-0", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "input-1", "type": "input", "squash": "IDENTITY", "bias": 0.0}},
+                    {{"uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "type": "output", "squash": "LOGISTIC", "bias": 0.0}}
+                ],
+                "synapses": [
+                    {{"fromUUID": "input-0", "toUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "weight": 0.5}},
+                    {{"fromUUID": "input-1", "toUUID": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "weight": -0.3}}
+                ],
+                "input": 2,
+                "output": 1
+            }},
+            "training_data": [
+                {{
+                    "input": [0.5, 0.3],
+                    "output": [0.7],
+                    "neuron_data": [
+                        {{"neuron_uuid": "a1b2c3d4-e5f6-4789-abcd-ef0123456789", "activation": 0.7, "errors": [-0.05]}}
+                    ]
+                }}
+            ],
+            "temp_dir": "{temp_path}"
+        }}"#
+    );
+
+    let result = neat_ai_discovery::record_discovery_internal(&input_json)
+        .expect("internal call must not panic");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result).expect("response must be valid JSON");
+    assert_eq!(parsed["success"], true, "recording must succeed: {result}");
+    assert!(
+        parsed.get("schemaVersion").is_some(),
+        "response must include schemaVersion field: {result}"
+    );
+    assert!(
+        parsed["schemaVersion"].is_string(),
+        "schemaVersion must be a string"
+    );
+}
+
+/// Version response must include schemaVersion.
+#[test]
+fn get_version_response_includes_schema_version() {
+    let result =
+        neat_ai_discovery::get_library_version_internal().expect("version call must not panic");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&result).expect("response must be valid JSON");
+    assert!(
+        parsed.get("schemaVersion").is_some(),
+        "version response must include schemaVersion: {result}"
+    );
+}
+
+// ============================================================================
+// Coordinated structural operations use UUID references
+// ============================================================================
+
+/// Coordinated structural operations must serialise with UUID-based
+/// neuron references (neuronUuid, fromNeuronUuid, toNeuronUuid).
+#[test]
+fn coordinated_op_serialises_uuid_references() {
+    use neat_ai_discovery::CoordinatedStructuralOpJson;
+
+    let op = CoordinatedStructuralOpJson::AddNeuron {
+        neuron_uuid: "a1b2c3d4-e5f6-4789-abcd-ef0123456789".to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias: 0.1,
+        insert_before_neuron_uuid: Some("b2c3d4e5-f6a7-4890-bcde-f01234567890".to_string()),
+    };
+
+    let json = serde_json::to_string(&op).expect("serialisation must succeed");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    // All identity fields must use UUID format
+    assert!(
+        parsed.get("neuronUuid").is_some(),
+        "AddNeuron must have neuronUuid field"
+    );
+    assert!(
+        parsed.get("insertBeforeNeuronUuid").is_some(),
+        "AddNeuron must have insertBeforeNeuronUuid field"
+    );
+
+    // Verify no numeric-only values in identity fields
+    let neuron_uuid = parsed["neuronUuid"].as_str().unwrap();
+    assert!(
+        !neuron_uuid.chars().all(|c| c.is_ascii_digit()),
+        "neuronUuid must not be a purely numeric string"
+    );
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -6,3 +6,4 @@ mod common;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;
+mod issue_952_uuid_only_ffi_contract;

--- a/tests/infrastructure/issue_874_module_split_backward_compat.rs
+++ b/tests/infrastructure/issue_874_module_split_backward_compat.rs
@@ -140,6 +140,7 @@ fn response_types_accessible() {
     // Verify the types can be constructed — proves they are accessible
     let _output = RecordDiscoveryOutput {
         success: true,
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
         temp_dir: None,
         file: None,
         error: None,
@@ -159,6 +160,7 @@ fn response_types_accessible() {
     let _output = GetVersionOutput {
         success: true,
         version: "test".to_string(),
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
         error: None,
         error_kind: None,
         retryable: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,11 +59,11 @@ fn test_record_discovery_integration() {
     let output: serde_json::Value = serde_json::from_str(&result).unwrap();
 
     assert_eq!(output["success"], true);
-    assert!(output["temp_dir"].as_str().is_some());
+    assert!(output["tempDir"].as_str().is_some());
     assert_eq!(output["file"], "discovery_data.parquet");
 
     // Verify Parquet file was created
-    let parquet_file = std::path::Path::new(output["temp_dir"].as_str().unwrap())
+    let parquet_file = std::path::Path::new(output["tempDir"].as_str().unwrap())
         .join(output["file"].as_str().unwrap());
     assert!(parquet_file.exists());
 }


### PR DESCRIPTION
## Summary

Enforce UUID-only FFI discovery contract by rejecting purely numeric integer
neuron/synapse IDs at the FFI boundary. Internal numeric IDs are an optimisation
detail that must never leak into JSON, cache files, or cross-library payloads.
Closes #952.

### Changes

- **UUID validation**: Added `deserialise_neuron_uuid` and `deserialise_synapse_uuid`
  custom deserialisers to `NeuronJson::uuid`, `SynapseJson::from_uuid`/`to_uuid`,
  and `NeuronData::neuron_uuid`. These reject purely numeric strings (e.g. `"0"`,
  `"42"`, `"999999"`) with a `data_validation` error.
- **Schema version**: Added `schemaVersion` field to `RecordDiscoveryOutput`,
  `AnalyzeParallelOutput`, `RankFocusNeuronsOutput`, and `GetVersionOutput`.
  Current schema version is `"2"`. Callers can use this to reject stale cached
  payloads.
- **Wire format**: `RecordDiscoveryOutput` now uses `camelCase` field names
  (`tempDir`, `schemaVersion`, `errorKind`) consistent with other response types.
- **Documentation**: Updated `FFI_API.md` with the neuron identity contract and
  schema version field.
- **Dead code removal**: Removed comments and documentation referencing numeric ID
  acceptance (Issue #950 compatibility).

## Evidence

All 158 tests pass including:
- `tests/ffi/issue_952_uuid_only_ffi_contract.rs` — 11 new tests verifying UUID
  enforcement, numeric ID rejection, and schema version presence
- `tests/ffi/issue_950_numeric_neuron_ids.rs` — Rewritten to test UUID-format IDs
  through the full pipeline (deserialisation, recording, reading, interning)
- Updated existing tests in `tests/integration.rs`,
  `tests/analysis/issue_337_candidate_type_contract.rs`, and
  `tests/infrastructure/issue_874_module_split_backward_compat.rs`

## Test Plan

- `reject_creature_with_numeric_neuron_ids` — Verifies numeric neuron UUIDs are rejected
- `reject_synapse_with_numeric_from_uuid` — Verifies numeric synapse UUIDs are rejected
- `reject_neuron_data_with_numeric_id` — Verifies numeric `NeuronData` UUIDs are rejected
- `reject_large_numeric_neuron_ids` — Verifies large numeric strings are rejected
- `accept_rfc4122_uuids` — Verifies RFC 4122 UUIDs are accepted
- `accept_input_neuron_format` — Verifies `input-N` format is accepted
- `accept_neuron_data_with_uuid` — Verifies UUID `NeuronData` is accepted
- `ffi_record_discovery_rejects_numeric_ids` — Full FFI pipeline rejection test
- `record_discovery_response_includes_schema_version` — Schema version in responses
- `get_version_response_includes_schema_version` — Schema version in version output
- `coordinated_op_serialises_uuid_references` — Coordinated ops use UUID references

---

## Automated Fix Details
This PR addresses issue #952: **Enforce UUID-only FFI discovery contract**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #952
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-952 -->