### PR TITLE
feat: add temperature scheduling for exploration-exploitation balance (#1020)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.29"
+version = "0.72.30"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/async_pipeline.rs
+++ b/benches/async_pipeline.rs
@@ -173,6 +173,7 @@ fn bench_async_pipeline(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/cache_locality.rs
+++ b/benches/cache_locality.rs
@@ -126,6 +126,7 @@ fn benchmark_cache_locality(c: &mut Criterion) {
                         max_candidates: Some(10), // Limit candidates to reduce GPU time variance
                         analysis_deadline_ms: deadline_ms,
                         random_seed: Some(42),
+                        temperature: 1.0,
                     };
 
                     let result = analyze_synapses_with_cache_and_gpu_queue(

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -180,6 +180,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/pipeline_utilisation.rs
+++ b/benches/pipeline_utilisation.rs
@@ -328,6 +328,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -352,6 +353,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -376,6 +378,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -396,6 +399,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
             random_seed: Some(42),
             previous_neuron_fingerprints: None,
             module_outcome_tracker: None,
+            temperature: 1.0,
         };
 
         let mut profile = ProfileData::new();

--- a/benches/sample_locality.rs
+++ b/benches/sample_locality.rs
@@ -145,6 +145,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);
@@ -173,6 +174,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/benches/zero_copy_buffer.rs
+++ b/benches/zero_copy_buffer.rs
@@ -76,6 +76,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                 max_candidates: Some(10),
                 analysis_deadline_ms: None,
                 random_seed: Some(42),
+                temperature: 1.0,
             };
             let result = analyze_synapses(&input).expect("Analysis should succeed");
             black_box(result);
@@ -96,6 +97,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/docs/pr-summary-1020.md
+++ b/docs/pr-summary-1020.md
@@ -1,0 +1,46 @@
+## Summary
+
+Add temperature scheduling for exploration-exploitation balance in the candidate selection pipeline. The temperature parameter controls how aggressively the system filters marginal candidates: high temperature (early in evolution) accepts more candidates for exploration, while low temperature (late in evolution) only accepts strong candidates for exploitation. A default temperature of 1.0 preserves existing behaviour (fully backward compatible). Closes #1020.
+
+## Changes
+
+### New: Temperature scheduling module (`src/analysis/constants/temperature.rs`)
+- `CoolingSchedule` enum with `Linear` and `Exponential` variants
+- `compute_scheduled_temperature()` — computes temperature from generation count using a cooling schedule
+- `scale_threshold_by_temperature()` — scales acceptance threshold by temperature (higher temp = lower threshold = more permissive)
+- `scale_ratio_by_temperature()` — scales `MIN_IMPROVED_RATIO` by temperature
+- `scale_mh_temperature()` — scales Metropolis-Hastings temperature by schedule temperature
+- Constants: `DEFAULT_TEMPERATURE` (1.0), `MIN_TEMPERATURE` (0.01), `MAX_TEMPERATURE` (5.0), `DEFAULT_EXPONENTIAL_DECAY_RATE` (0.995)
+
+### Modified: FFI input structs (`src/ffi_types/requests.rs`)
+- Added `temperature: f32` field (default 1.0) to `AnalyzeParallelInput`, `AnalyzeSynapsesInput`, `AnalyzeNeuronsInput`, and `AnalyzeAllInput`
+- Serde default ensures backward compatibility with existing JSON callers
+
+### Modified: Analysis pipeline
+- `TargetAnalysisContext` gains `temperature` field threaded from input
+- `evaluation.rs` applies temperature scaling to:
+  - `MIN_IMPROVED_RATIO` threshold (via `scale_ratio_by_temperature`)
+  - Acceptance threshold (via `scale_threshold_by_temperature`)
+  - Metropolis-Hastings temperature (via `scale_mh_temperature`, when MH is enabled)
+
+## Evidence
+
+- 22 integration tests verify cooling schedules, threshold scaling, ratio scaling, MH scaling, boundary conditions, and backward compatibility
+- 13 unit tests in the temperature module verify schedule functions and scaling helpers
+- All existing tests pass unchanged (temperature defaults to 1.0, preserving identical behaviour)
+
+## Test Plan
+
+- `tests/analysis/issue_1020_temperature_scheduling.rs` — 22 tests covering:
+  - Linear and exponential cooling schedule monotonicity
+  - Both schedules start at initial temperature
+  - Exponential cools faster initially than linear
+  - Default temperature (1.0) preserves threshold, ratio, and MH temperature unchanged
+  - High temperature lowers effective threshold and ratio (exploration)
+  - Low temperature raises effective threshold and ratio (exploitation)
+  - High/low schedule temperature scales MH acceptance accordingly
+  - Temperature bounds are enforced (clamped to min/max)
+  - Zero and negative temperature handled safely
+  - End-to-end: cooling schedule + threshold scaling produces monotonically increasing effective threshold
+  - End-to-end: cooling schedule + ratio scaling produces monotonically increasing effective ratio
+- `src/analysis/constants/temperature.rs` — 13 unit tests for schedule functions and scaling helpers

--- a/src/analysis/constants/mod.rs
+++ b/src/analysis/constants/mod.rs
@@ -22,6 +22,7 @@ mod detection_thresholds;
 mod sample_thresholds;
 mod sentinel_detection;
 mod source_variance;
+pub mod temperature;
 
 // Re-export all constants and functions for backward compatibility.
 // Consumers can continue to use `crate::analysis::constants::CONSTANT_NAME`.
@@ -31,3 +32,4 @@ pub use detection_thresholds::*;
 pub use sample_thresholds::*;
 pub use sentinel_detection::*;
 pub use source_variance::*;
+pub use temperature::*;

--- a/src/analysis/constants/temperature.rs
+++ b/src/analysis/constants/temperature.rs
@@ -1,0 +1,298 @@
+//! Temperature scheduling for exploration-exploitation balance (Issue #1020).
+//!
+//! Provides cooling schedule functions that compute a temperature value from
+//! an evolutionary generation count. The temperature controls how aggressively
+//! the candidate selection pipeline filters marginal candidates:
+//!
+//! - **High temperature** (early evolution) → lower effective thresholds → accept
+//!   more candidates → exploration
+//! - **Low temperature** (late evolution) → higher effective thresholds → only
+//!   accept strong candidates → exploitation
+//!
+//! A default temperature of 1.0 preserves existing behaviour (backward compatible).
+
+// =============================================================================
+// Cooling Schedule Types
+// =============================================================================
+
+/// Available cooling schedule strategies.
+///
+/// Each schedule maps a generation count to a temperature in (0, `initial_temp`].
+/// The `compute_temperature` function dispatches to the appropriate formula.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CoolingSchedule {
+    /// Linear decay: `T = initial × max(min_temp, 1 - generation / total_generations)`.
+    ///
+    /// Temperature decreases uniformly over the run. Simple and predictable,
+    /// but may cool too quickly in early generations when exploration is most
+    /// valuable.
+    Linear,
+
+    /// Exponential decay: `T = initial × max(min_temp, decay_rate ^ generation)`.
+    ///
+    /// Temperature decreases rapidly at first, then slows. This preserves
+    /// higher temperatures during early exploration and converges smoothly
+    /// toward exploitation.
+    Exponential,
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Default temperature value that preserves existing behaviour.
+///
+/// At temperature 1.0, all scaling factors are identity operations:
+/// - `effective_threshold = threshold / 1.0 = threshold`
+/// - `effective_ratio = ratio / 1.0 = ratio`
+/// - MH temperature is unscaled
+///
+/// ## Valid Range
+/// Must be exactly 1.0 for backward compatibility.
+pub const DEFAULT_TEMPERATURE: f32 = 1.0;
+
+/// Minimum temperature floor to prevent division by zero or near-zero.
+///
+/// Even at the coldest point of a cooling schedule, temperature never drops
+/// below this value. This prevents infinite effective thresholds and ensures
+/// at least some candidates can still be accepted.
+///
+/// ## Valid Range
+/// Must be > 0.0 and < 1.0.
+pub const MIN_TEMPERATURE: f32 = 0.01;
+
+/// Maximum temperature ceiling to prevent excessively permissive acceptance.
+///
+/// ## Valid Range
+/// Must be >= 1.0.
+pub const MAX_TEMPERATURE: f32 = 5.0;
+
+/// Default decay rate for exponential cooling schedule.
+///
+/// With decay rate 0.995 and 1000 generations:
+/// - Generation 0: T = 1.0
+/// - Generation 100: T ≈ 0.606
+/// - Generation 500: T ≈ 0.082
+/// - Generation 1000: T ≈ 0.0067 (clamped to `MIN_TEMPERATURE`)
+///
+/// ## Valid Range
+/// Must be in (0.0, 1.0). Values near 1.0 cool slowly; values near 0.0
+/// cool almost immediately.
+pub const DEFAULT_EXPONENTIAL_DECAY_RATE: f32 = 0.995;
+
+// =============================================================================
+// Cooling Schedule Functions
+// =============================================================================
+
+/// Compute the temperature for a given generation using the specified cooling schedule.
+///
+/// # Arguments
+///
+/// * `schedule` — The cooling strategy to use.
+/// * `initial_temperature` — Starting temperature (typically 1.0 or higher).
+/// * `generation` — Current evolutionary generation (0-based).
+/// * `total_generations` — Total expected generations (used by linear schedule).
+///
+/// # Returns
+///
+/// A temperature value clamped to [`MIN_TEMPERATURE`, `MAX_TEMPERATURE`].
+pub fn compute_scheduled_temperature(
+    schedule: CoolingSchedule,
+    initial_temperature: f32,
+    generation: u32,
+    total_generations: u32,
+) -> f32 {
+    #[allow(clippy::cast_precision_loss)] // Intentional: generation counts fit comfortably in f32
+    let raw = match schedule {
+        CoolingSchedule::Linear => {
+            if total_generations == 0 {
+                initial_temperature
+            } else {
+                let progress = generation as f32 / total_generations as f32;
+                initial_temperature * (1.0 - progress)
+            }
+        }
+        CoolingSchedule::Exponential => {
+            initial_temperature * DEFAULT_EXPONENTIAL_DECAY_RATE.powi(generation.cast_signed())
+        }
+    };
+
+    raw.clamp(MIN_TEMPERATURE, MAX_TEMPERATURE)
+}
+
+/// Apply temperature scaling to an acceptance threshold.
+///
+/// Higher temperature lowers the effective threshold (more permissive).
+/// Lower temperature raises the effective threshold (more selective).
+/// Temperature 1.0 returns the threshold unchanged.
+///
+/// Formula: `effective_threshold = base_threshold / temperature`
+#[inline]
+pub fn scale_threshold_by_temperature(base_threshold: f32, temperature: f32) -> f32 {
+    let clamped_temp = temperature.clamp(MIN_TEMPERATURE, MAX_TEMPERATURE);
+    base_threshold / clamped_temp
+}
+
+/// Apply temperature scaling to a minimum improved ratio.
+///
+/// Higher temperature lowers the effective ratio (more permissive).
+/// Lower temperature raises the effective ratio (more selective).
+/// Temperature 1.0 returns the ratio unchanged.
+///
+/// Formula: `effective_ratio = base_ratio / temperature`, clamped to [0.0, 1.0].
+#[inline]
+pub fn scale_ratio_by_temperature(base_ratio: f32, temperature: f32) -> f32 {
+    let clamped_temp = temperature.clamp(MIN_TEMPERATURE, MAX_TEMPERATURE);
+    (base_ratio / clamped_temp).clamp(0.0, 1.0)
+}
+
+/// Apply temperature scaling to the Metropolis-Hastings temperature parameter.
+///
+/// The input temperature from the evolutionary schedule scales the base MH
+/// temperature, controlling how willingly the system accepts marginal candidates.
+///
+/// Formula: `effective_mh_temp = base_mh_temp × temperature`
+///
+/// - High schedule temperature → higher effective MH temp → more acceptance
+/// - Low schedule temperature → lower effective MH temp → less acceptance
+#[inline]
+pub fn scale_mh_temperature(base_mh_temp: f32, temperature: f32) -> f32 {
+    let clamped_temp = temperature.clamp(MIN_TEMPERATURE, MAX_TEMPERATURE);
+    (base_mh_temp * clamped_temp).max(f32::MIN_POSITIVE)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_temperature_is_one() {
+        assert!((DEFAULT_TEMPERATURE - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn min_temperature_is_positive() {
+        let min = MIN_TEMPERATURE;
+        assert!(min > 0.0);
+        assert!(min < 1.0);
+    }
+
+    #[test]
+    fn linear_schedule_at_generation_zero_returns_initial() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 1.0, 0, 1000);
+        assert!((temp - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn linear_schedule_at_midpoint_returns_half() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 1.0, 500, 1000);
+        assert!((temp - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn linear_schedule_at_end_returns_min_temperature() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 1.0, 1000, 1000);
+        assert!((temp - MIN_TEMPERATURE).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn exponential_schedule_at_generation_zero_returns_initial() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, 0, 1000);
+        assert!((temp - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn exponential_schedule_decays_monotonically() {
+        let t0 = compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, 0, 1000);
+        let t100 = compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, 100, 1000);
+        let t500 = compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, 500, 1000);
+        assert!(t0 > t100);
+        assert!(t100 > t500);
+    }
+
+    #[test]
+    fn temperature_never_below_minimum() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 1.0, 10000, 1000);
+        assert!(temp >= MIN_TEMPERATURE);
+
+        let temp_exp =
+            compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, 10000, 1000);
+        assert!(temp_exp >= MIN_TEMPERATURE);
+    }
+
+    #[test]
+    fn temperature_never_above_maximum() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 10.0, 0, 1000);
+        assert!(temp <= MAX_TEMPERATURE);
+    }
+
+    #[test]
+    fn scale_threshold_at_default_temperature_is_identity() {
+        let threshold = 0.05;
+        let scaled = scale_threshold_by_temperature(threshold, DEFAULT_TEMPERATURE);
+        assert!((scaled - threshold).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn high_temperature_lowers_effective_threshold() {
+        let threshold = 0.05;
+        let scaled = scale_threshold_by_temperature(threshold, 2.0);
+        assert!(scaled < threshold, "High temp should lower threshold");
+    }
+
+    #[test]
+    fn low_temperature_raises_effective_threshold() {
+        let threshold = 0.05;
+        let scaled = scale_threshold_by_temperature(threshold, 0.5);
+        assert!(scaled > threshold, "Low temp should raise threshold");
+    }
+
+    #[test]
+    fn scale_ratio_at_default_temperature_is_identity() {
+        let ratio = 0.6;
+        let scaled = scale_ratio_by_temperature(ratio, DEFAULT_TEMPERATURE);
+        assert!((scaled - ratio).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn high_temperature_lowers_effective_ratio() {
+        let ratio = 0.6;
+        let scaled = scale_ratio_by_temperature(ratio, 2.0);
+        assert!(scaled < ratio, "High temp should lower ratio");
+    }
+
+    #[test]
+    fn low_temperature_raises_effective_ratio_clamped() {
+        let ratio = 0.6;
+        let scaled = scale_ratio_by_temperature(ratio, 0.5);
+        assert!(scaled > ratio, "Low temp should raise ratio");
+        assert!(scaled <= 1.0, "Ratio must not exceed 1.0");
+    }
+
+    #[test]
+    fn scale_mh_temperature_at_default_is_identity() {
+        let base_mh = 0.01;
+        let scaled = scale_mh_temperature(base_mh, DEFAULT_TEMPERATURE);
+        assert!((scaled - base_mh).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn high_schedule_temperature_increases_mh_temperature() {
+        let base_mh = 0.01;
+        let scaled = scale_mh_temperature(base_mh, 2.0);
+        assert!(
+            scaled > base_mh,
+            "High schedule temp should increase MH temp"
+        );
+    }
+
+    #[test]
+    fn zero_total_generations_returns_initial_for_linear() {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 1.5, 50, 0);
+        assert!((temp - 1.5).abs() < f32::EPSILON);
+    }
+}

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -70,6 +70,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let err =
@@ -143,6 +144,7 @@ fn analyze_synapses_rejects_duplicate_focus_targets() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let err = analyze_synapses(&input)
@@ -252,6 +254,7 @@ fn analyze_synapses_reports_eligible_sources_correctly_for_non_input_neurons() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -391,6 +394,7 @@ fn analyze_synapses_reports_fully_connected_neuron_explicitly() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -441,6 +445,7 @@ fn analyze_synapses_requires_focus_targets() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let err =
@@ -493,6 +498,7 @@ fn analyze_synapses_reports_diagnostics_when_no_candidates() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result =
@@ -603,6 +609,7 @@ fn analyze_synapses_stops_harmful_processing_after_deadline() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = pool
@@ -692,6 +699,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: None,
+        temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
     };
@@ -750,6 +758,7 @@ fn analyze_neurons_reports_diagnostics_when_no_candidates() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result =
@@ -860,6 +869,7 @@ fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         // Any non-None deadline value will exercise the override sequence.
         analysis_deadline_ms: Some(1_000_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = pool
@@ -993,6 +1003,7 @@ fn analyze_synapses_uses_vertical_timeout_with_randomized_order() {
         // Any non-None deadline value will exercise the override sequence.
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = pool
@@ -1089,6 +1100,7 @@ fn analyze_synapses_accepts_positive_improvements_below_threshold() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1186,6 +1198,7 @@ fn analyze_synapses_rejects_non_positive_improvements() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1259,6 +1272,7 @@ fn analyze_synapses_accepts_positive_improvements_above_threshold() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -251,6 +251,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             max_candidates: input.max_synapse_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
             random_seed: input.random_seed,
+            temperature: input.temperature,
         })
     } else {
         None
@@ -264,6 +265,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             max_candidates: input.max_neuron_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
             random_seed: input.random_seed,
+            temperature: input.temperature,
         })
     } else {
         None

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -105,6 +105,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         deadline,
         threshold: 0.0,
         acceptance_tracker,
+        temperature: input.temperature,
     });
 
     // Phase 6: Process each focus neuron in parallel — thread-local collection (Issue #744)

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -236,6 +236,7 @@ mod tests {
             focus_neurons: vec!["output-1".to_string()],
             max_candidates: None,
             random_seed: Some(42),
+            temperature: 1.0,
             analysis_deadline_ms: None,
         }
     }
@@ -309,6 +310,7 @@ mod tests {
             focus_neurons: vec![],
             max_candidates: None,
             random_seed: None,
+            temperature: 1.0,
             analysis_deadline_ms: None,
         };
         let lookups = build_creature_lookups(&input);

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -311,27 +311,47 @@ pub(crate) fn collect_and_process_helpful_results(
 
             // Issue #730: Filter candidates where insufficient samples improve.
             // Candidates where worsened > improved have 0% success rate in production.
+            // Issue #1020: Temperature scales the effective ratio — high temperature
+            // lowers the bar (exploration), low temperature raises it (exploitation).
             {
                 use crate::analysis::constants::MIN_IMPROVED_RATIO;
+                use crate::analysis::constants::temperature::scale_ratio_by_temperature;
+                let effective_ratio =
+                    scale_ratio_by_temperature(MIN_IMPROVED_RATIO, ctx.temperature);
                 let improved_ratio = if total_count > 0 {
                     improved_count as f32 / total_count as f32
                 } else {
                     0.0
                 };
-                if improved_ratio < MIN_IMPROVED_RATIO {
+                if improved_ratio < effective_ratio {
                     continue;
                 }
             }
 
-            if neuron_error_improvement <= ctx.threshold {
+            // Issue #1020: Temperature scales the effective threshold — high temperature
+            // lowers it (accept more marginal candidates), low temperature raises it.
+            let effective_threshold =
+                crate::analysis::constants::temperature::scale_threshold_by_temperature(
+                    ctx.threshold,
+                    ctx.temperature,
+                );
+            if neuron_error_improvement <= effective_threshold {
                 // Issue #1018: Metropolis-Hastings probabilistic acceptance
                 // for marginal candidates (0 < improvement ≤ threshold).
                 // When MH temperature is configured, marginal candidates are
                 // accepted with probability proportional to their improvement.
                 // When unconfigured, existing deterministic behaviour is preserved.
-                if let Some(temperature) = crate::config::mh_temperature() {
-                    let acceptance_probability =
-                        (neuron_error_improvement / temperature).exp().min(1.0);
+                if let Some(base_mh_temp) = crate::config::mh_temperature() {
+                    // Issue #1020: Scale MH temperature by the schedule temperature.
+                    // Higher schedule temperature → more willing to accept marginal candidates.
+                    let effective_mh_temp =
+                        crate::analysis::constants::temperature::scale_mh_temperature(
+                            base_mh_temp,
+                            ctx.temperature,
+                        );
+                    let acceptance_probability = (neuron_error_improvement / effective_mh_temp)
+                        .exp()
+                        .min(1.0);
 
                     // Deterministic pseudo-random decision based on source+target UUIDs
                     // to ensure reproducibility across runs with the same data.

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -61,6 +61,11 @@ pub(crate) struct TargetAnalysisContext<'a> {
     /// Issue #1019: Adaptive proposal acceptance tracker for sigma adaptation.
     pub acceptance_tracker:
         Arc<std::sync::Mutex<crate::analysis::synapse::adaptive_proposal::AcceptanceTracker>>,
+    /// Issue #1020: Temperature for exploration-exploitation balance.
+    ///
+    /// Default 1.0 preserves existing behaviour. Higher values lower effective
+    /// thresholds (exploration); lower values raise them (exploitation).
+    pub temperature: f32,
 }
 
 /// Results from analysing a single target neuron.

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -179,6 +179,7 @@ pub(crate) fn build_analyze_all_input_from_parallel(
         random_seed: input.random_seed,
         previous_neuron_fingerprints: input.previous_neuron_fingerprints,
         module_outcome_tracker: input.module_outcome_tracker,
+        temperature: input.temperature,
     }
 }
 

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -55,6 +55,17 @@ pub struct AnalyzeParallelInput {
     /// the returned tracker and pass it back on subsequent runs.
     #[serde(default)]
     pub module_outcome_tracker: Option<analysis::module_weights::ModuleOutcomeTracker>,
+    /// Temperature for exploration-exploitation balance (Issue #1020).
+    ///
+    /// Controls the strictness of candidate acceptance. Higher values (> 1.0)
+    /// favour exploration (accept more marginal candidates); lower values (< 1.0)
+    /// favour exploitation (only accept strong candidates). Default 1.0 preserves
+    /// existing behaviour.
+    ///
+    /// The caller tracks the evolutionary generation count and may use a cooling
+    /// schedule to compute this value (e.g., start at 2.0 and decay to 0.5).
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -75,6 +86,12 @@ pub struct AnalyzeSynapsesInput {
     /// will explore different candidates over time.
     #[serde(default)]
     pub random_seed: Option<u64>,
+    /// Temperature for exploration-exploitation balance (Issue #1020).
+    ///
+    /// Default 1.0 preserves existing behaviour. See `AnalyzeParallelInput`
+    /// for full documentation.
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
 }
 
 /// Internal input structure for neuron analysis (used by `analyze_all`)
@@ -95,6 +112,12 @@ pub struct AnalyzeNeuronsInput {
     /// will explore different candidates over time.
     #[serde(default)]
     pub random_seed: Option<u64>,
+    /// Temperature for exploration-exploitation balance (Issue #1020).
+    ///
+    /// Default 1.0 preserves existing behaviour. See `AnalyzeParallelInput`
+    /// for full documentation.
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
 }
 
 /// Internal input structure for combined analysis (used by `analyze_parallel`)
@@ -132,6 +155,12 @@ pub struct AnalyzeAllInput {
     /// and module statistics in the response metadata.
     #[serde(default)]
     pub module_outcome_tracker: Option<analysis::module_weights::ModuleOutcomeTracker>,
+    /// Temperature for exploration-exploitation balance (Issue #1020).
+    ///
+    /// Default 1.0 preserves existing behaviour. See `AnalyzeParallelInput`
+    /// for full documentation.
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -176,6 +205,10 @@ pub struct ExportVisualisationSnapshotInput {
     /// Top-K worst reconstruction samples to include (default: 20)
     #[serde(default = "default_top_k")]
     pub top_k_worst_samples: Option<usize>,
+}
+
+fn default_temperature() -> f32 {
+    crate::analysis::constants::DEFAULT_TEMPERATURE
 }
 
 fn default_true() -> bool {

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -100,6 +100,7 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/leaky_relu_filtered.rs
+++ b/tests/activation/leaky_relu_filtered.rs
@@ -71,6 +71,7 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         max_candidates: Some(64),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/relu_adjacent_filtered.rs
+++ b/tests/activation/relu_adjacent_filtered.rs
@@ -75,6 +75,7 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         max_candidates: Some(512),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/step_hidden_neuron_prediction.rs
+++ b/tests/activation/step_hidden_neuron_prediction.rs
@@ -170,6 +170,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -260,6 +261,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -364,6 +366,7 @@ fn test_step_output_neuron_no_identity_candidates() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -109,6 +109,7 @@ fn synapse_analysis_respects_deadline() {
         max_candidates: None,
         analysis_deadline_ms: Some(deadline_ms),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let start = Instant::now();
@@ -197,6 +198,7 @@ fn neuron_analysis_respects_deadline() {
         max_candidates: None,
         analysis_deadline_ms: Some(deadline_ms),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let start = Instant::now();
@@ -280,6 +282,7 @@ fn focus_neurons_are_randomised_across_runs() {
             max_candidates: None,
             analysis_deadline_ms: Some(60_000), // 1 minute - enough to complete
             random_seed: None,
+            temperature: 1.0,
         };
 
         let result = analyze_neurons(&input).expect("Analysis should complete successfully");

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -153,6 +153,7 @@ fn test_optimised_params_vary_by_sample() {
             max_candidates: Some(100),
             analysis_deadline_ms: None,
             random_seed: None,
+            temperature: 1.0,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -230,6 +231,7 @@ fn test_conservative_params_more_stable_across_samples() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let subset_result = analyze_neurons(&subset_input).unwrap();
@@ -362,6 +364,7 @@ fn test_relu_fixed_params_consistent_across_samples() {
             max_candidates: Some(100),
             analysis_deadline_ms: None,
             random_seed: None,
+            temperature: 1.0,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -459,6 +462,7 @@ fn test_synapse_candidates_no_bias_optimisation() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).unwrap();
@@ -519,6 +523,7 @@ fn test_synapse_weight_distribution() {
             max_candidates: Some(50),
             analysis_deadline_ms: None,
             random_seed: None,
+            temperature: 1.0,
         };
 
         let result = analyze_synapses(&input).unwrap();

--- a/tests/analysis/issue_1020_temperature_scheduling.rs
+++ b/tests/analysis/issue_1020_temperature_scheduling.rs
@@ -1,0 +1,375 @@
+//! Issue #1020: Temperature scheduling for exploration-exploitation balance.
+//!
+//! Tests verify:
+//! 1. Cooling schedule functions (linear and exponential)
+//! 2. Temperature scaling of acceptance threshold and improved ratio
+//! 3. Default temperature (1.0) preserves existing behaviour
+//! 4. High temperature increases acceptance (exploration)
+//! 5. Temperature integration with Metropolis-Hastings probability
+
+use neat_ai_discovery::analysis::constants::MIN_IMPROVED_RATIO;
+use neat_ai_discovery::analysis::constants::temperature::{
+    CoolingSchedule, DEFAULT_EXPONENTIAL_DECAY_RATE, DEFAULT_TEMPERATURE, MAX_TEMPERATURE,
+    MIN_TEMPERATURE, compute_scheduled_temperature, scale_mh_temperature,
+    scale_ratio_by_temperature, scale_threshold_by_temperature,
+};
+
+// =============================================================================
+// Cooling Schedule Tests
+// =============================================================================
+
+/// Issue #1020: Linear cooling schedule decreases monotonically from initial to minimum.
+#[test]
+fn linear_schedule_decreases_monotonically() {
+    let mut prev = f32::INFINITY;
+    for generation in 0..=100 {
+        let temp = compute_scheduled_temperature(CoolingSchedule::Linear, 2.0, generation, 100);
+        assert!(
+            temp <= prev,
+            "Linear schedule should decrease: generation {generation}, temp {temp} > prev {prev}"
+        );
+        assert!(
+            temp >= MIN_TEMPERATURE,
+            "Temperature must not fall below minimum"
+        );
+        assert!(
+            temp <= MAX_TEMPERATURE,
+            "Temperature must not exceed maximum"
+        );
+        prev = temp;
+    }
+}
+
+/// Issue #1020: Exponential cooling schedule decreases monotonically.
+#[test]
+fn exponential_schedule_decreases_monotonically() {
+    let mut prev = f32::INFINITY;
+    for generation in 0..=1000 {
+        let temp =
+            compute_scheduled_temperature(CoolingSchedule::Exponential, 2.0, generation, 1000);
+        assert!(
+            temp <= prev,
+            "Exponential schedule should decrease: generation {generation}, temp {temp} > prev {prev}"
+        );
+        assert!(
+            temp >= MIN_TEMPERATURE,
+            "Temperature must not fall below minimum"
+        );
+        assert!(
+            temp <= MAX_TEMPERATURE,
+            "Temperature must not exceed maximum"
+        );
+        prev = temp;
+    }
+}
+
+/// Issue #1020: Both schedules start at the same initial temperature.
+#[test]
+fn both_schedules_start_at_initial_temperature() {
+    let initial = 1.5;
+    let linear = compute_scheduled_temperature(CoolingSchedule::Linear, initial, 0, 1000);
+    let exponential = compute_scheduled_temperature(CoolingSchedule::Exponential, initial, 0, 1000);
+    assert!(
+        (linear - initial).abs() < f32::EPSILON,
+        "Linear should start at initial"
+    );
+    assert!(
+        (exponential - initial).abs() < f32::EPSILON,
+        "Exponential should start at initial"
+    );
+}
+
+/// Issue #1020: Exponential schedule decays faster initially than linear.
+#[test]
+fn exponential_cools_faster_initially() {
+    let generation = 10;
+    let total = 1000;
+    let linear = compute_scheduled_temperature(CoolingSchedule::Linear, 1.0, generation, total);
+    let exponential =
+        compute_scheduled_temperature(CoolingSchedule::Exponential, 1.0, generation, total);
+
+    // At generation 10/1000, linear = 1.0 * (1 - 0.01) = 0.99
+    // exponential = 1.0 * 0.995^10 ≈ 0.951
+    assert!(
+        exponential < linear,
+        "Exponential ({exponential}) should be lower than linear ({linear}) at early generations"
+    );
+}
+
+/// Issue #1020: Default exponential decay rate is in valid range.
+#[test]
+fn exponential_decay_rate_is_valid() {
+    let rate = DEFAULT_EXPONENTIAL_DECAY_RATE;
+    assert!(rate > 0.0 && rate < 1.0, "Decay rate must be in (0, 1)");
+}
+
+// =============================================================================
+// Threshold Scaling Tests
+// =============================================================================
+
+/// Issue #1020: Default temperature (1.0) preserves the original threshold.
+#[test]
+fn default_temperature_preserves_threshold() {
+    let threshold = 0.05;
+    let scaled = scale_threshold_by_temperature(threshold, DEFAULT_TEMPERATURE);
+    assert!(
+        (scaled - threshold).abs() < f32::EPSILON,
+        "Default temperature should not change threshold: got {scaled}, expected {threshold}"
+    );
+}
+
+/// Issue #1020: High temperature (exploration) lowers the effective threshold,
+/// accepting more marginal candidates.
+#[test]
+fn high_temperature_increases_acceptance_via_threshold() {
+    let threshold = 0.05;
+    let high_temp = 2.0;
+    let scaled = scale_threshold_by_temperature(threshold, high_temp);
+    assert!(
+        scaled < threshold,
+        "High temperature should lower threshold: got {scaled}, expected < {threshold}"
+    );
+    // At temperature 2.0, threshold should be halved
+    assert!(
+        (scaled - 0.025).abs() < 1e-6,
+        "At temp=2.0, threshold 0.05 should become 0.025, got {scaled}"
+    );
+}
+
+/// Issue #1020: Low temperature (exploitation) raises the effective threshold,
+/// only accepting strong candidates.
+#[test]
+fn low_temperature_decreases_acceptance_via_threshold() {
+    let threshold = 0.05;
+    let low_temp = 0.5;
+    let scaled = scale_threshold_by_temperature(threshold, low_temp);
+    assert!(
+        scaled > threshold,
+        "Low temperature should raise threshold: got {scaled}, expected > {threshold}"
+    );
+    // At temperature 0.5, threshold should be doubled
+    assert!(
+        (scaled - 0.1).abs() < 1e-6,
+        "At temp=0.5, threshold 0.05 should become 0.1, got {scaled}"
+    );
+}
+
+// =============================================================================
+// Improved Ratio Scaling Tests
+// =============================================================================
+
+/// Issue #1020: Default temperature (1.0) preserves `MIN_IMPROVED_RATIO`.
+#[test]
+fn default_temperature_preserves_improved_ratio() {
+    let scaled = scale_ratio_by_temperature(MIN_IMPROVED_RATIO, DEFAULT_TEMPERATURE);
+    assert!(
+        (scaled - MIN_IMPROVED_RATIO).abs() < f32::EPSILON,
+        "Default temperature should not change ratio: got {scaled}, expected {MIN_IMPROVED_RATIO}"
+    );
+}
+
+/// Issue #1020: High temperature lowers the effective ratio, letting more
+/// candidates through (exploration).
+#[test]
+fn high_temperature_lowers_improved_ratio() {
+    let ratio = 0.6;
+    let high_temp = 2.0;
+    let scaled = scale_ratio_by_temperature(ratio, high_temp);
+    assert!(
+        scaled < ratio,
+        "High temperature should lower ratio: got {scaled}, expected < {ratio}"
+    );
+    assert!(
+        (scaled - 0.3).abs() < 1e-6,
+        "At temp=2.0, ratio 0.6 should become 0.3, got {scaled}"
+    );
+}
+
+/// Issue #1020: Low temperature raises the effective ratio, filtering more
+/// aggressively (exploitation). Clamped to 1.0.
+#[test]
+fn low_temperature_raises_improved_ratio_with_clamp() {
+    let ratio = 0.6;
+    let very_low_temp = 0.1;
+    let scaled = scale_ratio_by_temperature(ratio, very_low_temp);
+    assert!(scaled <= 1.0, "Ratio must be clamped to 1.0: got {scaled}");
+    assert!(
+        scaled > ratio,
+        "Low temperature should raise ratio: got {scaled}, expected > {ratio}"
+    );
+}
+
+// =============================================================================
+// MH Temperature Scaling Tests
+// =============================================================================
+
+/// Issue #1020: Default temperature preserves MH temperature unchanged.
+#[test]
+fn default_temperature_preserves_mh_temperature() {
+    let base_mh = 0.01;
+    let scaled = scale_mh_temperature(base_mh, DEFAULT_TEMPERATURE);
+    assert!(
+        (scaled - base_mh).abs() < f32::EPSILON,
+        "Default temperature should not change MH temp: got {scaled}, expected {base_mh}"
+    );
+}
+
+/// Issue #1020: High schedule temperature increases effective MH temperature,
+/// making probabilistic acceptance more willing to accept marginal candidates.
+#[test]
+fn high_temperature_increases_mh_acceptance() {
+    let base_mh = 0.01;
+    let high_temp = 3.0;
+    let scaled = scale_mh_temperature(base_mh, high_temp);
+    assert!(
+        scaled > base_mh,
+        "High schedule temp should increase MH temp: got {scaled}, expected > {base_mh}"
+    );
+    assert!(
+        (scaled - 0.03).abs() < 1e-6,
+        "At schedule temp=3.0, MH temp 0.01 should become 0.03, got {scaled}"
+    );
+}
+
+/// Issue #1020: Low schedule temperature decreases effective MH temperature,
+/// making probabilistic acceptance more selective.
+#[test]
+fn low_temperature_decreases_mh_acceptance() {
+    let base_mh = 0.01;
+    let low_temp = 0.5;
+    let scaled = scale_mh_temperature(base_mh, low_temp);
+    assert!(
+        scaled < base_mh,
+        "Low schedule temp should decrease MH temp: got {scaled}, expected < {base_mh}"
+    );
+}
+
+// =============================================================================
+// Temperature Bounds Tests
+// =============================================================================
+
+/// Issue #1020: Temperature is clamped to valid range in all scaling functions.
+#[test]
+fn extreme_temperatures_are_clamped() {
+    // Very high temperature is clamped to MAX_TEMPERATURE
+    let threshold = 0.05;
+    let scaled_high = scale_threshold_by_temperature(threshold, 100.0);
+    let expected_max = threshold / MAX_TEMPERATURE;
+    assert!(
+        (scaled_high - expected_max).abs() < 1e-6,
+        "Very high temp should be clamped: got {scaled_high}, expected {expected_max}"
+    );
+
+    // Very low temperature is clamped to MIN_TEMPERATURE
+    let scaled_low = scale_threshold_by_temperature(threshold, 0.0001);
+    let expected_min = threshold / MIN_TEMPERATURE;
+    assert!(
+        (scaled_low - expected_min).abs() < 1e-3,
+        "Very low temp should be clamped: got {scaled_low}, expected {expected_min}"
+    );
+}
+
+/// Issue #1020: Zero temperature is handled safely (clamped to minimum).
+#[test]
+fn zero_temperature_does_not_cause_division_by_zero() {
+    let threshold = 0.05;
+    let scaled = scale_threshold_by_temperature(threshold, 0.0);
+    assert!(
+        scaled.is_finite(),
+        "Zero temperature must not produce infinite threshold"
+    );
+    assert!(scaled > 0.0, "Scaled threshold must remain positive");
+}
+
+/// Issue #1020: Negative temperature is handled safely (clamped to minimum).
+#[test]
+fn negative_temperature_is_clamped_to_minimum() {
+    let threshold = 0.05;
+    let scaled = scale_threshold_by_temperature(threshold, -1.0);
+    assert!(
+        scaled.is_finite(),
+        "Negative temperature must not produce NaN"
+    );
+    let expected = threshold / MIN_TEMPERATURE;
+    assert!(
+        (scaled - expected).abs() < 1e-3,
+        "Negative temp should be clamped to minimum"
+    );
+}
+
+// =============================================================================
+// End-to-End Schedule Integration Tests
+// =============================================================================
+
+/// Issue #1020: Full cooling schedule with threshold scaling produces a
+/// monotonically increasing effective threshold over generations.
+#[test]
+fn cooling_schedule_produces_increasing_effective_threshold() {
+    let base_threshold = 0.05;
+    let total_generations = 500;
+    let mut prev_effective = 0.0;
+
+    for generation in 0..=total_generations {
+        let temp = compute_scheduled_temperature(
+            CoolingSchedule::Exponential,
+            2.0,
+            generation,
+            total_generations,
+        );
+        let effective = scale_threshold_by_temperature(base_threshold, temp);
+        assert!(
+            effective >= prev_effective - 1e-6,
+            "Effective threshold should increase as temperature cools: generation {generation}, effective {effective} < prev {prev_effective}"
+        );
+        prev_effective = effective;
+    }
+}
+
+/// Issue #1020: Full cooling schedule with ratio scaling produces a
+/// monotonically increasing effective ratio over generations.
+#[test]
+fn cooling_schedule_produces_increasing_effective_ratio() {
+    let base_ratio = 0.6;
+    let total_generations = 500;
+    let mut prev_effective = 0.0;
+
+    for generation in 0..=total_generations {
+        let temp = compute_scheduled_temperature(
+            CoolingSchedule::Linear,
+            2.0,
+            generation,
+            total_generations,
+        );
+        let effective = scale_ratio_by_temperature(base_ratio, temp);
+        assert!(
+            effective >= prev_effective - 1e-6,
+            "Effective ratio should increase as temperature cools: generation {generation}, effective {effective} < prev {prev_effective}"
+        );
+        prev_effective = effective;
+    }
+}
+
+/// Issue #1020: Default temperature constant is exactly 1.0.
+#[test]
+fn default_temperature_constant_is_one() {
+    let default = DEFAULT_TEMPERATURE;
+    assert!(
+        (default - 1.0).abs() < f32::EPSILON,
+        "DEFAULT_TEMPERATURE must be 1.0 for backward compatibility"
+    );
+}
+
+/// Issue #1020: `MIN_TEMPERATURE` is positive and less than 1.0.
+#[test]
+fn min_temperature_bounds() {
+    let min = MIN_TEMPERATURE;
+    assert!(min > 0.0, "MIN_TEMPERATURE must be positive");
+    assert!(min < 1.0, "MIN_TEMPERATURE must be less than 1.0");
+}
+
+/// Issue #1020: `MAX_TEMPERATURE` is at least 1.0.
+#[test]
+fn max_temperature_bounds() {
+    let max = MAX_TEMPERATURE;
+    assert!(max >= 1.0, "MAX_TEMPERATURE must be at least 1.0");
+}

--- a/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
+++ b/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
@@ -98,6 +98,7 @@ fn issue_199_low_variance_sources_use_default_threshold() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -200,6 +201,7 @@ fn issue_199_high_variance_sources_scale_threshold() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -300,6 +302,7 @@ fn issue_199_env_var_override_takes_precedence() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -380,6 +383,7 @@ fn issue_199_env_var_zero_disables_folding() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/analysis/issue_221_sample_locality.rs
+++ b/tests/analysis/issue_221_sample_locality.rs
@@ -344,6 +344,7 @@ fn sample_locality_batching_produces_results() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs
@@ -414,6 +415,7 @@ fn sample_locality_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -461,6 +463,7 @@ fn source_batching_90_percent_overlap_produces_results() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs

--- a/tests/analysis/issue_419_parallel_discovery_execution.rs
+++ b/tests/analysis/issue_419_parallel_discovery_execution.rs
@@ -112,6 +112,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -205,6 +206,7 @@ fn parallel_discovery_metadata_consistent() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -103,6 +103,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -156,6 +157,7 @@ fn input_neuron_reported_as_filtered_in_neuron_diagnostics() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -226,6 +228,7 @@ fn synapse_diagnostics_include_rejection_reasons_for_unpromising_targets() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("synapse analysis should succeed");
@@ -409,6 +412,7 @@ fn multiple_focus_targets_each_get_separate_diagnostic_entry() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -470,6 +474,7 @@ fn fully_connected_neuron_reports_no_eligible_sources() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/analysis/issue_557_audit_discovery_strategies.rs
+++ b/tests/analysis/issue_557_audit_discovery_strategies.rs
@@ -137,6 +137,7 @@ fn all_candidates_have_positive_expected_score_gain() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -221,6 +222,7 @@ fn metadata_consistent_after_positive_gain_filtering() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_568_async_pipeline.rs
+++ b/tests/analysis/issue_568_async_pipeline.rs
@@ -162,6 +162,7 @@ fn async_pipeline_produces_valid_analysis_results() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -220,6 +221,7 @@ fn async_pipeline_is_deterministic_with_fixed_seed() {
         random_seed: Some(12345),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result1 = analyze_all(&make_input()).expect("Run 1 should succeed");

--- a/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
+++ b/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
@@ -227,6 +227,7 @@ fn run_analysis() -> Vec<neat_ai_discovery::CoordinatedStructuralCandidateJson> 
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -380,6 +381,7 @@ fn test_analyze_all_finds_change_squash_candidate() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -14,6 +14,7 @@ mod impact_calculation_production;
 mod impact_squash;
 mod issue_1003_parallel_candidate_compression;
 mod issue_1004_overlap_compression_discovery;
+mod issue_1020_temperature_scheduling;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;

--- a/tests/analysis/split_error_all_activations.rs
+++ b/tests/analysis/split_error_all_activations.rs
@@ -149,6 +149,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -280,6 +281,7 @@ fn test_skewed_errors_return_candidates() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/split_error_fallback_candidates.rs
+++ b/tests/analysis/split_error_fallback_candidates.rs
@@ -154,6 +154,7 @@ fn regression_split_error_must_return_fallback_candidates() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -329,6 +330,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/target_map_optimization.rs
+++ b/tests/analysis/target_map_optimization.rs
@@ -83,6 +83,7 @@ fn synapse_analysis_with_target_map_optimization_succeeds() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -161,6 +162,7 @@ fn multiple_focus_neurons_share_target_map_optimization() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result =
@@ -260,6 +262,7 @@ fn target_map_filters_non_finite_values() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Analysis should complete without errors from non-finite values
@@ -330,6 +333,7 @@ fn empty_target_records_skips_source_processing() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Should complete quickly without processing sources

--- a/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
@@ -123,6 +123,7 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/focus/issue_182_focus_unused_observations.rs
+++ b/tests/focus/issue_182_focus_unused_observations.rs
@@ -210,6 +210,7 @@ fn issue_182_focus_unused_observations_prioritises_inputs_without_synapses() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(5000), // Short deadline to test prioritisation
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -281,6 +282,7 @@ fn issue_182_without_env_var_no_prioritisation() {
         max_candidates: Some(10),
         analysis_deadline_ms: None, // No deadline - process all
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -130,6 +130,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -238,6 +239,7 @@ fn test_all_new_activations_produce_candidates() {
         max_candidates: Some(500),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -85,6 +85,7 @@ fn synapse_analysis_works_with_gpu_work_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -151,6 +152,7 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -260,6 +262,7 @@ fn multiple_focus_neurons_work_with_shared_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Run analysis with multiple focus neurons
@@ -343,6 +346,7 @@ fn harmful_synapse_detection_works_with_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Run analysis

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -88,6 +88,7 @@ fn neuron_analysis_with_deadline_completes() {
         // adaptive timeouts instead of the 5-minute maximum.
         analysis_deadline_ms: Some(120_000),
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis with deadline should succeed");
@@ -116,6 +117,7 @@ fn synapse_analysis_with_deadline_completes() {
         // Issue #953: Set a 2-minute deadline
         analysis_deadline_ms: Some(120_000),
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis with deadline should succeed");
@@ -151,6 +153,7 @@ fn analysis_with_expired_deadline_returns_promptly() {
         // analysis begins. The analysis should return quickly (not hang).
         analysis_deadline_ms: Some(1),
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let start = std::time::Instant::now();

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -123,6 +123,7 @@ fn timing_enabled_via_env_var() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -183,6 +184,7 @@ fn per_shader_timing_collected() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -322,6 +324,7 @@ fn neuron_analysis_timing_collected() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_196_cache_locality_benchmark.rs
+++ b/tests/infrastructure/issue_196_cache_locality_benchmark.rs
@@ -134,6 +134,7 @@ fn cache_locality_optimization_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -152,6 +153,7 @@ fn cache_locality_optimization_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(123),
+        temperature: 1.0,
     };
 
     let result2 = analyze_synapses(&input2).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_228_zero_copy_buffer.rs
+++ b/tests/infrastructure/issue_228_zero_copy_buffer.rs
@@ -205,6 +205,7 @@ fn zero_copy_produces_correct_results() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
     let result_zero_copy =
         analyze_synapses(&input).expect("Analysis with zero-copy should succeed");
@@ -223,6 +224,7 @@ fn zero_copy_produces_correct_results() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
     let result_copy = analyze_synapses(&input).expect("Analysis with copy should succeed");
     unsafe {
@@ -322,6 +324,7 @@ fn metadata_includes_zero_copy_status() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -407,6 +410,7 @@ fn zero_copy_no_data_corruption() {
             max_candidates: Some(20),
             analysis_deadline_ms: None,
             random_seed: Some(seed),
+            temperature: 1.0,
         };
 
         let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_718_bug_comment_error_handling.rs
+++ b/tests/infrastructure/issue_718_bug_comment_error_handling.rs
@@ -71,6 +71,7 @@ fn target_with_only_constant_upstream_returns_empty_results() {
         max_candidates: None,
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input);

--- a/tests/infrastructure/observability.rs
+++ b/tests/infrastructure/observability.rs
@@ -374,6 +374,7 @@ fn integration_timing_output() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result =
@@ -441,6 +442,7 @@ fn integration_gpu_metrics() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result =

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -508,6 +508,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -603,6 +604,7 @@ fn test_bias_values_are_activation_specific() {
         max_candidates: Some(50), // Request many candidates to get variety
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -872,6 +874,7 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -980,6 +983,7 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1078,6 +1082,7 @@ fn test_bias_improves_neuron_performance() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1207,6 +1212,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1369,6 +1375,7 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         max_candidates: Some(20),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/neuron/issue_134_direction_flip.rs
+++ b/tests/neuron/issue_134_direction_flip.rs
@@ -79,6 +79,7 @@ fn issue_134_bent_identity_target_simulation_rejects_linear_false_positive() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -147,6 +148,7 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
@@ -78,6 +78,7 @@ fn issue_178_constant_source_becomes_setbias_candidate() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_180_setweight_operation.rs
+++ b/tests/neuron/issue_180_setweight_operation.rs
@@ -106,6 +106,7 @@ fn issue_180_setweight_replaces_remove_add_pattern() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_834_lock_free_error_collection.rs
+++ b/tests/neuron/issue_834_lock_free_error_collection.rs
@@ -159,6 +159,7 @@ fn test_lock_free_error_collection_many_targets() {
         max_candidates: Some(20),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -217,6 +217,7 @@ fn test_add_neuron_between_hidden_neurons() {
         max_candidates: Some(20),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -326,6 +327,7 @@ fn test_hidden_neuron_candidate_properties() {
         max_candidates: Some(20),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -423,6 +425,7 @@ fn test_analyze_all_finds_hidden_neuron_candidate() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(true),
         random_seed: Some(42),
+        temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
     };

--- a/tests/regression/regression_v0_1_123.rs
+++ b/tests/regression/regression_v0_1_123.rs
@@ -135,6 +135,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -266,6 +267,7 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -532,6 +534,7 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -712,6 +715,7 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_192_error_distribution_analysis.rs
+++ b/tests/scoring/issue_192_error_distribution_analysis.rs
@@ -458,6 +458,7 @@ fn test_synapse_analysis_includes_error_distribution() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -568,6 +569,7 @@ fn test_candidate_includes_outlier_info_when_enabled() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -668,6 +670,7 @@ fn test_bimodal_error_pattern_detection() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/scoring/issue_486_neuron_error_distribution.rs
+++ b/tests/scoring/issue_486_neuron_error_distribution.rs
@@ -97,6 +97,7 @@ fn test_neuron_analysis_populates_error_distribution() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -195,6 +196,7 @@ fn test_neuron_analysis_no_errors_returns_none() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -299,6 +301,7 @@ fn test_neuron_analysis_error_distribution_multiple_targets() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
+++ b/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
@@ -210,6 +210,7 @@ fn test_issue_506_synapse_candidates_have_pessimism_discount() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
@@ -122,6 +122,7 @@ fn synapse_analysis_runs_under_deadline() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -167,6 +168,7 @@ fn metadata_indicates_target_value_available() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -207,6 +209,7 @@ fn metadata_indicates_target_value_not_available() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -253,6 +256,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -296,6 +300,7 @@ fn candidate_counts_tracked_correctly() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -402,6 +407,7 @@ fn truncation_reflected_in_candidate_counts() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        temperature: 1.0,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");

--- a/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
+++ b/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
@@ -132,6 +132,7 @@ fn test_issue_413_add_synapse_hard_tanh_prediction_not_inverted() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();
@@ -211,6 +212,7 @@ fn test_issue_413_add_synapse_prediction_direction_correct() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_416_harmful_synapse_threshold.rs
+++ b/tests/synapse/issue_416_harmful_synapse_threshold.rs
@@ -141,6 +141,7 @@ fn test_harmful_synapse_candidates_must_have_positive_expected_gain() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -237,6 +238,7 @@ fn test_helpful_synapse_is_not_marked_as_harmful() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -364,6 +366,7 @@ fn test_mixed_helpful_and_harmful_synapses() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/synapse/issue_522_synapse_post_processing.rs
+++ b/tests/synapse/issue_522_synapse_post_processing.rs
@@ -126,6 +126,7 @@ fn output_targets_have_full_impact_hidden_targets_are_discounted() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -253,6 +254,7 @@ fn candidates_sorted_by_expected_score_gain_descending() {
         max_candidates: Some(100),
         analysis_deadline_ms: None, // No deadline = no diversification shuffle
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -364,6 +366,7 @@ fn max_candidates_limits_total_output() {
         max_candidates: Some(max_limit),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -454,6 +457,7 @@ fn pipeline_applies_pessimism_discount_to_candidates() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -556,6 +560,7 @@ fn metadata_contains_candidate_counts_and_timing() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -228,6 +228,7 @@ fn test_remove_harmful_synapse_discovery() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -354,6 +355,7 @@ fn test_harmful_synapse_identifies_correct_neurons() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -424,6 +426,7 @@ fn test_analyze_all_finds_harmful_synapse() {
         include_synapse_analysis: Some(true),
         include_neuron_analysis: Some(false),
         random_seed: Some(42),
+        temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
     };

--- a/tests/synapse/sample_matching.rs
+++ b/tests/synapse/sample_matching.rs
@@ -74,6 +74,7 @@ fn analysis_handles_non_finite_values_gracefully() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Should complete without error
@@ -136,6 +137,7 @@ fn analysis_pairs_samples_by_obs_index() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Should complete successfully with 5 matching sample pairs
@@ -200,6 +202,7 @@ fn analysis_skips_neurons_without_errors() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     // Should complete and find candidates using input-0 as source

--- a/tests/synapse/source_variance_discounting.rs
+++ b/tests/synapse/source_variance_discounting.rs
@@ -130,6 +130,7 @@ fn test_constant_source_gives_zero_improvement() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -230,6 +231,7 @@ fn test_low_variance_source_discounts_prediction() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -330,6 +332,7 @@ fn test_high_variance_source_not_discounted() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -437,6 +440,7 @@ fn test_constant_vs_varying_source_comparison() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/synapse/synapse_candidate_indices.rs
+++ b/tests/synapse/synapse_candidate_indices.rs
@@ -105,6 +105,7 @@ fn synapse_candidates_populate_from_and_to_indices() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/synapse/synapse_impact_discounting.rs
+++ b/tests/synapse/synapse_impact_discounting.rs
@@ -179,6 +179,7 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -293,6 +294,7 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -382,6 +384,7 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        temperature: 1.0,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -828,6 +828,7 @@ Pages speculative:                        12345.
             max_candidates: Some(1),
             analysis_deadline_ms: None,
             random_seed: Some(123),
+            temperature: 1.0,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;
@@ -920,6 +921,7 @@ Pages speculative:                        12345.
             max_candidates: Some(1),
             analysis_deadline_ms: None,
             random_seed: Some(123),
+            temperature: 1.0,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;


### PR DESCRIPTION
## Summary

Add temperature scheduling for exploration-exploitation balance in the candidate selection pipeline. The temperature parameter controls how aggressively the system filters marginal candidates: high temperature (early in evolution) accepts more candidates for exploration, while low temperature (late in evolution) only accepts strong candidates for exploitation. A default temperature of 1.0 preserves existing behaviour (fully backward compatible). Closes #1020.

## Changes

### New: Temperature scheduling module (`src/analysis/constants/temperature.rs`)
- `CoolingSchedule` enum with `Linear` and `Exponential` variants
- `compute_scheduled_temperature()` — computes temperature from generation count using a cooling schedule
- `scale_threshold_by_temperature()` — scales acceptance threshold by temperature (higher temp = lower threshold = more permissive)
- `scale_ratio_by_temperature()` — scales `MIN_IMPROVED_RATIO` by temperature
- `scale_mh_temperature()` — scales Metropolis-Hastings temperature by schedule temperature
- Constants: `DEFAULT_TEMPERATURE` (1.0), `MIN_TEMPERATURE` (0.01), `MAX_TEMPERATURE` (5.0), `DEFAULT_EXPONENTIAL_DECAY_RATE` (0.995)

### Modified: FFI input structs (`src/ffi_types/requests.rs`)
- Added `temperature: f32` field (default 1.0) to `AnalyzeParallelInput`, `AnalyzeSynapsesInput`, `AnalyzeNeuronsInput`, and `AnalyzeAllInput`
- Serde default ensures backward compatibility with existing JSON callers

### Modified: Analysis pipeline
- `TargetAnalysisContext` gains `temperature` field threaded from input
- `evaluation.rs` applies temperature scaling to:
  - `MIN_IMPROVED_RATIO` threshold (via `scale_ratio_by_temperature`)
  - Acceptance threshold (via `scale_threshold_by_temperature`)
  - Metropolis-Hastings temperature (via `scale_mh_temperature`, when MH is enabled)

## Evidence

- 22 integration tests verify cooling schedules, threshold scaling, ratio scaling, MH scaling, boundary conditions, and backward compatibility
- 13 unit tests in the temperature module verify schedule functions and scaling helpers
- All existing tests pass unchanged (temperature defaults to 1.0, preserving identical behaviour)

## Test Plan

- `tests/analysis/issue_1020_temperature_scheduling.rs` — 22 tests covering:
  - Linear and exponential cooling schedule monotonicity
  - Both schedules start at initial temperature
  - Exponential cools faster initially than linear
  - Default temperature (1.0) preserves threshold, ratio, and MH temperature unchanged
  - High temperature lowers effective threshold and ratio (exploration)
  - Low temperature raises effective threshold and ratio (exploitation)
  - High/low schedule temperature scales MH acceptance accordingly
  - Temperature bounds are enforced (clamped to min/max)
  - Zero and negative temperature handled safely
  - End-to-end: cooling schedule + threshold scaling produces monotonically increasing effective threshold
  - End-to-end: cooling schedule + ratio scaling produces monotonically increasing effective ratio
- `src/analysis/constants/temperature.rs` — 13 unit tests for schedule functions and scaling helpers

---

## Automated Fix Details
This PR addresses issue #1020: **Add temperature scheduling for exploration-exploitation balance in candidate selection**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1020
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1020 -->