### PR TITLE
feat: add memory budget to discovery analysis phase (#1028)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.33"
+version = "0.72.34"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/async_pipeline.rs
+++ b/benches/async_pipeline.rs
@@ -173,6 +173,7 @@ fn bench_async_pipeline(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        max_analysis_memory_mb: None,
                         temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -180,6 +180,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        max_analysis_memory_mb: None,
                         temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))

--- a/benches/pipeline_utilisation.rs
+++ b/benches/pipeline_utilisation.rs
@@ -328,6 +328,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        max_analysis_memory_mb: None,
                         temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
@@ -353,6 +354,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        max_analysis_memory_mb: None,
                         temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
@@ -378,6 +380,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         random_seed: Some(42),
                         previous_neuron_fingerprints: None,
                         module_outcome_tracker: None,
+                        max_analysis_memory_mb: None,
                         temperature: 1.0,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
@@ -399,6 +402,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
             random_seed: Some(42),
             previous_neuron_fingerprints: None,
             module_outcome_tracker: None,
+            max_analysis_memory_mb: None,
             temperature: 1.0,
         };
 

--- a/docs/pr-summary-1028.md
+++ b/docs/pr-summary-1028.md
@@ -1,0 +1,50 @@
+## Summary
+
+Add a configurable `maxAnalysisMemoryMb` parameter to the analysis phase that
+prevents unbounded memory growth on memory-constrained machines. When the Rust
+heap allocation reaches 90% of the budget, the analysis returns partial results
+rather than continuing until the OS kills the process. Closes #1028.
+
+## Changes
+
+- **`src/ffi_types/requests.rs`**: Added `max_analysis_memory_mb: Option<u64>` to
+  `AnalyzeParallelInput` and `AnalyzeAllInput`
+- **`src/ffi_internal/analysis.rs`**: Propagated the field through
+  `build_analyze_all_input_from_parallel` and added `memory_budget_exceeded` to
+  all `AnalyzeParallelOutput` constructions
+- **`src/ffi_types/responses/analysis.rs`**: Added `memory_budget_exceeded: Option<bool>`
+  to `AnalyzeParallelOutput` (omitted from JSON when `None` for backwards compatibility)
+- **`src/analysis/shared/metadata.rs`**: Added `memory_budget_exceeded: bool` to
+  `AnalyzeAllResult`
+- **`src/analysis/utils/memory.rs`**: Added `check_memory_budget_exceeded()` (pure,
+  testable) and `is_memory_budget_exceeded()` (reads global allocator) utility functions
+  with a 90% threshold
+- **`src/analysis/orchestration.rs`**: Added three memory budget check points:
+  1. Before GPU analysis (after fingerprint filtering)
+  2. After parquet cache loading
+  3. After GPU analysis (gates post-processing)
+
+## Backwards Compatibility
+
+When `maxAnalysisMemoryMb` is omitted (the default), no memory limit is enforced
+and behaviour is identical to prior versions. The `memoryBudgetExceeded` field is
+omitted from the JSON response when not set.
+
+## Evidence
+
+All 11 new tests pass and the full quality gate (`./quality.sh`) passes cleanly.
+
+## Test Plan
+
+- `tests/ffi/issue_1028_memory_budget.rs`:
+  - `analyze_parallel_input_accepts_memory_budget` — deserialises the new field
+  - `analyze_parallel_input_defaults_to_none_when_omitted` — backwards compatibility
+  - `analyze_all_input_accepts_memory_budget` — field on combined input
+  - `check_memory_budget_returns_false_when_no_budget` — no budget = never exceeded
+  - `check_memory_budget_returns_false_when_under_budget` — within budget
+  - `check_memory_budget_returns_true_when_over_budget` — over budget
+  - `check_memory_budget_returns_true_when_approaching_budget` — 90% threshold
+  - `check_memory_budget_handles_zero_budget` — edge case
+  - `analyze_parallel_output_serialises_memory_budget_exceeded` — JSON field present
+  - `analyze_parallel_output_omits_memory_budget_exceeded_when_none` — omitted when None
+  - `analyze_all_input_propagates_memory_budget_via_json` — propagation test

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -702,6 +702,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
     };
 
     let result = analyze_all(&input).expect("Combined analysis should succeed");

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -194,6 +194,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         return Ok(AnalyzeAllResult {
             synapse: None,
             neuron: None,
+            memory_budget_exceeded: false,
             neuron_fingerprints: Some(current_fingerprints),
             fingerprint_cache_hits,
             fingerprint_cache_misses,
@@ -209,6 +210,25 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         return Ok(AnalyzeAllResult {
             synapse: None,
             neuron: None,
+            memory_budget_exceeded: false,
+            neuron_fingerprints: Some(current_fingerprints),
+            fingerprint_cache_hits,
+            fingerprint_cache_misses,
+            module_outcome_tracker: input.module_outcome_tracker.clone().unwrap_or_default(),
+        });
+    }
+
+    // Issue #1028: Check memory budget before expensive GPU work.
+    if utils::is_memory_budget_exceeded(input.max_analysis_memory_mb) {
+        tracing::warn!(
+            budget_mb = input.max_analysis_memory_mb,
+            allocated_bytes = crate::ALLOCATOR.allocated(),
+            "memory budget exceeded before GPU analysis — returning early with no candidates"
+        );
+        return Ok(AnalyzeAllResult {
+            synapse: None,
+            neuron: None,
+            memory_budget_exceeded: true,
             neuron_fingerprints: Some(current_fingerprints),
             fingerprint_cache_hits,
             fingerprint_cache_misses,
@@ -242,6 +262,26 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         parquet_loading_start.elapsed().as_millis() as u64,
     );
     crate::watchdog::beat("analysis::analyze_all → parquet cache loaded");
+
+    // Issue #1028: Check memory budget after parquet loading (often the largest
+    // single allocation). If the cache already consumed most of the budget,
+    // return early with partial results rather than proceeding to GPU analysis.
+    if utils::is_memory_budget_exceeded(input.max_analysis_memory_mb) {
+        tracing::warn!(
+            budget_mb = input.max_analysis_memory_mb,
+            allocated_bytes = crate::ALLOCATOR.allocated(),
+            "memory budget exceeded after parquet loading — returning early"
+        );
+        return Ok(AnalyzeAllResult {
+            synapse: None,
+            neuron: None,
+            memory_budget_exceeded: true,
+            neuron_fingerprints: Some(current_fingerprints),
+            fingerprint_cache_hits,
+            fingerprint_cache_misses,
+            module_outcome_tracker: input.module_outcome_tracker.clone().unwrap_or_default(),
+        });
+    }
 
     let synapse_input = if include_synapse {
         Some(AnalyzeSynapsesInput {
@@ -288,11 +328,24 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         &shared_gpu_queue,
     )?;
 
+    // Issue #1028: Check memory budget after GPU analysis. If exceeded, skip
+    // post-processing and return the candidates we have so far.
+    let memory_budget_exceeded = utils::is_memory_budget_exceeded(input.max_analysis_memory_mb);
+    if memory_budget_exceeded {
+        tracing::warn!(
+            budget_mb = input.max_analysis_memory_mb,
+            allocated_bytes = crate::ALLOCATOR.allocated(),
+            "memory budget exceeded after GPU analysis — skipping post-processing"
+        );
+    }
+
     // Post-process: convert certain add-neuron candidates into coordinated-structural replacements.
     let mut synapse_result = synapse_result;
     let mut neuron_result = neuron_result;
 
-    if let (Some(syn), Some(neuron)) = (synapse_result.as_mut(), neuron_result.as_mut()) {
+    if !memory_budget_exceeded
+        && let (Some(syn), Some(neuron)) = (synapse_result.as_mut(), neuron_result.as_mut())
+    {
         candidate_aggregation::convert_neurons_to_coordinated_replacements(
             input,
             syn,
@@ -304,135 +357,141 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Issue #792: Resolve the module outcome tracker from input or use a default.
     let tracker = input.module_outcome_tracker.clone().unwrap_or_default();
 
-    // Issue #1004: Overlap candidate compression with discovery module detection.
-    //
-    // Both compression (reads `helpful_synapses` immutably) and discovery module
-    // detection (reads creature/cache, runs ~48 detection closures) are independent
-    // in their detection phases. We run them concurrently via `rayon::join`, then
-    // merge results sequentially (compression first, then discovery modules) to
-    // preserve deterministic ordering.
-    if let Some(syn) = synapse_result.as_mut() {
-        let max_candidates = input.max_synapse_candidates;
-        let diversify = input.analysis_deadline_ms.is_some();
+    // Issue #1028: Skip post-processing when memory budget is exceeded.
+    // The candidates from GPU analysis are still returned, but compression,
+    // discovery module detection, and reranking are skipped to avoid further
+    // memory growth.
+    if !memory_budget_exceeded {
+        // Issue #1004: Overlap candidate compression with discovery module detection.
+        //
+        // Both compression (reads `helpful_synapses` immutably) and discovery module
+        // detection (reads creature/cache, runs ~48 detection closures) are independent
+        // in their detection phases. We run them concurrently via `rayon::join`, then
+        // merge results sequentially (compression first, then discovery modules) to
+        // preserve deterministic ordering.
+        if let Some(syn) = synapse_result.as_mut() {
+            let max_candidates = input.max_synapse_candidates;
+            let diversify = input.analysis_deadline_ms.is_some();
 
-        // Snapshot data needed by compression (immutable reads).
-        let helpful_synapses_snapshot = syn.helpful_synapses.clone();
-        let creature_for_compression = input.creature.clone();
+            // Snapshot data needed by compression (immutable reads).
+            let helpful_synapses_snapshot = syn.helpful_synapses.clone();
+            let creature_for_compression = input.creature.clone();
 
-        // Data needed by discovery module detection.
-        let creature = Arc::new(input.creature.clone());
-        let hidden_neurons: Arc<Vec<(String, String, f32)>> = Arc::new(
-            input
-                .creature
-                .neurons
-                .iter()
-                .filter(|n| n.neuron_type == "hidden")
-                .map(|n| {
-                    // Issue #753: ensure squash is uppercase even for
-                    // programmatically constructed NeuronJson (serde path
-                    // normalises during deserialisation, this covers the rest).
-                    let squash = if n.squash.bytes().all(|b| !b.is_ascii_lowercase()) {
-                        n.squash.clone()
-                    } else {
-                        n.squash.to_ascii_uppercase()
-                    };
-                    (n.uuid.clone(), squash, n.bias)
-                })
-                .collect(),
-        );
+            // Data needed by discovery module detection.
+            let creature = Arc::new(input.creature.clone());
+            let hidden_neurons: Arc<Vec<(String, String, f32)>> = Arc::new(
+                input
+                    .creature
+                    .neurons
+                    .iter()
+                    .filter(|n| n.neuron_type == "hidden")
+                    .map(|n| {
+                        // Issue #753: ensure squash is uppercase even for
+                        // programmatically constructed NeuronJson (serde path
+                        // normalises during deserialisation, this covers the rest).
+                        let squash = if n.squash.bytes().all(|b| !b.is_ascii_lowercase()) {
+                            n.squash.clone()
+                        } else {
+                            n.squash.to_ascii_uppercase()
+                        };
+                        (n.uuid.clone(), squash, n.bias)
+                    })
+                    .collect(),
+            );
 
-        // Issue #1004: Run compression detection and discovery module detection
-        // concurrently. The heavier discovery dispatch (~48 parallel modules)
-        // overlaps with the lighter compression work.
-        let (all_compressed, discovery_results) = rayon::join(
-            || {
-                // Issue #921 / #922: Compress IDENTITY and non-linear candidates.
-                let (identity_compressed, nonlinear_compressed) = rayon::join(
-                    || {
-                        candidate_compression::compress_identity_candidates(
-                            &helpful_synapses_snapshot,
-                            &creature_for_compression,
-                        )
-                    },
-                    || {
-                        candidate_compression::compress_nonlinear_candidates(
-                            &helpful_synapses_snapshot,
-                            &creature_for_compression,
-                        )
-                    },
+            // Issue #1004: Run compression detection and discovery module detection
+            // concurrently. The heavier discovery dispatch (~48 parallel modules)
+            // overlaps with the lighter compression work.
+            let (all_compressed, discovery_results) = rayon::join(
+                || {
+                    // Issue #921 / #922: Compress IDENTITY and non-linear candidates.
+                    let (identity_compressed, nonlinear_compressed) = rayon::join(
+                        || {
+                            candidate_compression::compress_identity_candidates(
+                                &helpful_synapses_snapshot,
+                                &creature_for_compression,
+                            )
+                        },
+                        || {
+                            candidate_compression::compress_nonlinear_candidates(
+                                &helpful_synapses_snapshot,
+                                &creature_for_compression,
+                            )
+                        },
+                    );
+                    let mut all = identity_compressed;
+                    all.extend(nonlinear_compressed);
+                    all
+                },
+                || {
+                    // Issue #375 / #419: Discovery module detection phase only.
+                    // Issue #1029: Pass the analysis deadline so detection modules
+                    // are skipped when time runs out, preventing lockups.
+                    let discovery_deadline = utils::build_deadline(input.analysis_deadline_ms);
+                    module_dispatch_specs::prepare_and_detect_discovery_modules(
+                        &creature,
+                        &hidden_neurons,
+                        &shared_cache,
+                        &tracker,
+                        discovery_deadline,
+                    )
+                },
+            );
+
+            // Sequential merge phase: compression results first, then discovery modules.
+            // This preserves the same ordering as the previous sequential pipeline.
+            if !all_compressed.is_empty() {
+                candidate_aggregation::merge_coordinated_structural_replacements(
+                    syn,
+                    all_compressed,
+                    max_candidates,
+                    diversify,
                 );
-                let mut all = identity_compressed;
-                all.extend(nonlinear_compressed);
-                all
-            },
-            || {
-                // Issue #375 / #419: Discovery module detection phase only.
-                // Issue #1029: Pass the analysis deadline so detection modules
-                // are skipped when time runs out, preventing lockups.
-                let discovery_deadline = utils::build_deadline(input.analysis_deadline_ms);
-                module_dispatch_specs::prepare_and_detect_discovery_modules(
-                    &creature,
-                    &hidden_neurons,
-                    &shared_cache,
-                    &tracker,
-                    discovery_deadline,
-                )
-            },
-        );
+            }
 
-        // Sequential merge phase: compression results first, then discovery modules.
-        // This preserves the same ordering as the previous sequential pipeline.
-        if !all_compressed.is_empty() {
-            candidate_aggregation::merge_coordinated_structural_replacements(
+            discovery_dispatch::merge_discovery_module_results(
                 syn,
-                all_compressed,
+                discovery_results,
                 max_candidates,
                 diversify,
+                &tracker,
             );
         }
 
-        discovery_dispatch::merge_discovery_module_results(
-            syn,
-            discovery_results,
-            max_candidates,
-            diversify,
-            &tracker,
-        );
-    }
+        // Issue #963: Cross-detection candidate synthesis — synthesise combined
+        // candidates when multiple detection modules flag the same neuron.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_dispatch_specs::synthesise_cross_detection_candidates(syn);
+        }
 
-    // Issue #963: Cross-detection candidate synthesis — synthesise combined
-    // candidates when multiple detection modules flag the same neuron.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_dispatch_specs::synthesise_cross_detection_candidates(syn);
-    }
+        // Issue #489: Cross-module candidate deduplication.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_dispatch_specs::deduplicate_cross_module_candidates(syn);
+        }
 
-    // Issue #489: Cross-module candidate deduplication.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_dispatch_specs::deduplicate_cross_module_candidates(syn);
-    }
+        // Issue #572: Ensemble candidate scoring — combine predictions across modules.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_dispatch_specs::apply_ensemble_scoring(syn, &tracker);
+        }
 
-    // Issue #572: Ensemble candidate scoring — combine predictions across modules.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_dispatch_specs::apply_ensemble_scoring(syn, &tracker);
-    }
+        // Issue #792: Apply per-module boost factors to candidate expected gains.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_weights::apply_module_boost_to_candidates(
+                &mut syn.coordinated_structural_candidates,
+                &tracker,
+            );
+        }
 
-    // Issue #792: Apply per-module boost factors to candidate expected gains.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_weights::apply_module_boost_to_candidates(
-            &mut syn.coordinated_structural_candidates,
-            &tracker,
-        );
-    }
+        // Issue #610: Diversity-aware reranking — penalise structurally similar candidates.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_dispatch_specs::apply_diversity_reranking(syn);
+        }
 
-    // Issue #610: Diversity-aware reranking — penalise structurally similar candidates.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_dispatch_specs::apply_diversity_reranking(syn);
-    }
-
-    // Issue #224: Candidate clustering to reduce redundant ablation tests.
-    if let Some(syn) = synapse_result.as_mut() {
-        module_dispatch_specs::cluster_synapse_candidates(syn, &input.creature);
-    }
+        // Issue #224: Candidate clustering to reduce redundant ablation tests.
+        if let Some(syn) = synapse_result.as_mut() {
+            module_dispatch_specs::cluster_synapse_candidates(syn, &input.creature);
+        }
+    } // end if !memory_budget_exceeded (Issue #1028)
 
     // Collect final profile data (Issue #214)
     let synapse_candidates = synapse_result.as_ref().map_or(0, |s| {
@@ -484,6 +543,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     Ok(AnalyzeAllResult {
         synapse: synapse_result,
         neuron: neuron_result,
+        memory_budget_exceeded,
         neuron_fingerprints: Some(current_fingerprints),
         fingerprint_cache_hits,
         fingerprint_cache_misses,

--- a/src/analysis/shared/metadata.rs
+++ b/src/analysis/shared/metadata.rs
@@ -159,6 +159,9 @@ pub struct AnalyzeNeuronsResult {
 pub struct AnalyzeAllResult {
     pub synapse: Option<AnalyzeSynapsesResult>,
     pub neuron: Option<AnalyzeNeuronsResult>,
+    /// Whether the analysis was cut short because the memory budget was
+    /// approached or exceeded (Issue #1028). `false` when no budget is set.
+    pub memory_budget_exceeded: bool,
     /// Current neuron fingerprints for incremental analysis (Issue #490).
     ///
     /// Callers should store these and pass them back on the next run.

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -509,6 +509,45 @@ pub fn get_work_queue_capacity() -> usize {
 }
 
 // =============================================================================
+// Memory Budget Checking (Issue #1028)
+// =============================================================================
+
+/// Threshold fraction of the memory budget at which we consider it exceeded.
+///
+/// We trigger at 90% to allow the analysis to return partial results before
+/// the OS kills the process.
+const MEMORY_BUDGET_THRESHOLD: f64 = 0.9;
+
+/// Check whether the current Rust heap usage exceeds the configured memory budget.
+///
+/// Returns `true` when `allocated_bytes` reaches 90% of `budget_mb` (converted to
+/// bytes). Returns `false` when no budget is set (`budget_mb` is `None`).
+///
+/// This is a pure function to enable deterministic testing without relying on
+/// the global allocator.
+pub fn check_memory_budget_exceeded(budget_mb: Option<u64>, allocated_bytes: u64) -> bool {
+    let Some(budget) = budget_mb else {
+        return false;
+    };
+    if budget == 0 {
+        return allocated_bytes > 0;
+    }
+    let budget_bytes = budget as f64 * 1024.0 * 1024.0;
+    let threshold_bytes = budget_bytes * MEMORY_BUDGET_THRESHOLD;
+    allocated_bytes as f64 >= threshold_bytes
+}
+
+/// Check memory budget against the live Rust heap allocator (Issue #1028).
+///
+/// Reads the current allocation from the global tracking allocator and
+/// compares it to `budget_mb`. Returns `true` if the budget is approached
+/// (90% threshold) or exceeded.
+pub fn is_memory_budget_exceeded(budget_mb: Option<u64>) -> bool {
+    let allocated = crate::ALLOCATOR.allocated() as u64;
+    check_memory_budget_exceeded(budget_mb, allocated)
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -46,8 +46,9 @@ pub fn into_inner_or_bail<T>(mutex: Mutex<T>, _context: &str) -> anyhow::Result<
 pub use memory::{
     DEFAULT_GPU_BATCH_SIZE, HIGH_PERF_GPU_BATCH_SIZE, LOW_MEMORY_GPU_BATCH_SIZE, MemoryPressure,
     MemoryTier, cap_gpu_batch_size_by_bytes, categorise_memory_pressure, categorise_memory_tier,
-    check_memory_for_parquet, check_system_memory_requirements, detect_memory_pressure,
-    detect_memory_tier, get_memory_info, get_work_queue_capacity, get_work_queue_capacity_for_tier,
+    check_memory_budget_exceeded, check_memory_for_parquet, check_system_memory_requirements,
+    detect_memory_pressure, detect_memory_tier, get_memory_info, get_work_queue_capacity,
+    get_work_queue_capacity_for_tier, is_memory_budget_exceeded,
     validate_parquet_memory_requirements,
 };
 

--- a/src/ffi/analysis.rs
+++ b/src/ffi/analysis.rs
@@ -133,6 +133,7 @@ pub unsafe extern "C" fn analyze_parallel(
                     fingerprint_cache_hits: None,
                     fingerprint_cache_misses: None,
                     module_outcome_tracker: None,
+                    memory_budget_exceeded: None,
                     error: Some(err_msg),
                     error_kind,
                     retryable,

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -34,6 +34,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 fingerprint_cache_hits: None,
                 fingerprint_cache_misses: None,
                 module_outcome_tracker: None,
+                memory_budget_exceeded: None,
                 error: Some(typed.to_string()),
                 error_kind: Some(kind),
                 retryable: Some(kind.is_retryable()),
@@ -71,6 +72,12 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     Some(s.candidate_clusters.clone())
                 }
             });
+
+            let memory_budget_exceeded = if result.memory_budget_exceeded {
+                Some(true)
+            } else {
+                None
+            };
 
             let output = AnalyzeParallelOutput {
                 success: true,
@@ -129,6 +136,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 } else {
                     Some(result.module_outcome_tracker)
                 },
+                memory_budget_exceeded,
                 error: None,
                 error_kind: None,
                 retryable: None,
@@ -156,6 +164,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                 fingerprint_cache_hits: None,
                 fingerprint_cache_misses: None,
                 module_outcome_tracker: None,
+                memory_budget_exceeded: None,
                 error: Some(err_msg),
                 error_kind,
                 retryable,
@@ -181,6 +190,7 @@ pub(crate) fn build_analyze_all_input_from_parallel(
         previous_neuron_fingerprints: input.previous_neuron_fingerprints,
         module_outcome_tracker: input.module_outcome_tracker,
         temperature: input.temperature,
+        max_analysis_memory_mb: input.max_analysis_memory_mb,
     }
 }
 

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -66,6 +66,14 @@ pub struct AnalyzeParallelInput {
     /// schedule to compute this value (e.g., start at 2.0 and decay to 0.5).
     #[serde(default = "default_temperature")]
     pub temperature: f32,
+    /// Memory budget in megabytes for the analysis phase (Issue #1028).
+    ///
+    /// When set, the analysis phase periodically checks Rust-side heap usage
+    /// against this budget. If usage reaches 90% of the budget, remaining
+    /// analysis is skipped and partial results are returned. When `None`,
+    /// no memory limit is enforced (backwards compatible).
+    #[serde(default)]
+    pub max_analysis_memory_mb: Option<u64>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -161,6 +169,11 @@ pub struct AnalyzeAllInput {
     /// for full documentation.
     #[serde(default = "default_temperature")]
     pub temperature: f32,
+    /// Memory budget in megabytes for the analysis phase (Issue #1028).
+    ///
+    /// See `AnalyzeParallelInput` for full documentation.
+    #[serde(default)]
+    pub max_analysis_memory_mb: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -72,6 +72,13 @@ pub struct AnalyzeParallelOutput {
     /// `moduleOutcomeTracker` on the next discovery run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub module_outcome_tracker: Option<analysis::module_weights::ModuleOutcomeTracker>,
+    /// Whether the analysis was cut short because the Rust-side memory usage
+    /// approached or exceeded the configured `maxAnalysisMemoryMb` (Issue #1028).
+    ///
+    /// When `true`, the results are partial — some focus neurons or post-processing
+    /// steps may have been skipped. Always `false` when no budget is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_budget_exceeded: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     /// Structured error classification for retry decisions (Issue #651).

--- a/tests/analysis/issue_337_candidate_type_contract.rs
+++ b/tests/analysis/issue_337_candidate_type_contract.rs
@@ -316,6 +316,7 @@ fn analyze_parallel_output_contains_all_candidate_fields() {
         fingerprint_cache_hits: None,
         fingerprint_cache_misses: None,
         module_outcome_tracker: None,
+        memory_budget_exceeded: None,
         error: None,
         error_kind: None,
         retryable: None,

--- a/tests/analysis/issue_419_parallel_discovery_execution.rs
+++ b/tests/analysis/issue_419_parallel_discovery_execution.rs
@@ -112,6 +112,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -206,6 +207,7 @@ fn parallel_discovery_metadata_consistent() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/issue_557_audit_discovery_strategies.rs
+++ b/tests/analysis/issue_557_audit_discovery_strategies.rs
@@ -137,6 +137,7 @@ fn all_candidates_have_positive_expected_score_gain() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -222,6 +223,7 @@ fn metadata_consistent_after_positive_gain_filtering() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/issue_568_async_pipeline.rs
+++ b/tests/analysis/issue_568_async_pipeline.rs
@@ -162,6 +162,7 @@ fn async_pipeline_produces_valid_analysis_results() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -221,6 +222,7 @@ fn async_pipeline_is_deterministic_with_fixed_seed() {
         random_seed: Some(12345),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
+++ b/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
@@ -227,6 +227,7 @@ fn run_analysis() -> Vec<neat_ai_discovery::CoordinatedStructuralCandidateJson> 
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -381,6 +382,7 @@ fn test_analyze_all_finds_change_squash_candidate() {
         random_seed: Some(42),
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 

--- a/tests/ffi/issue_1028_memory_budget.rs
+++ b/tests/ffi/issue_1028_memory_budget.rs
@@ -1,0 +1,202 @@
+//! Tests for memory budget in the analysis phase (Issue #1028).
+//!
+//! The analysis phase can accumulate unbounded data structures on
+//! memory-constrained machines. This test verifies that a configurable
+//! `maxAnalysisMemoryMb` parameter is accepted and that the library
+//! reports `memoryBudgetExceeded` when the budget is breached.
+
+// ============================================================================
+// Parameter deserialisation — maxAnalysisMemoryMb is accepted
+// ============================================================================
+
+#[test]
+fn analyze_parallel_input_accepts_memory_budget() {
+    let json = r#"{
+        "parquetFile": "/tmp/test.parquet",
+        "creature": { "neurons": [], "synapses": [], "input": 1, "output": 1 },
+        "focusNeurons": [],
+        "maxAnalysisMemoryMb": 512
+    }"#;
+    let input: neat_ai_discovery::AnalyzeParallelInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.max_analysis_memory_mb, Some(512));
+}
+
+#[test]
+fn analyze_parallel_input_defaults_to_none_when_omitted() {
+    let json = r#"{
+        "parquetFile": "/tmp/test.parquet",
+        "creature": { "neurons": [], "synapses": [], "input": 1, "output": 1 },
+        "focusNeurons": []
+    }"#;
+    let input: neat_ai_discovery::AnalyzeParallelInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.max_analysis_memory_mb, None);
+}
+
+#[test]
+fn analyze_all_input_accepts_memory_budget() {
+    let json = r#"{
+        "parquetFile": "/tmp/test.parquet",
+        "creature": { "neurons": [], "synapses": [], "input": 1, "output": 1 },
+        "focusNeurons": [],
+        "maxAnalysisMemoryMb": 1024
+    }"#;
+    let input: neat_ai_discovery::AnalyzeAllInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.max_analysis_memory_mb, Some(1024));
+}
+
+// ============================================================================
+// Memory budget check utility — pure function tests
+// ============================================================================
+
+#[test]
+fn check_memory_budget_returns_false_when_no_budget() {
+    let exceeded = neat_ai_discovery::analysis::utils::memory::check_memory_budget_exceeded(
+        None,
+        500_000_000, // 500 MB allocated
+    );
+    assert!(!exceeded, "No budget set should never report exceeded");
+}
+
+#[test]
+fn check_memory_budget_returns_false_when_under_budget() {
+    let exceeded = neat_ai_discovery::analysis::utils::memory::check_memory_budget_exceeded(
+        Some(1024),  // 1024 MB budget
+        500_000_000, // 500 MB allocated
+    );
+    assert!(
+        !exceeded,
+        "500 MB used with 1024 MB budget should not be exceeded"
+    );
+}
+
+#[test]
+fn check_memory_budget_returns_true_when_over_budget() {
+    let exceeded = neat_ai_discovery::analysis::utils::memory::check_memory_budget_exceeded(
+        Some(256),   // 256 MB budget
+        300_000_000, // ~300 MB allocated
+    );
+    assert!(
+        exceeded,
+        "300 MB used with 256 MB budget should be exceeded"
+    );
+}
+
+#[test]
+fn check_memory_budget_returns_true_when_approaching_budget() {
+    // The check triggers at 90% of budget to allow graceful shutdown
+    let budget_mb: u64 = 1000;
+    let ninety_percent_bytes: u64 = 900 * 1024 * 1024; // 900 MB = 90% of 1000 MB
+    let exceeded = neat_ai_discovery::analysis::utils::memory::check_memory_budget_exceeded(
+        Some(budget_mb),
+        ninety_percent_bytes + 1,
+    );
+    assert!(exceeded, "90%+ of budget should report exceeded");
+}
+
+#[test]
+fn check_memory_budget_handles_zero_budget() {
+    let exceeded = neat_ai_discovery::analysis::utils::memory::check_memory_budget_exceeded(
+        Some(0),
+        1, // any allocation exceeds a zero budget
+    );
+    assert!(exceeded, "Zero budget should always report exceeded");
+}
+
+// ============================================================================
+// Output serialisation includes memoryBudgetExceeded when true
+// ============================================================================
+
+#[test]
+fn analyze_parallel_output_serialises_memory_budget_exceeded() {
+    // Construct an AnalyzeParallelOutput directly and verify the field serialises.
+    let output = neat_ai_discovery::AnalyzeParallelOutput {
+        success: true,
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
+        helpful_synapses: None,
+        harmful_synapses: None,
+        synapse_diagnostics: None,
+        synapse_gpu_used: None,
+        synapse_metadata: None,
+        helpful_neurons: None,
+        synapse_weight_updates: None,
+        coordinated_structural_candidates: None,
+        candidate_clusters: None,
+        neuron_diagnostics: None,
+        neuron_gpu_used: None,
+        neuron_metadata: None,
+        neuron_fingerprints: None,
+        fingerprint_cache_hits: None,
+        fingerprint_cache_misses: None,
+        module_outcome_tracker: None,
+        memory_budget_exceeded: Some(true),
+        error: None,
+        error_kind: None,
+        retryable: None,
+    };
+
+    let json_str = serde_json::to_string(&output).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(
+        parsed
+            .get("memoryBudgetExceeded")
+            .and_then(serde_json::Value::as_bool),
+        Some(true),
+        "memoryBudgetExceeded should be true in serialised JSON"
+    );
+}
+
+#[test]
+fn analyze_parallel_output_omits_memory_budget_exceeded_when_none() {
+    // When memory budget is not set, the field should be omitted from JSON.
+    let output = neat_ai_discovery::AnalyzeParallelOutput {
+        success: true,
+        schema_version: neat_ai_discovery::SCHEMA_VERSION.to_string(),
+        helpful_synapses: None,
+        harmful_synapses: None,
+        synapse_diagnostics: None,
+        synapse_gpu_used: None,
+        synapse_metadata: None,
+        helpful_neurons: None,
+        synapse_weight_updates: None,
+        coordinated_structural_candidates: None,
+        candidate_clusters: None,
+        neuron_diagnostics: None,
+        neuron_gpu_used: None,
+        neuron_metadata: None,
+        neuron_fingerprints: None,
+        fingerprint_cache_hits: None,
+        fingerprint_cache_misses: None,
+        module_outcome_tracker: None,
+        memory_budget_exceeded: None,
+        error: None,
+        error_kind: None,
+        retryable: None,
+    };
+
+    let json_str = serde_json::to_string(&output).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+    assert!(
+        parsed.get("memoryBudgetExceeded").is_none(),
+        "memoryBudgetExceeded should be omitted when None"
+    );
+}
+
+// ============================================================================
+// AnalyzeAllInput also deserialises maxAnalysisMemoryMb
+// ============================================================================
+
+#[test]
+fn analyze_all_input_propagates_memory_budget_via_json() {
+    // Verify that AnalyzeAllInput deserialises the field independently,
+    // confirming it is available to the internal orchestration path.
+    let json = r#"{
+        "parquetFile": "/tmp/test.parquet",
+        "creature": { "neurons": [], "synapses": [], "input": 1, "output": 1 },
+        "focusNeurons": [],
+        "maxAnalysisMemoryMb": 768
+    }"#;
+    let input: neat_ai_discovery::AnalyzeAllInput = serde_json::from_str(json).unwrap();
+    assert_eq!(input.max_analysis_memory_mb, Some(768));
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -4,6 +4,7 @@
 mod common;
 
 mod issue_1027_memory_usage_ffi;
+mod issue_1028_memory_budget;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -428,6 +428,7 @@ fn test_analyze_all_finds_hidden_neuron_candidate() {
         temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
@@ -122,6 +122,7 @@ fn synapse_analysis_runs_under_deadline() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -168,6 +169,7 @@ fn metadata_indicates_target_value_available() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -209,6 +211,7 @@ fn metadata_indicates_target_value_not_available() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -256,6 +259,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -300,6 +304,7 @@ fn candidate_counts_tracked_correctly() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 
@@ -407,6 +412,7 @@ fn truncation_reflected_in_candidate_counts() {
         random_seed: None,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -429,6 +429,7 @@ fn test_analyze_all_finds_harmful_synapse() {
         temperature: 1.0,
         previous_neuron_fingerprints: None,
         module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");


### PR DESCRIPTION
## Summary

Add a configurable `maxAnalysisMemoryMb` parameter to the analysis phase that
prevents unbounded memory growth on memory-constrained machines. When the Rust
heap allocation reaches 90% of the budget, the analysis returns partial results
rather than continuing until the OS kills the process. Closes #1028.

## Changes

- **`src/ffi_types/requests.rs`**: Added `max_analysis_memory_mb: Option<u64>` to
  `AnalyzeParallelInput` and `AnalyzeAllInput`
- **`src/ffi_internal/analysis.rs`**: Propagated the field through
  `build_analyze_all_input_from_parallel` and added `memory_budget_exceeded` to
  all `AnalyzeParallelOutput` constructions
- **`src/ffi_types/responses/analysis.rs`**: Added `memory_budget_exceeded: Option<bool>`
  to `AnalyzeParallelOutput` (omitted from JSON when `None` for backwards compatibility)
- **`src/analysis/shared/metadata.rs`**: Added `memory_budget_exceeded: bool` to
  `AnalyzeAllResult`
- **`src/analysis/utils/memory.rs`**: Added `check_memory_budget_exceeded()` (pure,
  testable) and `is_memory_budget_exceeded()` (reads global allocator) utility functions
  with a 90% threshold
- **`src/analysis/orchestration.rs`**: Added three memory budget check points:
  1. Before GPU analysis (after fingerprint filtering)
  2. After parquet cache loading
  3. After GPU analysis (gates post-processing)

## Backwards Compatibility

When `maxAnalysisMemoryMb` is omitted (the default), no memory limit is enforced
and behaviour is identical to prior versions. The `memoryBudgetExceeded` field is
omitted from the JSON response when not set.

## Evidence

All 11 new tests pass and the full quality gate (`./quality.sh`) passes cleanly.

## Test Plan

- `tests/ffi/issue_1028_memory_budget.rs`:
  - `analyze_parallel_input_accepts_memory_budget` — deserialises the new field
  - `analyze_parallel_input_defaults_to_none_when_omitted` — backwards compatibility
  - `analyze_all_input_accepts_memory_budget` — field on combined input
  - `check_memory_budget_returns_false_when_no_budget` — no budget = never exceeded
  - `check_memory_budget_returns_false_when_under_budget` — within budget
  - `check_memory_budget_returns_true_when_over_budget` — over budget
  - `check_memory_budget_returns_true_when_approaching_budget` — 90% threshold
  - `check_memory_budget_handles_zero_budget` — edge case
  - `analyze_parallel_output_serialises_memory_budget_exceeded` — JSON field present
  - `analyze_parallel_output_omits_memory_budget_exceeded_when_none` — omitted when None
  - `analyze_all_input_propagates_memory_budget_via_json` — propagation test

---

## Automated Fix Details
This PR addresses issue #1028: **Add memory budget to Discovery analysis phase to prevent unbounded growth**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1028
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1028 -->