### PR TITLE
docs: add streaming API guide and cache tuning documentation (#1041)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.43"
+version = "0.72.44"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ All dependencies build automatically on remote, unattended machines.
 | [docs/ANALYSIS_DEEP_DIVE.md](docs/ANALYSIS_DEEP_DIVE.md) | Detailed analysis workflow and detection algorithms |
 | [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) | GPU performance tuning, troubleshooting, and debugging |
 | [docs/FFI_API.md](docs/FFI_API.md) | Full FFI API reference and JSON interface |
+| [docs/STREAMING_GUIDE.md](docs/STREAMING_GUIDE.md) | Step-by-step streaming recording API guide with TypeScript examples |
+| [docs/CACHE_TUNING.md](docs/CACHE_TUNING.md) | Cache tier tuning, diagnostics, and example configurations |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Benchmark regression tracking and comparison workflow |
 | [docs/CANDIDATE_PIPELINE_MCMC_AUDIT.md](docs/CANDIDATE_PIPELINE_MCMC_AUDIT.md) | MCMC applicability audit for candidate selection pipeline |
 | [CodeWiki](https://codewiki.google/github.com/stsoftwareau/neat-ai-discovery) | AI-powered documentation and code exploration |

--- a/docs/CACHE_TUNING.md
+++ b/docs/CACHE_TUNING.md
@@ -1,0 +1,326 @@
+# Cache Tuning Guide
+
+This guide explains how the record cache works during the analysis phase, how
+to tune it for your deployment, and how to diagnose cache-related performance
+issues.
+
+For the streaming recording API (which writes the Parquet files that the cache
+reads), see [STREAMING_GUIDE.md](STREAMING_GUIDE.md).
+
+---
+
+## Overview
+
+After recording, the analysis phase loads neuron records from a Parquet file.
+The record cache sits between the analysis engine and the Parquet file,
+providing fast access to neuron data. The cache automatically selects one of
+three tiers based on the Parquet file size and available system memory.
+
+```
+Analysis Engine
+     │
+     ▼
+┌─────────────┐
+│ Record Cache │  ← Automatic tier selection
+├─────────────┤
+│ PreloadAll  │  Small files   — load everything into memory
+│ LRU Cache   │  Medium files  — keep hot neurons, evict cold ones
+│ Streaming   │  Large files   — load on-demand per neuron
+└─────────────┘
+     │
+     ▼
+  Parquet File
+```
+
+---
+
+## Cache Tiers
+
+### Tier 1 — PreloadAll
+
+**When selected:** Estimated expanded file size < available memory / 4.
+
+The entire Parquet file is loaded into memory upfront, grouped by neuron UUID.
+All subsequent lookups are instant (no I/O).
+
+| Aspect | Detail |
+|--------|--------|
+| **Speed** | Fastest — all data in memory |
+| **Memory** | Highest — entire dataset resident |
+| **I/O** | Single bulk read at startup |
+| **Best for** | Small-to-medium creatures with ample RAM |
+
+**How it works:**
+1. Reads all Parquet row groups in one pass.
+2. Groups records by neuron UUID into a `HashMap`.
+3. Wraps each group in `Arc` for zero-copy sharing across threads.
+4. Subsequent `get(neuron_uuid)` calls return the `Arc` directly — no I/O.
+
+### Tier 2 — LRU Cache
+
+**When selected:** Estimated expanded file size is between available memory / 4
+and available memory.
+
+Keeps frequently-accessed neurons in a bounded memory pool. When the pool is
+full, the least-recently-used neuron's records are evicted to make room.
+
+| Aspect | Detail |
+|--------|--------|
+| **Speed** | Fast for hot neurons; cold neurons require Parquet I/O |
+| **Memory** | Bounded — capacity is half of available memory |
+| **I/O** | On-demand per neuron (cache misses) |
+| **Best for** | Medium-sized creatures or memory-constrained systems |
+
+**How it works:**
+1. On first access for a neuron, loads its records from Parquet.
+2. Stores the records in a `HashMap` with an LRU timestamp.
+3. When total cached bytes exceed the capacity, evicts the
+   least-recently-used entry.
+4. Subsequent accesses for the same neuron are served from memory (cache hit).
+
+**Compressed variant (LZ4):** For even greater memory efficiency, the
+`CompressedLruRecordCache` compresses records using LZ4 before caching.
+Typical compression ratios of 2–4x allow the cache to hold significantly more
+neurons in the same memory footprint. LZ4 decompression runs at approximately
+4 GB/s on modern hardware, so the CPU overhead is minimal compared to the I/O
+savings from fewer cache misses.
+
+### Tier 3 — Streaming
+
+**When selected:** Estimated expanded file size >= available memory.
+
+Loads records on-demand per neuron without retaining them in a cache. Each
+neuron access scans the Parquet file. This is the slowest mode but works on
+any system regardless of RAM.
+
+| Aspect | Detail |
+|--------|--------|
+| **Speed** | Slowest — full Parquet scan per neuron |
+| **Memory** | Minimal — only the current neuron's records in memory |
+| **I/O** | One Parquet scan per `get()` call |
+| **Best for** | Very large datasets that exceed available memory |
+
+**Additional streaming features** (when using `StreamingRecordCache` directly):
+- **Block-based loading** from Parquet row groups
+- **LRU block eviction** for bounded memory usage
+- **Prefetch** — background loading of adjacent blocks
+
+---
+
+## Tier Selection Logic
+
+The cache uses a simple heuristic based on the Parquet file size and available
+system memory. The estimated expanded size accounts for Parquet compression
+(approximately 3x decompression ratio).
+
+```
+estimated_expanded = file_size_bytes × 3
+
+if estimated_expanded < available_memory / 4:
+    → PreloadAll
+
+elif estimated_expanded < available_memory:
+    → LRU Cache (capacity = available_memory / 2)
+
+else:
+    → Streaming
+```
+
+### Examples
+
+| File Size | Available RAM | Estimated Expanded | Tier Selected |
+|-----------|---------------|-------------------|---------------|
+| 10 MB | 8 GB | 30 MB | PreloadAll |
+| 500 MB | 8 GB | 1.5 GB | PreloadAll |
+| 1 GB | 8 GB | 3 GB | LRU Cache |
+| 4 GB | 8 GB | 12 GB | Streaming |
+| 100 MB | 1 GB | 300 MB | LRU Cache |
+| 500 MB | 1 GB | 1.5 GB | Streaming |
+
+---
+
+## How `max_analysis_memory_mb` Interacts with Cache Selection
+
+The `max_analysis_memory_mb` parameter in `analyze_parallel` sets a memory
+budget for the entire analysis phase, not just the cache. However, cache
+selection runs before the memory budget is checked. The interaction is:
+
+1. **Cache tier is selected first** based on system memory and file size.
+2. **Memory budget is checked** at two points during analysis:
+   - Before GPU work submission
+   - After Parquet loading
+3. **If the budget is exceeded**, analysis returns early with
+   `memory_budget_exceeded: true` and whatever candidates have been found so
+   far.
+
+### Practical guidance
+
+- **If analysis frequently hits the memory budget**, consider reducing the
+  Parquet file size (record fewer training samples) or increasing the budget.
+- **The cache tier adapts to system memory**, so `max_analysis_memory_mb` does
+  not directly control which tier is used.
+- **On memory-constrained systems** (e.g., 4 GB RAM), set
+  `max_analysis_memory_mb` to 50–75% of available RAM to leave headroom for
+  V8 and the OS.
+
+---
+
+## Environment Variables
+
+These environment variables control cache and streaming behaviour:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEAT_AI_DISCOVERY_PRELOAD_ALL` | off | Force PreloadAll tier (disable streaming) |
+| `NEAT_AI_DISCOVERY_MAX_CACHED_BLOCKS` | adaptive | Maximum blocks in streaming cache |
+| `NEAT_AI_DISCOVERY_PREFETCH_DEPTH` | 2 | Streaming prefetch depth (0 = disabled) |
+| `NEAT_AI_DISCOVERY_BLOCK_SIZE` | 10000 | Records per streaming block (min: 10, max: 100000) |
+
+### Forcing a specific tier
+
+- **Force PreloadAll:** Set `NEAT_AI_DISCOVERY_PRELOAD_ALL=1`. This bypasses
+  the automatic tier selection and loads everything into memory. Only use this
+  when you are confident the dataset fits comfortably in RAM.
+- **There is no environment variable to force LRU or Streaming.** The
+  automatic selection handles these cases based on available memory.
+
+---
+
+## Diagnosing Cache-Related Performance Issues
+
+### Symptom: Analysis is slow despite having enough RAM
+
+**Possible cause:** The cache selected Streaming or LRU when PreloadAll would
+have been faster.
+
+**Diagnosis:**
+1. Enable verbose logging: `NEAT_AI_DISCOVERY_VERBOSE=1`
+2. Look for the log line: `tiered loading strategy selected`
+3. Check which strategy was chosen and whether memory estimates are accurate.
+
+**Fix:** If the system has ample free RAM, set `NEAT_AI_DISCOVERY_PRELOAD_ALL=1`
+to force PreloadAll mode.
+
+### Symptom: Out of memory (exit code 137 / OOM killer)
+
+**Possible cause:** PreloadAll was selected for a dataset that is too large for
+the available memory, or the memory budget was set too high.
+
+**Diagnosis:**
+1. Check the Parquet file size: `ls -lh discovery_data.parquet`
+2. Estimate the expanded size: `file_size × 3`
+3. Compare against available RAM: `free -h` (Linux) or Activity Monitor (macOS)
+
+**Fix:**
+- Reduce the number of training samples recorded.
+- Lower `max_analysis_memory_mb` to cap Rust-side memory usage.
+- Ensure other processes are not consuming excessive memory.
+
+### Symptom: High cache miss rate in LRU mode
+
+**Possible cause:** The LRU cache capacity is too small for the working set.
+
+**Diagnosis:**
+1. Enable verbose logging: `NEAT_AI_DISCOVERY_VERBOSE=1`
+2. Look for eviction count in cache statistics logs.
+3. A high eviction count relative to cache hits indicates thrashing.
+
+**Fix:**
+- Free memory from other processes to increase available RAM (the LRU
+  capacity scales with available memory at startup).
+- Record fewer training samples to reduce the dataset size.
+
+### Symptom: Analysis returns `memory_budget_exceeded: true`
+
+**Possible cause:** The memory budget in `max_analysis_memory_mb` is too low
+for the dataset size.
+
+**Diagnosis:**
+1. Check the `memory_budget_exceeded` field in the analysis output.
+2. Use `discovery_memory_usage_bytes()` to monitor Rust-side memory usage
+   during analysis.
+
+**Fix:**
+- Increase `max_analysis_memory_mb`.
+- Reduce the number of training samples.
+- Analysis returns partial results when the budget is exceeded — coverage
+  improves over repeated runs.
+
+### Symptom: Parquet file is missing or analysis fails to load records
+
+**Possible cause:** The Parquet file was deleted while analysis was still
+reading from it.
+
+**Diagnosis:**
+1. Check whether `is_analysis_active()` returns `1` — if so, analysis is
+   still in flight.
+2. On Unix, deleting the file path while a handle is open does not destroy
+   the data (the inode stays alive). However, recreation at the same path
+   will not contain the original data.
+
+**Fix:**
+- Follow the recommended shutdown sequence:
+  1. Call `cancel_analysis()` when SIGTERM arrives.
+  2. Wait for the analysis FFI call to return.
+  3. Optionally poll `is_analysis_active()` until it returns `0`.
+  4. Delete the temp directory.
+
+---
+
+## Example Configurations
+
+### Development (macOS, 16 GB RAM)
+
+No configuration needed. The defaults work well:
+- Small-to-medium datasets use PreloadAll (fastest).
+- The LRU cache handles larger datasets automatically.
+
+### Production Server (Linux, 8 GB RAM, shared with NEAT-AI)
+
+```bash
+# Cap Rust-side memory at 4 GB (leave 4 GB for V8 and the OS)
+# Set via analyze_parallel input: max_analysis_memory_mb: 4096
+
+# If datasets are consistently large, enable streaming prefetch
+export NEAT_AI_DISCOVERY_PREFETCH_DEPTH=2
+
+# Optionally limit cached blocks for predictable memory usage
+export NEAT_AI_DISCOVERY_MAX_CACHED_BLOCKS=50
+```
+
+### Memory-Constrained (4 GB RAM)
+
+```bash
+# Conservative memory budget
+# Set via analyze_parallel input: max_analysis_memory_mb: 2048
+
+# Reduce block size for lower per-block memory usage
+export NEAT_AI_DISCOVERY_BLOCK_SIZE=5000
+
+# Limit prefetch to reduce peak memory
+export NEAT_AI_DISCOVERY_PREFETCH_DEPTH=1
+```
+
+### Large Dataset (multi-GB Parquet files)
+
+```bash
+# Force streaming mode if automatic detection is not aggressive enough
+# The cache will automatically select Streaming for files that exceed RAM,
+# but you can disable preload explicitly:
+export NEAT_AI_DISCOVERY_PRELOAD_ALL=0
+
+# Increase prefetch depth for sequential access patterns
+export NEAT_AI_DISCOVERY_PREFETCH_DEPTH=4
+
+# Increase block size for fewer, larger reads
+export NEAT_AI_DISCOVERY_BLOCK_SIZE=50000
+```
+
+---
+
+## Related Documentation
+
+- [STREAMING_GUIDE.md](STREAMING_GUIDE.md) — Streaming recording API guide
+- [FFI_API.md](FFI_API.md) — Full FFI API reference and JSON schemas
+- [GPU_GUIDE.md](GPU_GUIDE.md) — GPU performance tuning and troubleshooting
+- [README.md](../README.md) — Project overview and quick start

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -61,7 +61,9 @@ usage and candidate selection behaviour:
 
 Limits the Rust-side memory consumption during the analysis phase. When the
 allocated memory exceeds the budget, analysis returns early with
-`memory_budget_exceeded: true` in the output.
+`memory_budget_exceeded: true` in the output. For guidance on how this
+interacts with cache tier selection, see
+[CACHE_TUNING.md](CACHE_TUNING.md).
 
 - **Field**: `max_analysis_memory_mb` (optional `u64`)
 - **Default**: no limit
@@ -261,6 +263,10 @@ FFI boundary.
 ---
 
 ## 🔄 Streaming Recording API (v0.2.8+)
+
+> **For a step-by-step guide** with TypeScript code examples, error handling
+> patterns, and best practices, see
+> [STREAMING_GUIDE.md](STREAMING_GUIDE.md).
 
 The streaming API solves the JavaScript "Invalid string length" error that occurs when
 trying to serialise large datasets (6+ minutes of recording) into a single JSON string.

--- a/docs/STREAMING_GUIDE.md
+++ b/docs/STREAMING_GUIDE.md
@@ -1,0 +1,422 @@
+# Streaming API Guide
+
+This guide walks through the streaming recording API for TypeScript/Deno
+consumers. The streaming API replaces the single-call `record_discovery`
+function for large datasets, avoiding JavaScript/V8 string length limits.
+
+For the full FFI API reference and JSON schemas, see
+[FFI_API.md](FFI_API.md).
+
+---
+
+## Why Streaming?
+
+JavaScript/V8 has a maximum string length of approximately 2^28 characters.
+When a discovery run accumulates 6+ minutes of training data and attempts to
+`JSON.stringify` it all at once for a single FFI call, V8 throws an
+`Invalid string length` error. The streaming API keeps each FFI call small by
+sending data in batches.
+
+**Benefits:**
+
+- **No string length limits** — each batch is small enough to serialise
+- **Unlimited sample sizes** — can record for hours without memory issues
+- **Fail-safe** — already-written data is preserved in the Parquet file if the
+  process crashes mid-recording
+- **Reduced memory pressure** — TypeScript can discard batches after flushing
+
+---
+
+## Workflow Overview
+
+The streaming workflow has three phases:
+
+```
+1. start_discovery_session()    →  Creates session + Parquet file
+2. append_discovery_records()   →  Writes batches (repeat as needed)
+3. finish_discovery_session()   →  Finalises Parquet file
+```
+
+```mermaid
+sequenceDiagram
+    participant TS as TypeScript
+    participant RS as Rust Library
+
+    TS->>RS: 1. start_discovery_session()
+    RS-->>TS: sessionId
+
+    loop Collect data batches
+        Note over TS: Collect records<br/>(estimate size)
+        TS->>RS: 2. append_discovery_records()
+        Note over RS: Writes batch<br/>to Parquet
+        RS-->>TS: recordsWritten
+    end
+
+    TS->>RS: 3. finish_discovery_session()
+    RS-->>TS: tempDir, file, totalRecords
+```
+
+---
+
+## Step 1 — Start a Session
+
+Open the library and call `start_discovery_session` with the creature
+definition and a temporary directory path.
+
+```typescript
+// Load the native library
+const lib = Deno.dlopen("libneat_ai_discovery.dylib", {
+  start_discovery_session: { parameters: ["buffer"], result: "pointer" },
+  append_discovery_records: { parameters: ["buffer"], result: "pointer" },
+  finish_discovery_session: { parameters: ["buffer"], result: "pointer" },
+  cancel_discovery_session: { parameters: ["buffer"], result: "pointer" },
+  free_discovery_result: { parameters: ["pointer"], result: "void" },
+});
+
+// Prepare the session request
+const startRequest = JSON.stringify({
+  creature: {
+    neurons: [
+      { uuid: "input-0", type: "input", squash: "IDENTITY", bias: 0.0 },
+      { uuid: "hidden-1", type: "hidden", squash: "TANH", bias: 0.1 },
+      { uuid: "output-0", type: "output", squash: "IDENTITY", bias: 0.0 },
+    ],
+    synapses: [
+      { from_uuid: "input-0", to_uuid: "hidden-1", weight: 0.5 },
+      { from_uuid: "hidden-1", to_uuid: "output-0", weight: 0.8 },
+    ],
+    input: 1,
+    output: 1,
+  },
+  tempDir: ".discovery/abc123_456789",
+});
+
+// Call the FFI function
+const startPtr = lib.symbols.start_discovery_session(
+  new TextEncoder().encode(startRequest + "\0"),
+);
+const startResult = JSON.parse(
+  new Deno.UnsafePointerView(startPtr).getCString(),
+);
+lib.symbols.free_discovery_result(startPtr);
+
+if (!startResult.success) {
+  throw new Error(`Session start failed: ${startResult.error}`);
+}
+
+const sessionId: string = startResult.sessionId;
+```
+
+### Start Session Input/Output
+
+**Input:**
+```json
+{
+  "creature": {
+    "neurons": [{ "uuid": "hidden-1", "type": "hidden", "squash": "TANH", "bias": 0.0 }],
+    "synapses": [{ "from_uuid": "input-0", "to_uuid": "hidden-1", "weight": 0.5 }],
+    "input": 20,
+    "output": 2
+  },
+  "tempDir": ".discovery/abc123_456789"
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+---
+
+## Step 2 — Append Record Batches
+
+During training, collect neuron activation data and flush it to the Rust
+library periodically. Each batch should be well under V8's string limit —
+flushing at approximately 50 MB is a safe default.
+
+```typescript
+const FLUSH_THRESHOLD = 50 * 1024 * 1024; // 50 MB
+
+let pendingObservations: Observation[] = [];
+
+for (const trainingRecord of trainingData) {
+  // Activate the creature and collect neuron data
+  const neuronData = creature.activate(trainingRecord.input);
+
+  pendingObservations.push({
+    obsIndex: trainingRecord.index,
+    neuronData: neuronData.map((nd) => ({
+      neuronUuid: nd.uuid,
+      activation: nd.activation,
+      value: nd.value,
+      errors: nd.errors,
+    })),
+    inputs: trainingRecord.input,
+  });
+
+  // Estimate the JSON size and flush when approaching the threshold
+  const estimatedBytes = pendingObservations.length * (
+    200 * creature.neurons.length + 4 * creature.input
+  );
+
+  if (estimatedBytes > FLUSH_THRESHOLD) {
+    await flushBatch(sessionId, pendingObservations);
+    pendingObservations = []; // Reset for next batch
+  }
+}
+
+// Flush any remaining records
+if (pendingObservations.length > 0) {
+  await flushBatch(sessionId, pendingObservations);
+}
+```
+
+The `flushBatch` helper serialises and sends a batch:
+
+```typescript
+function flushBatch(
+  sessionId: string,
+  observations: Observation[],
+): void {
+  const appendRequest = JSON.stringify({
+    sessionId,
+    observations,
+  });
+
+  const appendPtr = lib.symbols.append_discovery_records(
+    new TextEncoder().encode(appendRequest + "\0"),
+  );
+  const appendResult = JSON.parse(
+    new Deno.UnsafePointerView(appendPtr).getCString(),
+  );
+  lib.symbols.free_discovery_result(appendPtr);
+
+  if (!appendResult.success) {
+    throw new Error(`Append failed: ${appendResult.error}`);
+  }
+}
+```
+
+### Append Input/Output
+
+**Input:**
+```json
+{
+  "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+  "observations": [
+    {
+      "obsIndex": 0,
+      "neuronData": [
+        { "neuronUuid": "hidden-1", "activation": 0.5, "value": 0.4, "errors": [0.1] }
+      ],
+      "inputs": [0.1, 0.2, 0.3]
+    }
+  ]
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "recordsWritten": 42
+}
+```
+
+---
+
+## Step 3 — Finish the Session
+
+After all batches have been appended, finalise the session. This closes the
+Parquet file and returns the file location for subsequent analysis.
+
+```typescript
+const finishRequest = JSON.stringify({ sessionId });
+const finishPtr = lib.symbols.finish_discovery_session(
+  new TextEncoder().encode(finishRequest + "\0"),
+);
+const finishResult = JSON.parse(
+  new Deno.UnsafePointerView(finishPtr).getCString(),
+);
+lib.symbols.free_discovery_result(finishPtr);
+
+if (!finishResult.success) {
+  throw new Error(`Finish failed: ${finishResult.error}`);
+}
+
+console.log(`Wrote ${finishResult.totalRecords} records`);
+console.log(`Parquet file: ${finishResult.tempDir}/${finishResult.file}`);
+```
+
+### Finish Output
+
+```json
+{
+  "success": true,
+  "tempDir": ".discovery/abc123_456789",
+  "file": "discovery_data.parquet",
+  "totalRecords": 12345
+}
+```
+
+---
+
+## Error Handling and Recovery
+
+### Append Failures
+
+If `append_discovery_records` returns `success: false`, the session remains
+open and valid. You can retry the failed batch or cancel the session:
+
+```typescript
+const result = appendBatch(sessionId, observations);
+if (!result.success) {
+  // Option 1: Retry the batch
+  const retry = appendBatch(sessionId, observations);
+  if (!retry.success) {
+    // Option 2: Cancel the session and start fresh
+    cancelSession(sessionId);
+    throw new Error(`Append failed after retry: ${retry.error}`);
+  }
+}
+```
+
+### Session Cancellation
+
+Use `cancel_discovery_session` to clean up without finalising. This removes
+the session and deletes any partially-written temporary files:
+
+```typescript
+function cancelSession(sessionId: string): void {
+  const cancelRequest = JSON.stringify({ sessionId });
+  const cancelPtr = lib.symbols.cancel_discovery_session(
+    new TextEncoder().encode(cancelRequest + "\0"),
+  );
+  const cancelResult = JSON.parse(
+    new Deno.UnsafePointerView(cancelPtr).getCString(),
+  );
+  lib.symbols.free_discovery_result(cancelPtr);
+
+  if (!cancelResult.success) {
+    console.warn(`Cancel failed: ${cancelResult.error}`);
+  }
+}
+```
+
+### Process Crash Recovery
+
+If the process crashes mid-recording:
+
+- The Rust library writes to a `.parquet.tmp` file during the session.
+- On `finish_discovery_session`, the temporary file is atomically renamed to
+  `discovery_data.parquet`.
+- If the session is never finished (crash or panic), the `Drop` implementation
+  automatically cleans up the incomplete `.parquet.tmp` file.
+- Already-written batches are preserved in the temporary file until cleanup
+  occurs.
+
+### Empty Session Guard
+
+Calling `finish_discovery_session` without appending any records returns an
+error. Always append at least one batch before finishing:
+
+```json
+{
+  "success": false,
+  "error": "No records were written to the session"
+}
+```
+
+### Invalid Session ID
+
+Using a non-existent or already-finished session ID returns an error:
+
+```json
+{
+  "success": false,
+  "error": "Session not found: <session_id>"
+}
+```
+
+---
+
+## Best Practices
+
+### Batch Sizing
+
+- **Target 50 MB per batch** — well under V8's ~256 MB string limit, leaving
+  headroom for JSON encoding overhead.
+- **Estimate size before serialising** — use the rough formula:
+  `observations.length * (200 * neuronCount + 4 * inputCount)` bytes.
+- **Avoid very small batches** — each FFI call has overhead. Batches under
+  1 MB are inefficient.
+- **Avoid very large batches** — batches over 100 MB risk approaching string
+  limits and increase memory pressure.
+
+### Session Lifecycle
+
+- **One session per creature per discovery run** — do not reuse session IDs.
+- **Always finish or cancel** — leaving sessions open leaks memory in the
+  global session storage.
+- **Use try/finally** — wrap the session lifecycle to ensure cleanup:
+
+```typescript
+const sessionId = startSession(creature, tempDir);
+try {
+  for (const batch of collectBatches(trainingData)) {
+    appendBatch(sessionId, batch);
+  }
+  const result = finishSession(sessionId);
+  return result;
+} catch (error) {
+  cancelSession(sessionId);
+  throw error;
+}
+```
+
+### Memory Management
+
+- **Free every FFI result** — every pointer returned by `start_discovery_session`,
+  `append_discovery_records`, `finish_discovery_session`, and
+  `cancel_discovery_session` must be freed with `free_discovery_result()`.
+  Failure to do so leaks memory.
+- **Discard batches after flushing** — set the batch array to `[]` after each
+  successful append to allow garbage collection.
+- **Monitor Rust-side memory** — use `discovery_memory_usage_bytes()` to track
+  Rust allocator usage alongside `Deno.memoryUsage().heapUsed` for total
+  process memory monitoring.
+
+### Atomic Record Writes
+
+Each observation must contain data from a single training record. Never mix
+activations or errors from different training records within the same
+observation. The analysis phase matches records by `obsIndex` — misaligned
+data produces incorrect analysis results.
+
+---
+
+## When to Use Streaming vs Single-Call
+
+| Scenario | Recommended API |
+|----------|----------------|
+| Small datasets (< 1 minute recording) | `record_discovery` (single-call) |
+| Large datasets (> 1 minute recording) | Streaming API |
+| Unknown dataset size | Streaming API (always safe) |
+| Memory-constrained environments | Streaming API |
+
+The streaming API is the **preferred** approach for all new integrations. The
+single-call `record_discovery` function remains available for backward
+compatibility but should be avoided for large runs.
+
+---
+
+## Related Documentation
+
+- [FFI_API.md](FFI_API.md) — Full FFI API reference and JSON schemas
+- [CACHE_TUNING.md](CACHE_TUNING.md) — Cache tier tuning for the analysis phase
+- [GPU_GUIDE.md](GPU_GUIDE.md) — GPU performance tuning and troubleshooting
+- [README.md](../README.md) — Project overview and quick start

--- a/docs/STREAMING_GUIDE.md
+++ b/docs/STREAMING_GUIDE.md
@@ -149,11 +149,11 @@ for (const trainingRecord of trainingData) {
 
   pendingObservations.push({
     obsIndex: trainingRecord.index,
-    neuronData: neuronData.map((nd) => ({
-      neuronUuid: nd.uuid,
-      activation: nd.activation,
-      value: nd.value,
-      errors: nd.errors,
+    neuronData: neuronData.map((item) => ({
+      neuronUuid: item.uuid,
+      activation: item.activation,
+      value: item.value,
+      errors: item.errors,
     })),
     inputs: trainingRecord.input,
   });

--- a/docs/pr-summary-1041.md
+++ b/docs/pr-summary-1041.md
@@ -1,0 +1,28 @@
+## Summary
+
+Add two new documentation guides for common workflows: streaming API usage and cache tier tuning. Closes #1041.
+
+**`docs/STREAMING_GUIDE.md`** — Step-by-step guide for the streaming recording workflow (`start_discovery_session` → `append_discovery_records` → `finish_discovery_session`) with TypeScript/Deno code examples, error handling and recovery patterns, and best practices for batch sizing and session lifecycle.
+
+**`docs/CACHE_TUNING.md`** — Overview of the three cache tiers (PreloadAll, LRU Cache, Streaming), how `max_analysis_memory_mb` interacts with tier selection, diagnostic steps for cache-related performance issues, and example configurations for common deployment scenarios.
+
+Cross-references added from `README.md` (Additional Documentation table) and `docs/FFI_API.md` (streaming API section and memory budget section).
+
+Both documents use Australian English spelling throughout.
+
+## Evidence
+
+- All 8 new tests in `tests/doc_cache_tuning_examples.rs` pass — these call the real `select_loading_strategy` function with the exact scenarios documented in the tier selection table, ensuring documentation stays in sync with the implementation.
+- `./quality.sh` passes cleanly (fmt, clippy, all tests, doc build, release build).
+
+## Test Plan
+
+- Added `tests/doc_cache_tuning_examples.rs` with 8 tests validating documented cache tier selection examples against the real `select_loading_strategy` function:
+  - `doc_example_small_file_preload` — 10 MB file, 8 GB RAM → PreloadAll
+  - `doc_example_medium_file_preload` — 500 MB file, 8 GB RAM → PreloadAll
+  - `doc_example_1gb_file_lru` — 1 GB file, 8 GB RAM → LRU Cache
+  - `doc_example_large_file_streaming` — 4 GB file, 8 GB RAM → Streaming
+  - `doc_example_constrained_ram_lru` — 100 MB file, 1 GB RAM → LRU Cache
+  - `doc_example_constrained_ram_streaming` — 500 MB file, 1 GB RAM → Streaming
+  - `decompression_ratio_boundary_preload` — boundary test at PreloadAll threshold
+  - `decompression_ratio_boundary_lru` — boundary test at LRU threshold

--- a/tests/doc_cache_tuning_examples.rs
+++ b/tests/doc_cache_tuning_examples.rs
@@ -1,0 +1,98 @@
+//! Tests that validate the cache tier selection examples documented in
+//! `docs/CACHE_TUNING.md`. These tests call the real `select_loading_strategy`
+//! function with the scenarios from the documentation and verify the expected
+//! tier is selected.
+//!
+//! Issue #1041: Ensures documentation stays in sync with implementation.
+
+use neat_ai_discovery::analysis::cache::{LoadingStrategy, select_loading_strategy};
+
+const GB: u64 = 1024 * 1024 * 1024;
+const MB: u64 = 1024 * 1024;
+
+/// Documented example: 10 MB file, 8 GB RAM selects `PreloadAll`.
+#[test]
+fn doc_example_small_file_preload() {
+    let strategy = select_loading_strategy(10 * MB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::PreloadAll),
+        "10 MB file with 8 GB RAM should select PreloadAll, got {strategy:?}"
+    );
+}
+
+/// Documented example: 500 MB file, 8 GB RAM selects `PreloadAll`
+/// (expanded 1.5 GB < 2 GB threshold).
+#[test]
+fn doc_example_medium_file_preload() {
+    let strategy = select_loading_strategy(500 * MB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::PreloadAll),
+        "500 MB file with 8 GB RAM should select PreloadAll, got {strategy:?}"
+    );
+}
+
+/// Documented example: 1 GB file, 8 GB RAM selects `LruCache`.
+#[test]
+fn doc_example_1gb_file_lru() {
+    let strategy = select_loading_strategy(GB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::LruCache { .. }),
+        "1 GB file with 8 GB RAM should select LruCache, got {strategy:?}"
+    );
+}
+
+/// Documented example: 4 GB file, 8 GB RAM selects `Streaming`.
+#[test]
+fn doc_example_large_file_streaming() {
+    let strategy = select_loading_strategy(4 * GB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::Streaming),
+        "4 GB file with 8 GB RAM should select Streaming, got {strategy:?}"
+    );
+}
+
+/// Documented example: 100 MB file, 1 GB RAM selects `LruCache`.
+#[test]
+fn doc_example_constrained_ram_lru() {
+    let strategy = select_loading_strategy(100 * MB, GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::LruCache { .. }),
+        "100 MB file with 1 GB RAM should select LruCache, got {strategy:?}"
+    );
+}
+
+/// Documented example: 500 MB file, 1 GB RAM selects `Streaming`.
+#[test]
+fn doc_example_constrained_ram_streaming() {
+    let strategy = select_loading_strategy(500 * MB, GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::Streaming),
+        "500 MB file with 1 GB RAM should select Streaming, got {strategy:?}"
+    );
+}
+
+/// Verify the documented decompression ratio (3x) is used in tier selection.
+/// A file whose expanded size (`file_size * 3`) is just under `available_memory / 4`
+/// should select `PreloadAll`.
+#[test]
+fn decompression_ratio_boundary_preload() {
+    // available / 4 = 2 GB. estimated_expanded = file_size * 3.
+    // file_size * 3 < 2 GB → file_size < 682 MB → use 600 MB
+    let strategy = select_loading_strategy(600 * MB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::PreloadAll),
+        "600 MB file (expanded 1.8 GB) with 8 GB RAM should select PreloadAll, got {strategy:?}"
+    );
+}
+
+/// Verify that at the boundary between `PreloadAll` and LRU, a file whose
+/// expanded size exceeds `available_memory / 4` selects LRU.
+#[test]
+fn decompression_ratio_boundary_lru() {
+    // available / 4 = 2 GB. file_size * 3 > 2 GB → file_size > 682 MB → use 700 MB
+    let strategy = select_loading_strategy(700 * MB, 8 * GB);
+    assert!(
+        matches!(strategy, LoadingStrategy::LruCache { .. }),
+        "700 MB file (expanded 2.1 GB) with 8 GB RAM should select LruCache, got {strategy:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Add two new documentation guides for common workflows: streaming API usage and cache tier tuning. Closes #1041.

**`docs/STREAMING_GUIDE.md`** — Step-by-step guide for the streaming recording workflow (`start_discovery_session` → `append_discovery_records` → `finish_discovery_session`) with TypeScript/Deno code examples, error handling and recovery patterns, and best practices for batch sizing and session lifecycle.

**`docs/CACHE_TUNING.md`** — Overview of the three cache tiers (PreloadAll, LRU Cache, Streaming), how `max_analysis_memory_mb` interacts with tier selection, diagnostic steps for cache-related performance issues, and example configurations for common deployment scenarios.

Cross-references added from `README.md` (Additional Documentation table) and `docs/FFI_API.md` (streaming API section and memory budget section).

Both documents use Australian English spelling throughout.

## Evidence

- All 8 new tests in `tests/doc_cache_tuning_examples.rs` pass — these call the real `select_loading_strategy` function with the exact scenarios documented in the tier selection table, ensuring documentation stays in sync with the implementation.
- `./quality.sh` passes cleanly (fmt, clippy, all tests, doc build, release build).

## Test Plan

- Added `tests/doc_cache_tuning_examples.rs` with 8 tests validating documented cache tier selection examples against the real `select_loading_strategy` function:
  - `doc_example_small_file_preload` — 10 MB file, 8 GB RAM → PreloadAll
  - `doc_example_medium_file_preload` — 500 MB file, 8 GB RAM → PreloadAll
  - `doc_example_1gb_file_lru` — 1 GB file, 8 GB RAM → LRU Cache
  - `doc_example_large_file_streaming` — 4 GB file, 8 GB RAM → Streaming
  - `doc_example_constrained_ram_lru` — 100 MB file, 1 GB RAM → LRU Cache
  - `doc_example_constrained_ram_streaming` — 500 MB file, 1 GB RAM → Streaming
  - `decompression_ratio_boundary_preload` — boundary test at PreloadAll threshold
  - `decompression_ratio_boundary_lru` — boundary test at LRU threshold

---

## Automated Fix Details
This PR addresses issue #1041: **docs: add streaming API guide and cache tuning documentation**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1041
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1041 -->