### PR TITLE
feat: per-scale success rate tracking for weight variant selection (#964)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.4"
+version = "0.72.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-964.md
+++ b/docs/pr-summary-964.md
@@ -1,0 +1,26 @@
+## Summary
+
+Add per-scale success rate tracking for weight variant selection. The new
+`ScaleOutcomeTracker` records outcomes keyed by `(module_name, weight_scale_tier)`
+using the same Bayesian Beta(1,1) prior as the existing `ModuleOutcomeTracker`.
+Per-scale boost factors (clamped to [0.5, 2.0]) can be applied to variant
+`expected_multiplier` values, biasing future generation toward historically
+successful scales. Includes decay factor to prevent stale data dominance and
+JSON serialisation for persistence. Closes #964.
+
+## Evidence
+
+All 22 new unit tests pass, covering:
+- Per-(module, scale) outcome recording and independent tracking
+- Bayesian success rate computation with Beta(1,1) prior
+- Per-scale boost factor computation with MIN_BOOST_SAMPLES threshold
+- Boost clamping to [0.5, 2.0] range
+- Decay factor with rounding safety (successes never exceed attempts)
+- JSON serialisation round-trip
+- Scale tier extraction from variant candidate comments
+- `apply_scale_boosts_to_candidates` integration with coordinated structural candidates
+
+## Test Plan
+
+- Added `tests/analysis/issue_964_per_scale_success_rate.rs` (22 tests)
+- `quality.sh` passes cleanly

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -47,6 +47,7 @@ pub mod module_weights;
 pub mod neuron;
 pub mod neuron_fingerprint;
 pub mod samples;
+pub mod scale_outcomes;
 pub mod shared;
 pub mod streaming;
 pub mod synapse;

--- a/src/analysis/scale_outcomes.rs
+++ b/src/analysis/scale_outcomes.rs
@@ -1,0 +1,231 @@
+//! Per-scale success rate tracking for weight variant selection (Issue #964).
+//!
+//! Extends the module outcome tracking system to record success rates per weight
+//! scale magnitude (Conservative, Gentle Nudge, Micro-Nudge, Feather-Touch, Whisper)
+//! per module type. Uses this data to learn which weight scales work best and bias
+//! future variant generation toward historically successful scales.
+//!
+//! ## Design
+//!
+//! - Outcomes are keyed by `(module_name, weight_scale_tier)`.
+//! - Uses the same Bayesian Beta(1,1) prior and smoothing as `ModuleOutcomeTracker`.
+//! - Per-scale boost factors are clamped to [0.5, 2.0].
+//! - Decay factor prevents stale data from permanently biasing scale selection.
+//! - Serialisable to JSON for persistence alongside the creature.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // Intentional numeric casts for neural network computation (Issue #873)
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use super::constants::MIN_BOOST_SAMPLES;
+
+/// Per-scale success/failure statistics.
+///
+/// Tracks how many candidates at a particular weight scale tier have been
+/// accepted or rejected during ablation testing.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScaleStats {
+    /// Total number of candidates at this scale that were ablation-tested.
+    pub attempts: u32,
+    /// Number of candidates at this scale that passed ablation testing.
+    pub successes: u32,
+}
+
+impl ScaleStats {
+    /// Returns the Bayesian success rate using Beta distribution posterior mean.
+    ///
+    /// Uses Beta(1,1) prior (uniform):
+    /// - No data → 0.5 (neutral prior)
+    /// - Converges to raw success rate with many samples
+    /// - Never returns exactly 0.0 or 1.0
+    pub fn success_rate(&self) -> f64 {
+        if self.attempts == 0 {
+            return 0.5;
+        }
+        let alpha = self.successes as f64 + 1.0;
+        let beta = (self.attempts - self.successes) as f64 + 1.0;
+        alpha / (alpha + beta)
+    }
+}
+
+/// Tracker for per-(module, scale-tier) outcomes.
+///
+/// Serialisable to JSON for persistence alongside the creature, enabling
+/// cross-run learning of which weight scales work best for each module.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScaleOutcomeTracker {
+    /// Outer key: module name, inner key: scale tier name.
+    modules: HashMap<String, HashMap<String, ScaleStats>>,
+}
+
+impl Default for ScaleOutcomeTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScaleOutcomeTracker {
+    /// Creates a new empty tracker.
+    pub fn new() -> Self {
+        Self {
+            modules: HashMap::new(),
+        }
+    }
+
+    /// Returns true if no outcomes have been tracked.
+    pub fn is_empty(&self) -> bool {
+        self.modules.is_empty()
+    }
+
+    /// Returns the number of distinct modules being tracked.
+    pub fn module_count(&self) -> usize {
+        self.modules.len()
+    }
+
+    /// Records an accept/reject outcome for a specific (module, scale tier).
+    pub fn record(&mut self, module_name: &str, scale_tier: &str, succeeded: bool) {
+        let scales = self.modules.entry(module_name.to_string()).or_default();
+        let stats = scales.entry(scale_tier.to_string()).or_default();
+        stats.attempts += 1;
+        if succeeded {
+            stats.successes += 1;
+        }
+    }
+
+    /// Returns the statistics for a given (module, scale tier) combination.
+    ///
+    /// Returns default (empty) stats for unknown combinations.
+    pub fn stats(&self, module_name: &str, scale_tier: &str) -> ScaleStats {
+        self.modules
+            .get(module_name)
+            .and_then(|scales| scales.get(scale_tier))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns all module statistics as a nested map.
+    pub fn all_stats(&self) -> &HashMap<String, HashMap<String, ScaleStats>> {
+        &self.modules
+    }
+
+    /// Applies a decay factor to all scale statistics.
+    ///
+    /// Multiplies `attempts` and `successes` by the given `factor` (clamped to [0.0, 1.0]),
+    /// rounding to nearest. This prevents historical data from permanently biasing
+    /// scale selection by gradually reducing the weight of old outcomes.
+    ///
+    /// - `factor = 1.0` — no change (preserve all history)
+    /// - `factor = 0.5` — halve all counts (moderate decay)
+    /// - `factor = 0.0` — clear all counts (full reset)
+    pub fn apply_decay(&mut self, factor: f64) {
+        let factor = factor.clamp(0.0, 1.0);
+        for scales in self.modules.values_mut() {
+            for stats in scales.values_mut() {
+                stats.attempts = (stats.attempts as f64 * factor).round() as u32;
+                stats.successes = (stats.successes as f64 * factor).round() as u32;
+                // Ensure successes never exceeds attempts after rounding.
+                if stats.successes > stats.attempts {
+                    stats.successes = stats.attempts;
+                }
+            }
+        }
+    }
+
+    /// Returns a scoring boost factor for a specific (module, scale tier).
+    ///
+    /// The boost is based on the Bayesian success rate. Scale tiers with higher
+    /// success rates get a larger boost.
+    ///
+    /// Returns 1.0 (neutral) when:
+    /// - The combination is unknown (no data)
+    /// - There are fewer than [`MIN_BOOST_SAMPLES`] attempts (insufficient data)
+    ///
+    /// The boost factor is computed as: `2.0 * success_rate`, clamped to [0.5, 2.0].
+    pub fn scale_boost(&self, module_name: &str, scale_tier: &str) -> f64 {
+        let Some(scales) = self.modules.get(module_name) else {
+            return 1.0;
+        };
+        let Some(stats) = scales.get(scale_tier) else {
+            return 1.0;
+        };
+
+        if (stats.attempts as usize) < MIN_BOOST_SAMPLES {
+            return 1.0;
+        }
+
+        let rate = stats.success_rate();
+        (2.0 * rate).clamp(0.5, 2.0)
+    }
+}
+
+/// Known weight scale tier names matching variant generation comments.
+const KNOWN_SCALE_TIERS: [&str; 5] = [
+    "Conservative",
+    "Gentle Nudge",
+    "Micro-Nudge",
+    "Feather-Touch",
+    "Whisper",
+];
+
+/// Extract the weight scale tier from a candidate comment string.
+///
+/// Returns `None` if the comment does not match any known tier.
+pub fn extract_scale_tier(comment: &str) -> Option<&'static str> {
+    for tier in &KNOWN_SCALE_TIERS {
+        if comment.starts_with(tier) || comment.contains(&format!("{tier} variant")) {
+            return Some(tier);
+        }
+    }
+    None
+}
+
+/// Extract the module name from a candidate comment string.
+///
+/// Module names are typically the prefix before `:` or `|` in comments.
+fn extract_module_name(comment: &str) -> &str {
+    comment
+        .split(&[':', '|'][..])
+        .next()
+        .unwrap_or("unknown")
+        .trim()
+}
+
+/// Apply per-scale boost factors to coordinated structural candidate expected gains (Issue #964).
+///
+/// For each candidate, extracts the module name and scale tier from the comment,
+/// then multiplies `expected_creature_score_gain` by the tracker's `scale_boost()`
+/// for that (module, tier) combination. Candidates from unknown modules/tiers or
+/// an empty tracker receive a neutral boost (1.0).
+pub fn apply_scale_boosts_to_candidates(
+    candidates: &mut [crate::CoordinatedStructuralCandidateJson],
+    tracker: &ScaleOutcomeTracker,
+) {
+    if tracker.is_empty() {
+        return;
+    }
+
+    for candidate in candidates.iter_mut() {
+        let comment = match candidate.comment.as_ref() {
+            Some(c) => c.as_str(),
+            None => continue,
+        };
+
+        let scale_tier = match extract_scale_tier(comment) {
+            Some(tier) => tier,
+            None => continue,
+        };
+
+        let module_name = extract_module_name(comment);
+        let boost = tracker.scale_boost(module_name, scale_tier);
+        if (boost - 1.0).abs() > f64::EPSILON {
+            candidate.expected_creature_score_gain *= boost as f32;
+        }
+    }
+}

--- a/tests/analysis/issue_964_per_scale_success_rate.rs
+++ b/tests/analysis/issue_964_per_scale_success_rate.rs
@@ -1,0 +1,471 @@
+//! Tests for Issue #964: Per-scale success rate tracking for weight variant selection.
+//!
+//! The `ScaleOutcomeTracker` records outcomes keyed by `(module_name, weight_scale_tier)`
+//! and computes Bayesian success rates per scale tier. This enables biasing future
+//! variant generation toward historically successful scales.
+//!
+//! ## Key Behaviours Verified
+//!
+//! - Recording per-scale outcomes (success/failure)
+//! - Computing Bayesian success rates per (module, scale) combination
+//! - Providing per-scale boost factors clamped to [0.5, 2.0]
+//! - Decay factor prevents stale data dominance
+//! - Serialisation/deserialisation for persistence
+//! - Applying per-scale boosts to variant `expected_multiplier` values
+//! - Extracting scale tier from candidate comments
+
+use neat_ai_discovery::analysis::scale_outcomes::{
+    ScaleOutcomeTracker, ScaleStats, apply_scale_boosts_to_candidates,
+};
+
+// =============================================================================
+// Basic Recording and Lookup
+// =============================================================================
+
+#[test]
+fn empty_tracker_has_no_stats() {
+    let tracker = ScaleOutcomeTracker::new();
+    assert!(tracker.is_empty());
+    let stats = tracker.stats("saturation detection", "Conservative");
+    assert_eq!(stats.attempts, 0);
+    assert_eq!(stats.successes, 0);
+}
+
+#[test]
+fn record_outcome_and_retrieve_stats() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("saturation detection", "Conservative", true);
+    tracker.record("saturation detection", "Conservative", true);
+    tracker.record("saturation detection", "Conservative", false);
+
+    let stats = tracker.stats("saturation detection", "Conservative");
+    assert_eq!(stats.attempts, 3);
+    assert_eq!(stats.successes, 2);
+}
+
+#[test]
+fn different_scales_tracked_independently() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("saturation detection", "Conservative", true);
+    tracker.record("saturation detection", "Micro-Nudge", false);
+    tracker.record("saturation detection", "Micro-Nudge", false);
+
+    let conservative = tracker.stats("saturation detection", "Conservative");
+    assert_eq!(conservative.attempts, 1);
+    assert_eq!(conservative.successes, 1);
+
+    let micro = tracker.stats("saturation detection", "Micro-Nudge");
+    assert_eq!(micro.attempts, 2);
+    assert_eq!(micro.successes, 0);
+}
+
+#[test]
+fn different_modules_tracked_independently() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("saturation detection", "Conservative", true);
+    tracker.record("dead neuron detection", "Conservative", false);
+
+    let sat = tracker.stats("saturation detection", "Conservative");
+    assert_eq!(sat.successes, 1);
+
+    let dead = tracker.stats("dead neuron detection", "Conservative");
+    assert_eq!(dead.successes, 0);
+}
+
+// =============================================================================
+// Bayesian Success Rate
+// =============================================================================
+
+#[test]
+fn bayesian_success_rate_with_no_data_returns_prior() {
+    let stats = ScaleStats::default();
+    let rate = stats.success_rate();
+    assert!(
+        (rate - 0.5).abs() < f64::EPSILON,
+        "Empty stats should return prior 0.5, got {rate}"
+    );
+}
+
+#[test]
+fn bayesian_success_rate_converges_to_raw_rate() {
+    let stats = ScaleStats {
+        attempts: 1000,
+        successes: 450,
+    };
+    let rate = stats.success_rate();
+    assert!(
+        (rate - 0.45).abs() < 0.01,
+        "With 1000 samples at 45% raw rate, Bayesian rate should be ~0.45, got {rate}"
+    );
+}
+
+#[test]
+fn bayesian_rate_never_exactly_zero_or_one() {
+    let all_fail = ScaleStats {
+        attempts: 100,
+        successes: 0,
+    };
+    assert!(all_fail.success_rate() > 0.0);
+
+    let all_succeed = ScaleStats {
+        attempts: 100,
+        successes: 100,
+    };
+    assert!(all_succeed.success_rate() < 1.0);
+}
+
+// =============================================================================
+// Per-Scale Boost Factor
+// =============================================================================
+
+#[test]
+fn boost_neutral_when_insufficient_data() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    // Record fewer than MIN_BOOST_SAMPLES outcomes
+    for _ in 0..5 {
+        tracker.record("module-a", "Conservative", true);
+    }
+    let boost = tracker.scale_boost("module-a", "Conservative");
+    assert!(
+        (boost - 1.0).abs() < f64::EPSILON,
+        "Insufficient data should give neutral boost 1.0, got {boost}"
+    );
+}
+
+#[test]
+fn boost_reflects_scale_success_rate() {
+    let mut tracker = ScaleOutcomeTracker::new();
+
+    // High-success scale: 80% (8 of 10)
+    for i in 0..10 {
+        tracker.record("module-a", "Conservative", i < 8);
+    }
+
+    // Low-success scale: 20% (2 of 10)
+    for i in 0..10 {
+        tracker.record("module-a", "Micro-Nudge", i < 2);
+    }
+
+    let high_boost = tracker.scale_boost("module-a", "Conservative");
+    let low_boost = tracker.scale_boost("module-a", "Micro-Nudge");
+
+    assert!(
+        high_boost > low_boost,
+        "High-success boost ({high_boost}) should be > low-success boost ({low_boost})"
+    );
+    assert!(
+        high_boost > 1.0,
+        "80% success should give boost > 1.0, got {high_boost}"
+    );
+    assert!(
+        low_boost < 1.0,
+        "20% success should give boost < 1.0, got {low_boost}"
+    );
+}
+
+#[test]
+fn boost_clamped_within_bounds() {
+    let mut tracker = ScaleOutcomeTracker::new();
+
+    for _ in 0..20 {
+        tracker.record("module-a", "Conservative", true);
+    }
+    for _ in 0..20 {
+        tracker.record("module-a", "Micro-Nudge", false);
+    }
+
+    let perfect = tracker.scale_boost("module-a", "Conservative");
+    let failure = tracker.scale_boost("module-a", "Micro-Nudge");
+
+    assert!(
+        perfect <= 2.0,
+        "Perfect boost should be clamped to <= 2.0, got {perfect}"
+    );
+    assert!(
+        failure >= 0.5,
+        "Failure boost should be clamped to >= 0.5, got {failure}"
+    );
+}
+
+#[test]
+fn unknown_module_or_scale_gets_neutral_boost() {
+    let tracker = ScaleOutcomeTracker::new();
+    let boost = tracker.scale_boost("nonexistent", "Conservative");
+    assert!(
+        (boost - 1.0).abs() < f64::EPSILON,
+        "Unknown module/scale should get neutral boost 1.0, got {boost}"
+    );
+}
+
+// =============================================================================
+// Decay Factor
+// =============================================================================
+
+#[test]
+fn decay_reduces_counts_proportionally() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    for _ in 0..20 {
+        tracker.record("module-a", "Conservative", true);
+    }
+    for _ in 0..10 {
+        tracker.record("module-a", "Conservative", false);
+    }
+
+    let before = tracker.stats("module-a", "Conservative");
+    assert_eq!(before.attempts, 30);
+    assert_eq!(before.successes, 20);
+
+    tracker.apply_decay(0.5);
+
+    let after = tracker.stats("module-a", "Conservative");
+    // 30 * 0.5 = 15, 20 * 0.5 = 10
+    assert_eq!(after.attempts, 15);
+    assert_eq!(after.successes, 10);
+}
+
+#[test]
+fn decay_preserves_success_rate_approximately() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    for _ in 0..100 {
+        tracker.record("module-a", "Conservative", true);
+    }
+    for _ in 0..100 {
+        tracker.record("module-a", "Conservative", false);
+    }
+
+    let rate_before = tracker.stats("module-a", "Conservative").success_rate();
+    tracker.apply_decay(0.5);
+    let rate_after = tracker.stats("module-a", "Conservative").success_rate();
+
+    assert!(
+        (rate_before - rate_after).abs() < 0.05,
+        "Decay should approximately preserve success rate: before={rate_before}, after={rate_after}"
+    );
+}
+
+#[test]
+fn decay_clamps_factor_to_valid_range() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    for _ in 0..10 {
+        tracker.record("module-a", "Conservative", true);
+    }
+
+    // Factor > 1.0 should be clamped to 1.0 (no change)
+    tracker.apply_decay(2.0);
+    let stats = tracker.stats("module-a", "Conservative");
+    assert_eq!(stats.attempts, 10);
+
+    // Factor < 0.0 should be clamped to 0.0 (full reset)
+    tracker.apply_decay(-1.0);
+    let stats = tracker.stats("module-a", "Conservative");
+    assert_eq!(stats.attempts, 0);
+}
+
+#[test]
+fn decay_ensures_successes_never_exceed_attempts() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    // 3 successes out of 5 attempts — after decay with rounding, successes
+    // could potentially exceed attempts without the safety clamp.
+    for _ in 0..3 {
+        tracker.record("module-a", "Conservative", true);
+    }
+    for _ in 0..2 {
+        tracker.record("module-a", "Conservative", false);
+    }
+
+    tracker.apply_decay(0.3);
+    let stats = tracker.stats("module-a", "Conservative");
+    assert!(
+        stats.successes <= stats.attempts,
+        "Successes ({}) should never exceed attempts ({})",
+        stats.successes,
+        stats.attempts,
+    );
+}
+
+// =============================================================================
+// Serialisation Round-Trip
+// =============================================================================
+
+#[test]
+fn serialisation_round_trip() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("saturation detection", "Conservative", true);
+    tracker.record("saturation detection", "Conservative", false);
+    tracker.record("saturation detection", "Micro-Nudge", true);
+    tracker.record("dead neuron detection", "Whisper", false);
+
+    let json = serde_json::to_string(&tracker).expect("Serialisation should succeed");
+    let deserialized: ScaleOutcomeTracker =
+        serde_json::from_str(&json).expect("Deserialisation should succeed");
+
+    assert_eq!(tracker, deserialized);
+
+    let sat_cons = deserialized.stats("saturation detection", "Conservative");
+    assert_eq!(sat_cons.attempts, 2);
+    assert_eq!(sat_cons.successes, 1);
+
+    let sat_micro = deserialized.stats("saturation detection", "Micro-Nudge");
+    assert_eq!(sat_micro.attempts, 1);
+    assert_eq!(sat_micro.successes, 1);
+
+    let dead_whisper = deserialized.stats("dead neuron detection", "Whisper");
+    assert_eq!(dead_whisper.attempts, 1);
+    assert_eq!(dead_whisper.successes, 0);
+}
+
+// =============================================================================
+// Scale Tier Extraction from Candidate Comments
+// =============================================================================
+
+#[test]
+fn extract_scale_tier_from_variant_comments() {
+    use neat_ai_discovery::analysis::scale_outcomes::extract_scale_tier;
+
+    assert_eq!(
+        extract_scale_tier("Conservative variant (clamped incoming/bias, outgoing scaled)"),
+        Some("Conservative")
+    );
+    assert_eq!(
+        extract_scale_tier("Gentle Nudge variant (tight outgoing, bias tamed)"),
+        Some("Gentle Nudge")
+    );
+    assert_eq!(
+        extract_scale_tier(
+            "Micro-Nudge variant (ultra-conservative outgoing, tight incoming/bias)"
+        ),
+        Some("Micro-Nudge")
+    );
+    assert_eq!(
+        extract_scale_tier(
+            "Feather-Touch variant (near-equilibrium outgoing, minimal perturbation)"
+        ),
+        Some("Feather-Touch")
+    );
+    assert_eq!(
+        extract_scale_tier("Whisper variant (minimal outgoing, near-zero perturbation)"),
+        Some("Whisper")
+    );
+    assert_eq!(extract_scale_tier("some random comment"), None);
+}
+
+// =============================================================================
+// Apply Scale Boosts to Coordinated Structural Candidates
+// =============================================================================
+
+#[test]
+fn apply_scale_boosts_modifies_expected_multiplier() {
+    let mut tracker = ScaleOutcomeTracker::new();
+
+    // Conservative has high success rate
+    for _ in 0..20 {
+        tracker.record("test module", "Conservative", true);
+    }
+    // Micro-Nudge has low success rate
+    for _ in 0..20 {
+        tracker.record("test module", "Micro-Nudge", false);
+    }
+
+    let mut candidates = vec![
+        make_candidate(
+            1.0,
+            "test module: Conservative variant (weight scaled to 0.5\u{00d7})",
+        ),
+        make_candidate(
+            1.0,
+            "test module: Micro-Nudge variant (weight scaled to 0.1\u{00d7})",
+        ),
+    ];
+
+    apply_scale_boosts_to_candidates(&mut candidates, &tracker);
+
+    // Conservative should be boosted (gain > 1.0)
+    assert!(
+        candidates[0].expected_creature_score_gain > 1.0,
+        "Conservative should be boosted, got {}",
+        candidates[0].expected_creature_score_gain
+    );
+
+    // Micro-Nudge should be penalised (gain < 1.0)
+    assert!(
+        candidates[1].expected_creature_score_gain < 1.0,
+        "Micro-Nudge should be penalised, got {}",
+        candidates[1].expected_creature_score_gain
+    );
+}
+
+#[test]
+fn apply_scale_boosts_no_effect_on_empty_tracker() {
+    let tracker = ScaleOutcomeTracker::new();
+    let mut candidates = vec![make_candidate(
+        1.0,
+        "test module: Conservative variant (weight scaled to 0.5\u{00d7})",
+    )];
+
+    apply_scale_boosts_to_candidates(&mut candidates, &tracker);
+
+    assert!(
+        (candidates[0].expected_creature_score_gain - 1.0).abs() < f32::EPSILON,
+        "Empty tracker should not modify candidates, got {}",
+        candidates[0].expected_creature_score_gain
+    );
+}
+
+#[test]
+fn apply_scale_boosts_ignores_candidates_without_scale_tier() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    for _ in 0..20 {
+        tracker.record("test module", "Conservative", true);
+    }
+
+    let mut candidates = vec![make_candidate(
+        1.0,
+        "test module: some detection without variant tier",
+    )];
+
+    apply_scale_boosts_to_candidates(&mut candidates, &tracker);
+
+    assert!(
+        (candidates[0].expected_creature_score_gain - 1.0).abs() < f32::EPSILON,
+        "Candidates without scale tier should not be modified, got {}",
+        candidates[0].expected_creature_score_gain
+    );
+}
+
+#[test]
+fn module_count_tracks_distinct_modules() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("module-a", "Conservative", true);
+    tracker.record("module-a", "Micro-Nudge", false);
+    tracker.record("module-b", "Conservative", true);
+
+    assert_eq!(tracker.module_count(), 2);
+}
+
+#[test]
+fn all_stats_returns_nested_structure() {
+    let mut tracker = ScaleOutcomeTracker::new();
+    tracker.record("module-a", "Conservative", true);
+    tracker.record("module-a", "Micro-Nudge", false);
+
+    let all = tracker.all_stats();
+    assert!(all.contains_key("module-a"));
+    let module_a = &all["module-a"];
+    assert!(module_a.contains_key("Conservative"));
+    assert!(module_a.contains_key("Micro-Nudge"));
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+fn make_candidate(
+    gain: f32,
+    comment: &str,
+) -> neat_ai_discovery::CoordinatedStructuralCandidateJson {
+    neat_ai_discovery::CoordinatedStructuralCandidateJson {
+        operations: vec![],
+        expected_creature_score_gain: gain,
+        comment: Some(comment.to_string()),
+    }
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -52,6 +52,7 @@ mod issue_930_change_squash_suboptimal_activation;
 mod issue_938_constants_submodule_organisation;
 mod issue_962_ultra_conservative_variants;
 mod issue_963_cross_detection_candidate_synthesis;
+mod issue_964_per_scale_success_rate;
 mod split_error_all_activations;
 mod split_error_fallback_candidates;
 mod target_map_optimization;


### PR DESCRIPTION
## Summary

Add per-scale success rate tracking for weight variant selection. The new
`ScaleOutcomeTracker` records outcomes keyed by `(module_name, weight_scale_tier)`
using the same Bayesian Beta(1,1) prior as the existing `ModuleOutcomeTracker`.
Per-scale boost factors (clamped to [0.5, 2.0]) can be applied to variant
`expected_multiplier` values, biasing future generation toward historically
successful scales. Includes decay factor to prevent stale data dominance and
JSON serialisation for persistence. Closes #964.

## Evidence

All 22 new unit tests pass, covering:
- Per-(module, scale) outcome recording and independent tracking
- Bayesian success rate computation with Beta(1,1) prior
- Per-scale boost factor computation with MIN_BOOST_SAMPLES threshold
- Boost clamping to [0.5, 2.0] range
- Decay factor with rounding safety (successes never exceed attempts)
- JSON serialisation round-trip
- Scale tier extraction from variant candidate comments
- `apply_scale_boosts_to_candidates` integration with coordinated structural candidates

## Test Plan

- Added `tests/analysis/issue_964_per_scale_success_rate.rs` (22 tests)
- `quality.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)