### PR TITLE
feat: adaptive candidate budget allocation by module success rate (#967)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.7"
+version = "0.72.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-967.md
+++ b/docs/pr-summary-967.md
@@ -1,0 +1,33 @@
+## Summary
+
+Implement adaptive candidate budget allocation by module success rate. Discovery modules now receive candidate generation budgets proportional to their Bayesian success rate from `ModuleOutcomeTracker`, with high-success modules getting up to 2x base allocation and low-success modules getting a minimum of 0.5x (never starving exploration). A global candidate cap prevents total candidate count explosion. Closes #967.
+
+## Changes
+
+1. **`CandidateBudgetConfig` struct** (`src/analysis/module_weights.rs`): Configurable budget allocation parameters — base candidates per module, global max cap, min/max allocation factors.
+2. **`allocate_candidate_budgets` function** (`src/analysis/module_weights.rs`): Computes per-module candidate budgets using Bayesian success rates, with proportional scaling under a global cap and verbose logging for observability.
+3. **`max_candidates` field on `DiscoveryModuleSpec`** (`src/analysis/discovery_dispatch.rs`): Each module spec now carries its allocated candidate budget.
+4. **Per-module truncation** (`src/analysis/discovery_dispatch.rs`): During the sequential merge phase, each module's candidates are truncated to its allocated budget before merging.
+5. **Budget allocation wiring** (`src/analysis/module_dispatch_specs/mod.rs`): `dispatch_and_merge_discovery_modules` now calls `allocate_candidate_budgets` and assigns budgets to each module spec before dispatch.
+6. **Macro updates** (`src/analysis/module_dispatch_specs/macros.rs`): All four `discovery_spec!` macro variants initialise `max_candidates: 0` (overridden at dispatch time).
+
+## Evidence
+
+- All 12 new integration tests pass, covering: success-rate scaling, equal allocation, 0.5x–2.0x bounds, global cap, sparse/unknown module fallback, edge cases, and the `max_candidates` field on `DiscoveryModuleSpec`.
+- `quality.sh` passes cleanly (fmt, clippy, tests, docs, release build).
+
+## Test Plan
+
+- Added `tests/analysis/issue_967_adaptive_candidate_budget.rs` with 12 tests:
+  - `test_high_success_module_gets_more_candidates` — verifies proportional allocation
+  - `test_equal_success_gives_equal_budgets` — verifies equal rates yield equal budgets
+  - `test_max_budget_is_two_times_base` — verifies upper bound clamping
+  - `test_min_budget_is_half_base` — verifies lower bound clamping
+  - `test_global_cap_limits_total_candidates` — verifies global cap enforcement
+  - `test_global_cap_preserves_proportions` — verifies proportions under cap
+  - `test_sparse_history_gets_base_allocation` — verifies fallback for sparse data
+  - `test_unknown_module_gets_base_allocation` — verifies fallback for unknown modules
+  - `test_empty_module_list_returns_empty` — edge case
+  - `test_every_module_gets_at_least_one_candidate` — minimum floor
+  - `test_default_config_has_sensible_values` — config invariants
+  - `test_module_spec_includes_max_candidates` — field accessibility

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -81,10 +81,14 @@ pub fn run_discovery_module(
 /// Specification for a single discovery module to be dispatched in parallel.
 ///
 /// Each module provides a name (for logging/watchdog), a phase name (for timing),
-/// and a detection closure that returns candidates independently.
+/// a maximum candidate budget (Issue #967), and a detection closure that returns
+/// candidates independently.
 pub struct DiscoveryModuleSpec {
     pub module_name: String,
     pub phase_name: &'static str,
+    /// Maximum number of candidates this module should generate (Issue #967).
+    /// Allocated by `allocate_candidate_budgets` based on historical success rate.
+    pub max_candidates: usize,
     pub detect_fn: Box<dyn FnOnce() -> Option<DiscoveryDetectionResult> + Send>,
 }
 
@@ -114,11 +118,21 @@ pub fn run_discovery_modules_parallel(
 
     // Parallel detection phase: run all closures concurrently.
     // `into_par_iter().map().collect()` preserves input order for indexed iterators.
-    let results: Vec<(String, &'static str, Option<DiscoveryDetectionResult>)> = modules
+    let results: Vec<(
+        String,
+        &'static str,
+        usize,
+        Option<DiscoveryDetectionResult>,
+    )> = modules
         .into_par_iter()
         .map(|spec| {
             let result = (spec.detect_fn)();
-            (spec.module_name, spec.phase_name, result)
+            (
+                spec.module_name,
+                spec.phase_name,
+                spec.max_candidates,
+                result,
+            )
         })
         .collect();
 
@@ -126,7 +140,7 @@ pub fn run_discovery_modules_parallel(
 
     // Sequential merge phase: iterate in original order and merge non-empty results.
     // Also collect per-module stats for metadata (Issue #485, #792).
-    for (module_name, _phase_name, result) in results {
+    for (module_name, _phase_name, max_candidates, result) in results {
         let candidates_produced = result.as_ref().map_or(0, |r| r.candidates.len());
 
         // Record per-module stats in metadata from historical tracker (Issue #792).
@@ -141,14 +155,28 @@ pub fn run_discovery_modules_parallel(
                 success_rate: historical.success_rate(),
             });
 
-        if let Some(result) = result
+        if let Some(mut result) = result
             && !result.candidates.is_empty()
         {
+            // Issue #967: Truncate to per-module candidate budget if set.
+            if max_candidates > 0 && result.candidates.len() > max_candidates {
+                if utils::verbose_enabled() {
+                    tracing::debug!(
+                        module = %module_name,
+                        before = result.candidates.len(),
+                        budget = max_candidates,
+                        "Truncating candidates to module budget (Issue #967)"
+                    );
+                }
+                result.candidates.truncate(max_candidates);
+            }
+
             if utils::verbose_enabled() {
                 tracing::debug!(
                     module = %module_name,
                     detections = result.detected_count,
                     candidates = result.candidates.len(),
+                    budget = max_candidates,
                     "discovery module results"
                 );
             }

--- a/src/analysis/discovery_dispatch_parallel_tests.rs
+++ b/src/analysis/discovery_dispatch_parallel_tests.rs
@@ -42,6 +42,7 @@ fn make_module(
     DiscoveryModuleSpec {
         module_name: name.to_string(),
         phase_name: "test_phase",
+        max_candidates: 0,
         detect_fn: Box::new(move || {
             candidates.map(|c| DiscoveryDetectionResult {
                 detected_count,

--- a/src/analysis/module_dispatch_specs/macros.rs
+++ b/src/analysis/module_dispatch_specs/macros.rs
@@ -74,6 +74,7 @@ macro_rules! discovery_spec {
             $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
                 module_name: $name.to_string(),
                 phase_name: $phase,
+                max_candidates: 0,
                 detect_fn: Box::new(move || {
                     $( if $guard.is_empty() { return None; } )?
                     let $rec = $load_records;
@@ -104,6 +105,7 @@ macro_rules! discovery_spec {
             $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
                 module_name: $name.to_string(),
                 phase_name: $phase,
+                max_candidates: 0,
                 detect_fn: Box::new(move || {
                     let $rec = $load_records;
                     if $rec.is_empty() {
@@ -136,6 +138,7 @@ macro_rules! discovery_spec {
             $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
                 module_name: $name.to_string(),
                 phase_name: $phase,
+                max_candidates: 0,
                 detect_fn: Box::new(move || {
                     if $guard_var.len() < $min_count {
                         return None;
@@ -165,6 +168,7 @@ macro_rules! discovery_spec {
             $modules.push($crate::analysis::discovery_dispatch::DiscoveryModuleSpec {
                 module_name: $name.to_string(),
                 phase_name: $phase,
+                max_candidates: 0,
                 detect_fn: Box::new($closure),
             });
         }

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -27,7 +27,8 @@ use std::sync::Arc;
 use super::detection::topology_cache::CreatureTopologyCache;
 use super::{
     cache, candidate_clustering, candidate_diversity, discovery_dispatch, ensemble_scoring,
-    module_weights::ModuleOutcomeTracker, shared, utils,
+    module_weights::{self, CandidateBudgetConfig, ModuleOutcomeTracker},
+    shared, utils,
 };
 
 /// Build all discovery module specs for parallel dispatch.
@@ -73,7 +74,18 @@ pub(crate) fn dispatch_and_merge_discovery_modules(
 ) {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
-    let modules = build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo);
+    let mut modules = build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo);
+
+    // Issue #967: Allocate candidate budgets based on module success rates.
+    let config = CandidateBudgetConfig::default();
+    let module_names: Vec<String> = modules.iter().map(|m| m.module_name.clone()).collect();
+    let budgets = module_weights::allocate_candidate_budgets(&module_names, tracker, &config);
+    for module in &mut modules {
+        if let Some(&budget) = budgets.get(&module.module_name) {
+            module.max_candidates = budget;
+        }
+    }
+
     discovery_dispatch::run_discovery_modules_parallel(
         syn,
         modules,

--- a/src/analysis/module_weights.rs
+++ b/src/analysis/module_weights.rs
@@ -253,6 +253,134 @@ pub fn allocate_time_budgets(
     budgets
 }
 
+/// Configuration for adaptive candidate budget allocation (Issue #967).
+///
+/// Controls how candidate generation budgets are distributed across discovery
+/// modules based on their historical success rates.
+#[derive(Debug, Clone)]
+pub struct CandidateBudgetConfig {
+    /// Base number of candidates per module before adaptive scaling.
+    pub base_candidates: usize,
+    /// Maximum total candidates across all modules (global cap).
+    pub global_max_candidates: usize,
+    /// Minimum allocation factor (floor). Modules never receive fewer than
+    /// `base_candidates * min_allocation_factor` candidates.
+    pub min_allocation_factor: f64,
+    /// Maximum allocation factor (ceiling). Modules never receive more than
+    /// `base_candidates * max_allocation_factor` candidates.
+    pub max_allocation_factor: f64,
+}
+
+impl Default for CandidateBudgetConfig {
+    fn default() -> Self {
+        Self {
+            base_candidates: 10,
+            global_max_candidates: 500,
+            min_allocation_factor: 0.5,
+            max_allocation_factor: 2.0,
+        }
+    }
+}
+
+/// Allocate candidate generation budgets to discovery modules based on historical
+/// success rates (Issue #967).
+///
+/// Each module receives a number of candidate slots proportional to its Bayesian
+/// success rate, clamped to [`CandidateBudgetConfig::min_allocation_factor`] –
+/// [`CandidateBudgetConfig::max_allocation_factor`] times the base allocation.
+/// The total is capped by [`CandidateBudgetConfig::global_max_candidates`].
+///
+/// Modules with insufficient history (fewer than [`MIN_BOOST_SAMPLES`] attempts)
+/// receive the base allocation (neutral).
+///
+/// # Arguments
+///
+/// * `module_names` — Names of modules to allocate budgets for.
+/// * `tracker` — Historical outcome tracker with per-module success/failure data.
+/// * `config` — Budget allocation configuration.
+///
+/// # Returns
+///
+/// A map from module name to allocated candidate count.
+pub fn allocate_candidate_budgets(
+    module_names: &[String],
+    tracker: &ModuleOutcomeTracker,
+    config: &CandidateBudgetConfig,
+) -> HashMap<String, usize> {
+    let mut budgets = HashMap::new();
+    if module_names.is_empty() {
+        return budgets;
+    }
+
+    // Compute per-module allocation factors based on success rate.
+    let factors: Vec<f64> = module_names
+        .iter()
+        .map(|name| {
+            let stats = tracker.stats(name);
+            if (stats.attempts as usize) < MIN_BOOST_SAMPLES {
+                // Insufficient data — neutral allocation.
+                1.0
+            } else {
+                // Scale factor: 2.0 * success_rate, clamped to [min, max].
+                let rate = stats.success_rate();
+                (2.0 * rate).clamp(config.min_allocation_factor, config.max_allocation_factor)
+            }
+        })
+        .collect();
+
+    // Compute raw budgets (before global cap).
+    let mut raw_budgets: Vec<usize> = factors
+        .iter()
+        .map(|&factor| {
+            let raw = (config.base_candidates as f64 * factor).round() as usize;
+            // Ensure every module gets at least 1 candidate.
+            raw.max(1)
+        })
+        .collect();
+
+    // Apply global cap: scale down proportionally if total exceeds cap.
+    let total: usize = raw_budgets.iter().sum();
+    if total > config.global_max_candidates {
+        let scale = config.global_max_candidates as f64 / total as f64;
+        for budget in &mut raw_budgets {
+            *budget = ((*budget as f64) * scale).round() as usize;
+            // Ensure every module still gets at least 1 candidate after scaling.
+            if *budget == 0 {
+                *budget = 1;
+            }
+        }
+    }
+
+    // Log allocation decisions for observability.
+    if super::utils::verbose_enabled() {
+        let total_allocated: usize = raw_budgets.iter().sum();
+        tracing::debug!(
+            modules = module_names.len(),
+            base = config.base_candidates,
+            global_cap = config.global_max_candidates,
+            total_allocated,
+            "Candidate budget allocation (Issue #967)"
+        );
+        for (i, name) in module_names.iter().enumerate() {
+            let stats = tracker.stats(name);
+            tracing::debug!(
+                module = %name,
+                budget = raw_budgets[i],
+                factor = format!("{:.2}", factors[i]),
+                success_rate = format!("{:.3}", stats.success_rate()),
+                attempts = stats.attempts,
+                "Module candidate budget"
+            );
+        }
+    }
+
+    for (i, name) in module_names.iter().enumerate() {
+        budgets.insert(name.clone(), raw_budgets[i]);
+    }
+
+    budgets
+}
+
 /// Per-module statistics for JSON metadata output.
 ///
 /// A flattened representation of module stats suitable for inclusion in

--- a/tests/analysis/issue_485_adaptive_module_weighting.rs
+++ b/tests/analysis/issue_485_adaptive_module_weighting.rs
@@ -280,6 +280,7 @@ fn discovery_module_stats_populated_after_parallel_dispatch() {
         DiscoveryModuleSpec {
             module_name: "test module A".to_string(),
             phase_name: "test_a",
+            max_candidates: 0,
             detect_fn: Box::new(|| {
                 Some(DiscoveryDetectionResult {
                     detected_count: 2,
@@ -290,11 +291,13 @@ fn discovery_module_stats_populated_after_parallel_dispatch() {
         DiscoveryModuleSpec {
             module_name: "test module B".to_string(),
             phase_name: "test_b",
+            max_candidates: 0,
             detect_fn: Box::new(|| None), // No detections
         },
         DiscoveryModuleSpec {
             module_name: "test module C".to_string(),
             phase_name: "test_c",
+            max_candidates: 0,
             detect_fn: Box::new(|| {
                 Some(DiscoveryDetectionResult {
                     detected_count: 1,

--- a/tests/analysis/issue_792_adaptive_module_wiring.rs
+++ b/tests/analysis/issue_792_adaptive_module_wiring.rs
@@ -70,6 +70,7 @@ fn tracker_stats_populate_metadata_in_parallel_dispatch() {
         DiscoveryModuleSpec {
             module_name: "high-success module".to_string(),
             phase_name: "test_792_high",
+            max_candidates: 0,
             detect_fn: Box::new(|| {
                 Some(DiscoveryDetectionResult {
                     detected_count: 1,
@@ -80,6 +81,7 @@ fn tracker_stats_populate_metadata_in_parallel_dispatch() {
         DiscoveryModuleSpec {
             module_name: "low-success module".to_string(),
             phase_name: "test_792_low",
+            max_candidates: 0,
             detect_fn: Box::new(|| {
                 Some(DiscoveryDetectionResult {
                     detected_count: 1,

--- a/tests/analysis/issue_967_adaptive_candidate_budget.rs
+++ b/tests/analysis/issue_967_adaptive_candidate_budget.rs
@@ -1,0 +1,304 @@
+//! Integration tests for adaptive candidate budget allocation by module success rate (Issue #967).
+//!
+//! Tests that candidate generation budgets are allocated to discovery modules based
+//! on their historical Bayesian success rates, with a minimum floor to maintain
+//! exploration and a global cap to prevent candidate explosion.
+
+use neat_ai_discovery::analysis::module_weights::{
+    CandidateBudgetConfig, ModuleOutcomeTracker, allocate_candidate_budgets,
+};
+
+/// Helper to create a tracker with known module history.
+fn tracker_with_history(entries: &[(&str, u32, u32)]) -> ModuleOutcomeTracker {
+    let mut tracker = ModuleOutcomeTracker::new();
+    for &(name, attempts, successes) in entries {
+        for i in 0..attempts {
+            tracker.record(name, i < successes);
+        }
+    }
+    tracker
+}
+
+// =============================================================================
+// Budget allocation scales with success rate
+// =============================================================================
+
+#[test]
+fn test_high_success_module_gets_more_candidates() {
+    let tracker = tracker_with_history(&[
+        ("saturation", 20, 18), // 90% success
+        ("dead_neuron", 20, 2), // 10% success
+    ]);
+
+    let module_names = vec!["saturation".to_string(), "dead_neuron".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    let sat_budget = budgets["saturation"];
+    let dead_budget = budgets["dead_neuron"];
+
+    assert!(
+        sat_budget > dead_budget,
+        "High-success module ({sat_budget}) should get more candidates than low-success ({dead_budget})"
+    );
+}
+
+#[test]
+fn test_equal_success_gives_equal_budgets() {
+    let tracker = tracker_with_history(&[("mod_a", 20, 10), ("mod_b", 20, 10), ("mod_c", 20, 10)]);
+
+    let module_names = vec![
+        "mod_a".to_string(),
+        "mod_b".to_string(),
+        "mod_c".to_string(),
+    ];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert_eq!(budgets["mod_a"], budgets["mod_b"]);
+    assert_eq!(budgets["mod_b"], budgets["mod_c"]);
+}
+
+// =============================================================================
+// Budget bounds (0.5x-2.0x range)
+// =============================================================================
+
+#[test]
+fn test_max_budget_is_two_times_base() {
+    let tracker = tracker_with_history(&[
+        ("perfect", 20, 20), // 100% success
+    ]);
+
+    let module_names = vec!["perfect".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert!(
+        budgets["perfect"] <= 20,
+        "Budget should not exceed 2x base (20), got {}",
+        budgets["perfect"]
+    );
+}
+
+#[test]
+fn test_min_budget_is_half_base() {
+    let tracker = tracker_with_history(&[
+        ("failure", 20, 0), // 0% success
+    ]);
+
+    let module_names = vec!["failure".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert!(
+        budgets["failure"] >= 5,
+        "Budget should not drop below 0.5x base (5), got {}",
+        budgets["failure"]
+    );
+}
+
+// =============================================================================
+// Global candidate cap
+// =============================================================================
+
+#[test]
+fn test_global_cap_limits_total_candidates() {
+    let tracker = tracker_with_history(&[
+        ("mod_a", 20, 18),
+        ("mod_b", 20, 16),
+        ("mod_c", 20, 14),
+        ("mod_d", 20, 12),
+    ]);
+
+    let module_names = vec![
+        "mod_a".to_string(),
+        "mod_b".to_string(),
+        "mod_c".to_string(),
+        "mod_d".to_string(),
+    ];
+    let config = CandidateBudgetConfig {
+        base_candidates: 20,
+        global_max_candidates: 50,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    let total: usize = budgets.values().sum();
+    assert!(
+        total <= 50,
+        "Total candidates ({total}) should not exceed global cap (50)"
+    );
+}
+
+#[test]
+fn test_global_cap_preserves_proportions() {
+    let tracker = tracker_with_history(&[
+        ("high", 20, 18), // ~90% success
+        ("low", 20, 2),   // ~10% success
+    ]);
+
+    let module_names = vec!["high".to_string(), "low".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 20,
+        global_max_candidates: 20, // Force scaling down
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    // High-success module should still get more than low-success even after capping.
+    assert!(
+        budgets["high"] >= budgets["low"],
+        "Proportions should be preserved after capping: high={}, low={}",
+        budgets["high"],
+        budgets["low"]
+    );
+
+    let total: usize = budgets.values().sum();
+    assert!(
+        total <= 20,
+        "Total ({total}) should not exceed global cap (20)"
+    );
+}
+
+// =============================================================================
+// Sparse/unknown modules get base allocation
+// =============================================================================
+
+#[test]
+fn test_sparse_history_gets_base_allocation() {
+    let tracker = tracker_with_history(&[
+        ("sparse", 3, 3), // Too few attempts for adaptive
+    ]);
+
+    let module_names = vec!["sparse".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert_eq!(
+        budgets["sparse"], 10,
+        "Sparse-history module should get base allocation"
+    );
+}
+
+#[test]
+fn test_unknown_module_gets_base_allocation() {
+    let tracker = ModuleOutcomeTracker::new();
+
+    let module_names = vec!["unknown".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 10,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert_eq!(
+        budgets["unknown"], 10,
+        "Unknown module should get base allocation"
+    );
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_empty_module_list_returns_empty() {
+    let tracker = ModuleOutcomeTracker::new();
+    let module_names: Vec<String> = vec![];
+    let config = CandidateBudgetConfig::default();
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert!(budgets.is_empty());
+}
+
+#[test]
+fn test_every_module_gets_at_least_one_candidate() {
+    let tracker = tracker_with_history(&[
+        ("terrible", 20, 0), // 0% success
+    ]);
+
+    let module_names = vec!["terrible".to_string()];
+    let config = CandidateBudgetConfig {
+        base_candidates: 2,
+        ..Default::default()
+    };
+
+    let budgets = allocate_candidate_budgets(&module_names, &tracker, &config);
+
+    assert!(
+        budgets["terrible"] >= 1,
+        "Every module must get at least 1 candidate, got {}",
+        budgets["terrible"]
+    );
+}
+
+#[test]
+fn test_default_config_has_sensible_values() {
+    let config = CandidateBudgetConfig::default();
+
+    assert!(
+        config.base_candidates > 0,
+        "Base candidates must be positive"
+    );
+    assert!(
+        config.global_max_candidates >= config.base_candidates,
+        "Global cap must be >= base"
+    );
+    assert!(
+        (0.0..=1.0).contains(&config.min_allocation_factor),
+        "Min factor must be in [0.0, 1.0]"
+    );
+    assert!(
+        config.max_allocation_factor >= 1.0,
+        "Max factor must be >= 1.0"
+    );
+}
+
+// =============================================================================
+// DiscoveryModuleSpec max_candidates field
+// =============================================================================
+
+#[test]
+fn test_module_spec_includes_max_candidates() {
+    use neat_ai_discovery::analysis::discovery_dispatch::{
+        DiscoveryDetectionResult, DiscoveryModuleSpec,
+    };
+
+    let spec = DiscoveryModuleSpec {
+        module_name: "test".to_string(),
+        phase_name: "test_phase",
+        max_candidates: 15,
+        detect_fn: Box::new(|| {
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![],
+            })
+        }),
+    };
+
+    assert_eq!(spec.max_candidates, 15);
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -53,6 +53,7 @@ mod issue_938_constants_submodule_organisation;
 mod issue_962_ultra_conservative_variants;
 mod issue_963_cross_detection_candidate_synthesis;
 mod issue_964_per_scale_success_rate;
+mod issue_967_adaptive_candidate_budget;
 mod split_error_all_activations;
 mod split_error_fallback_candidates;
 mod target_map_optimization;


### PR DESCRIPTION
## Summary

Implement adaptive candidate budget allocation by module success rate. Discovery modules now receive candidate generation budgets proportional to their Bayesian success rate from `ModuleOutcomeTracker`, with high-success modules getting up to 2x base allocation and low-success modules getting a minimum of 0.5x (never starving exploration). A global candidate cap prevents total candidate count explosion. Closes #967.

## Changes

1. **`CandidateBudgetConfig` struct** (`src/analysis/module_weights.rs`): Configurable budget allocation parameters — base candidates per module, global max cap, min/max allocation factors.
2. **`allocate_candidate_budgets` function** (`src/analysis/module_weights.rs`): Computes per-module candidate budgets using Bayesian success rates, with proportional scaling under a global cap and verbose logging for observability.
3. **`max_candidates` field on `DiscoveryModuleSpec`** (`src/analysis/discovery_dispatch.rs`): Each module spec now carries its allocated candidate budget.
4. **Per-module truncation** (`src/analysis/discovery_dispatch.rs`): During the sequential merge phase, each module's candidates are truncated to its allocated budget before merging.
5. **Budget allocation wiring** (`src/analysis/module_dispatch_specs/mod.rs`): `dispatch_and_merge_discovery_modules` now calls `allocate_candidate_budgets` and assigns budgets to each module spec before dispatch.
6. **Macro updates** (`src/analysis/module_dispatch_specs/macros.rs`): All four `discovery_spec!` macro variants initialise `max_candidates: 0` (overridden at dispatch time).

## Evidence

- All 12 new integration tests pass, covering: success-rate scaling, equal allocation, 0.5x–2.0x bounds, global cap, sparse/unknown module fallback, edge cases, and the `max_candidates` field on `DiscoveryModuleSpec`.
- `quality.sh` passes cleanly (fmt, clippy, tests, docs, release build).

## Test Plan

- Added `tests/analysis/issue_967_adaptive_candidate_budget.rs` with 12 tests:
  - `test_high_success_module_gets_more_candidates` — verifies proportional allocation
  - `test_equal_success_gives_equal_budgets` — verifies equal rates yield equal budgets
  - `test_max_budget_is_two_times_base` — verifies upper bound clamping
  - `test_min_budget_is_half_base` — verifies lower bound clamping
  - `test_global_cap_limits_total_candidates` — verifies global cap enforcement
  - `test_global_cap_preserves_proportions` — verifies proportions under cap
  - `test_sparse_history_gets_base_allocation` — verifies fallback for sparse data
  - `test_unknown_module_gets_base_allocation` — verifies fallback for unknown modules
  - `test_empty_module_list_returns_empty` — edge case
  - `test_every_module_gets_at_least_one_candidate` — minimum floor
  - `test_default_config_has_sensible_values` — config invariants
  - `test_module_spec_includes_max_candidates` — field accessibility

---

## Automated Fix Details
This PR addresses issue #967: **feat: adaptive candidate budget allocation by module success rate**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #967
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-967 -->