### PR TITLE
refactor: extract shared GPU pipeline builder to reduce boilerplate (#978)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,7 @@ src/
 │   │   ├── relu_evaluation.rs     # ReLU activation GPU evaluation
 │   │   ├── activation_evaluation.rs # Activation function GPU evaluation
 │   │   ├── bias_evaluation.rs     # Bias GPU evaluation
+│   │   ├── pipeline_builder.rs    # Shared compute pipeline builder (Issue #978)
 │   │   ├── queue/            # GPU work queue (Issue #608)
 │   │   │   ├── mod.rs            # Public API, re-exports, queue types
 │   │   │   ├── submission.rs     # Work item submission and batching

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.11"
+version = "0.72.12"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-978.md
+++ b/docs/pr-summary-978.md
@@ -1,0 +1,24 @@
+## Summary
+
+Extract shared GPU compute pipeline builder to eliminate duplicated boilerplate across five GPU evaluation modules. Closes #978.
+
+A new `pipeline_builder.rs` module provides a reusable `build_compute_pipeline()` function that accepts shader source, binding specifications, and labels — replacing ~200 lines of near-identical pipeline construction code that was previously copy-pasted across `helpful_evaluation.rs`, `harmful_evaluation.rs`, `activation_evaluation.rs`, `relu_evaluation.rs`, and `bias_evaluation.rs`.
+
+Two predefined binding layouts are provided:
+- `STANDARD_BINDINGS` (3 bindings: storage RO, storage RW, uniform) — used by 7 of 8 pipelines
+- `BIAS_BINDINGS` (4 bindings: 2x storage RO, storage RW, uniform) — used by the bias pipeline
+
+No functional changes — all GPU compute results remain identical.
+
+## Evidence
+
+- All 158 tests pass
+- All quality checks pass (clippy, fmt, doc build, release build)
+- The refactored pipeline builders delegate to the shared helper with identical labels, shader sources, and binding types
+
+## Test Plan
+
+- Added unit tests in `pipeline_builder.rs` verifying:
+  - `STANDARD_BINDINGS` has correct count (3) and binding types
+  - `BIAS_BINDINGS` has correct count (4) and binding types
+- All existing tests continue to pass unchanged (158 tests)

--- a/src/analysis/gpu/activation_evaluation.rs
+++ b/src/analysis/gpu/activation_evaluation.rs
@@ -13,6 +13,7 @@ use wgpu::util::DeviceExt;
 use crate::analysis::gpu::device::{
     GPU_BUFFER_MAP_TIMEOUT_SECS, wait_for_buffer_map, wait_for_buffer_maps_batch,
 };
+use crate::analysis::gpu::pipeline_builder::{STANDARD_BINDINGS, build_compute_pipeline};
 use crate::analysis::gpu::shaders::{
     ACTIVATION_REDUCE_SHADER, ACTIVATION_SHADER, GPU_REDUCTION_THRESHOLD, WORKGROUP_SIZE,
 };
@@ -32,63 +33,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("activation-shader"),
-            source: wgpu::ShaderSource::Wgsl(ACTIVATION_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("activation-bind-group"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "activation-shader",
+            ACTIVATION_SHADER,
+            "activation-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 
     /// Build the activation output reduction pipeline (Issue #567).
@@ -99,63 +51,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("activation-reduce-shader"),
-            source: wgpu::ShaderSource::Wgsl(ACTIVATION_REDUCE_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("activation-reduce-bind-group"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "activation-reduce-shader",
+            ACTIVATION_REDUCE_SHADER,
+            "activation-reduce-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 }
 

--- a/src/analysis/gpu/bias_evaluation.rs
+++ b/src/analysis/gpu/bias_evaluation.rs
@@ -10,6 +10,7 @@ use std::sync::mpsc;
 use wgpu::util::DeviceExt;
 
 use crate::analysis::gpu::device::{GPU_BUFFER_MAP_TIMEOUT_SECS, wait_for_buffer_map};
+use crate::analysis::gpu::pipeline_builder::{BIAS_BINDINGS, build_compute_pipeline};
 use crate::analysis::gpu::shaders::{BIAS_SHADER, MIN_NEURON_SAMPLE_COUNT, WORKGROUP_SIZE};
 use crate::analysis::samples::{
     BiasResult, BiasUniforms, EPSILON, GpuHelpfulSample, HelpfulSample,
@@ -26,77 +27,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("bias-shader"),
-            source: wgpu::ShaderSource::Wgsl(BIAS_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("bias-bind-group"),
-            entries: &[
-                // Binding 0: samples (read-only)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 1: bias_candidates (read-only)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 2: results (read-write)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 3: uniforms
-                wgpu::BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "bias-shader",
+            BIAS_SHADER,
+            "bias-bind-group",
+            &BIAS_BINDINGS,
+            label,
+        )
     }
 }
 

--- a/src/analysis/gpu/harmful_evaluation.rs
+++ b/src/analysis/gpu/harmful_evaluation.rs
@@ -14,6 +14,7 @@ use wgpu::util::DeviceExt;
 use crate::analysis::gpu::device::{
     GPU_BUFFER_MAP_TIMEOUT_SECS, poll_device_until_idle, wait_for_buffer_maps_batch,
 };
+use crate::analysis::gpu::pipeline_builder::{STANDARD_BINDINGS, build_compute_pipeline};
 use crate::analysis::gpu::shaders::{
     GPU_REDUCTION_THRESHOLD, HARMFUL_REDUCE_SHADER, HARMFUL_SHADER, WORKGROUP_SIZE,
 };
@@ -34,63 +35,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("harmful-synapse-shader"),
-            source: wgpu::ShaderSource::Wgsl(HARMFUL_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("harmful-synapse-bind-group"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "harmful-synapse-shader",
+            HARMFUL_SHADER,
+            "harmful-synapse-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 
     /// Build the harmful contribution reduction pipeline (Issue #218).
@@ -101,66 +53,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("harmful-reduce-shader"),
-            source: wgpu::ShaderSource::Wgsl(HARMFUL_REDUCE_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("harmful-reduce-bind-group"),
-            entries: &[
-                // Binding 0: contributions (read-only input)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 1: partial_sums (read-write output)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 2: uniforms
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "harmful-reduce-shader",
+            HARMFUL_REDUCE_SHADER,
+            "harmful-reduce-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 }
 

--- a/src/analysis/gpu/helpful_evaluation.rs
+++ b/src/analysis/gpu/helpful_evaluation.rs
@@ -14,6 +14,7 @@ use wgpu::util::DeviceExt;
 use crate::analysis::gpu::device::{
     GPU_BUFFER_MAP_TIMEOUT_SECS, poll_device_until_idle, wait_for_buffer_maps_batch,
 };
+use crate::analysis::gpu::pipeline_builder::{STANDARD_BINDINGS, build_compute_pipeline};
 use crate::analysis::gpu::shaders::{
     GPU_REDUCTION_THRESHOLD, HELPFUL_REDUCE_SHADER, HELPFUL_SHADER, WORKGROUP_SIZE,
 };
@@ -34,63 +35,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("helpful-synapse-shader"),
-            source: wgpu::ShaderSource::Wgsl(HELPFUL_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("helpful-synapse-bind-group"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "helpful-synapse-shader",
+            HELPFUL_SHADER,
+            "helpful-synapse-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 
     /// Build the helpful contribution reduction pipeline (Issue #218).
@@ -101,66 +53,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("helpful-reduce-shader"),
-            source: wgpu::ShaderSource::Wgsl(HELPFUL_REDUCE_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("helpful-reduce-bind-group"),
-            entries: &[
-                // Binding 0: contributions (read-only input)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 1: partial_sums (read-write output)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                // Binding 2: uniforms
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "helpful-reduce-shader",
+            HELPFUL_REDUCE_SHADER,
+            "helpful-reduce-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 }
 

--- a/src/analysis/gpu/mod.rs
+++ b/src/analysis/gpu/mod.rs
@@ -16,6 +16,7 @@
 //! ├── relu_evaluation.rs        <- ReLU activation GPU evaluation (Issue #520)
 //! ├── activation_evaluation.rs  <- Activation function GPU evaluation (Issue #520)
 //! ├── bias_evaluation.rs        <- Bias GPU evaluation (Issue #520)
+//! ├── pipeline_builder.rs      <- Shared compute pipeline builder (Issue #978)
 //! ├── queue/                    <- GPU work queue (Issue #274, #608)
 //! │   ├── mod.rs                <- Public API, re-exports, queue types
 //! │   ├── submission.rs         <- Work item submission and batching
@@ -37,6 +38,7 @@ pub mod bias_evaluation;
 pub mod device;
 pub mod harmful_evaluation;
 pub mod helpful_evaluation;
+pub(crate) mod pipeline_builder;
 pub mod queue;
 pub mod relu_evaluation;
 pub mod shaders;

--- a/src/analysis/gpu/pipeline_builder.rs
+++ b/src/analysis/gpu/pipeline_builder.rs
@@ -1,0 +1,157 @@
+//! Shared GPU compute pipeline builder (Issue #978).
+//!
+//! Provides a reusable helper for constructing `wgpu` bind group layouts,
+//! pipeline layouts, and compute pipelines — eliminating the boilerplate
+//! that was previously duplicated across the five GPU evaluation modules.
+
+/// Describes a single buffer binding in a compute pipeline's bind group layout.
+pub(crate) struct BufferBindingSpec {
+    /// Whether the buffer is read-only storage, read-write storage, or uniform.
+    pub ty: wgpu::BufferBindingType,
+}
+
+/// Build a complete compute pipeline from a WGSL shader source and binding specifications.
+///
+/// Returns the `(BindGroupLayout, ComputePipeline)` tuple needed by each evaluation module.
+/// All pipelines share a common structure: a single bind group layout, entry point `"main"`,
+/// and default compilation options.
+pub(crate) fn build_compute_pipeline(
+    device: &wgpu::Device,
+    shader_label: &str,
+    shader_source: &str,
+    bind_group_label: &str,
+    bindings: &[BufferBindingSpec],
+    pipeline_label: &str,
+) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some(shader_label),
+        source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+    });
+
+    let entries: Vec<wgpu::BindGroupLayoutEntry> = bindings
+        .iter()
+        .enumerate()
+        .map(|(i, spec)| wgpu::BindGroupLayoutEntry {
+            #[allow(clippy::cast_possible_truncation)] // Bind group index is always < 5
+            binding: i as u32,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: spec.ty,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        })
+        .collect();
+
+    let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some(bind_group_label),
+        entries: &entries,
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(pipeline_label),
+        bind_group_layouts: &[Some(&layout)],
+        immediate_size: 0,
+    });
+
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some(pipeline_label),
+        layout: Some(&pipeline_layout),
+        module: &shader,
+        entry_point: Some("main"),
+        compilation_options: wgpu::PipelineCompilationOptions::default(),
+        cache: None,
+    });
+
+    (layout, pipeline)
+}
+
+/// Standard 3-binding layout: storage read-only, storage read-write, uniform.
+///
+/// Used by helpful, harmful, `ReLU`, activation, and their reduction pipelines.
+pub(crate) const STANDARD_BINDINGS: [BufferBindingSpec; 3] = [
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Storage { read_only: true },
+    },
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Storage { read_only: false },
+    },
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Uniform,
+    },
+];
+
+/// Bias-specific 4-binding layout: two storage read-only, one storage read-write, one uniform.
+pub(crate) const BIAS_BINDINGS: [BufferBindingSpec; 4] = [
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Storage { read_only: true },
+    },
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Storage { read_only: true },
+    },
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Storage { read_only: false },
+    },
+    BufferBindingSpec {
+        ty: wgpu::BufferBindingType::Uniform,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_standard_bindings_has_correct_count() {
+        assert_eq!(STANDARD_BINDINGS.len(), 3);
+    }
+
+    #[test]
+    fn test_bias_bindings_has_correct_count() {
+        assert_eq!(BIAS_BINDINGS.len(), 4);
+    }
+
+    #[test]
+    fn test_standard_bindings_types() {
+        // Binding 0: storage read-only
+        assert!(matches!(
+            STANDARD_BINDINGS[0].ty,
+            wgpu::BufferBindingType::Storage { read_only: true }
+        ));
+        // Binding 1: storage read-write
+        assert!(matches!(
+            STANDARD_BINDINGS[1].ty,
+            wgpu::BufferBindingType::Storage { read_only: false }
+        ));
+        // Binding 2: uniform
+        assert!(matches!(
+            STANDARD_BINDINGS[2].ty,
+            wgpu::BufferBindingType::Uniform
+        ));
+    }
+
+    #[test]
+    fn test_bias_bindings_types() {
+        // Binding 0: storage read-only (samples)
+        assert!(matches!(
+            BIAS_BINDINGS[0].ty,
+            wgpu::BufferBindingType::Storage { read_only: true }
+        ));
+        // Binding 1: storage read-only (bias candidates)
+        assert!(matches!(
+            BIAS_BINDINGS[1].ty,
+            wgpu::BufferBindingType::Storage { read_only: true }
+        ));
+        // Binding 2: storage read-write (results)
+        assert!(matches!(
+            BIAS_BINDINGS[2].ty,
+            wgpu::BufferBindingType::Storage { read_only: false }
+        ));
+        // Binding 3: uniform
+        assert!(matches!(
+            BIAS_BINDINGS[3].ty,
+            wgpu::BufferBindingType::Uniform
+        ));
+    }
+}

--- a/src/analysis/gpu/relu_evaluation.rs
+++ b/src/analysis/gpu/relu_evaluation.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc;
 use wgpu::util::DeviceExt;
 
 use crate::analysis::gpu::device::{GPU_BUFFER_MAP_TIMEOUT_SECS, wait_for_buffer_map};
+use crate::analysis::gpu::pipeline_builder::{STANDARD_BINDINGS, build_compute_pipeline};
 use crate::analysis::gpu::shaders::{RELU_SHADER, WORKGROUP_SIZE};
 use crate::analysis::samples::{
     EPSILON, GpuHelpfulSample, HelpfulSample, ReluContribution, ReluOrientation, ReluStats,
@@ -28,63 +29,14 @@ impl GpuAnalyzer {
         device: &wgpu::Device,
         label: &str,
     ) -> (wgpu::BindGroupLayout, wgpu::ComputePipeline) {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("relu-shader"),
-            source: wgpu::ShaderSource::Wgsl(RELU_SHADER.into()),
-        });
-
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("relu-bind-group"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some(label),
-            bind_group_layouts: &[Some(&layout)],
-            immediate_size: 0,
-        });
-
-        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some(label),
-            layout: Some(&pipeline_layout),
-            module: &shader,
-            entry_point: Some("main"),
-            compilation_options: wgpu::PipelineCompilationOptions::default(),
-            cache: None,
-        });
-
-        (layout, pipeline)
+        build_compute_pipeline(
+            device,
+            "relu-shader",
+            RELU_SHADER,
+            "relu-bind-group",
+            &STANDARD_BINDINGS,
+            label,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Extract shared GPU compute pipeline builder to eliminate duplicated boilerplate across five GPU evaluation modules. Closes #978.

A new `pipeline_builder.rs` module provides a reusable `build_compute_pipeline()` function that accepts shader source, binding specifications, and labels — replacing ~200 lines of near-identical pipeline construction code that was previously copy-pasted across `helpful_evaluation.rs`, `harmful_evaluation.rs`, `activation_evaluation.rs`, `relu_evaluation.rs`, and `bias_evaluation.rs`.

Two predefined binding layouts are provided:
- `STANDARD_BINDINGS` (3 bindings: storage RO, storage RW, uniform) — used by 7 of 8 pipelines
- `BIAS_BINDINGS` (4 bindings: 2x storage RO, storage RW, uniform) — used by the bias pipeline

No functional changes — all GPU compute results remain identical.

## Evidence

- All 158 tests pass
- All quality checks pass (clippy, fmt, doc build, release build)
- The refactored pipeline builders delegate to the shared helper with identical labels, shader sources, and binding types

## Test Plan

- Added unit tests in `pipeline_builder.rs` verifying:
  - `STANDARD_BINDINGS` has correct count (3) and binding types
  - `BIAS_BINDINGS` has correct count (4) and binding types
- All existing tests continue to pass unchanged (158 tests)

---

## Automated Fix Details
This PR addresses issue #978: **Extract shared GPU pipeline builder to reduce boilerplate**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #978
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-978 -->