### PR TITLE
feat: expose Rust-side memory usage to Deno via FFI (#1027)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ src/
 │   ├── gpu.rs                # GPU probe entry points (check_gpu_available)
 │   ├── recording.rs          # Recording entry points (streaming and single-call)
 │   ├── analysis.rs           # Analysis entry points (rank_focus_neurons, analyze_parallel)
-│   └── utilities.rs          # Utility entry points (merge, read, export, version)
+│   └── utilities.rs          # Utility entry points (merge, read, export, version, memory usage)
 ├── ffi_types/                # JSON request/response structs for FFI boundary (Issue #596)
 │   ├── mod.rs                # Public API, re-exports, shared types (Creature, Neuron, Synapse)
 │   ├── requests.rs           # FFI request structs (input from NEAT-AI)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }  # Deadloc
 signal-hook = "0.4"  # Signal handling (SIGUSR1 for thread dumps)
 tracing = "0.1"  # Structured logging framework (Issue #575)
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }  # Subscriber with EnvFilter (Issue #575)
+cap = { version = "0.1", features = ["stats"] }  # Tracking allocator for Rust-side memory usage reporting (Issue #1027)
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.31"
+version = "0.72.32"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -20,7 +20,35 @@ The most commonly used entry points are:
   - Single-call: `record_discovery` (avoid for large runs; prefer streaming to prevent JS/V8 string limits)
 - **Analysis**: `rank_focus_neurons`, `analyze_parallel`
 - **Utilities**: `merge_discovery_parquet`, `read_discovery_records_ffi`, `export_visualisation_snapshot`
+- **Memory usage**: `discovery_memory_usage_bytes()` (returns `u64`)
 - **Memory management**: `free_discovery_result`
+
+---
+
+## 🧠 Rust-side Memory Usage (Issue #1027)
+
+The Rust library allocates memory outside V8's heap, making it invisible to
+Deno-side memory monitors. Use `discovery_memory_usage_bytes()` to query the
+current Rust allocator usage and combine it with `Deno.memoryUsage().heapUsed`
+for accurate total-process memory monitoring.
+
+- **Symbol**: `discovery_memory_usage_bytes`
+- **Input**: no arguments
+- **Output**: `u64` — current Rust heap allocation in bytes
+- **Overhead**: reads a single atomic counter; suitable for polling every 5–30 seconds
+- **Panic safety**: catches panics and returns `0` on failure
+
+### Example (Deno FFI)
+
+```typescript
+const lib = Deno.dlopen("libneat_ai_discovery.dylib", {
+  discovery_memory_usage_bytes: { parameters: [], result: "u64" },
+});
+
+const rustBytes = lib.symbols.discovery_memory_usage_bytes();
+const v8Bytes = Deno.memoryUsage().heapUsed;
+const totalBytes = rustBytes + BigInt(v8Bytes);
+```
 
 ---
 

--- a/docs/pr-summary-1027.md
+++ b/docs/pr-summary-1027.md
@@ -1,0 +1,36 @@
+## Summary
+
+Add `discovery_memory_usage_bytes()` FFI function that reports current Rust-side
+heap allocation in bytes, enabling the Deno-side MemoryWatchdog to track total
+process memory (V8 + Rust) and prevent OOM kills. Closes #1027.
+
+The implementation uses the `cap` crate as a global tracking allocator wrapper
+around `std::alloc::System`. It maintains a single atomic counter that is
+incremented/decremented on every allocation/deallocation, making the query
+function essentially free for periodic polling (every 5-30 seconds).
+
+## Changes
+
+- **`Cargo.toml`**: Added `cap` dependency (MIT OR Apache-2.0) with `stats` feature
+- **`src/lib.rs`**: Set `cap::Cap<System>` as the `#[global_allocator]`
+- **`src/ffi/utilities.rs`**: Added `discovery_memory_usage_bytes()` FFI export
+- **`docs/FFI_API.md`**: Documented the new symbol with usage example
+- **`AGENTS.md`**: Updated source layout comment
+
+## Evidence
+
+The new FFI symbol is verified exported from the release build:
+```
+nm -gU target/release/libneat_ai_discovery.dylib | grep discovery_memory_usage_bytes
+00000000002513a4 T _discovery_memory_usage_bytes
+```
+
+All 3 new tests pass, and the full quality gate (`./quality.sh`) passes cleanly
+with 171 tests (including the 3 new ones).
+
+## Test Plan
+
+- `tests/ffi/issue_1027_memory_usage_ffi.rs`:
+  - `discovery_memory_usage_bytes_returns_nonzero` — verifies the function returns > 0
+  - `discovery_memory_usage_bytes_increases_after_allocation` — verifies usage increases after a 1 MB allocation
+  - `discovery_memory_usage_bytes_is_callable_many_times` — verifies safe repeated polling

--- a/src/ffi/utilities.rs
+++ b/src/ffi/utilities.rs
@@ -304,6 +304,31 @@ pub unsafe extern "C" fn get_calibration_summary(
 }
 
 // ============================================================================
+// Memory usage (Issue #1027)
+// ============================================================================
+
+/// Return the current Rust-side heap allocation in bytes.
+///
+/// This function is designed for periodic polling (every 5–30 seconds) by the
+/// Deno-side memory watchdog. It reads a single atomic counter maintained by
+/// the tracking allocator, so overhead is negligible.
+///
+/// The returned value reflects memory allocated through Rust's global
+/// allocator. It does **not** include V8/Deno heap usage — callers should
+/// combine this with `Deno.memoryUsage().heapUsed` for total process memory.
+#[unsafe(no_mangle)]
+pub extern "C" fn discovery_memory_usage_bytes() -> u64 {
+    use std::panic;
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        #[allow(clippy::cast_possible_truncation)]
+        let bytes = crate::ALLOCATOR.allocated() as u64;
+        bytes
+    }))
+    .unwrap_or(0)
+}
+
+// ============================================================================
 // Library cleanup (Issue #994)
 // ============================================================================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,12 @@
 //! during the discovery training phase, then scanning recorded data to identify
 //! beneficial new synapses/neurons that would reduce error.
 
+// Global tracking allocator — wraps the system allocator to report Rust-side
+// memory usage via FFI (Issue #1027). Overhead is a single atomic add/sub per
+// allocation, which is negligible for polling every 5-30 seconds.
+#[global_allocator]
+static ALLOCATOR: cap::Cap<std::alloc::System> = cap::Cap::new(std::alloc::System, usize::MAX);
+
 pub mod activations;
 pub mod analysis;
 pub mod config;

--- a/tests/ffi/issue_1027_memory_usage_ffi.rs
+++ b/tests/ffi/issue_1027_memory_usage_ffi.rs
@@ -1,0 +1,58 @@
+//! Issue #1027 — Expose Rust-side memory usage to Deno via FFI.
+//!
+//! The Rust library allocates memory outside V8's heap, making it invisible to
+//! the GRQ `MemoryWatchdog`. This test verifies that the
+//! `discovery_memory_usage_bytes()` FFI function returns a reasonable
+//! approximation of Rust-side memory usage suitable for periodic polling.
+
+// ============================================================================
+// discovery_memory_usage_bytes — returns non-zero usage
+// ============================================================================
+
+#[test]
+fn discovery_memory_usage_bytes_returns_nonzero() {
+    // The library itself has already allocated memory by this point
+    // (static initialisers, test harness, etc.), so usage should be > 0.
+    let usage = neat_ai_discovery::ffi::discovery_memory_usage_bytes();
+    assert!(
+        usage > 0,
+        "Expected non-zero Rust memory usage, got {usage}"
+    );
+}
+
+#[test]
+fn discovery_memory_usage_bytes_increases_after_allocation() {
+    let before = neat_ai_discovery::ffi::discovery_memory_usage_bytes();
+
+    // Allocate a known chunk of memory that the tracking allocator should see.
+    let large_vec: Vec<u8> = vec![42u8; 1_000_000];
+
+    let after = neat_ai_discovery::ffi::discovery_memory_usage_bytes();
+
+    // The usage should have increased by at least the size of our allocation.
+    // We allow some tolerance because other threads may free memory concurrently.
+    assert!(
+        after > before,
+        "Expected memory usage to increase after 1 MB allocation: before={before}, after={after}"
+    );
+
+    // Ensure the allocation is not optimised away.
+    assert_eq!(large_vec.len(), 1_000_000);
+}
+
+#[test]
+fn discovery_memory_usage_bytes_is_callable_many_times() {
+    // The function must be safe to call repeatedly for periodic polling.
+    // We simply verify it does not panic or return wildly different values
+    // within a tight loop (no timing assertions — that belongs in benchmarks).
+    let mut values = Vec::with_capacity(100);
+    for _ in 0..100 {
+        values.push(neat_ai_discovery::ffi::discovery_memory_usage_bytes());
+    }
+
+    // All values should be non-zero (the process always has some allocations).
+    assert!(
+        values.iter().all(|&v| v > 0),
+        "All polled values should be non-zero"
+    );
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -3,6 +3,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod issue_1027_memory_usage_ffi;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
## Summary

Add `discovery_memory_usage_bytes()` FFI function that reports current Rust-side
heap allocation in bytes, enabling the Deno-side MemoryWatchdog to track total
process memory (V8 + Rust) and prevent OOM kills. Closes #1027.

The implementation uses the `cap` crate as a global tracking allocator wrapper
around `std::alloc::System`. It maintains a single atomic counter that is
incremented/decremented on every allocation/deallocation, making the query
function essentially free for periodic polling (every 5-30 seconds).

## Changes

- **`Cargo.toml`**: Added `cap` dependency (MIT OR Apache-2.0) with `stats` feature
- **`src/lib.rs`**: Set `cap::Cap<System>` as the `#[global_allocator]`
- **`src/ffi/utilities.rs`**: Added `discovery_memory_usage_bytes()` FFI export
- **`docs/FFI_API.md`**: Documented the new symbol with usage example
- **`AGENTS.md`**: Updated source layout comment

## Evidence

The new FFI symbol is verified exported from the release build:
```
nm -gU target/release/libneat_ai_discovery.dylib | grep discovery_memory_usage_bytes
00000000002513a4 T _discovery_memory_usage_bytes
```

All 3 new tests pass, and the full quality gate (`./quality.sh`) passes cleanly
with 171 tests (including the 3 new ones).

## Test Plan

- `tests/ffi/issue_1027_memory_usage_ffi.rs`:
  - `discovery_memory_usage_bytes_returns_nonzero` — verifies the function returns > 0
  - `discovery_memory_usage_bytes_increases_after_allocation` — verifies usage increases after a 1 MB allocation
  - `discovery_memory_usage_bytes_is_callable_many_times` — verifies safe repeated polling

---

## Automated Fix Details
This PR addresses issue #1027: **Expose Rust-side memory usage to Deno via FFI for OOM prevention**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1027
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1027 -->