### PR TITLE
perf: overlap candidate compression with discovery module detection (#1004)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.23"
+version = "0.72.24"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1004.md
+++ b/docs/pr-summary-1004.md
@@ -1,0 +1,38 @@
+## Summary
+
+Overlap candidate compression with discovery module detection phase in `analyze_all()` post-processing pipeline. Closes #1004.
+
+Previously, candidate compression (identity + nonlinear) and discovery module detection (~48 modules) ran sequentially. Both phases read from the synapse result immutably during detection — compression reads `helpful_synapses`, and discovery module detection closures capture their data before execution. This change runs both detection phases concurrently via `rayon::join`, then merges results sequentially (compression first, then discovery modules) to preserve deterministic ordering.
+
+### Changes
+
+1. **`src/analysis/discovery_dispatch.rs`** — Split `run_discovery_modules_parallel` into two composable functions:
+   - `detect_discovery_modules_parallel` — runs all detection closures concurrently, returns `DiscoveryModuleDetectionResults`
+   - `merge_discovery_module_results` — merges detection results into synapse result sequentially
+   - `run_discovery_modules_parallel` retained as a convenience wrapper calling both
+
+2. **`src/analysis/module_dispatch_specs/mod.rs`** — Added `prepare_and_detect_discovery_modules` that builds specs, allocates budgets, and runs detection without merging. Removed unused `dispatch_and_merge_discovery_modules`.
+
+3. **`src/analysis/orchestration.rs`** — Restructured post-processing to use `rayon::join` to overlap compression detection with discovery module detection, then merge sequentially.
+
+### Performance
+
+Wall-clock time for post-processing decreases because the lighter compression work (identity + nonlinear via nested `rayon::join`) overlaps with the heavier discovery module dispatch (~48 parallel detection closures). Benchmarks require GPU hardware and can be measured with `cargo bench --bench pipeline_utilisation`.
+
+## Evidence
+- 8 new integration tests verify:
+  - Split detect + merge produces identical results to the combined function
+  - Detection results preserve original module order
+  - Empty inputs handled correctly
+  - Overlapped compression + detection produces same results as sequential
+  - Deterministic across 10 repeated runs (no race conditions)
+  - Merge ordering: compression before discovery
+  - `max_synapse_candidates` respected through split path
+- All 17 existing `discovery_dispatch` unit tests pass unchanged
+- All 158 analysis integration tests pass
+- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)
+
+## Test Plan
+- Added `tests/analysis/issue_1004_overlap_compression_discovery.rs` with 8 tests
+- Existing tests verified: `discovery_dispatch_tests.rs`, `discovery_dispatch_parallel_tests.rs`, `issue_1003_parallel_candidate_compression.rs`
+- Run: `cargo test --test analysis -- issue_1004`

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -92,6 +92,129 @@ pub struct DiscoveryModuleSpec {
     pub detect_fn: Box<dyn FnOnce() -> Option<DiscoveryDetectionResult> + Send>,
 }
 
+/// A single module's detection output, paired with its metadata for the merge phase.
+pub struct DiscoveryModuleDetectionEntry {
+    pub module_name: String,
+    pub phase_name: &'static str,
+    pub max_candidates: usize,
+    pub result: Option<DiscoveryDetectionResult>,
+}
+
+/// Collected detection results from all discovery modules (Issue #1004).
+///
+/// Returned by [`detect_discovery_modules_parallel`] for deferred merging,
+/// allowing the detection phase to overlap with other concurrent work
+/// (e.g., candidate compression).
+pub struct DiscoveryModuleDetectionResults {
+    pub entries: Vec<DiscoveryModuleDetectionEntry>,
+}
+
+/// Run all discovery module detection phases in parallel, returning results
+/// without merging into the synapse result (Issue #1004).
+///
+/// Detection closures execute concurrently via `rayon::into_par_iter()`. Results
+/// are collected in original module order (rayon preserves indexed iterator order),
+/// ensuring deterministic output regardless of thread scheduling.
+///
+/// Call [`merge_discovery_module_results`] afterwards to merge into `syn`.
+#[tracing::instrument(skip_all, fields(module_count = modules.len()))]
+pub fn detect_discovery_modules_parallel(
+    modules: Vec<DiscoveryModuleSpec>,
+) -> DiscoveryModuleDetectionResults {
+    if modules.is_empty() {
+        return DiscoveryModuleDetectionResults {
+            entries: Vec::new(),
+        };
+    }
+
+    crate::watchdog::beat("analysis::analyze_all → parallel discovery detection starting");
+    let _timer = PhaseTimer::new("parallel_discovery_detection");
+
+    // Parallel detection phase: run all closures concurrently.
+    // `into_par_iter().map().collect()` preserves input order for indexed iterators.
+    let entries: Vec<DiscoveryModuleDetectionEntry> = modules
+        .into_par_iter()
+        .map(|spec| {
+            let result = (spec.detect_fn)();
+            DiscoveryModuleDetectionEntry {
+                module_name: spec.module_name,
+                phase_name: spec.phase_name,
+                max_candidates: spec.max_candidates,
+                result,
+            }
+        })
+        .collect();
+
+    crate::watchdog::beat("analysis::analyze_all → parallel discovery detection finished");
+
+    DiscoveryModuleDetectionResults { entries }
+}
+
+/// Merge previously-detected discovery module results into the synapse result (Issue #1004).
+///
+/// Iterates entries in original order and merges non-empty results sequentially.
+/// Also collects per-module stats for metadata (Issue #485, #792).
+pub fn merge_discovery_module_results(
+    syn: &mut shared::AnalyzeSynapsesResult,
+    detection_results: DiscoveryModuleDetectionResults,
+    max_synapse_candidates: Option<usize>,
+    diversify: bool,
+    tracker: &ModuleOutcomeTracker,
+) {
+    for entry in detection_results.entries {
+        let candidates_produced = entry.result.as_ref().map_or(0, |r| r.candidates.len());
+
+        // Record per-module stats in metadata from historical tracker (Issue #792).
+        let historical = tracker.stats(&entry.module_name);
+        syn.metadata
+            .discovery_module_stats
+            .push(DiscoveryModuleStatsJson {
+                module_name: entry.module_name.clone(),
+                candidates_produced,
+                attempts: historical.attempts,
+                successes: historical.successes,
+                success_rate: historical.success_rate(),
+            });
+
+        if let Some(mut result) = entry.result
+            && !result.candidates.is_empty()
+        {
+            // Issue #967: Truncate to per-module candidate budget if set.
+            if entry.max_candidates > 0 && result.candidates.len() > entry.max_candidates {
+                if utils::verbose_enabled() {
+                    tracing::debug!(
+                        module = %entry.module_name,
+                        before = result.candidates.len(),
+                        budget = entry.max_candidates,
+                        "Truncating candidates to module budget (Issue #967)"
+                    );
+                }
+                result.candidates.truncate(entry.max_candidates);
+            }
+
+            if utils::verbose_enabled() {
+                tracing::debug!(
+                    module = %entry.module_name,
+                    detections = result.detected_count,
+                    candidates = result.candidates.len(),
+                    budget = entry.max_candidates,
+                    "discovery module results"
+                );
+            }
+
+            super::merge_coordinated_structural_replacements(
+                syn,
+                result.candidates,
+                max_synapse_candidates,
+                diversify,
+            );
+        }
+
+        let finished = format!("analysis::analyze_all → {} finished", entry.module_name);
+        crate::watchdog::beat(&finished);
+    }
+}
+
 /// Run all discovery module detection phases in parallel, then merge results
 /// sequentially into the synapse result (Issue #419).
 ///
@@ -109,89 +232,14 @@ pub fn run_discovery_modules_parallel(
     diversify: bool,
     tracker: &ModuleOutcomeTracker,
 ) {
-    if modules.is_empty() {
-        return;
-    }
-
-    crate::watchdog::beat("analysis::analyze_all → parallel discovery detection starting");
-    let _timer = PhaseTimer::new("parallel_discovery_detection");
-
-    // Parallel detection phase: run all closures concurrently.
-    // `into_par_iter().map().collect()` preserves input order for indexed iterators.
-    let results: Vec<(
-        String,
-        &'static str,
-        usize,
-        Option<DiscoveryDetectionResult>,
-    )> = modules
-        .into_par_iter()
-        .map(|spec| {
-            let result = (spec.detect_fn)();
-            (
-                spec.module_name,
-                spec.phase_name,
-                spec.max_candidates,
-                result,
-            )
-        })
-        .collect();
-
-    crate::watchdog::beat("analysis::analyze_all → parallel discovery detection finished");
-
-    // Sequential merge phase: iterate in original order and merge non-empty results.
-    // Also collect per-module stats for metadata (Issue #485, #792).
-    for (module_name, _phase_name, max_candidates, result) in results {
-        let candidates_produced = result.as_ref().map_or(0, |r| r.candidates.len());
-
-        // Record per-module stats in metadata from historical tracker (Issue #792).
-        let historical = tracker.stats(&module_name);
-        syn.metadata
-            .discovery_module_stats
-            .push(DiscoveryModuleStatsJson {
-                module_name: module_name.clone(),
-                candidates_produced,
-                attempts: historical.attempts,
-                successes: historical.successes,
-                success_rate: historical.success_rate(),
-            });
-
-        if let Some(mut result) = result
-            && !result.candidates.is_empty()
-        {
-            // Issue #967: Truncate to per-module candidate budget if set.
-            if max_candidates > 0 && result.candidates.len() > max_candidates {
-                if utils::verbose_enabled() {
-                    tracing::debug!(
-                        module = %module_name,
-                        before = result.candidates.len(),
-                        budget = max_candidates,
-                        "Truncating candidates to module budget (Issue #967)"
-                    );
-                }
-                result.candidates.truncate(max_candidates);
-            }
-
-            if utils::verbose_enabled() {
-                tracing::debug!(
-                    module = %module_name,
-                    detections = result.detected_count,
-                    candidates = result.candidates.len(),
-                    budget = max_candidates,
-                    "discovery module results"
-                );
-            }
-
-            super::merge_coordinated_structural_replacements(
-                syn,
-                result.candidates,
-                max_synapse_candidates,
-                diversify,
-            );
-        }
-
-        let finished = format!("analysis::analyze_all → {module_name} finished");
-        crate::watchdog::beat(&finished);
-    }
+    let detection_results = detect_discovery_modules_parallel(modules);
+    merge_discovery_module_results(
+        syn,
+        detection_results,
+        max_synapse_candidates,
+        diversify,
+        tracker,
+    );
 }
 
 #[cfg(test)]

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -62,16 +62,20 @@ pub(crate) fn build_discovery_module_specs(
     modules
 }
 
-/// Dispatch all discovery modules and merge results into the synapse result.
-pub(crate) fn dispatch_and_merge_discovery_modules(
-    syn: &mut shared::AnalyzeSynapsesResult,
+/// Prepare and run discovery module detection phases without merging (Issue #1004).
+///
+/// Builds module specs, allocates candidate budgets, and runs all detection
+/// closures in parallel. Returns the detection results for deferred merging
+/// via [`discovery_dispatch::merge_discovery_module_results`].
+///
+/// This separation allows the detection phase to overlap with other concurrent
+/// work (e.g., candidate compression) before merging results sequentially.
+pub(crate) fn prepare_and_detect_discovery_modules(
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
     shared_cache: &Arc<cache::RecordCache>,
-    max_candidates: Option<usize>,
-    diversify: bool,
     tracker: &ModuleOutcomeTracker,
-) {
+) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
     let mut modules = build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo);
@@ -86,13 +90,7 @@ pub(crate) fn dispatch_and_merge_discovery_modules(
         }
     }
 
-    discovery_dispatch::run_discovery_modules_parallel(
-        syn,
-        modules,
-        max_candidates,
-        diversify,
-        tracker,
-    );
+    discovery_dispatch::detect_discovery_modules_parallel(modules)
 }
 
 /// Synthesise cross-detection candidates for co-flagged neurons (Issue #963).

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -17,8 +17,8 @@ use crate::{AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput};
 
 use super::shared::{AnalyzeAllResult, AnalyzeNeuronsResult, AnalyzeSynapsesResult};
 use super::{
-    cache, candidate_aggregation, candidate_compression, module_dispatch_specs, module_weights,
-    neuron, neuron_fingerprint, synapse, utils,
+    cache, candidate_aggregation, candidate_compression, discovery_dispatch, module_dispatch_specs,
+    module_weights, neuron, neuron_fingerprint, synapse, utils,
 };
 
 pub(crate) fn run_optional_analysis<T>(
@@ -299,45 +299,25 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         );
     }
 
-    // Issue #921: Compress compatible IDENTITY candidates into coordinated candidates.
-    // Issue #922: Also compress using non-linear squash functions (TANH, GELU).
-    if let Some(syn) = synapse_result.as_mut() {
-        let (identity_compressed, nonlinear_compressed) = rayon::join(
-            || {
-                candidate_compression::compress_identity_candidates(
-                    &syn.helpful_synapses,
-                    &input.creature,
-                )
-            },
-            || {
-                candidate_compression::compress_nonlinear_candidates(
-                    &syn.helpful_synapses,
-                    &input.creature,
-                )
-            },
-        );
-
-        let mut all_compressed = identity_compressed;
-        all_compressed.extend(nonlinear_compressed);
-
-        if !all_compressed.is_empty() {
-            candidate_aggregation::merge_coordinated_structural_replacements(
-                syn,
-                all_compressed,
-                input.max_synapse_candidates,
-                input.analysis_deadline_ms.is_some(),
-            );
-        }
-    }
-
     // Issue #792: Resolve the module outcome tracker from input or use a default.
     let tracker = input.module_outcome_tracker.clone().unwrap_or_default();
 
-    // Issue #375 / Issue #419: Discovery module dispatch using parallel pattern.
+    // Issue #1004: Overlap candidate compression with discovery module detection.
+    //
+    // Both compression (reads `helpful_synapses` immutably) and discovery module
+    // detection (reads creature/cache, runs ~48 detection closures) are independent
+    // in their detection phases. We run them concurrently via `rayon::join`, then
+    // merge results sequentially (compression first, then discovery modules) to
+    // preserve deterministic ordering.
     if let Some(syn) = synapse_result.as_mut() {
         let max_candidates = input.max_synapse_candidates;
         let diversify = input.analysis_deadline_ms.is_some();
 
+        // Snapshot data needed by compression (immutable reads).
+        let helpful_synapses_snapshot = syn.helpful_synapses.clone();
+        let creature_for_compression = input.creature.clone();
+
+        // Data needed by discovery module detection.
         let creature = Arc::new(input.creature.clone());
         let hidden_neurons: Arc<Vec<(String, String, f32)>> = Arc::new(
             input
@@ -359,11 +339,55 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 .collect(),
         );
 
-        module_dispatch_specs::dispatch_and_merge_discovery_modules(
+        // Issue #1004: Run compression detection and discovery module detection
+        // concurrently. The heavier discovery dispatch (~48 parallel modules)
+        // overlaps with the lighter compression work.
+        let (all_compressed, discovery_results) = rayon::join(
+            || {
+                // Issue #921 / #922: Compress IDENTITY and non-linear candidates.
+                let (identity_compressed, nonlinear_compressed) = rayon::join(
+                    || {
+                        candidate_compression::compress_identity_candidates(
+                            &helpful_synapses_snapshot,
+                            &creature_for_compression,
+                        )
+                    },
+                    || {
+                        candidate_compression::compress_nonlinear_candidates(
+                            &helpful_synapses_snapshot,
+                            &creature_for_compression,
+                        )
+                    },
+                );
+                let mut all = identity_compressed;
+                all.extend(nonlinear_compressed);
+                all
+            },
+            || {
+                // Issue #375 / #419: Discovery module detection phase only.
+                module_dispatch_specs::prepare_and_detect_discovery_modules(
+                    &creature,
+                    &hidden_neurons,
+                    &shared_cache,
+                    &tracker,
+                )
+            },
+        );
+
+        // Sequential merge phase: compression results first, then discovery modules.
+        // This preserves the same ordering as the previous sequential pipeline.
+        if !all_compressed.is_empty() {
+            candidate_aggregation::merge_coordinated_structural_replacements(
+                syn,
+                all_compressed,
+                max_candidates,
+                diversify,
+            );
+        }
+
+        discovery_dispatch::merge_discovery_module_results(
             syn,
-            &creature,
-            &hidden_neurons,
-            &shared_cache,
+            discovery_results,
             max_candidates,
             diversify,
             &tracker,

--- a/tests/analysis/issue_1004_overlap_compression_discovery.rs
+++ b/tests/analysis/issue_1004_overlap_compression_discovery.rs
@@ -1,0 +1,473 @@
+//! Integration tests for Issue #1004: Overlap candidate compression with
+//! discovery module detection phase.
+//!
+//! Verifies that:
+//! 1. The split detect + merge pattern for discovery modules produces identical
+//!    results to the combined `run_discovery_modules_parallel`.
+//! 2. `detect_discovery_modules_parallel` correctly captures all detection results.
+//! 3. `merge_discovery_module_results` correctly merges into synapse results.
+//! 4. Compression and discovery detection can overlap via `rayon::join` without
+//!    affecting correctness.
+
+use neat_ai_discovery::analysis::candidate_compression::{
+    compress_identity_candidates, compress_nonlinear_candidates,
+};
+use neat_ai_discovery::analysis::discovery_dispatch::{
+    DiscoveryDetectionResult, DiscoveryModuleDetectionEntry, DiscoveryModuleDetectionResults,
+    DiscoveryModuleSpec, detect_discovery_modules_parallel, merge_discovery_module_results,
+    run_discovery_modules_parallel,
+};
+use neat_ai_discovery::analysis::module_weights::ModuleOutcomeTracker;
+use neat_ai_discovery::analysis::shared::{self, SynapseAnalysisMetadata};
+use neat_ai_discovery::{
+    CandidateSynapseJson, CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson,
+    CreatureJson, NeuronJson, SynapseJson,
+};
+
+fn empty_synapse_result() -> shared::AnalyzeSynapsesResult {
+    shared::AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: SynapseAnalysisMetadata {
+            candidates_found: 0,
+            candidates_returned: 0,
+            ..Default::default()
+        },
+    }
+}
+
+fn make_candidate(gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(format!("test gain={gain}")),
+    }
+}
+
+fn make_module(
+    name: &str,
+    candidates: Option<Vec<CoordinatedStructuralCandidateJson>>,
+) -> DiscoveryModuleSpec {
+    let detected_count = candidates.as_ref().map_or(0, std::vec::Vec::len);
+    DiscoveryModuleSpec {
+        module_name: name.to_string(),
+        phase_name: "test_phase",
+        max_candidates: 0,
+        detect_fn: Box::new(move || {
+            candidates.map(|c| DiscoveryDetectionResult {
+                detected_count,
+                candidates: c,
+            })
+        }),
+    }
+}
+
+fn synapse_candidate(from: &str, to: &str, weight: f32, gain: f32) -> CandidateSynapseJson {
+    CandidateSynapseJson {
+        from_neuron_uuid: from.to_string(),
+        to_neuron_uuid: to.to_string(),
+        from_neuron_index: None,
+        to_neuron_index: None,
+        weight,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: gain,
+        expected_creature_score_gain: gain,
+        improved_count: 80,
+        total_count: 100,
+        target_neuron_stats: None,
+        outlier_reduction_info: None,
+        prediction_confidence: 0.8,
+        expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
+        comment: None,
+    }
+}
+
+fn make_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-a".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-b".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-c".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-1".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-a".to_string(),
+                to_uuid: "output-1".to_string(),
+                weight: 0.3,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-b".to_string(),
+                to_uuid: "output-1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "input-c".to_string(),
+                to_uuid: "output-1".to_string(),
+                weight: 0.4,
+                synapse_type: None,
+            },
+        ],
+        input: 3,
+        output: 1,
+    }
+}
+
+// =============================================================================
+// Issue #1004: Split detect + merge equivalence tests
+// =============================================================================
+
+/// Verify that `detect_discovery_modules_parallel` returns all detection results
+/// in the original module order.
+#[test]
+fn detect_returns_results_in_original_order() {
+    let modules = vec![
+        make_module("mod_a", Some(vec![make_candidate(1.0)])),
+        make_module("mod_b", None),
+        make_module(
+            "mod_c",
+            Some(vec![make_candidate(2.0), make_candidate(3.0)]),
+        ),
+    ];
+
+    let results = detect_discovery_modules_parallel(modules);
+
+    assert_eq!(results.entries.len(), 3, "should have 3 entries");
+    assert_eq!(results.entries[0].module_name, "mod_a");
+    assert_eq!(results.entries[1].module_name, "mod_b");
+    assert_eq!(results.entries[2].module_name, "mod_c");
+
+    // mod_a: 1 candidate
+    assert!(results.entries[0].result.is_some());
+    assert_eq!(
+        results.entries[0].result.as_ref().unwrap().candidates.len(),
+        1
+    );
+
+    // mod_b: None
+    assert!(results.entries[1].result.is_none());
+
+    // mod_c: 2 candidates
+    assert!(results.entries[2].result.is_some());
+    assert_eq!(
+        results.entries[2].result.as_ref().unwrap().candidates.len(),
+        2
+    );
+}
+
+/// Verify that split detect + merge produces the same synapse result as the
+/// combined `run_discovery_modules_parallel`.
+#[test]
+fn split_detect_merge_matches_combined() {
+    let tracker = ModuleOutcomeTracker::new();
+
+    // Combined approach.
+    let mut syn_combined = empty_synapse_result();
+    let modules_combined = vec![
+        make_module("mod_a", Some(vec![make_candidate(2.0)])),
+        make_module(
+            "mod_b",
+            Some(vec![make_candidate(1.0), make_candidate(0.5)]),
+        ),
+        make_module("mod_c", None),
+    ];
+    run_discovery_modules_parallel(&mut syn_combined, modules_combined, None, false, &tracker);
+
+    // Split approach.
+    let mut syn_split = empty_synapse_result();
+    let modules_split = vec![
+        make_module("mod_a", Some(vec![make_candidate(2.0)])),
+        make_module(
+            "mod_b",
+            Some(vec![make_candidate(1.0), make_candidate(0.5)]),
+        ),
+        make_module("mod_c", None),
+    ];
+    let detection_results = detect_discovery_modules_parallel(modules_split);
+    merge_discovery_module_results(&mut syn_split, detection_results, None, false, &tracker);
+
+    // Both should produce identical results.
+    assert_eq!(
+        syn_combined.coordinated_structural_candidates.len(),
+        syn_split.coordinated_structural_candidates.len(),
+        "candidate count must match"
+    );
+    for (combined, split) in syn_combined
+        .coordinated_structural_candidates
+        .iter()
+        .zip(syn_split.coordinated_structural_candidates.iter())
+    {
+        assert!(
+            (combined.expected_creature_score_gain - split.expected_creature_score_gain).abs()
+                < 1e-6,
+            "gains must match"
+        );
+    }
+    assert_eq!(
+        syn_combined.metadata.candidates_returned, syn_split.metadata.candidates_returned,
+        "metadata must match"
+    );
+    assert_eq!(
+        syn_combined.metadata.discovery_module_stats.len(),
+        syn_split.metadata.discovery_module_stats.len(),
+        "per-module stats count must match"
+    );
+}
+
+/// Verify that `merge_discovery_module_results` handles empty detection results.
+#[test]
+fn merge_empty_detection_results_is_noop() {
+    let mut syn = empty_synapse_result();
+    let tracker = ModuleOutcomeTracker::new();
+    let empty_results = DiscoveryModuleDetectionResults {
+        entries: Vec::new(),
+    };
+    merge_discovery_module_results(&mut syn, empty_results, None, false, &tracker);
+
+    assert!(syn.coordinated_structural_candidates.is_empty());
+    assert_eq!(syn.metadata.candidates_returned, 0);
+}
+
+/// Verify that detect returns empty results for empty module list.
+#[test]
+fn detect_empty_modules_returns_empty() {
+    let results = detect_discovery_modules_parallel(Vec::new());
+    assert!(results.entries.is_empty());
+}
+
+// =============================================================================
+// Issue #1004: Overlapped compression + discovery detection tests
+// =============================================================================
+
+/// Verify that compression and discovery detection can overlap via `rayon::join`
+/// without affecting the correctness of either phase.
+#[test]
+fn overlapped_compression_and_detection_produces_correct_results() {
+    let creature = make_creature();
+    let helpful_synapses = vec![
+        synapse_candidate("input-a", "output-1", 0.3, 0.05),
+        synapse_candidate("input-b", "output-1", 0.5, 0.06),
+        synapse_candidate("input-c", "output-1", 0.4, 0.04),
+    ];
+
+    // Sequential: compression first, then detection.
+    let seq_identity = compress_identity_candidates(&helpful_synapses, &creature);
+    let seq_nonlinear = compress_nonlinear_candidates(&helpful_synapses, &creature);
+    let mut seq_compressed = seq_identity;
+    seq_compressed.extend(seq_nonlinear);
+
+    let modules_seq = vec![
+        make_module("mod_a", Some(vec![make_candidate(1.0)])),
+        make_module("mod_b", Some(vec![make_candidate(0.5)])),
+    ];
+    let tracker = ModuleOutcomeTracker::new();
+    let mut syn_seq = empty_synapse_result();
+    run_discovery_modules_parallel(&mut syn_seq, modules_seq, None, false, &tracker);
+
+    // Overlapped: compression and detection run concurrently.
+    let (par_compressed, par_detection) = rayon::join(
+        || {
+            let (identity, nonlinear) = rayon::join(
+                || compress_identity_candidates(&helpful_synapses, &creature),
+                || compress_nonlinear_candidates(&helpful_synapses, &creature),
+            );
+            let mut all = identity;
+            all.extend(nonlinear);
+            all
+        },
+        || {
+            let modules = vec![
+                make_module("mod_a", Some(vec![make_candidate(1.0)])),
+                make_module("mod_b", Some(vec![make_candidate(0.5)])),
+            ];
+            detect_discovery_modules_parallel(modules)
+        },
+    );
+
+    let mut syn_par = empty_synapse_result();
+    let tracker_par = ModuleOutcomeTracker::new();
+    merge_discovery_module_results(&mut syn_par, par_detection, None, false, &tracker_par);
+
+    // Compression results should be identical.
+    assert_eq!(
+        seq_compressed.len(),
+        par_compressed.len(),
+        "compression candidate count must match"
+    );
+    for (seq, par) in seq_compressed.iter().zip(par_compressed.iter()) {
+        assert!(
+            (seq.expected_creature_score_gain - par.expected_creature_score_gain).abs() < 1e-6,
+            "compression gains must match"
+        );
+    }
+
+    // Discovery results should be identical.
+    assert_eq!(
+        syn_seq.coordinated_structural_candidates.len(),
+        syn_par.coordinated_structural_candidates.len(),
+        "discovery candidate count must match"
+    );
+}
+
+/// Verify overlapped execution multiple times to expose potential race conditions.
+#[test]
+fn overlapped_execution_is_deterministic_across_runs() {
+    let creature = make_creature();
+    let helpful_synapses = vec![
+        synapse_candidate("input-a", "output-1", 0.3, 0.05),
+        synapse_candidate("input-b", "output-1", 0.5, 0.06),
+    ];
+
+    let mut all_compression_counts: Vec<usize> = Vec::new();
+    let mut all_detection_counts: Vec<usize> = Vec::new();
+
+    for _ in 0..10 {
+        let snapshot = helpful_synapses.clone();
+        let creature_clone = creature.clone();
+
+        let (compressed, detection) = rayon::join(
+            || {
+                let (identity, nonlinear) = rayon::join(
+                    || compress_identity_candidates(&snapshot, &creature_clone),
+                    || compress_nonlinear_candidates(&snapshot, &creature_clone),
+                );
+                let mut all = identity;
+                all.extend(nonlinear);
+                all
+            },
+            || {
+                let modules = vec![
+                    make_module("mod_1", Some(vec![make_candidate(1.0)])),
+                    make_module("mod_2", Some(vec![make_candidate(2.0)])),
+                    make_module("mod_3", Some(vec![make_candidate(3.0)])),
+                ];
+                detect_discovery_modules_parallel(modules)
+            },
+        );
+
+        all_compression_counts.push(compressed.len());
+        all_detection_counts.push(detection.entries.len());
+    }
+
+    // All runs should produce identical counts.
+    let first_compression = all_compression_counts[0];
+    let first_detection = all_detection_counts[0];
+    for (i, (&c, &d)) in all_compression_counts
+        .iter()
+        .zip(all_detection_counts.iter())
+        .enumerate()
+    {
+        assert_eq!(c, first_compression, "compression count differs on run {i}");
+        assert_eq!(d, first_detection, "detection count differs on run {i}");
+    }
+}
+
+/// Verify that merge ordering is deterministic: compression results merged first,
+/// then discovery results, matching the sequential pipeline order.
+#[test]
+fn merge_ordering_compression_before_discovery() {
+    let mut syn = empty_synapse_result();
+    let tracker = ModuleOutcomeTracker::new();
+
+    // First merge compression results (gain = 5.0) — simulated by adding directly.
+    syn.coordinated_structural_candidates
+        .push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::AddNeuron {
+                neuron_uuid: "compress-test".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+                insert_before_neuron_uuid: None,
+            }],
+            expected_creature_score_gain: 5.0,
+            comment: Some("compression candidate".to_string()),
+        });
+
+    // Then merge discovery results (gain = 3.0).
+    let discovery_results = DiscoveryModuleDetectionResults {
+        entries: vec![DiscoveryModuleDetectionEntry {
+            module_name: "test_module".to_string(),
+            phase_name: "test_phase",
+            max_candidates: 0,
+            result: Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(3.0)],
+            }),
+        }],
+    };
+    merge_discovery_module_results(&mut syn, discovery_results, None, false, &tracker);
+
+    // Both candidates should be present.
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        2,
+        "should have both compression and discovery candidates"
+    );
+
+    // In non-diversify mode, candidates are sorted by gain descending.
+    // The compression candidate (5.0) should come first.
+    assert!(
+        syn.coordinated_structural_candidates[0].expected_creature_score_gain >= 5.0 - 1e-6,
+        "compression candidate (gain=5.0) should be first"
+    );
+    assert!(
+        syn.coordinated_structural_candidates[1].expected_creature_score_gain >= 3.0 - 1e-6,
+        "discovery candidate (gain=3.0) should be second"
+    );
+}
+
+/// Verify that the split detect + merge respects `max_synapse_candidates`.
+#[test]
+fn split_detect_merge_respects_max_candidates() {
+    let tracker = ModuleOutcomeTracker::new();
+    let mut syn = empty_synapse_result();
+
+    let modules = vec![
+        make_module(
+            "mod_a",
+            Some(vec![make_candidate(3.0), make_candidate(2.0)]),
+        ),
+        make_module("mod_b", Some(vec![make_candidate(1.0)])),
+    ];
+
+    let detection_results = detect_discovery_modules_parallel(modules);
+    merge_discovery_module_results(&mut syn, detection_results, Some(2), false, &tracker);
+
+    let total = syn.helpful_synapses.len()
+        + syn.harmful_synapses.len()
+        + syn.coordinated_structural_candidates.len();
+    assert!(
+        total <= 2,
+        "expected truncation to max_synapse_candidates=2, got {total}"
+    );
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -13,6 +13,7 @@ mod impact_caching;
 mod impact_calculation_production;
 mod impact_squash;
 mod issue_1003_parallel_candidate_compression;
+mod issue_1004_overlap_compression_discovery;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Overlap candidate compression with discovery module detection phase in `analyze_all()` post-processing pipeline. Closes #1004.

Previously, candidate compression (identity + nonlinear) and discovery module detection (~48 modules) ran sequentially. Both phases read from the synapse result immutably during detection — compression reads `helpful_synapses`, and discovery module detection closures capture their data before execution. This change runs both detection phases concurrently via `rayon::join`, then merges results sequentially (compression first, then discovery modules) to preserve deterministic ordering.

### Changes

1. **`src/analysis/discovery_dispatch.rs`** — Split `run_discovery_modules_parallel` into two composable functions:
   - `detect_discovery_modules_parallel` — runs all detection closures concurrently, returns `DiscoveryModuleDetectionResults`
   - `merge_discovery_module_results` — merges detection results into synapse result sequentially
   - `run_discovery_modules_parallel` retained as a convenience wrapper calling both

2. **`src/analysis/module_dispatch_specs/mod.rs`** — Added `prepare_and_detect_discovery_modules` that builds specs, allocates budgets, and runs detection without merging. Removed unused `dispatch_and_merge_discovery_modules`.

3. **`src/analysis/orchestration.rs`** — Restructured post-processing to use `rayon::join` to overlap compression detection with discovery module detection, then merge sequentially.

### Performance

Wall-clock time for post-processing decreases because the lighter compression work (identity + nonlinear via nested `rayon::join`) overlaps with the heavier discovery module dispatch (~48 parallel detection closures). Benchmarks require GPU hardware and can be measured with `cargo bench --bench pipeline_utilisation`.

## Evidence
- 8 new integration tests verify:
  - Split detect + merge produces identical results to the combined function
  - Detection results preserve original module order
  - Empty inputs handled correctly
  - Overlapped compression + detection produces same results as sequential
  - Deterministic across 10 repeated runs (no race conditions)
  - Merge ordering: compression before discovery
  - `max_synapse_candidates` respected through split path
- All 17 existing `discovery_dispatch` unit tests pass unchanged
- All 158 analysis integration tests pass
- `quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

## Test Plan
- Added `tests/analysis/issue_1004_overlap_compression_discovery.rs` with 8 tests
- Existing tests verified: `discovery_dispatch_tests.rs`, `discovery_dispatch_parallel_tests.rs`, `issue_1003_parallel_candidate_compression.rs`
- Run: `cargo test --test analysis -- issue_1004`

---

## Automated Fix Details
This PR addresses issue #1004: **Overlap candidate compression with discovery module detection phase**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1004
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1004 -->