### PR TITLE
feat: add deadline enforcement to discovery module detection (#1029)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.32"
+version = "0.72.33"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1029.md
+++ b/docs/pr-summary-1029.md
@@ -1,0 +1,38 @@
+## Summary
+
+Discovery module detection (48 parallel closures via rayon) had no deadline
+awareness. When the analysis time budget was exhausted, modules would continue
+running indefinitely, causing the process to exceed its `max-task-hours` limit
+and get killed by the task controller.
+
+This change threads the analysis deadline into `detect_discovery_modules_parallel`
+so that each module checks `deadline_passed()` before executing its detection
+closure. Modules that start after the deadline are skipped, and a shared
+`AtomicBool` flag propagates the timeout signal across rayon worker threads to
+minimise repeated syscalls.
+
+Closes #1029.
+
+## Changes
+
+- `detect_discovery_modules_parallel` now accepts an `Option<SystemTime>` deadline
+  parameter. When the deadline is reached, remaining modules are skipped.
+- `prepare_and_detect_discovery_modules` accepts and forwards the deadline.
+- `analyze_all` (orchestration) builds a deadline from `analysis_deadline_ms`
+  and passes it to the discovery detection phase.
+- Existing callers (`run_discovery_modules_parallel`, integration tests) pass
+  `None` to preserve existing behaviour.
+
+## Evidence
+
+- Tests verify that modules are skipped when the deadline has already passed
+- Tests verify that modules run normally with no deadline or a future deadline
+- Tests verify that module metadata is preserved even when skipped
+
+## Test Plan
+
+- `parallel_detection_skips_modules_when_deadline_already_passed` — past deadline skips all closures
+- `parallel_detection_runs_all_modules_when_no_deadline` — no deadline runs everything
+- `parallel_detection_runs_all_modules_when_deadline_is_far_future` — future deadline runs everything
+- `parallel_detection_preserves_module_metadata_when_skipped` — metadata intact on skip
+- All existing tests pass (171 integration tests, all unit tests)

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -12,6 +12,9 @@
 //! via `rayon::into_par_iter()`, then merges results sequentially. This
 //! preserves deterministic ordering while utilising multiple CPU cores.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::SystemTime;
+
 use crate::CoordinatedStructuralCandidateJson;
 use crate::observability::PhaseTimer;
 use rayon::prelude::*;
@@ -116,10 +119,18 @@ pub struct DiscoveryModuleDetectionResults {
 /// are collected in original module order (rayon preserves indexed iterator order),
 /// ensuring deterministic output regardless of thread scheduling.
 ///
+/// ## Deadline enforcement (Issue #1029)
+///
+/// When a deadline is provided, each module checks `deadline_passed()` before
+/// executing its detection closure. Modules that start after the deadline are
+/// skipped (returning `None`), preventing the parallel detection phase from
+/// running indefinitely when the analysis time budget is exhausted.
+///
 /// Call [`merge_discovery_module_results`] afterwards to merge into `syn`.
 #[tracing::instrument(skip_all, fields(module_count = modules.len()))]
 pub fn detect_discovery_modules_parallel(
     modules: Vec<DiscoveryModuleSpec>,
+    deadline: Option<SystemTime>,
 ) -> DiscoveryModuleDetectionResults {
     if modules.is_empty() {
         return DiscoveryModuleDetectionResults {
@@ -130,11 +141,30 @@ pub fn detect_discovery_modules_parallel(
     crate::watchdog::beat("analysis::analyze_all → parallel discovery detection starting");
     let _timer = PhaseTimer::new("parallel_discovery_detection");
 
+    // Issue #1029: Shared flag so that once the deadline is observed by any thread,
+    // all remaining modules skip execution promptly without repeated syscalls.
+    let timed_out = AtomicBool::new(false);
+
     // Parallel detection phase: run all closures concurrently.
     // `into_par_iter().map().collect()` preserves input order for indexed iterators.
     let entries: Vec<DiscoveryModuleDetectionEntry> = modules
         .into_par_iter()
         .map(|spec| {
+            // Issue #1029: Skip detection if the analysis deadline has passed.
+            if timed_out.load(Ordering::Relaxed) || utils::deadline_passed(&deadline) {
+                timed_out.store(true, Ordering::Relaxed);
+                tracing::debug!(
+                    module = %spec.module_name,
+                    "Skipping discovery module — deadline passed (Issue #1029)"
+                );
+                return DiscoveryModuleDetectionEntry {
+                    module_name: spec.module_name,
+                    phase_name: spec.phase_name,
+                    max_candidates: spec.max_candidates,
+                    result: None,
+                };
+            }
+
             let result = (spec.detect_fn)();
             DiscoveryModuleDetectionEntry {
                 module_name: spec.module_name,
@@ -144,6 +174,16 @@ pub fn detect_discovery_modules_parallel(
             }
         })
         .collect();
+
+    let skipped = timed_out.load(Ordering::Relaxed);
+    if skipped {
+        let skipped_count = entries.iter().filter(|e| e.result.is_none()).count();
+        tracing::info!(
+            skipped_count,
+            total = entries.len(),
+            "Discovery detection reached deadline — some modules were skipped (Issue #1029)"
+        );
+    }
 
     crate::watchdog::beat("analysis::analyze_all → parallel discovery detection finished");
 
@@ -232,7 +272,7 @@ pub fn run_discovery_modules_parallel(
     diversify: bool,
     tracker: &ModuleOutcomeTracker,
 ) {
-    let detection_results = detect_discovery_modules_parallel(modules);
+    let detection_results = detect_discovery_modules_parallel(modules, None);
     merge_discovery_module_results(
         syn,
         detection_results,

--- a/src/analysis/discovery_dispatch_parallel_tests.rs
+++ b/src/analysis/discovery_dispatch_parallel_tests.rs
@@ -1,9 +1,13 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime};
+
 use crate::analysis::shared;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 
 use super::{
     DiscoveryDetectionResult, DiscoveryModuleSpec, ModuleOutcomeTracker,
-    run_discovery_modules_parallel,
+    detect_discovery_modules_parallel, run_discovery_modules_parallel,
 };
 
 fn empty_synapse_result() -> shared::AnalyzeSynapsesResult {
@@ -346,4 +350,193 @@ fn parallel_dispatch_filters_all_non_positive_returns_empty() {
         syn.coordinated_structural_candidates.is_empty(),
         "all-non-positive module should produce zero candidates"
     );
+}
+
+// =============================================================================
+// Issue #1029: Deadline-aware discovery module detection tests
+// =============================================================================
+
+#[test]
+fn parallel_detection_skips_modules_when_deadline_already_passed() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    // Track how many detection closures actually execute.
+    let execution_count = Arc::new(AtomicUsize::new(0));
+
+    let modules: Vec<DiscoveryModuleSpec> = (0..5)
+        .map(|i| {
+            let counter = Arc::clone(&execution_count);
+            DiscoveryModuleSpec {
+                module_name: format!("module_{i}"),
+                phase_name: "test_phase",
+                max_candidates: 0,
+                detect_fn: Box::new(move || {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    Some(DiscoveryDetectionResult {
+                        detected_count: 1,
+                        candidates: vec![make_candidate(1.0)],
+                    })
+                }),
+            }
+        })
+        .collect();
+
+    // Deadline is already in the past — all modules should be skipped.
+    let past_deadline = Some(SystemTime::now() - Duration::from_secs(10));
+    let results = detect_discovery_modules_parallel(modules, past_deadline);
+
+    // All entries should have result = None (skipped).
+    assert_eq!(results.entries.len(), 5);
+    for entry in &results.entries {
+        assert!(
+            entry.result.is_none(),
+            "Module '{}' should have been skipped due to past deadline",
+            entry.module_name
+        );
+    }
+
+    // No detection closures should have executed.
+    assert_eq!(
+        execution_count.load(Ordering::Relaxed),
+        0,
+        "No detection closures should execute when deadline has already passed"
+    );
+}
+
+#[test]
+fn parallel_detection_runs_all_modules_when_no_deadline() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    let execution_count = Arc::new(AtomicUsize::new(0));
+
+    let modules: Vec<DiscoveryModuleSpec> = (0..3)
+        .map(|i| {
+            let counter = Arc::clone(&execution_count);
+            DiscoveryModuleSpec {
+                module_name: format!("module_{i}"),
+                phase_name: "test_phase",
+                max_candidates: 0,
+                detect_fn: Box::new(move || {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    Some(DiscoveryDetectionResult {
+                        detected_count: 1,
+                        candidates: vec![make_candidate(1.0)],
+                    })
+                }),
+            }
+        })
+        .collect();
+
+    // No deadline — all modules should run.
+    let results = detect_discovery_modules_parallel(modules, None);
+
+    assert_eq!(results.entries.len(), 3);
+    assert_eq!(
+        execution_count.load(Ordering::Relaxed),
+        3,
+        "All detection closures should execute when no deadline is set"
+    );
+    for entry in &results.entries {
+        assert!(
+            entry.result.is_some(),
+            "Module '{}' should have produced results without a deadline",
+            entry.module_name
+        );
+    }
+}
+
+#[test]
+fn parallel_detection_runs_all_modules_when_deadline_is_far_future() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    let execution_count = Arc::new(AtomicUsize::new(0));
+
+    let modules: Vec<DiscoveryModuleSpec> = (0..3)
+        .map(|i| {
+            let counter = Arc::clone(&execution_count);
+            DiscoveryModuleSpec {
+                module_name: format!("module_{i}"),
+                phase_name: "test_phase",
+                max_candidates: 0,
+                detect_fn: Box::new(move || {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    Some(DiscoveryDetectionResult {
+                        detected_count: 1,
+                        candidates: vec![make_candidate(1.0)],
+                    })
+                }),
+            }
+        })
+        .collect();
+
+    // Deadline far in the future — all modules should run.
+    let future_deadline = Some(SystemTime::now() + Duration::from_secs(3600));
+    let results = detect_discovery_modules_parallel(modules, future_deadline);
+
+    assert_eq!(results.entries.len(), 3);
+    assert_eq!(
+        execution_count.load(Ordering::Relaxed),
+        3,
+        "All detection closures should execute when deadline is far in the future"
+    );
+}
+
+#[test]
+fn parallel_detection_preserves_module_metadata_when_skipped() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    let modules = vec![
+        DiscoveryModuleSpec {
+            module_name: "alpha".to_string(),
+            phase_name: "phase_alpha",
+            max_candidates: 10,
+            detect_fn: Box::new(|| {
+                Some(DiscoveryDetectionResult {
+                    detected_count: 1,
+                    candidates: vec![make_candidate(1.0)],
+                })
+            }),
+        },
+        DiscoveryModuleSpec {
+            module_name: "beta".to_string(),
+            phase_name: "phase_beta",
+            max_candidates: 20,
+            detect_fn: Box::new(|| {
+                Some(DiscoveryDetectionResult {
+                    detected_count: 1,
+                    candidates: vec![make_candidate(2.0)],
+                })
+            }),
+        },
+    ];
+
+    let past_deadline = Some(SystemTime::now() - Duration::from_secs(10));
+    let results = detect_discovery_modules_parallel(modules, past_deadline);
+
+    // Module metadata (name, phase, budget) should be preserved even when skipped.
+    assert_eq!(results.entries[0].module_name, "alpha");
+    assert_eq!(results.entries[0].phase_name, "phase_alpha");
+    assert_eq!(results.entries[0].max_candidates, 10);
+    assert!(results.entries[0].result.is_none());
+
+    assert_eq!(results.entries[1].module_name, "beta");
+    assert_eq!(results.entries[1].phase_name, "phase_beta");
+    assert_eq!(results.entries[1].max_candidates, 20);
+    assert!(results.entries[1].result.is_none());
 }

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -70,11 +70,18 @@ pub(crate) fn build_discovery_module_specs(
 ///
 /// This separation allows the detection phase to overlap with other concurrent
 /// work (e.g., candidate compression) before merging results sequentially.
+///
+/// ## Deadline enforcement (Issue #1029)
+///
+/// The `deadline` parameter is forwarded to [`discovery_dispatch::detect_discovery_modules_parallel`]
+/// so that modules are skipped when the analysis time budget is exhausted,
+/// preventing the detection phase from running indefinitely.
 pub(crate) fn prepare_and_detect_discovery_modules(
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
     shared_cache: &Arc<cache::RecordCache>,
     tracker: &ModuleOutcomeTracker,
+    deadline: Option<std::time::SystemTime>,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
@@ -90,7 +97,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
         }
     }
 
-    discovery_dispatch::detect_discovery_modules_parallel(modules)
+    discovery_dispatch::detect_discovery_modules_parallel(modules, deadline)
 }
 
 /// Synthesise cross-detection candidates for co-flagged neurons (Issue #963).

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -367,11 +367,15 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             },
             || {
                 // Issue #375 / #419: Discovery module detection phase only.
+                // Issue #1029: Pass the analysis deadline so detection modules
+                // are skipped when time runs out, preventing lockups.
+                let discovery_deadline = utils::build_deadline(input.analysis_deadline_ms);
                 module_dispatch_specs::prepare_and_detect_discovery_modules(
                     &creature,
                     &hidden_neurons,
                     &shared_cache,
                     &tracker,
+                    discovery_deadline,
                 )
             },
         );

--- a/tests/analysis/issue_1004_overlap_compression_discovery.rs
+++ b/tests/analysis/issue_1004_overlap_compression_discovery.rs
@@ -160,7 +160,7 @@ fn detect_returns_results_in_original_order() {
         ),
     ];
 
-    let results = detect_discovery_modules_parallel(modules);
+    let results = detect_discovery_modules_parallel(modules, None);
 
     assert_eq!(results.entries.len(), 3, "should have 3 entries");
     assert_eq!(results.entries[0].module_name, "mod_a");
@@ -213,7 +213,7 @@ fn split_detect_merge_matches_combined() {
         ),
         make_module("mod_c", None),
     ];
-    let detection_results = detect_discovery_modules_parallel(modules_split);
+    let detection_results = detect_discovery_modules_parallel(modules_split, None);
     merge_discovery_module_results(&mut syn_split, detection_results, None, false, &tracker);
 
     // Both should produce identical results.
@@ -261,7 +261,7 @@ fn merge_empty_detection_results_is_noop() {
 /// Verify that detect returns empty results for empty module list.
 #[test]
 fn detect_empty_modules_returns_empty() {
-    let results = detect_discovery_modules_parallel(Vec::new());
+    let results = detect_discovery_modules_parallel(Vec::new(), None);
     assert!(results.entries.is_empty());
 }
 
@@ -310,7 +310,7 @@ fn overlapped_compression_and_detection_produces_correct_results() {
                 make_module("mod_a", Some(vec![make_candidate(1.0)])),
                 make_module("mod_b", Some(vec![make_candidate(0.5)])),
             ];
-            detect_discovery_modules_parallel(modules)
+            detect_discovery_modules_parallel(modules, None)
         },
     );
 
@@ -371,7 +371,7 @@ fn overlapped_execution_is_deterministic_across_runs() {
                     make_module("mod_2", Some(vec![make_candidate(2.0)])),
                     make_module("mod_3", Some(vec![make_candidate(3.0)])),
                 ];
-                detect_discovery_modules_parallel(modules)
+                detect_discovery_modules_parallel(modules, None)
             },
         );
 
@@ -460,7 +460,7 @@ fn split_detect_merge_respects_max_candidates() {
         make_module("mod_b", Some(vec![make_candidate(1.0)])),
     ];
 
-    let detection_results = detect_discovery_modules_parallel(modules);
+    let detection_results = detect_discovery_modules_parallel(modules, None);
     merge_discovery_module_results(&mut syn, detection_results, Some(2), false, &tracker);
 
     let total = syn.helpful_synapses.len()


### PR DESCRIPTION
## Summary

Discovery module detection (48 parallel closures via rayon) had no deadline
awareness. When the analysis time budget was exhausted, modules would continue
running indefinitely, causing the process to exceed its `max-task-hours` limit
and get killed by the task controller.

This change threads the analysis deadline into `detect_discovery_modules_parallel`
so that each module checks `deadline_passed()` before executing its detection
closure. Modules that start after the deadline are skipped, and a shared
`AtomicBool` flag propagates the timeout signal across rayon worker threads to
minimise repeated syscalls.

Closes #1029.

## Changes

- `detect_discovery_modules_parallel` now accepts an `Option<SystemTime>` deadline
  parameter. When the deadline is reached, remaining modules are skipped.
- `prepare_and_detect_discovery_modules` accepts and forwards the deadline.
- `analyze_all` (orchestration) builds a deadline from `analysis_deadline_ms`
  and passes it to the discovery detection phase.
- Existing callers (`run_discovery_modules_parallel`, integration tests) pass
  `None` to preserve existing behaviour.

## Evidence

- Tests verify that modules are skipped when the deadline has already passed
- Tests verify that modules run normally with no deadline or a future deadline
- Tests verify that module metadata is preserved even when skipped

## Test Plan

- `parallel_detection_skips_modules_when_deadline_already_passed` — past deadline skips all closures
- `parallel_detection_runs_all_modules_when_no_deadline` — no deadline runs everything
- `parallel_detection_runs_all_modules_when_deadline_is_far_future` — future deadline runs everything
- `parallel_detection_preserves_module_metadata_when_skipped` — metadata intact on skip
- All existing tests pass (171 integration tests, all unit tests)

---

## Automated Fix Details
This PR addresses issue #1029: **Lockup and didn't finished within timelimit**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1029
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1029 -->