### PR TITLE
test: add malformed input tests for FFI boundary error handling (#975)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.8"
+version = "0.72.9"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-975.md
+++ b/docs/pr-summary-975.md
@@ -1,0 +1,28 @@
+## Summary
+
+The FFI boundary production code already has proper error handling — all `unwrap()` calls
+at the line numbers referenced in the issue are in `#[cfg(test)]` test blocks, not in
+production code. Every FFI entry point uses `catch_unwind`, validates null pointers and
+UTF-8, handles JSON parse errors gracefully with `match`, and returns structured JSON
+error responses with `success: false`, `error`, and `errorKind` fields.
+
+This PR adds comprehensive malformed-input test coverage for the two internal entry points
+that were not previously tested for malformed input: `analyze_parallel_internal` and
+`get_calibration_summary_internal`. It also adds tests verifying that all seven internal
+FFI entry points return structured error responses with `errorKind` fields for diagnostic
+classification. Closes #975.
+
+## Evidence
+
+- All FFI entry points in `src/ffi/*.rs` use `catch_unwind` + `match` error handling
+- No `unwrap()` or `expect()` on external data exists in production code under `src/ffi/`
+  or `src/ffi_internal/` (only in `#[cfg(test)]` blocks)
+- All quality checks pass including the new tests
+
+## Test Plan
+
+- Added `tests/ffi/issue_975_ffi_boundary_error_handling.rs` with 4 tests:
+  - `analyze_parallel_internal_returns_error_json_for_malformed_input` — 9 malformed inputs
+  - `get_calibration_summary_internal_returns_error_json_for_malformed_input` — 8 malformed inputs
+  - `all_internal_entry_points_return_structured_error_for_garbage_input` — all 7 entry points
+  - `error_responses_include_error_kind_field` — verifies `errorKind` in all 7 entry points

--- a/tests/ffi/issue_975_ffi_boundary_error_handling.rs
+++ b/tests/ffi/issue_975_ffi_boundary_error_handling.rs
@@ -1,0 +1,217 @@
+//! Issue #975 — Verify FFI boundary never panics on malformed input.
+//!
+//! The FFI boundary must return structured JSON error responses instead of
+//! panicking when given malformed, truncated, or invalid input. Panics across
+//! FFI boundaries are undefined behaviour in Rust.
+//!
+//! This test file complements `issue_574_ffi_json_fuzz_edge_cases.rs` by
+//! ensuring full coverage of all internal entry points that accept external
+//! JSON input, including `analyze_parallel_internal` and
+//! `get_calibration_summary_internal` which were previously untested for
+//! malformed input in the systematic malformed-input test.
+
+// ============================================================================
+// Helper
+// ============================================================================
+
+/// Verify that a JSON string from an internal function is well-formed and
+/// contains `"success": false`.
+fn assert_error_json(json: &str, context: &str) {
+    let parsed: serde_json::Value = serde_json::from_str(json).unwrap_or_else(|e| {
+        panic!("{context}: response should be valid JSON, got error: {e}, raw: {json}")
+    });
+    assert_eq!(
+        parsed["success"], false,
+        "{context}: invalid input should yield success=false, got: {json}"
+    );
+}
+
+// ============================================================================
+// analyze_parallel_internal — malformed JSON produces error responses
+// ============================================================================
+
+#[test]
+fn analyze_parallel_internal_returns_error_json_for_malformed_input() {
+    let malformed_inputs: Vec<&str> = vec![
+        "",
+        "null",
+        "42",
+        "{",
+        "{}",
+        r#"{"creature": null}"#,
+        r#"{"parquetFile": 123}"#,
+        r#"{"parquetFile": "/tmp/test.parquet"}"#,
+        r#"not json at all"#,
+    ];
+
+    for input in &malformed_inputs {
+        let result = neat_ai_discovery::analyze_parallel_internal(input);
+        assert!(
+            result.is_ok(),
+            "analyze_parallel_internal should not return Err for input: {input}"
+        );
+        assert_error_json(
+            &result.unwrap(),
+            &format!("analyze_parallel_internal({input})"),
+        );
+    }
+}
+
+// ============================================================================
+// get_calibration_summary_internal — malformed JSON produces error responses
+// ============================================================================
+
+#[test]
+fn get_calibration_summary_internal_returns_error_json_for_malformed_input() {
+    let malformed_inputs: Vec<&str> = vec![
+        "",
+        "null",
+        "42",
+        "{",
+        "{}",
+        r#"{"discoveryHistory": null}"#,
+        r#"not json at all"#,
+        r#"{"discoveryHistory": 12345}"#,
+    ];
+
+    for input in &malformed_inputs {
+        let result = neat_ai_discovery::get_calibration_summary_internal(input);
+        assert!(
+            result.is_ok(),
+            "get_calibration_summary_internal should not return Err for input: {input}"
+        );
+        assert_error_json(
+            &result.unwrap(),
+            &format!("get_calibration_summary_internal({input})"),
+        );
+    }
+}
+
+// ============================================================================
+// All internal entry points — structured error response validation
+// ============================================================================
+
+/// Verify that every internal FFI entry point that accepts JSON input returns
+/// a structured error response with `error` and `errorKind` fields when given
+/// completely invalid JSON.
+#[test]
+fn all_internal_entry_points_return_structured_error_for_garbage_input() {
+    let garbage = "this is not json {{{[[[";
+
+    // record_discovery_internal
+    let result = neat_ai_discovery::record_discovery_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "record_discovery_internal should include an error message"
+    );
+
+    // merge_discovery_parquet_internal
+    let result = neat_ai_discovery::merge_discovery_parquet_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "merge_discovery_parquet_internal should include an error message"
+    );
+
+    // rank_focus_neurons_internal
+    let result = neat_ai_discovery::rank_focus_neurons_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "rank_focus_neurons_internal should include an error message"
+    );
+
+    // analyze_parallel_internal
+    let result = neat_ai_discovery::analyze_parallel_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "analyze_parallel_internal should include an error message"
+    );
+
+    // export_visualisation_snapshot_internal
+    let result = neat_ai_discovery::export_visualisation_snapshot_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "export_visualisation_snapshot_internal should include an error message"
+    );
+
+    // read_discovery_records
+    let result = neat_ai_discovery::read_discovery_records(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "read_discovery_records should include an error message"
+    );
+
+    // get_calibration_summary_internal
+    let result = neat_ai_discovery::get_calibration_summary_internal(garbage);
+    assert!(result.is_ok());
+    let json = result.unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["error"].is_string(),
+        "get_calibration_summary_internal should include an error message"
+    );
+}
+
+/// Verify that error responses include `errorKind` for diagnostic classification.
+#[test]
+fn error_responses_include_error_kind_field() {
+    let garbage = "<<<not json>>>";
+
+    let check_error_kind = |name: &str, json_str: &str| {
+        let parsed: serde_json::Value = serde_json::from_str(json_str)
+            .unwrap_or_else(|e| panic!("{name}: response should be valid JSON: {e}"));
+        assert_eq!(parsed["success"], false, "{name}: should fail");
+        // The field may be serialised as camelCase or snake_case depending on
+        // the output type's serde configuration.
+        let has_error_kind = parsed["errorKind"].is_string() || parsed["error_kind"].is_string();
+        assert!(
+            has_error_kind,
+            "{name}: error response should include errorKind or error_kind field, got: {json_str}"
+        );
+    };
+
+    let result = neat_ai_discovery::record_discovery_internal(garbage).unwrap();
+    check_error_kind("record_discovery_internal", &result);
+
+    let result = neat_ai_discovery::analyze_parallel_internal(garbage).unwrap();
+    check_error_kind("analyze_parallel_internal", &result);
+
+    let result = neat_ai_discovery::rank_focus_neurons_internal(garbage).unwrap();
+    check_error_kind("rank_focus_neurons_internal", &result);
+
+    let result = neat_ai_discovery::get_calibration_summary_internal(garbage).unwrap();
+    check_error_kind("get_calibration_summary_internal", &result);
+
+    let result = neat_ai_discovery::merge_discovery_parquet_internal(garbage).unwrap();
+    check_error_kind("merge_discovery_parquet_internal", &result);
+
+    let result = neat_ai_discovery::read_discovery_records(garbage).unwrap();
+    check_error_kind("read_discovery_records", &result);
+
+    let result = neat_ai_discovery::export_visualisation_snapshot_internal(garbage).unwrap();
+    check_error_kind("export_visualisation_snapshot_internal", &result);
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -7,3 +7,4 @@ mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;
 mod issue_952_uuid_only_ffi_contract;
+mod issue_975_ffi_boundary_error_handling;


### PR DESCRIPTION
## Summary

The FFI boundary production code already has proper error handling — all `unwrap()` calls
at the line numbers referenced in the issue are in `#[cfg(test)]` test blocks, not in
production code. Every FFI entry point uses `catch_unwind`, validates null pointers and
UTF-8, handles JSON parse errors gracefully with `match`, and returns structured JSON
error responses with `success: false`, `error`, and `errorKind` fields.

This PR adds comprehensive malformed-input test coverage for the two internal entry points
that were not previously tested for malformed input: `analyze_parallel_internal` and
`get_calibration_summary_internal`. It also adds tests verifying that all seven internal
FFI entry points return structured error responses with `errorKind` fields for diagnostic
classification. Closes #975.

## Evidence

- All FFI entry points in `src/ffi/*.rs` use `catch_unwind` + `match` error handling
- No `unwrap()` or `expect()` on external data exists in production code under `src/ffi/`
  or `src/ffi_internal/` (only in `#[cfg(test)]` blocks)
- All quality checks pass including the new tests

## Test Plan

- Added `tests/ffi/issue_975_ffi_boundary_error_handling.rs` with 4 tests:
  - `analyze_parallel_internal_returns_error_json_for_malformed_input` — 9 malformed inputs
  - `get_calibration_summary_internal_returns_error_json_for_malformed_input` — 8 malformed inputs
  - `all_internal_entry_points_return_structured_error_for_garbage_input` — all 7 entry points
  - `error_responses_include_error_kind_field` — verifies `errorKind` in all 7 entry points

---

## Automated Fix Details
This PR addresses issue #975: **Replace unwrap() calls in FFI boundary with proper error handling**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #975
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-975 -->