### PR TITLE
feat: add exponential backoff and observability to GPU retry recovery (#1038)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.37"
+version = "0.72.38"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1038.md
+++ b/docs/pr-summary-1038.md
@@ -1,0 +1,36 @@
+## Summary
+
+Add exponential backoff and observability improvements to GPU retry recovery. Closes #1038.
+
+**Changes:**
+- Added exponential backoff between GPU retry attempts (10ms -> 20ms -> 40ms, capped at 1s) to give the GPU driver time to recover before re-initialisation
+- Enhanced tracing instrumentation on each retry attempt to include backoff delay, attempt number, and error details via `tracing::warn!`
+- Fixed typo in error pattern string: `"a]location failed"` -> `"allocation failed"`
+- Added `backoff_delay_ms()` function with configurable initial delay and maximum cap
+- Exported new backoff constants (`DEFAULT_BACKOFF_INITIAL_MS`, `DEFAULT_BACKOFF_MAX_MS`) and function for external use
+
+Part of #1035.
+
+## Evidence
+
+All quality checks pass (`./quality.sh`), including clippy, tests, and documentation build. The backoff function is pure and deterministic, so correctness is verified entirely via unit and integration tests.
+
+## Test Plan
+
+- Added 7 unit tests in `src/analysis/gpu/queue/recovery.rs`:
+  - `test_backoff_delay_initial_attempt` — verifies first attempt returns initial delay
+  - `test_backoff_delay_doubles_each_attempt` — verifies exponential doubling across 7 attempts
+  - `test_backoff_delay_respects_cap` — verifies delay is capped at maximum
+  - `test_backoff_delay_zero_attempt_returns_initial` — verifies edge case handling
+  - `test_backoff_delay_with_default_constants` — verifies behaviour with production constants
+  - `test_backoff_delay_large_attempt_does_not_overflow` — verifies no panic on large attempt numbers
+  - `test_default_backoff_constants` — verifies constant values
+  - `test_is_device_lost_error_detects_allocation_failed` — verifies corrected typo pattern
+- Added 5 integration tests in `tests/gpu/issue_647_gpu_device_lost_recovery.rs`:
+  - `test_device_lost_error_detects_allocation_failed_pattern` — verifies corrected pattern via public API
+  - `test_backoff_delay_doubles_exponentially` — end-to-end exponential doubling check
+  - `test_backoff_delay_caps_at_max` — end-to-end cap verification
+  - `test_backoff_delay_does_not_overflow_on_large_attempt` — overflow safety
+  - `test_backoff_constants_are_sensible` — sanity checks on exported constants
+- All 171 existing integration tests pass
+- All existing GPU recovery tests continue to pass

--- a/src/analysis/gpu/mod.rs
+++ b/src/analysis/gpu/mod.rs
@@ -60,7 +60,8 @@ pub use analyzer::{GPU_MAX_BATCH_ALLOC_BYTES, GpuAnalyzer, GpuEvaluator};
 // Re-export queue module contents (Issue #274, #647)
 pub use queue::GpuWorkQueue;
 pub use queue::recovery::{
-    DEFAULT_GPU_RETRY_LIMIT, GPU_RETRY_LIMIT_ENV, get_gpu_retry_limit, is_device_lost_error,
+    DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, DEFAULT_GPU_RETRY_LIMIT,
+    GPU_RETRY_LIMIT_ENV, backoff_delay_ms, get_gpu_retry_limit, is_device_lost_error,
 };
 
 // Re-export shader module contents (Issue #277)

--- a/src/analysis/gpu/queue/execution.rs
+++ b/src/analysis/gpu/queue/execution.rs
@@ -14,9 +14,12 @@
 use anyhow::Result;
 use crossbeam_channel::Receiver;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use super::recovery::{get_gpu_retry_limit, is_device_lost_error};
+use super::recovery::{
+    DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, backoff_delay_ms, get_gpu_retry_limit,
+    is_device_lost_error,
+};
 use super::{GpuWorkQueue, GpuWorkRequest};
 use crate::analysis::gpu::analyzer::{GpuAnalyzer, GpuEvaluator};
 use crate::analysis::samples::{HelpfulSample, ReluStats};
@@ -280,11 +283,20 @@ impl GpuWorkQueue {
 
                     let mut recovered = false;
                     for attempt in 1..=retry_limit {
+                        let delay_ms = backoff_delay_ms(
+                            attempt,
+                            DEFAULT_BACKOFF_INITIAL_MS,
+                            DEFAULT_BACKOFF_MAX_MS,
+                        );
                         tracing::warn!(
                             attempt = attempt,
                             max_attempts = retry_limit,
-                            "Re-initialising GpuAnalyzer (attempt {attempt}/{retry_limit})"
+                            backoff_ms = delay_ms,
+                            error = %device_err,
+                            "GPU recovery attempt {attempt}/{retry_limit} — \
+                             waiting {delay_ms}ms before re-initialising GpuAnalyzer"
                         );
+                        std::thread::sleep(Duration::from_millis(delay_ms));
 
                         match GpuAnalyzer::new() {
                             Ok(new_analyzer) => {

--- a/src/analysis/gpu/queue/recovery.rs
+++ b/src/analysis/gpu/queue/recovery.rs
@@ -12,6 +12,31 @@ pub const DEFAULT_GPU_RETRY_LIMIT: u32 = 3;
 /// Environment variable name for configuring the GPU retry limit.
 pub const GPU_RETRY_LIMIT_ENV: &str = "NEAT_AI_DISCOVERY_GPU_RETRY_LIMIT";
 
+/// Initial backoff delay between GPU retry attempts (milliseconds).
+pub const DEFAULT_BACKOFF_INITIAL_MS: u64 = 10;
+
+/// Maximum backoff delay cap between GPU retry attempts (milliseconds).
+pub const DEFAULT_BACKOFF_MAX_MS: u64 = 1_000;
+
+/// Calculate the exponential backoff delay for a given retry attempt.
+///
+/// Uses exponential doubling: `initial_ms * 2^(attempt - 1)`, capped at
+/// `max_ms`. Attempt numbers start at 1.
+///
+/// # Examples
+///
+/// With defaults (10ms initial, 1000ms cap):
+/// - Attempt 1: 10ms
+/// - Attempt 2: 20ms
+/// - Attempt 3: 40ms
+/// - Attempt 7: 640ms
+/// - Attempt 8: 1000ms (capped)
+pub fn backoff_delay_ms(attempt: u32, initial_ms: u64, max_ms: u64) -> u64 {
+    let exponent = attempt.saturating_sub(1);
+    let delay = initial_ms.saturating_mul(1u64.checked_shl(exponent).unwrap_or(u64::MAX));
+    delay.min(max_ms)
+}
+
 /// Get the configured GPU retry limit.
 ///
 /// Delegates to [`crate::config::gpu_retry_limit()`].
@@ -34,7 +59,7 @@ pub fn is_device_lost_error(error: &anyhow::Error) -> bool {
         || msg.contains("gpu device poll error")
         || msg.contains("internal error")
         || msg.contains("out of memory")
-        || msg.contains("a]location failed")
+        || msg.contains("allocation failed")
         || msg.contains("command buffer")
         || msg.contains("too many command buffers")
         || msg.contains("device creation failed")
@@ -99,5 +124,73 @@ mod tests {
     fn test_is_device_lost_error_case_insensitive() {
         let err = anyhow::anyhow!("DEVICE IS LOST");
         assert!(is_device_lost_error(&err));
+    }
+
+    #[test]
+    fn test_is_device_lost_error_detects_allocation_failed() {
+        let err = anyhow::anyhow!("GPU allocation failed for buffer");
+        assert!(
+            is_device_lost_error(&err),
+            "Expected device-lost detection for allocation failed"
+        );
+    }
+
+    #[test]
+    fn test_backoff_delay_initial_attempt() {
+        assert_eq!(backoff_delay_ms(1, 10, 1_000), 10);
+    }
+
+    #[test]
+    fn test_backoff_delay_doubles_each_attempt() {
+        assert_eq!(backoff_delay_ms(1, 10, 1_000), 10);
+        assert_eq!(backoff_delay_ms(2, 10, 1_000), 20);
+        assert_eq!(backoff_delay_ms(3, 10, 1_000), 40);
+        assert_eq!(backoff_delay_ms(4, 10, 1_000), 80);
+        assert_eq!(backoff_delay_ms(5, 10, 1_000), 160);
+        assert_eq!(backoff_delay_ms(6, 10, 1_000), 320);
+        assert_eq!(backoff_delay_ms(7, 10, 1_000), 640);
+    }
+
+    #[test]
+    fn test_backoff_delay_respects_cap() {
+        assert_eq!(backoff_delay_ms(8, 10, 1_000), 1_000);
+        assert_eq!(backoff_delay_ms(9, 10, 1_000), 1_000);
+        assert_eq!(backoff_delay_ms(20, 10, 1_000), 1_000);
+    }
+
+    #[test]
+    fn test_backoff_delay_zero_attempt_returns_initial() {
+        // Attempt 0 is treated as attempt 1 (saturating_sub prevents underflow)
+        assert_eq!(backoff_delay_ms(0, 10, 1_000), 10);
+    }
+
+    #[test]
+    fn test_backoff_delay_with_default_constants() {
+        assert_eq!(
+            backoff_delay_ms(1, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS),
+            10
+        );
+        assert_eq!(
+            backoff_delay_ms(3, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS),
+            40
+        );
+        // Should cap at 1000ms
+        assert_eq!(
+            backoff_delay_ms(10, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS),
+            1_000
+        );
+    }
+
+    #[test]
+    fn test_backoff_delay_large_attempt_does_not_overflow() {
+        // Even with very large attempt numbers, should not panic
+        let result = backoff_delay_ms(100, 10, 1_000);
+        assert_eq!(result, 1_000);
+    }
+
+    #[test]
+    fn test_default_backoff_constants() {
+        assert_eq!(DEFAULT_BACKOFF_INITIAL_MS, 10);
+        assert_eq!(DEFAULT_BACKOFF_MAX_MS, 1_000);
     }
 }

--- a/tests/gpu/issue_647_gpu_device_lost_recovery.rs
+++ b/tests/gpu/issue_647_gpu_device_lost_recovery.rs
@@ -157,5 +157,5 @@ fn test_backoff_delay_does_not_overflow_on_large_attempt() {
 fn test_backoff_constants_are_sensible() {
     assert_eq!(DEFAULT_BACKOFF_INITIAL_MS, 10);
     assert_eq!(DEFAULT_BACKOFF_MAX_MS, 1_000);
-    assert!(DEFAULT_BACKOFF_INITIAL_MS < DEFAULT_BACKOFF_MAX_MS);
+    const { assert!(DEFAULT_BACKOFF_INITIAL_MS < DEFAULT_BACKOFF_MAX_MS) };
 }

--- a/tests/gpu/issue_647_gpu_device_lost_recovery.rs
+++ b/tests/gpu/issue_647_gpu_device_lost_recovery.rs
@@ -6,7 +6,8 @@
 //! device-lost event.
 
 use neat_ai_discovery::analysis::gpu::{
-    DEFAULT_GPU_RETRY_LIMIT, GPU_RETRY_LIMIT_ENV, is_device_lost_error,
+    DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, DEFAULT_GPU_RETRY_LIMIT,
+    GPU_RETRY_LIMIT_ENV, backoff_delay_ms, is_device_lost_error,
 };
 
 // =============================================================================
@@ -114,4 +115,47 @@ fn test_device_lost_error_with_allocation_failure() {
         "Failed to create staging buffer: Out of memory (requested 256MB, available 0)"
     );
     assert!(is_device_lost_error(&err));
+}
+
+#[test]
+fn test_device_lost_error_detects_allocation_failed_pattern() {
+    // Issue #1038: Verify the corrected "allocation failed" pattern is detected
+    let err = anyhow::anyhow!("GPU allocation failed for compute buffer");
+    assert!(
+        is_device_lost_error(&err),
+        "Expected device-lost detection for 'allocation failed'"
+    );
+}
+
+// =============================================================================
+// Exponential backoff (Issue #1038)
+// =============================================================================
+
+#[test]
+fn test_backoff_delay_doubles_exponentially() {
+    let delays: Vec<u64> = (1..=7)
+        .map(|a| backoff_delay_ms(a, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS))
+        .collect();
+    assert_eq!(delays, vec![10, 20, 40, 80, 160, 320, 640]);
+}
+
+#[test]
+fn test_backoff_delay_caps_at_max() {
+    // Attempt 8 with 10ms initial = 10 * 128 = 1280, capped at 1000
+    let delay = backoff_delay_ms(8, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS);
+    assert_eq!(delay, DEFAULT_BACKOFF_MAX_MS);
+}
+
+#[test]
+fn test_backoff_delay_does_not_overflow_on_large_attempt() {
+    // Very large attempt number must not panic
+    let delay = backoff_delay_ms(200, DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS);
+    assert_eq!(delay, DEFAULT_BACKOFF_MAX_MS);
+}
+
+#[test]
+fn test_backoff_constants_are_sensible() {
+    assert_eq!(DEFAULT_BACKOFF_INITIAL_MS, 10);
+    assert_eq!(DEFAULT_BACKOFF_MAX_MS, 1_000);
+    assert!(DEFAULT_BACKOFF_INITIAL_MS < DEFAULT_BACKOFF_MAX_MS);
 }


### PR DESCRIPTION
## Summary

Add exponential backoff and observability improvements to GPU retry recovery. Closes #1038.

**Changes:**
- Added exponential backoff between GPU retry attempts (10ms -> 20ms -> 40ms, capped at 1s) to give the GPU driver time to recover before re-initialisation
- Enhanced tracing instrumentation on each retry attempt to include backoff delay, attempt number, and error details via `tracing::warn!`
- Fixed typo in error pattern string: `"a]location failed"` -> `"allocation failed"`
- Added `backoff_delay_ms()` function with configurable initial delay and maximum cap
- Exported new backoff constants (`DEFAULT_BACKOFF_INITIAL_MS`, `DEFAULT_BACKOFF_MAX_MS`) and function for external use

Part of #1035.

## Evidence

All quality checks pass (`./quality.sh`), including clippy, tests, and documentation build. The backoff function is pure and deterministic, so correctness is verified entirely via unit and integration tests.

## Test Plan

- Added 7 unit tests in `src/analysis/gpu/queue/recovery.rs`:
  - `test_backoff_delay_initial_attempt` — verifies first attempt returns initial delay
  - `test_backoff_delay_doubles_each_attempt` — verifies exponential doubling across 7 attempts
  - `test_backoff_delay_respects_cap` — verifies delay is capped at maximum
  - `test_backoff_delay_zero_attempt_returns_initial` — verifies edge case handling
  - `test_backoff_delay_with_default_constants` — verifies behaviour with production constants
  - `test_backoff_delay_large_attempt_does_not_overflow` — verifies no panic on large attempt numbers
  - `test_default_backoff_constants` — verifies constant values
  - `test_is_device_lost_error_detects_allocation_failed` — verifies corrected typo pattern
- Added 5 integration tests in `tests/gpu/issue_647_gpu_device_lost_recovery.rs`:
  - `test_device_lost_error_detects_allocation_failed_pattern` — verifies corrected pattern via public API
  - `test_backoff_delay_doubles_exponentially` — end-to-end exponential doubling check
  - `test_backoff_delay_caps_at_max` — end-to-end cap verification
  - `test_backoff_delay_does_not_overflow_on_large_attempt` — overflow safety
  - `test_backoff_constants_are_sensible` — sanity checks on exported constants
- All 171 existing integration tests pass
- All existing GPU recovery tests continue to pass

---

## Automated Fix Details
This PR addresses issue #1038: **feat: add exponential backoff and observability to GPU retry recovery**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1038
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1038 -->