### PR TITLE
feat: cross-detection candidate synthesis for co-flagged neurons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.3"
+version = "0.72.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-963.md
+++ b/docs/pr-summary-963.md
@@ -1,0 +1,58 @@
+## Summary
+
+Add cross-detection candidate synthesis for co-flagged neurons. When multiple
+detection modules independently flag the same neuron (e.g., saturation +
+restricted range + high error), the system now synthesises combined remediation
+candidates that address multiple issues simultaneously, rather than only
+generating independent single-issue candidates. Closes #963.
+
+### What changed
+
+- **New module** `src/analysis/detection/cross_detection_synthesis.rs`:
+  - Groups single-operation detection candidates by target neuron UUID
+  - When 2+ modules flag the same neuron with compatible operations, synthesises
+    a combined `CoordinatedStructuralCandidateJson` containing all operations
+  - Compatibility rules: modifications (ChangeSquash, SetBias, SetWeight) merge
+    with each other; removals (RemoveNeuron, RemoveSynapse) merge with each
+    other; removals do NOT merge with modifications
+  - Individual candidates are always preserved (synthesis is additive)
+  - Synthesised candidates are tagged with `cross-detection synthesis` in their
+    comment for success rate tracking via `ModuleOutcomeTracker`
+
+- **Orchestration integration** (`src/analysis/orchestration.rs`):
+  - Synthesis runs after discovery module dispatch and before cross-module
+    deduplication and ensemble scoring
+
+- **Pipeline wrapper** (`src/analysis/module_dispatch_specs/mod.rs`):
+  - Added `synthesise_cross_detection_candidates()` wrapper with watchdog beats,
+    phase timing, and verbose logging
+
+## Evidence
+
+All 21 tests pass (15 integration + 6 unit). `quality.sh` passes cleanly.
+
+## Test Plan
+
+- **Integration tests** (`tests/analysis/issue_963_cross_detection_candidate_synthesis.rs`):
+  - `test_group_candidates_by_neuron_groups_correctly` — verifies grouping by UUID
+  - `test_group_candidates_empty_input` — empty input passthrough
+  - `test_group_candidates_multi_op_candidates_excluded` — multi-op excluded from grouping
+  - `test_synthesise_produces_combined_candidate_for_coflagged_neuron` — co-flagged synthesis
+  - `test_synthesise_preserves_individual_candidates` — synthesis is additive
+  - `test_single_detection_neuron_produces_no_synthesis` — no false positives
+  - `test_empty_input_passthrough` — empty input
+  - `test_merge_change_squash_and_set_bias` — ChangeSquash + SetBias compatibility
+  - `test_merge_change_squash_and_set_weight` — ChangeSquash + SetWeight compatibility
+  - `test_merge_remove_neuron_and_remove_synapse` — removal compatibility
+  - `test_incompatible_remove_and_modify_not_merged` — incompatible ops rejected
+  - `test_synthesised_candidate_gain_uses_best_individual` — gain scoring
+  - `test_synthesised_candidate_comment_identifies_source_modules` — attribution
+  - `test_synthesis_result_counts` — result structure validation
+  - `test_three_way_coflagging_produces_synthesis` — 3+ module co-flagging
+- **Unit tests** (`src/analysis/detection/cross_detection_synthesis.rs`):
+  - `primary_neuron_uuid_for_change_squash` — UUID extraction
+  - `primary_neuron_uuid_for_set_weight_uses_target` — target UUID for synapse ops
+  - `primary_neuron_uuid_none_for_multi_op` — multi-op exclusion
+  - `compatible_modifications` — modification compatibility check
+  - `compatible_removals` — removal compatibility check
+  - `incompatible_removal_with_modification` — incompatibility check

--- a/src/analysis/detection/cross_detection_synthesis.rs
+++ b/src/analysis/detection/cross_detection_synthesis.rs
@@ -1,0 +1,301 @@
+//! Cross-detection candidate synthesis for co-flagged neurons (Issue #963).
+//!
+//! When multiple detection modules independently flag the same neuron,
+//! this module synthesises combined remediation candidates that address
+//! multiple issues simultaneously rather than generating independent
+//! single-issue candidates.
+//!
+//! ## Synthesis Rules
+//!
+//! Compatible operation combinations that produce synthesised candidates:
+//! - `ChangeSquash` + `SetBias` → single coordinated candidate (e.g., saturation + restricted range)
+//! - `ChangeSquash` + `SetWeight` → single coordinated candidate (e.g., saturation + weight magnitude)
+//! - `RemoveNeuron` + `RemoveSynapse` → single coordinated candidate (e.g., dead neuron + dormant synapse)
+//! - `SetBias` + `SetWeight` → single coordinated candidate (e.g., bias perturbation + weight issue)
+//!
+//! Incompatible combinations (not synthesised):
+//! - `RemoveNeuron` + any modification (`ChangeSquash`, `SetBias`, `SetWeight`)
+//!   — cannot modify a neuron that is being removed
+//!
+//! ## Integration
+//!
+//! Called from `orchestration::analyze_all` after discovery modules run and before
+//! ensemble scoring. Synthesised candidates are added alongside (not replacing)
+//! the individual candidates from each module.
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
+
+use std::collections::HashMap;
+
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Result of cross-detection candidate synthesis.
+pub struct SynthesisResult {
+    /// All candidates: original individuals plus any synthesised combined candidates.
+    pub candidates: Vec<CoordinatedStructuralCandidateJson>,
+    /// Number of synthesised (combined) candidates that were added.
+    pub synthesised_count: usize,
+}
+
+/// Extract the primary neuron UUID targeted by a single-operation candidate.
+///
+/// Returns `None` for multi-operation candidates (which are already coordinated).
+fn primary_neuron_uuid(candidate: &CoordinatedStructuralCandidateJson) -> Option<String> {
+    if candidate.operations.len() != 1 {
+        return None;
+    }
+
+    match &candidate.operations[0] {
+        CoordinatedStructuralOpJson::ChangeSquash { neuron_uuid, .. }
+        | CoordinatedStructuralOpJson::SetBias { neuron_uuid, .. }
+        | CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid }
+        | CoordinatedStructuralOpJson::AddNeuron { neuron_uuid, .. } => Some(neuron_uuid.clone()),
+        CoordinatedStructuralOpJson::SetWeight { to_neuron_uuid, .. } => {
+            Some(to_neuron_uuid.clone())
+        }
+        CoordinatedStructuralOpJson::RemoveSynapse { to_neuron_uuid, .. } => {
+            Some(to_neuron_uuid.clone())
+        }
+        CoordinatedStructuralOpJson::AddSynapse { to_neuron_uuid, .. } => {
+            Some(to_neuron_uuid.clone())
+        }
+    }
+}
+
+/// Group single-operation candidates by their target neuron UUID.
+///
+/// Multi-operation candidates (already coordinated) are excluded from grouping.
+/// Returns a map from neuron UUID to the indices of candidates targeting that neuron.
+pub fn group_candidates_by_neuron(
+    candidates: &[CoordinatedStructuralCandidateJson],
+) -> HashMap<String, Vec<usize>> {
+    let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for (i, candidate) in candidates.iter().enumerate() {
+        if let Some(uuid) = primary_neuron_uuid(candidate) {
+            groups.entry(uuid).or_default().push(i);
+        }
+    }
+
+    groups
+}
+
+/// Classify a single operation as either "removal" or "modification".
+fn is_removal_op(op: &CoordinatedStructuralOpJson) -> bool {
+    matches!(
+        op,
+        CoordinatedStructuralOpJson::RemoveNeuron { .. }
+            | CoordinatedStructuralOpJson::RemoveSynapse { .. }
+    )
+}
+
+/// Check whether a set of operations are compatible for synthesis.
+///
+/// Rules:
+/// - All removals are compatible with each other.
+/// - All modifications are compatible with each other.
+/// - Removals are NOT compatible with modifications (cannot modify a removed neuron).
+fn are_operations_compatible(ops: &[&CoordinatedStructuralOpJson]) -> bool {
+    if ops.len() <= 1 {
+        return true;
+    }
+
+    let has_removal = ops.iter().any(|op| is_removal_op(op));
+    let has_modification = ops.iter().any(|op| !is_removal_op(op));
+
+    // Incompatible: mixing removals with modifications
+    !(has_removal && has_modification)
+}
+
+/// Extract the module name from a candidate's comment for attribution.
+fn extract_module_name(candidate: &CoordinatedStructuralCandidateJson) -> String {
+    candidate.comment.as_ref().map_or_else(
+        || "unknown".to_string(),
+        |c| {
+            c.split(&[':', '|'][..])
+                .next()
+                .unwrap_or("unknown")
+                .trim()
+                .to_string()
+        },
+    )
+}
+
+/// Synthesise cross-detection candidates for co-flagged neurons (Issue #963).
+///
+/// Groups single-operation candidates by their target neuron UUID. When 2+
+/// detection modules flag the same neuron with compatible operations, a
+/// combined `CoordinatedStructuralCandidateJson` is synthesised containing
+/// all operations.
+///
+/// Individual candidates are always preserved — synthesis is additive.
+pub fn synthesise_cross_detection_candidates(
+    candidates: Vec<CoordinatedStructuralCandidateJson>,
+) -> SynthesisResult {
+    if candidates.is_empty() {
+        return SynthesisResult {
+            candidates: Vec::new(),
+            synthesised_count: 0,
+        };
+    }
+
+    let groups = group_candidates_by_neuron(&candidates);
+
+    let mut synthesised: Vec<CoordinatedStructuralCandidateJson> = Vec::new();
+
+    for indices in groups.values() {
+        // Only synthesise when 2+ modules flag the same neuron
+        if indices.len() < 2 {
+            continue;
+        }
+
+        // Collect the single operations from each candidate in this group
+        let ops: Vec<&CoordinatedStructuralOpJson> = indices
+            .iter()
+            .map(|&i| &candidates[i].operations[0])
+            .collect();
+
+        // Check compatibility before merging
+        if !are_operations_compatible(&ops) {
+            continue;
+        }
+
+        // Build the synthesised candidate with all operations combined
+        let combined_ops: Vec<CoordinatedStructuralOpJson> = indices
+            .iter()
+            .map(|&i| candidates[i].operations[0].clone())
+            .collect();
+
+        // Use the best individual gain as the base for the synthesised candidate
+        let best_gain = indices
+            .iter()
+            .map(|&i| candidates[i].expected_creature_score_gain)
+            .fold(f32::NEG_INFINITY, f32::max);
+
+        // Collect module names for attribution
+        let module_names: Vec<String> = indices
+            .iter()
+            .map(|&i| extract_module_name(&candidates[i]))
+            .collect();
+        let modules_str = module_names.join(" + ");
+
+        let comment = format!(
+            "cross-detection synthesis: combined {} modules ({modules_str})",
+            indices.len()
+        );
+
+        synthesised.push(CoordinatedStructuralCandidateJson {
+            operations: combined_ops,
+            expected_creature_score_gain: best_gain,
+            comment: Some(comment),
+        });
+    }
+
+    let synthesised_count = synthesised.len();
+
+    // Preserve all original candidates and append synthesised ones
+    let mut result = candidates;
+    result.extend(synthesised);
+
+    SynthesisResult {
+        candidates: result,
+        synthesised_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primary_neuron_uuid_for_change_squash() {
+        let c = CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: "abc".to_string(),
+                squash: "RELU".to_string(),
+            }],
+            expected_creature_score_gain: 0.01,
+            comment: None,
+        };
+        assert_eq!(primary_neuron_uuid(&c), Some("abc".to_string()));
+    }
+
+    #[test]
+    fn primary_neuron_uuid_for_set_weight_uses_target() {
+        let c = CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::SetWeight {
+                from_neuron_uuid: "source".to_string(),
+                to_neuron_uuid: "target".to_string(),
+                weight: 0.5,
+            }],
+            expected_creature_score_gain: 0.01,
+            comment: None,
+        };
+        assert_eq!(primary_neuron_uuid(&c), Some("target".to_string()));
+    }
+
+    #[test]
+    fn primary_neuron_uuid_none_for_multi_op() {
+        let c = CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::ChangeSquash {
+                    neuron_uuid: "a".to_string(),
+                    squash: "RELU".to_string(),
+                },
+                CoordinatedStructuralOpJson::SetBias {
+                    neuron_uuid: "a".to_string(),
+                    bias: 0.1,
+                },
+            ],
+            expected_creature_score_gain: 0.01,
+            comment: None,
+        };
+        assert_eq!(primary_neuron_uuid(&c), None);
+    }
+
+    #[test]
+    fn compatible_modifications() {
+        let ops = [
+            CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: "a".to_string(),
+                squash: "RELU".to_string(),
+            },
+            CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: "a".to_string(),
+                bias: 0.1,
+            },
+        ];
+        let refs: Vec<&CoordinatedStructuralOpJson> = ops.iter().collect();
+        assert!(are_operations_compatible(&refs));
+    }
+
+    #[test]
+    fn compatible_removals() {
+        let ops = [
+            CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "a".to_string(),
+            },
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "b".to_string(),
+                to_neuron_uuid: "a".to_string(),
+            },
+        ];
+        let refs: Vec<&CoordinatedStructuralOpJson> = ops.iter().collect();
+        assert!(are_operations_compatible(&refs));
+    }
+
+    #[test]
+    fn incompatible_removal_with_modification() {
+        let ops = [
+            CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "a".to_string(),
+            },
+            CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: "a".to_string(),
+                squash: "RELU".to_string(),
+            },
+        ];
+        let refs: Vec<&CoordinatedStructuralOpJson> = ops.iter().collect();
+        assert!(!are_operations_compatible(&refs));
+    }
+}

--- a/src/analysis/detection/mod.rs
+++ b/src/analysis/detection/mod.rs
@@ -13,6 +13,7 @@ pub mod bounded_range;
 pub mod co_adaptation;
 pub mod compound_degradation;
 pub mod correlated_error;
+pub mod cross_detection_synthesis;
 pub mod dead_neuron;
 pub mod dormant_synapse;
 pub mod error_plateau;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -83,6 +83,46 @@ pub(crate) fn dispatch_and_merge_discovery_modules(
     );
 }
 
+/// Synthesise cross-detection candidates for co-flagged neurons (Issue #963).
+///
+/// When multiple detection modules flag the same neuron with compatible operations,
+/// a combined coordinated candidate is synthesised containing all operations.
+/// Individual candidates are always preserved — synthesis is additive.
+pub(crate) fn synthesise_cross_detection_candidates(syn: &mut shared::AnalyzeSynapsesResult) {
+    use crate::observability::PhaseTimer;
+
+    if syn.coordinated_structural_candidates.is_empty() {
+        return;
+    }
+
+    crate::watchdog::beat("analysis::analyze_all → cross-detection synthesis starting");
+    let _timer = PhaseTimer::new("cross_detection_synthesis");
+
+    let before_count = syn.coordinated_structural_candidates.len();
+
+    let result = super::detection::cross_detection_synthesis::synthesise_cross_detection_candidates(
+        std::mem::take(&mut syn.coordinated_structural_candidates),
+    );
+
+    syn.coordinated_structural_candidates = result.candidates;
+
+    if result.synthesised_count > 0 && utils::verbose_enabled() {
+        tracing::debug!(
+            before = before_count,
+            after = syn.coordinated_structural_candidates.len(),
+            synthesised = result.synthesised_count,
+            "Cross-detection synthesis: synthesised combined candidate(s) for co-flagged neuron(s)"
+        );
+    }
+
+    // Update metadata to reflect synthesised candidates.
+    syn.metadata.candidates_returned = syn.helpful_synapses.len()
+        + syn.harmful_synapses.len()
+        + syn.coordinated_structural_candidates.len();
+
+    crate::watchdog::beat("analysis::analyze_all → cross-detection synthesis finished");
+}
+
 /// Perform cross-module deduplication on coordinated structural candidates.
 pub(crate) fn deduplicate_cross_module_candidates(syn: &mut shared::AnalyzeSynapsesResult) {
     use crate::observability::PhaseTimer;

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -353,6 +353,12 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         );
     }
 
+    // Issue #963: Cross-detection candidate synthesis — synthesise combined
+    // candidates when multiple detection modules flag the same neuron.
+    if let Some(syn) = synapse_result.as_mut() {
+        module_dispatch_specs::synthesise_cross_detection_candidates(syn);
+    }
+
     // Issue #489: Cross-module candidate deduplication.
     if let Some(syn) = synapse_result.as_mut() {
         module_dispatch_specs::deduplicate_cross_module_candidates(syn);

--- a/tests/analysis/issue_963_cross_detection_candidate_synthesis.rs
+++ b/tests/analysis/issue_963_cross_detection_candidate_synthesis.rs
@@ -1,0 +1,519 @@
+//! Cross-detection candidate synthesis tests (Issue #963).
+//!
+//! When multiple detection modules independently flag the same neuron,
+//! the system should synthesise combined remediation candidates that
+//! address multiple issues simultaneously.
+//!
+//! ## TDD Test Plan
+//!
+//! 1. Test grouping detection outputs by target neuron UUID
+//! 2. Test that co-flagged neurons (2+ detections) produce synthesised candidates
+//! 3. Test that synthesised candidates use `CoordinatedStructuralCandidate`
+//! 4. Test that individual candidates are preserved (synthesis is additive)
+//! 5. Test success rate tracking distinguishes synthesised from individual
+//! 6. Test compatible operation merging (changeSquash + setBias)
+//! 7. Test compatible operation merging (changeSquash + setWeight)
+//! 8. Test compatible operation merging (removeNeuron + removeSynapse)
+//! 9. Test that incompatible operations are not merged (remove + changeSquash)
+//! 10. Test empty input passthrough
+//! 11. Test single-detection neurons produce no synthesis
+
+use neat_ai_discovery::analysis::detection::cross_detection_synthesis::{
+    group_candidates_by_neuron, synthesise_cross_detection_candidates,
+};
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+/// Helper: create a `ChangeSquash` candidate targeting a neuron.
+fn change_squash_candidate(
+    neuron_uuid: &str,
+    squash: &str,
+    gain: f32,
+    module: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::ChangeSquash {
+            neuron_uuid: neuron_uuid.to_string(),
+            squash: squash.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("{module}: detected issue on {neuron_uuid}")),
+    }
+}
+
+/// Helper: create a `SetBias` candidate targeting a neuron.
+fn set_bias_candidate(
+    neuron_uuid: &str,
+    bias: f32,
+    gain: f32,
+    module: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetBias {
+            neuron_uuid: neuron_uuid.to_string(),
+            bias,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("{module}: detected issue on {neuron_uuid}")),
+    }
+}
+
+/// Helper: create a `SetWeight` candidate targeting a synapse.
+fn set_weight_candidate(
+    from: &str,
+    to: &str,
+    weight: f32,
+    gain: f32,
+    module: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::SetWeight {
+            from_neuron_uuid: from.to_string(),
+            to_neuron_uuid: to.to_string(),
+            weight,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("{module}: detected issue on {to}")),
+    }
+}
+
+/// Helper: create a `RemoveNeuron` candidate.
+fn remove_neuron_candidate(
+    neuron_uuid: &str,
+    gain: f32,
+    module: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+            neuron_uuid: neuron_uuid.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("{module}: detected issue on {neuron_uuid}")),
+    }
+}
+
+/// Helper: create a `RemoveSynapse` candidate.
+fn remove_synapse_candidate(
+    from: &str,
+    to: &str,
+    gain: f32,
+    module: &str,
+) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: from.to_string(),
+            to_neuron_uuid: to.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("{module}: detected issue on {to}")),
+    }
+}
+
+// =========================================================================
+// Test: Group candidates by target neuron UUID
+// =========================================================================
+
+#[test]
+fn test_group_candidates_by_neuron_groups_correctly() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+        change_squash_candidate("neuron-b", "RELU", 0.04, "saturation detection"),
+    ];
+
+    let groups = group_candidates_by_neuron(&candidates);
+
+    // neuron-a should have 2 candidates, neuron-b should have 1
+    assert_eq!(
+        groups.get("neuron-a").map(Vec::len),
+        Some(2),
+        "neuron-a should have 2 candidates grouped"
+    );
+    assert_eq!(
+        groups.get("neuron-b").map(Vec::len),
+        Some(1),
+        "neuron-b should have 1 candidate grouped"
+    );
+}
+
+#[test]
+fn test_group_candidates_empty_input() {
+    let candidates: Vec<CoordinatedStructuralCandidateJson> = vec![];
+    let groups = group_candidates_by_neuron(&candidates);
+    assert!(groups.is_empty(), "empty input should produce empty groups");
+}
+
+#[test]
+fn test_group_candidates_multi_op_candidates_excluded() {
+    // Multi-operation candidates should not be grouped (they are already coordinated)
+    let multi_op = CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::ChangeSquash {
+                neuron_uuid: "neuron-a".to_string(),
+                squash: "IDENTITY".to_string(),
+            },
+            CoordinatedStructuralOpJson::SetBias {
+                neuron_uuid: "neuron-a".to_string(),
+                bias: 0.1,
+            },
+        ],
+        expected_creature_score_gain: 0.05,
+        comment: Some("multi-op: already coordinated".to_string()),
+    };
+
+    let candidates = vec![
+        multi_op,
+        change_squash_candidate("neuron-a", "RELU", 0.03, "saturation detection"),
+    ];
+
+    let groups = group_candidates_by_neuron(&candidates);
+
+    // Only the single-op candidate should be grouped
+    assert_eq!(
+        groups.get("neuron-a").map(Vec::len),
+        Some(1),
+        "multi-op candidates should be excluded from grouping"
+    );
+}
+
+// =========================================================================
+// Test: Synthesise combined candidates for co-flagged neurons
+// =========================================================================
+
+#[test]
+fn test_synthesise_produces_combined_candidate_for_coflagged_neuron() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    // Should produce at least one synthesised candidate
+    assert!(
+        result.synthesised_count > 0,
+        "co-flagged neuron should produce synthesised candidates"
+    );
+
+    // Synthesised candidates should have multiple operations
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert!(
+        !synthesised.is_empty(),
+        "should have at least one synthesised candidate with cross-detection comment"
+    );
+
+    // The synthesised candidate should have both operations
+    let synth = &synthesised[0];
+    assert!(
+        synth.operations.len() >= 2,
+        "synthesised candidate should combine multiple operations, got {}",
+        synth.operations.len()
+    );
+}
+
+#[test]
+fn test_synthesise_preserves_individual_candidates() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+    ];
+
+    let original_count = candidates.len();
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    // Individual candidates must still be present (synthesis is additive)
+    let individual_count = result.candidates.len() - result.synthesised_count;
+    assert!(
+        individual_count >= original_count,
+        "individual candidates must be preserved: expected >= {original_count}, got {individual_count}"
+    );
+}
+
+#[test]
+fn test_single_detection_neuron_produces_no_synthesis() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        change_squash_candidate("neuron-b", "RELU", 0.04, "restricted range detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    assert_eq!(
+        result.synthesised_count, 0,
+        "neurons with only one detection should not produce synthesised candidates"
+    );
+}
+
+#[test]
+fn test_empty_input_passthrough() {
+    let result = synthesise_cross_detection_candidates(vec![]);
+
+    assert!(result.candidates.is_empty());
+    assert_eq!(result.synthesised_count, 0);
+}
+
+// =========================================================================
+// Test: Compatible operation merging rules
+// =========================================================================
+
+#[test]
+fn test_merge_change_squash_and_set_bias() {
+    // Saturation + restricted range → combine ChangeSquash + SetBias
+    let candidates = vec![
+        change_squash_candidate("neuron-x", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-x", -0.2, 0.03, "bias perturbation"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert_eq!(
+        synthesised.len(),
+        1,
+        "should produce exactly one synthesised candidate"
+    );
+
+    let ops = &synthesised[0].operations;
+    let has_change_squash = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::ChangeSquash { .. }));
+    let has_set_bias = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::SetBias { .. }));
+
+    assert!(
+        has_change_squash,
+        "synthesised candidate should contain ChangeSquash"
+    );
+    assert!(has_set_bias, "synthesised candidate should contain SetBias");
+}
+
+#[test]
+fn test_merge_change_squash_and_set_weight() {
+    // Saturation + weight magnitude → combine ChangeSquash + SetWeight
+    let candidates = vec![
+        change_squash_candidate("neuron-x", "RELU", 0.06, "saturation detection"),
+        set_weight_candidate("input-1", "neuron-x", 0.5, 0.02, "weight magnitude reset"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert!(
+        !synthesised.is_empty(),
+        "changeSquash + setWeight should produce a synthesised candidate"
+    );
+
+    let ops = &synthesised[0].operations;
+    let has_change_squash = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::ChangeSquash { .. }));
+    let has_set_weight = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::SetWeight { .. }));
+
+    assert!(has_change_squash, "should contain ChangeSquash");
+    assert!(has_set_weight, "should contain SetWeight");
+}
+
+#[test]
+fn test_merge_remove_neuron_and_remove_synapse() {
+    // Dead neuron + dormant synapse → combine removals
+    let candidates = vec![
+        remove_neuron_candidate("neuron-dead", 0.04, "dead neuron detection"),
+        remove_synapse_candidate("input-1", "neuron-dead", 0.02, "dormant synapse detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert!(
+        !synthesised.is_empty(),
+        "removeNeuron + removeSynapse should produce a synthesised candidate"
+    );
+
+    let ops = &synthesised[0].operations;
+    let has_remove_neuron = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::RemoveNeuron { .. }));
+    let has_remove_synapse = ops
+        .iter()
+        .any(|op| matches!(op, CoordinatedStructuralOpJson::RemoveSynapse { .. }));
+
+    assert!(has_remove_neuron, "should contain RemoveNeuron");
+    assert!(has_remove_synapse, "should contain RemoveSynapse");
+}
+
+// =========================================================================
+// Test: Incompatible operations are not merged
+// =========================================================================
+
+#[test]
+fn test_incompatible_remove_and_modify_not_merged() {
+    // RemoveNeuron conflicts with ChangeSquash (cannot change squash on a removed neuron)
+    let candidates = vec![
+        remove_neuron_candidate("neuron-x", 0.04, "dead neuron detection"),
+        change_squash_candidate("neuron-x", "RELU", 0.06, "saturation detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    // Should not synthesise when operations conflict (remove vs modify)
+    assert_eq!(
+        result.synthesised_count, 0,
+        "conflicting operations (remove vs modify) should not be synthesised"
+    );
+}
+
+// =========================================================================
+// Test: Scoring of synthesised candidates
+// =========================================================================
+
+#[test]
+fn test_synthesised_candidate_gain_uses_best_individual() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.08, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert!(!synthesised.is_empty());
+
+    // Synthesised gain should be based on the best individual gain (0.08)
+    // with some adjustment for the combined operation
+    let gain = synthesised[0].expected_creature_score_gain;
+    assert!(
+        gain > 0.0,
+        "synthesised candidate should have positive gain, got {gain}"
+    );
+}
+
+// =========================================================================
+// Test: Comment format for synthesised candidates
+// =========================================================================
+
+#[test]
+fn test_synthesised_candidate_comment_identifies_source_modules() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    let synthesised: Vec<_> = result
+        .candidates
+        .iter()
+        .filter(|c| {
+            c.comment
+                .as_ref()
+                .is_some_and(|com| com.contains("cross-detection synthesis"))
+        })
+        .collect();
+
+    assert!(!synthesised.is_empty());
+
+    let comment = synthesised[0].comment.as_ref().unwrap();
+    assert!(
+        comment.contains("cross-detection synthesis"),
+        "comment should identify as cross-detection synthesis: {comment}"
+    );
+}
+
+// =========================================================================
+// Test: SynthesisResult structure
+// =========================================================================
+
+#[test]
+fn test_synthesis_result_counts() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.05, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+        change_squash_candidate("neuron-b", "RELU", 0.04, "saturation detection"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    // Should have original candidates + synthesised
+    assert!(
+        result.candidates.len() >= 3,
+        "should have at least the original 3 candidates, got {}",
+        result.candidates.len()
+    );
+    assert_eq!(
+        result.synthesised_count, 1,
+        "should have exactly 1 synthesised candidate (from neuron-a co-flagging)"
+    );
+}
+
+// =========================================================================
+// Test: Three-way co-flagging
+// =========================================================================
+
+#[test]
+fn test_three_way_coflagging_produces_synthesis() {
+    let candidates = vec![
+        change_squash_candidate("neuron-a", "IDENTITY", 0.08, "saturation detection"),
+        set_bias_candidate("neuron-a", 0.1, 0.03, "restricted range detection"),
+        set_weight_candidate("input-1", "neuron-a", 0.5, 0.02, "weight magnitude reset"),
+    ];
+
+    let result = synthesise_cross_detection_candidates(candidates);
+
+    assert!(
+        result.synthesised_count >= 1,
+        "three-way co-flagging should produce at least one synthesised candidate"
+    );
+
+    // All original candidates should still be present
+    assert!(
+        result.candidates.len() >= 3,
+        "all original candidates must be preserved"
+    );
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -51,6 +51,7 @@ mod issue_928_verify_fan_in_synapse_discovery;
 mod issue_930_change_squash_suboptimal_activation;
 mod issue_938_constants_submodule_organisation;
 mod issue_962_ultra_conservative_variants;
+mod issue_963_cross_detection_candidate_synthesis;
 mod split_error_all_activations;
 mod split_error_fallback_candidates;
 mod target_map_optimization;


### PR DESCRIPTION
## Summary

Add cross-detection candidate synthesis for co-flagged neurons. When multiple
detection modules independently flag the same neuron (e.g., saturation +
restricted range + high error), the system now synthesises combined remediation
candidates that address multiple issues simultaneously, rather than only
generating independent single-issue candidates. Closes #963.

### What changed

- **New module** `src/analysis/detection/cross_detection_synthesis.rs`:
  - Groups single-operation detection candidates by target neuron UUID
  - When 2+ modules flag the same neuron with compatible operations, synthesises
    a combined `CoordinatedStructuralCandidateJson` containing all operations
  - Compatibility rules: modifications (ChangeSquash, SetBias, SetWeight) merge
    with each other; removals (RemoveNeuron, RemoveSynapse) merge with each
    other; removals do NOT merge with modifications
  - Individual candidates are always preserved (synthesis is additive)
  - Synthesised candidates are tagged with `cross-detection synthesis` in their
    comment for success rate tracking via `ModuleOutcomeTracker`

- **Orchestration integration** (`src/analysis/orchestration.rs`):
  - Synthesis runs after discovery module dispatch and before cross-module
    deduplication and ensemble scoring

- **Pipeline wrapper** (`src/analysis/module_dispatch_specs/mod.rs`):
  - Added `synthesise_cross_detection_candidates()` wrapper with watchdog beats,
    phase timing, and verbose logging

## Evidence

All 21 tests pass (15 integration + 6 unit). `quality.sh` passes cleanly.

## Test Plan

- **Integration tests** (`tests/analysis/issue_963_cross_detection_candidate_synthesis.rs`):
  - `test_group_candidates_by_neuron_groups_correctly` — verifies grouping by UUID
  - `test_group_candidates_empty_input` — empty input passthrough
  - `test_group_candidates_multi_op_candidates_excluded` — multi-op excluded from grouping
  - `test_synthesise_produces_combined_candidate_for_coflagged_neuron` — co-flagged synthesis
  - `test_synthesise_preserves_individual_candidates` — synthesis is additive
  - `test_single_detection_neuron_produces_no_synthesis` — no false positives
  - `test_empty_input_passthrough` — empty input
  - `test_merge_change_squash_and_set_bias` — ChangeSquash + SetBias compatibility
  - `test_merge_change_squash_and_set_weight` — ChangeSquash + SetWeight compatibility
  - `test_merge_remove_neuron_and_remove_synapse` — removal compatibility
  - `test_incompatible_remove_and_modify_not_merged` — incompatible ops rejected
  - `test_synthesised_candidate_gain_uses_best_individual` — gain scoring
  - `test_synthesised_candidate_comment_identifies_source_modules` — attribution
  - `test_synthesis_result_counts` — result structure validation
  - `test_three_way_coflagging_produces_synthesis` — 3+ module co-flagging
- **Unit tests** (`src/analysis/detection/cross_detection_synthesis.rs`):
  - `primary_neuron_uuid_for_change_squash` — UUID extraction
  - `primary_neuron_uuid_for_set_weight_uses_target` — target UUID for synapse ops
  - `primary_neuron_uuid_none_for_multi_op` — multi-op exclusion
  - `compatible_modifications` — modification compatibility check
  - `compatible_removals` — removal compatibility check
  - `incompatible_removal_with_modification` — incompatibility check

---

## Automated Fix Details
This PR addresses issue #963: **feat: cross-detection candidate synthesis for co-flagged neurons**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #963
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-963 -->