### PR TITLE
fix: handle missing parquet file gracefully in lazy cache reads (#1049)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.41"
+version = "0.72.42"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1049.md
+++ b/docs/pr-summary-1049.md
@@ -1,0 +1,22 @@
+## Summary
+
+Handle missing parquet file gracefully in lazy cache reads. When a parquet file is deleted between cache construction and a cache-miss read (e.g., due to the host cleaning up temp directories while analysis is still active), the library now returns a clear "Parquet file removed" error instead of a generic I/O error. Bulk load methods (which use `.ok()` to skip errors) naturally return partial results when the file disappears mid-analysis. Closes #1049.
+
+## Changes
+
+- **`src/parquet_format/reader.rs`**: Added `open_parquet_file()` helper that distinguishes `NotFound` errors (file externally deleted) from other I/O errors (corruption, permissions). All three public read functions (`read_all_records_grouped_by_neuron_with_deadline`, `read_records_from_parquet`, `read_records_from_parquet_with_limit`) now use this helper.
+- **`tests/cache_missing_parquet.rs`**: New integration test file with 5 tests covering cache behaviour when the parquet file is deleted after cache construction.
+
+## Evidence
+
+The fix flows through the existing call chain: `LruRecordCache::load_neuron_records()` and `CompressedLruRecordCache::load_neuron_records()` both call `read_records_from_parquet()`, which now uses `open_parquet_file()`. No changes needed in the cache modules themselves.
+
+Partial results already work because `RecordCache::load_records_for_uuids()` and similar bulk methods use `filter_map(|uuid| self.get(uuid).ok())`, silently skipping failed loads.
+
+## Test Plan
+
+- `lru_cache_handles_missing_parquet_without_panic` — LRU cache returns clear error on cache miss after file deletion
+- `compressed_cache_handles_missing_parquet_without_panic` — Compressed cache returns clear error on cache miss after file deletion
+- `record_cache_lazy_handles_missing_parquet_without_panic` — RecordCache with lazy loader returns error after file deletion
+- `read_records_from_parquet_returns_file_removed_error` — Low-level reader returns "file removed" error
+- `lru_cache_returns_cached_data_after_file_deletion` — Already-cached data remains accessible after file deletion

--- a/src/parquet_format/reader.rs
+++ b/src/parquet_format/reader.rs
@@ -9,6 +9,25 @@ use std::fs::File;
 use crate::types::DiscoverRecord;
 use std::time::SystemTime;
 
+/// Open a parquet file, returning a clear "file removed" error if the file
+/// no longer exists on disk (Issue #1049).
+///
+/// This distinguishes external deletion (e.g., host cleaned up temp directory)
+/// from other I/O errors such as corruption or permission issues, allowing
+/// callers to return partial results instead of crashing.
+fn open_parquet_file(file_path: &str) -> Result<File> {
+    File::open(file_path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow::anyhow!(
+                "Parquet file removed: the file '{file_path}' no longer exists on disk. \
+                 It may have been deleted by the host while analysis was still active."
+            )
+        } else {
+            anyhow::anyhow!("Failed to open Parquet file: {file_path}").context(e)
+        }
+    })
+}
+
 /// Read all discovery records from a Parquet file, grouped by neuron UUID.
 /// This is more efficient than calling `read_records_from_parquet` multiple times
 /// when you need records for multiple neurons.
@@ -36,8 +55,7 @@ pub fn read_all_records_grouped_by_neuron_with_deadline(
         anyhow::bail!("Parquet loading aborted: deadline already passed before loading started");
     }
 
-    let file = File::open(file_path)
-        .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
+    let file = open_parquet_file(file_path)?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
@@ -146,8 +164,7 @@ pub fn read_records_from_parquet(
     file_path: &str,
     neuron_uuid: &str,
 ) -> Result<Vec<DiscoverRecord>> {
-    let file = File::open(file_path)
-        .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
+    let file = open_parquet_file(file_path)?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
@@ -254,8 +271,7 @@ pub fn read_records_from_parquet_with_limit(
         return Ok(Vec::new());
     }
 
-    let file = File::open(file_path)
-        .with_context(|| format!("Failed to open Parquet file: {file_path}"))?;
+    let file = open_parquet_file(file_path)?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;

--- a/tests/cache_missing_parquet.rs
+++ b/tests/cache_missing_parquet.rs
@@ -1,0 +1,166 @@
+//! Tests for cache behaviour when a parquet file is deleted after cache construction (Issue #1049).
+//!
+//! Verifies that lazy cache reads handle missing parquet files gracefully,
+//! returning clear errors rather than panicking, and that bulk load methods
+//! return partial results when the file disappears mid-analysis.
+
+use neat_ai_discovery::analysis::cache::{CompressedLruRecordCache, LruRecordCache};
+use neat_ai_discovery::parquet_format::{read_records_from_parquet, write_records_to_parquet};
+use neat_ai_discovery::types::DiscoverRecord;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+
+/// Helper: create a temporary parquet file with test records and return the path.
+fn create_test_parquet() -> (NamedTempFile, String) {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let file_path = temp_file.path().to_str().unwrap().to_string();
+
+    let records = vec![
+        DiscoverRecord::new(0, "neuron-a".to_string(), Some(0.5), 0.7, vec![0.1, 0.2]),
+        DiscoverRecord::new(1, "neuron-a".to_string(), Some(0.6), 0.8, vec![0.15, 0.25]),
+        DiscoverRecord::new(0, "neuron-b".to_string(), Some(0.3), 0.5, vec![0.05]),
+        DiscoverRecord::new(1, "neuron-b".to_string(), Some(0.4), 0.6, vec![0.1]),
+    ];
+
+    write_records_to_parquet(&file_path, &records).expect("Failed to write test parquet");
+    (temp_file, file_path)
+}
+
+#[test]
+fn lru_cache_handles_missing_parquet_without_panic() {
+    let (temp_file, file_path) = create_test_parquet();
+
+    // Create cache while file exists
+    let cache =
+        LruRecordCache::new(&file_path, 10 * 1024 * 1024).expect("Cache creation should succeed");
+
+    // Verify cache works while file exists
+    let records = cache.get("neuron-a").expect("Should load neuron-a");
+    assert_eq!(records.len(), 2);
+
+    // Delete the file
+    drop(temp_file);
+    std::fs::remove_file(&file_path).ok(); // Ensure path is gone
+
+    // Cache miss for a neuron not yet cached should return an error, not panic
+    let result = cache.get("neuron-b");
+    assert!(
+        result.is_err(),
+        "Should return error when parquet file is missing"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("parquet file removed") || err_msg.contains("Parquet file removed"),
+        "Error should indicate file was removed, got: {err_msg}"
+    );
+}
+
+#[test]
+fn compressed_cache_handles_missing_parquet_without_panic() {
+    let (temp_file, file_path) = create_test_parquet();
+
+    // Create cache while file exists
+    let cache = CompressedLruRecordCache::new(&file_path, 10 * 1024 * 1024)
+        .expect("Cache creation should succeed");
+
+    // Verify cache works while file exists
+    let records = cache.get("neuron-a").expect("Should load neuron-a");
+    assert_eq!(records.len(), 2);
+
+    // Delete the file
+    drop(temp_file);
+    std::fs::remove_file(&file_path).ok();
+
+    // Cache miss for uncached neuron should return an error, not panic
+    let result = cache.get("neuron-b");
+    assert!(
+        result.is_err(),
+        "Should return error when parquet file is missing"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("parquet file removed") || err_msg.contains("Parquet file removed"),
+        "Error should indicate file was removed, got: {err_msg}"
+    );
+}
+
+#[test]
+fn record_cache_lazy_handles_missing_parquet_without_panic() {
+    use neat_ai_discovery::analysis::cache::RecordCache;
+
+    let (temp_file, file_path) = create_test_parquet();
+
+    // Create a lazy RecordCache using the custom loader path
+    // Use with_loader to simulate lazy loading behaviour
+    let cache = RecordCache::with_loader(
+        &file_path,
+        Arc::new(move |file: &str, neuron_uuid: &str| read_records_from_parquet(file, neuron_uuid)),
+    );
+
+    // Load neuron-a while file exists
+    let records = cache.get("neuron-a").expect("Should load neuron-a");
+    assert_eq!(records.len(), 2);
+
+    // Delete the file
+    drop(temp_file);
+    std::fs::remove_file(&file_path).ok();
+
+    // Cache miss for uncached neuron should return an error, not panic
+    let result = cache.get("neuron-b");
+    assert!(
+        result.is_err(),
+        "Should return error when parquet file is missing"
+    );
+}
+
+#[test]
+fn read_records_from_parquet_returns_file_removed_error() {
+    let (temp_file, file_path) = create_test_parquet();
+
+    // Verify reads work while file exists
+    let records = read_records_from_parquet(&file_path, "neuron-a").expect("Should read neuron-a");
+    assert_eq!(records.len(), 2);
+
+    // Delete the file
+    drop(temp_file);
+    std::fs::remove_file(&file_path).ok();
+
+    // Reading should return a clear error, not panic
+    let result = read_records_from_parquet(&file_path, "neuron-a");
+    assert!(result.is_err(), "Should return error for missing file");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("parquet file removed")
+            || err_msg.contains("Parquet file removed")
+            || err_msg.contains("no longer exists"),
+        "Error should indicate file was removed, got: {err_msg}"
+    );
+}
+
+#[test]
+fn lru_cache_returns_cached_data_after_file_deletion() {
+    let (temp_file, file_path) = create_test_parquet();
+
+    let cache =
+        LruRecordCache::new(&file_path, 10 * 1024 * 1024).expect("Cache creation should succeed");
+
+    // Load both neurons into cache while file exists
+    let records_a = cache.get("neuron-a").expect("Should load neuron-a");
+    let records_b = cache.get("neuron-b").expect("Should load neuron-b");
+    assert_eq!(records_a.len(), 2);
+    assert_eq!(records_b.len(), 2);
+
+    // Delete the file
+    drop(temp_file);
+    std::fs::remove_file(&file_path).ok();
+
+    // Cached data should still be accessible (cache hits don't need the file)
+    let records_a_again = cache
+        .get("neuron-a")
+        .expect("Cached neuron-a should still work");
+    assert_eq!(records_a_again.len(), 2);
+    let records_b_again = cache
+        .get("neuron-b")
+        .expect("Cached neuron-b should still work");
+    assert_eq!(records_b_again.len(), 2);
+}


### PR DESCRIPTION
## Summary

Handle missing parquet file gracefully in lazy cache reads. When a parquet file is deleted between cache construction and a cache-miss read (e.g., due to the host cleaning up temp directories while analysis is still active), the library now returns a clear "Parquet file removed" error instead of a generic I/O error. Bulk load methods (which use `.ok()` to skip errors) naturally return partial results when the file disappears mid-analysis. Closes #1049.

## Changes

- **`src/parquet_format/reader.rs`**: Added `open_parquet_file()` helper that distinguishes `NotFound` errors (file externally deleted) from other I/O errors (corruption, permissions). All three public read functions (`read_all_records_grouped_by_neuron_with_deadline`, `read_records_from_parquet`, `read_records_from_parquet_with_limit`) now use this helper.
- **`tests/cache_missing_parquet.rs`**: New integration test file with 5 tests covering cache behaviour when the parquet file is deleted after cache construction.

## Evidence

The fix flows through the existing call chain: `LruRecordCache::load_neuron_records()` and `CompressedLruRecordCache::load_neuron_records()` both call `read_records_from_parquet()`, which now uses `open_parquet_file()`. No changes needed in the cache modules themselves.

Partial results already work because `RecordCache::load_records_for_uuids()` and similar bulk methods use `filter_map(|uuid| self.get(uuid).ok())`, silently skipping failed loads.

## Test Plan

- `lru_cache_handles_missing_parquet_without_panic` — LRU cache returns clear error on cache miss after file deletion
- `compressed_cache_handles_missing_parquet_without_panic` — Compressed cache returns clear error on cache miss after file deletion
- `record_cache_lazy_handles_missing_parquet_without_panic` — RecordCache with lazy loader returns error after file deletion
- `read_records_from_parquet_returns_file_removed_error` — Low-level reader returns "file removed" error
- `lru_cache_returns_cached_data_after_file_deletion` — Already-cached data remains accessible after file deletion

---

## Automated Fix Details
This PR addresses issue #1049: **fix: handle missing parquet file gracefully in lazy cache reads**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1049
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1049 -->