### PR TITLE
fix: replace panic with graceful GPU unavailable error in analysis (#988)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.13"
+version = "0.72.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-988.md
+++ b/docs/pr-summary-988.md
@@ -1,0 +1,38 @@
+## Summary
+
+Replace `assert!` / `panic!` with graceful `DiscoveryError::GpuUnavailable` error
+returns in both neuron and synapse analysis when GPU is unavailable. Previously,
+calling `analyze_parallel` on a machine without a GPU caused a thread panic at
+`src/analysis/neuron/mod.rs:99` and `src/analysis/synapse/orchestration.rs:69`.
+Now these code paths return a structured JSON error with
+`{ "success": false, "errorKind": "gpu_permanent" }` that the TypeScript layer
+can handle gracefully. Closes #988.
+
+## Changes
+
+- `src/analysis/neuron/mod.rs`: Replaced `assert!(GpuAnalyzer::gpu_is_available(), ...)`
+  with an `if` check that returns `DiscoveryError::GpuUnavailable` via `anyhow`.
+- `src/analysis/synapse/orchestration.rs`: Same replacement for the synapse analysis
+  path.
+- Both errors propagate through the existing FFI error handling infrastructure
+  (`error_fields_from_anyhow` → `classify_anyhow_error`) to produce the correct
+  `gpu_permanent` error kind in the JSON response.
+
+## Evidence
+
+- On machines without a GPU, `analyze_parallel_internal` now returns structured
+  JSON with `errorKind: "gpu_permanent"` instead of panicking.
+- On machines with a GPU, behaviour is unchanged — the GPU availability check
+  passes and analysis proceeds normally.
+
+## Test Plan
+
+- Added `tests/infrastructure/issue_988_graceful_gpu_error.rs` with 3 tests:
+  - `gpu_unavailable_error_propagates_as_gpu_permanent_through_anyhow` — verifies
+    `DiscoveryError::GpuUnavailable` classifies as `GpuPermanent` through anyhow.
+  - `gpu_unavailable_error_fields_produce_correct_triple` — verifies the
+    `(error_msg, error_kind, retryable)` tuple is correct.
+  - `analyze_parallel_returns_structured_error_when_no_gpu` — end-to-end test
+    that calls `analyze_parallel_internal` and verifies structured JSON error
+    response on machines without GPU.
+- All existing tests continue to pass (`./quality.sh` clean).

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -94,12 +94,14 @@ pub(crate) fn analyze_neurons_with_cache(
     ));
 
     let deadline = build_deadline(input.analysis_deadline_ms);
-    // GPU is always required - TypeScript layer calls check_gpu_available() and skips
-    // discovery entirely on machines without GPU. Reaching here without GPU is a bug.
-    assert!(
-        GpuAnalyzer::gpu_is_available(),
-        "Discovery logic called without GPU - check_gpu_available should have prevented this"
-    );
+    // GPU is required for analysis. Return a structured error instead of panicking
+    // so the TypeScript layer receives a JSON response it can handle gracefully.
+    if !GpuAnalyzer::gpu_is_available() {
+        return Err(crate::ffi_types::DiscoveryError::GpuUnavailable {
+            reason: "No compatible GPU adapter found on this system".to_string(),
+        }
+        .into());
+    }
     let gpu_used = true;
     let analysis_timed_out = Arc::new(AtomicBool::new(false));
 

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -196,6 +196,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         });
     }
 
+    // Early GPU availability check (Issue #988): fail fast with a structured
+    // error before attempting expensive parquet I/O. The per-module checks in
+    // synapse/neuron analysis are retained as a defence-in-depth measure.
+    if !super::gpu::GpuAnalyzer::gpu_is_available() {
+        return Err(crate::ffi_types::DiscoveryError::GpuUnavailable {
+            reason: "No compatible GPU adapter found on this system".to_string(),
+        }
+        .into());
+    }
+
     crate::watchdog::beat("analysis::analyze_all → loading parquet cache");
 
     // Pre-load ALL records from parquet in one pass. This is MUCH faster than

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -66,10 +66,14 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     let total_focus_count = focus_order.len();
     let completed_count = Arc::new(AtomicUsize::new(0));
 
-    assert!(
-        GpuAnalyzer::gpu_is_available(),
-        "Discovery logic called without GPU - check_gpu_available should have prevented this"
-    );
+    // GPU is required for analysis. Return a structured error instead of panicking
+    // so the TypeScript layer receives a JSON response it can handle gracefully.
+    if !GpuAnalyzer::gpu_is_available() {
+        return Err(crate::ffi_types::DiscoveryError::GpuUnavailable {
+            reason: "No compatible GPU adapter found on this system".to_string(),
+        }
+        .into());
+    }
 
     // Phase 3: Shared atomic state for parallel processing (lock-free)
     let metadata = Arc::new(AtomicMetadata::new());

--- a/tests/infrastructure/issue_988_graceful_gpu_error.rs
+++ b/tests/infrastructure/issue_988_graceful_gpu_error.rs
@@ -74,7 +74,9 @@ fn analyze_parallel_returns_structured_error_when_no_gpu() {
             ],
             "synapses": [
                 {"fromUuid": "input-1", "toUuid": "output-1", "weight": 1.0}
-            ]
+            ],
+            "input": 1,
+            "output": 1
         },
         "focusNeurons": ["output-1"],
         "maxSynapseCandidates": 10,

--- a/tests/infrastructure/issue_988_graceful_gpu_error.rs
+++ b/tests/infrastructure/issue_988_graceful_gpu_error.rs
@@ -1,0 +1,108 @@
+//! Integration tests for graceful GPU unavailable error handling (Issue #988).
+//!
+//! Verifies that when `DiscoveryError::GpuUnavailable` is returned from analysis
+//! functions, it propagates through the FFI layer as a structured JSON error with
+//! `errorKind: "gpu_permanent"` instead of panicking the thread.
+
+use neat_ai_discovery::ffi_types::{
+    DiscoveryError, DiscoveryErrorKind, classify_anyhow_error, error_fields_from_anyhow,
+};
+
+// ============================================================================
+// GpuUnavailable error propagates correctly through anyhow
+// ============================================================================
+
+#[test]
+fn gpu_unavailable_error_propagates_as_gpu_permanent_through_anyhow() {
+    let typed_err = DiscoveryError::GpuUnavailable {
+        reason: "No compatible GPU adapter found on this system".to_string(),
+    };
+    let anyhow_err: anyhow::Error = typed_err.into();
+
+    let kind = classify_anyhow_error(&anyhow_err);
+    assert_eq!(kind, DiscoveryErrorKind::GpuPermanent);
+    assert!(
+        !kind.is_retryable(),
+        "GPU permanent errors should not be retryable"
+    );
+}
+
+#[test]
+fn gpu_unavailable_error_fields_produce_correct_triple() {
+    let typed_err = DiscoveryError::GpuUnavailable {
+        reason: "No compatible GPU adapter found on this system".to_string(),
+    };
+    let anyhow_err: anyhow::Error = typed_err.into();
+
+    let (err_msg, error_kind, retryable) = error_fields_from_anyhow(&anyhow_err);
+    assert!(
+        err_msg.contains("GPU unavailable"),
+        "Error message should contain 'GPU unavailable', got: {err_msg}"
+    );
+    assert_eq!(error_kind, Some(DiscoveryErrorKind::GpuPermanent));
+    assert_eq!(retryable, Some(false));
+}
+
+// ============================================================================
+// analyze_parallel_internal returns structured error when GPU is unavailable
+// ============================================================================
+
+/// On machines without a GPU, `analyze_parallel_internal` must return a
+/// structured JSON error with `errorKind: "gpu_permanent"` instead of panicking.
+///
+/// On machines with a GPU, the analysis proceeds normally (success or a
+/// different error), so the test only validates the no-GPU path when
+/// `GpuAnalyzer::gpu_is_available()` returns false.
+#[test]
+fn analyze_parallel_returns_structured_error_when_no_gpu() {
+    use neat_ai_discovery::analysis::GpuAnalyzer;
+
+    // Only test the no-GPU path on machines that actually lack a GPU.
+    // On GPU-equipped machines this test is a no-op (the fix is validated
+    // by the error propagation tests above).
+    if GpuAnalyzer::gpu_is_available() {
+        return;
+    }
+
+    // Minimal valid input that would previously trigger the panic
+    let input_json = serde_json::json!({
+        "parquetFile": "/tmp/nonexistent.parquet",
+        "creature": {
+            "neurons": [
+                {"uuid": "input-1", "neuronType": "input", "squash": "IDENTITY", "bias": 0.0},
+                {"uuid": "output-1", "neuronType": "output", "squash": "LOGISTIC", "bias": 0.0}
+            ],
+            "synapses": [
+                {"fromUuid": "input-1", "toUuid": "output-1", "weight": 1.0}
+            ]
+        },
+        "focusNeurons": ["output-1"],
+        "maxSynapseCandidates": 10,
+        "maxNeuronCandidates": 10,
+        "analysisDeadlineMs": 5000,
+        "randomSeed": 42
+    });
+
+    let result = neat_ai_discovery::analyze_parallel_internal(&input_json.to_string());
+    let json_str = result.expect("Should return Ok with error JSON, not panic");
+    let value: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(value["success"], false, "Should report failure");
+    assert_eq!(
+        value["errorKind"], "gpu_permanent",
+        "Should classify as gpu_permanent, got: {:?}",
+        value["errorKind"]
+    );
+    assert_eq!(
+        value["retryable"], false,
+        "GPU permanent errors should not be retryable"
+    );
+    assert!(
+        value["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("GPU unavailable"),
+        "Error message should mention GPU unavailable, got: {:?}",
+        value["error"]
+    );
+}

--- a/tests/infrastructure/main.rs
+++ b/tests/infrastructure/main.rs
@@ -20,4 +20,5 @@ mod issue_832_deadlock_stress;
 mod issue_836_deadlock_abort;
 mod issue_837_lock_contention_tracing;
 mod issue_874_module_split_backward_compat;
+mod issue_988_graceful_gpu_error;
 mod observability;


### PR DESCRIPTION
## Summary

Replace `assert!` / `panic!` with graceful `DiscoveryError::GpuUnavailable` error
returns in both neuron and synapse analysis when GPU is unavailable. Previously,
calling `analyze_parallel` on a machine without a GPU caused a thread panic at
`src/analysis/neuron/mod.rs:99` and `src/analysis/synapse/orchestration.rs:69`.
Now these code paths return a structured JSON error with
`{ "success": false, "errorKind": "gpu_permanent" }` that the TypeScript layer
can handle gracefully. Closes #988.

## Changes

- `src/analysis/neuron/mod.rs`: Replaced `assert!(GpuAnalyzer::gpu_is_available(), ...)`
  with an `if` check that returns `DiscoveryError::GpuUnavailable` via `anyhow`.
- `src/analysis/synapse/orchestration.rs`: Same replacement for the synapse analysis
  path.
- Both errors propagate through the existing FFI error handling infrastructure
  (`error_fields_from_anyhow` → `classify_anyhow_error`) to produce the correct
  `gpu_permanent` error kind in the JSON response.

## Evidence

- On machines without a GPU, `analyze_parallel_internal` now returns structured
  JSON with `errorKind: "gpu_permanent"` instead of panicking.
- On machines with a GPU, behaviour is unchanged — the GPU availability check
  passes and analysis proceeds normally.

## Test Plan

- Added `tests/infrastructure/issue_988_graceful_gpu_error.rs` with 3 tests:
  - `gpu_unavailable_error_propagates_as_gpu_permanent_through_anyhow` — verifies
    `DiscoveryError::GpuUnavailable` classifies as `GpuPermanent` through anyhow.
  - `gpu_unavailable_error_fields_produce_correct_triple` — verifies the
    `(error_msg, error_kind, retryable)` tuple is correct.
  - `analyze_parallel_returns_structured_error_when_no_gpu` — end-to-end test
    that calls `analyze_parallel_internal` and verifies structured JSON error
    response on machines without GPU.
- All existing tests continue to pass (`./quality.sh` clean).

---

## Automated Fix Details
This PR addresses issue #988: **Replace panic with graceful error in analyze_parallel when GPU is unavailable**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #988
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-988 -->