### PR TITLE
feat: gate add-synapse candidates behind success rate and density checks

### DIFF
--- a/benches/cache_locality.rs
+++ b/benches/cache_locality.rs
@@ -126,6 +126,7 @@ fn benchmark_cache_locality(c: &mut Criterion) {
                         max_candidates: Some(10), // Limit candidates to reduce GPU time variance
                         analysis_deadline_ms: deadline_ms,
                         random_seed: Some(42),
+                        module_outcome_tracker: None,
                         temperature: 1.0,
                     };
 

--- a/benches/sample_locality.rs
+++ b/benches/sample_locality.rs
@@ -145,6 +145,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    module_outcome_tracker: None,
                     temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -174,6 +175,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    module_outcome_tracker: None,
                     temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/benches/zero_copy_buffer.rs
+++ b/benches/zero_copy_buffer.rs
@@ -76,6 +76,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                 max_candidates: Some(10),
                 analysis_deadline_ms: None,
                 random_seed: Some(42),
+                module_outcome_tracker: None,
                 temperature: 1.0,
             };
             let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -97,6 +98,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                     max_candidates: Some(10),
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
+                    module_outcome_tracker: None,
                     temperature: 1.0,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/docs/pr-summary-1057.md
+++ b/docs/pr-summary-1057.md
@@ -1,0 +1,46 @@
+## Summary
+
+Gate add-synapse candidate generation behind historical success rate and synapse
+density checks to reduce wasted compute. Closes #1057.
+
+GRQ-sampler discovery cache shows add-synapse candidates have a near-zero success
+rate (~0.1-0.3%) across most creatures — only 3 of 43 creatures have any successes.
+This change skips add-synapse generation when:
+
+1. **ModuleOutcomeTracker shows <1% historical success rate** (configurable via
+   `ADD_SYNAPSE_MIN_SUCCESS_RATE`): When sufficient history exists (>=10 attempts)
+   and the Bayesian success rate falls below the threshold, helpful add-synapse
+   candidates are cleared before post-processing.
+
+2. **Synapse density ratio exceeds threshold** (configurable via
+   `ADD_SYNAPSE_MAX_DENSITY_RATIO`): When synapse_count/neuron_count > 14,
+   adding one synapse has minimal structural impact and generation is skipped.
+
+Both thresholds are configurable via override parameters and exposed as public
+constants for external use.
+
+### Changes
+
+- **New module**: `src/analysis/synapse/add_synapse_gating.rs` — contains
+  `should_skip_add_synapse_candidates()` and `compute_synapse_density_ratio()`
+- **New constants**: `ADD_SYNAPSE_MODULE_NAME`, `ADD_SYNAPSE_MIN_SUCCESS_RATE`,
+  `ADD_SYNAPSE_MAX_DENSITY_RATIO` in `src/analysis/constants/candidate_scoring.rs`
+- **Extended `AnalyzeSynapsesInput`** with optional `module_outcome_tracker` field,
+  passed from `analyze_all` orchestration
+- **Gating wired into `results.rs`**: Checks run before post-processing; when
+  triggered, helpful candidates are cleared with diagnostic logging
+
+## Evidence
+
+All 13 new tests pass, covering:
+- Density ratio computation (basic, zero neurons, no synapses)
+- Success rate gating (low rate, acceptable rate, no data, insufficient data, no tracker)
+- Density gating (high density, below threshold)
+- Custom threshold overrides
+- Constant range validation
+
+## Test Plan
+
+- Added `tests/analysis/issue_1057_add_synapse_gating.rs` with 13 unit tests
+- All 528+ existing tests continue to pass
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -746,3 +746,50 @@ pub const LOGISTIC_CALIBRATION_STEEPNESS: f32 = 8.0;
 /// Must be in (0.2, 0.9). Values below 0.3 do not sufficiently discount
 /// moderate ratios. Values above 0.8 discount too aggressively.
 pub const LOGISTIC_CALIBRATION_MIDPOINT: f32 = 0.6;
+
+// =============================================================================
+// Add-Synapse Candidate Gating (Issue #1057)
+// =============================================================================
+
+// GRQ-sampler discovery cache shows add-synapse candidates have a near-zero success
+// rate (~0.1-0.3%) across most creatures. Only 3 of 43 creatures have any add-synapse
+// successes. These gates skip add-synapse generation when historical data or network
+// structure indicates the candidates will almost certainly fail, saving compute.
+
+/// Module name used to track add-synapse outcomes in the `ModuleOutcomeTracker`.
+///
+/// The NEAT-AI controller records accept/reject outcomes with this module name
+/// when ablation results are available for add-synapse candidates.
+pub const ADD_SYNAPSE_MODULE_NAME: &str = "addSynapse";
+
+/// Minimum Bayesian success rate required before add-synapse candidates are generated.
+///
+/// When the `ModuleOutcomeTracker` has sufficient history (>= `MIN_BOOST_SAMPLES`)
+/// and the success rate falls below this threshold, add-synapse candidate generation
+/// is skipped entirely to save compute.
+///
+/// GRQ-sampler data shows ~0.1% actual success rate (3/1001). Setting the threshold
+/// at 1% provides a reasonable margin above the observed rate while still filtering
+/// out creatures with consistently zero successes.
+///
+/// ## Valid Range
+/// Must be in (0.0, 0.5). Values above 0.1 risk skipping generation for creatures
+/// that have a genuine (if low) success rate. Values below 0.005 provide no benefit.
+pub const ADD_SYNAPSE_MIN_SUCCESS_RATE: f64 = 0.01;
+
+/// Maximum synapse-to-neuron ratio before add-synapse candidates are skipped.
+///
+/// Adding one synapse to a network with very high synapse density (many synapses
+/// per neuron) has minimal structural impact — the signal-to-noise ratio is
+/// extremely low. When the ratio exceeds this threshold, add-synapse generation
+/// is skipped.
+///
+/// GRQ-sampler creature 066649c7 has ~19,000 synapses and ~1,400 neurons
+/// (ratio ~13.6). Setting the threshold at 14 captures the most extreme cases
+/// while allowing generation for moderately dense networks.
+///
+/// ## Valid Range
+/// Must be > 1.0. Values below 5.0 risk skipping generation for networks
+/// that could genuinely benefit from new synapses. Values above 25.0 provide
+/// no filtering benefit.
+pub const ADD_SYNAPSE_MAX_DENSITY_RATIO: f64 = 14.0;

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -144,6 +144,7 @@ fn analyze_synapses_rejects_duplicate_focus_targets() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -254,6 +255,7 @@ fn analyze_synapses_reports_eligible_sources_correctly_for_non_input_neurons() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -394,6 +396,7 @@ fn analyze_synapses_reports_fully_connected_neuron_explicitly() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -445,6 +448,7 @@ fn analyze_synapses_requires_focus_targets() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -498,6 +502,7 @@ fn analyze_synapses_reports_diagnostics_when_no_candidates() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -609,6 +614,7 @@ fn analyze_synapses_stops_harmful_processing_after_deadline() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -1004,6 +1010,7 @@ fn analyze_synapses_uses_vertical_timeout_with_randomized_order() {
         // Any non-None deadline value will exercise the override sequence.
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -1101,6 +1108,7 @@ fn analyze_synapses_accepts_positive_improvements_below_threshold() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -1199,6 +1207,7 @@ fn analyze_synapses_rejects_non_positive_improvements() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -1273,6 +1282,7 @@ fn analyze_synapses_accepts_positive_improvements_above_threshold() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -317,6 +317,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             max_candidates: input.max_synapse_candidates,
             analysis_deadline_ms: input.analysis_deadline_ms,
             random_seed: input.random_seed,
+            module_outcome_tracker: input.module_outcome_tracker.clone(),
             temperature: input.temperature,
         })
     } else {

--- a/src/analysis/synapse/add_synapse_gating.rs
+++ b/src/analysis/synapse/add_synapse_gating.rs
@@ -1,0 +1,119 @@
+//! Add-synapse candidate gating logic (Issue #1057).
+//!
+//! Determines whether add-synapse candidate generation should be skipped for a
+//! creature based on:
+//!
+//! 1. **Historical success rate**: If the `ModuleOutcomeTracker` shows that
+//!    add-synapse candidates have a success rate below a configurable threshold
+//!    (default 1%), generation is skipped to save compute.
+//!
+//! 2. **Synapse density**: If the creature's synapse-to-neuron ratio exceeds a
+//!    configurable threshold (default 14), adding one synapse has minimal
+//!    structural impact and generation is skipped.
+//!
+//! GRQ-sampler discovery cache shows add-synapse candidates have a near-zero
+//! success rate (~0.1-0.3%) across most creatures — only 3 of 43 creatures have
+//! any successes. These gates avoid wasting compute on candidates that will
+//! almost certainly fail.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // Intentional numeric casts for neural network computation (Issue #873)
+
+use crate::analysis::constants::{
+    ADD_SYNAPSE_MAX_DENSITY_RATIO, ADD_SYNAPSE_MIN_SUCCESS_RATE, ADD_SYNAPSE_MODULE_NAME,
+    MIN_BOOST_SAMPLES,
+};
+use crate::analysis::module_weights::ModuleOutcomeTracker;
+
+/// Result of the add-synapse gating check.
+#[derive(Debug, Clone)]
+pub struct AddSynapseGatingResult {
+    /// Whether add-synapse candidate generation should be skipped.
+    pub skip: bool,
+    /// Human-readable reason for the decision (for logging/diagnostics).
+    pub reason: String,
+}
+
+/// Compute the synapse-to-neuron density ratio for a creature.
+///
+/// Returns 0.0 when there are zero neurons (avoids division by zero).
+pub fn compute_synapse_density_ratio(synapse_count: usize, neuron_count: usize) -> f64 {
+    if neuron_count == 0 {
+        return 0.0;
+    }
+    synapse_count as f64 / neuron_count as f64
+}
+
+/// Determine whether add-synapse candidate generation should be skipped.
+///
+/// Checks two independent gates (either triggers a skip):
+///
+/// 1. **Success rate gate**: When the tracker has sufficient history
+///    (>= `MIN_BOOST_SAMPLES`) and the Bayesian success rate is below
+///    `min_success_rate` (default `ADD_SYNAPSE_MIN_SUCCESS_RATE`).
+///
+/// 2. **Density gate**: When the synapse-to-neuron ratio exceeds
+///    `max_density_ratio` (default `ADD_SYNAPSE_MAX_DENSITY_RATIO`).
+///
+/// # Arguments
+///
+/// * `tracker` — Optional historical outcome tracker. `None` or no data for
+///   the add-synapse module means the gate is not triggered.
+/// * `neuron_count` — Total number of neurons in the creature.
+/// * `synapse_count` — Total number of synapses in the creature.
+/// * `min_success_rate` — Override for the minimum success rate threshold.
+///   Pass `None` to use the default (`ADD_SYNAPSE_MIN_SUCCESS_RATE`).
+/// * `max_density_ratio` — Override for the maximum density ratio threshold.
+///   Pass `None` to use the default (`ADD_SYNAPSE_MAX_DENSITY_RATIO`).
+pub fn should_skip_add_synapse_candidates(
+    tracker: &Option<ModuleOutcomeTracker>,
+    neuron_count: usize,
+    synapse_count: usize,
+    min_success_rate: Option<f64>,
+    max_density_ratio: Option<f64>,
+) -> AddSynapseGatingResult {
+    let min_rate = min_success_rate.unwrap_or(ADD_SYNAPSE_MIN_SUCCESS_RATE);
+    let max_density = max_density_ratio.unwrap_or(ADD_SYNAPSE_MAX_DENSITY_RATIO);
+
+    // Gate 1: Check historical success rate from the ModuleOutcomeTracker.
+    if let Some(t) = tracker {
+        let stats = t.stats(ADD_SYNAPSE_MODULE_NAME);
+        if (stats.attempts as usize) >= MIN_BOOST_SAMPLES {
+            let rate = stats.success_rate();
+            if rate < min_rate {
+                return AddSynapseGatingResult {
+                    skip: true,
+                    reason: format!(
+                        "add-synapse success rate {:.3}% is below threshold {:.1}% \
+                         ({} attempts, {} successes) — skipping generation (Issue #1057)",
+                        rate * 100.0,
+                        min_rate * 100.0,
+                        stats.attempts,
+                        stats.successes,
+                    ),
+                };
+            }
+        }
+    }
+
+    // Gate 2: Check synapse density ratio.
+    let density = compute_synapse_density_ratio(synapse_count, neuron_count);
+    if density > max_density {
+        return AddSynapseGatingResult {
+            skip: true,
+            reason: format!(
+                "synapse density ratio {density:.1} ({synapse_count} synapses / \
+                 {neuron_count} neurons) exceeds threshold {max_density:.1} — \
+                 skipping add-synapse generation (Issue #1057)",
+            ),
+        };
+    }
+
+    AddSynapseGatingResult {
+        skip: false,
+        reason: String::new(),
+    }
+}

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -36,6 +36,7 @@
 mod activation_evaluation;
 mod activation_subset_evaluation;
 pub mod adaptive_proposal;
+pub mod add_synapse_gating;
 mod candidate_generation;
 mod filtering;
 mod gpu_evaluation;

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -236,6 +236,7 @@ mod tests {
             focus_neurons: vec!["output-1".to_string()],
             max_candidates: None,
             random_seed: Some(42),
+            module_outcome_tracker: None,
             temperature: 1.0,
             analysis_deadline_ms: None,
         }
@@ -310,6 +311,7 @@ mod tests {
             focus_neurons: vec![],
             max_candidates: None,
             random_seed: None,
+            module_outcome_tracker: None,
             temperature: 1.0,
             analysis_deadline_ms: None,
         };

--- a/src/analysis/synapse/results.rs
+++ b/src/analysis/synapse/results.rs
@@ -49,6 +49,26 @@ pub(super) fn finalise_synapse_results(
         log_analysis_timeout("synapse", completed, params.total_focus_count);
     }
 
+    // Issue #1057: Gate add-synapse candidates based on historical success rate and
+    // synapse density. When the tracker shows a near-zero success rate or the
+    // creature's synapse density is too high, skip helpful add-synapse candidates
+    // entirely to save compute on candidates that will almost certainly fail.
+    let gating_result = super::add_synapse_gating::should_skip_add_synapse_candidates(
+        &params.input.module_outcome_tracker,
+        params.input.creature.neurons.len(),
+        params.input.creature.synapses.len(),
+        None, // use default success rate threshold
+        None, // use default density threshold
+    );
+    if gating_result.skip {
+        tracing::info!(
+            reason = %gating_result.reason,
+            helpful_candidates_dropped = helpful_results.len(),
+            "Add-synapse gating: skipping helpful candidates (Issue #1057)"
+        );
+        helpful_results.clear();
+    }
+
     // Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
     let collapse_candidates =
         structural_patterns::detect_collapsible_hidden_neurons(params.input, params.cache.as_ref());

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -94,6 +94,13 @@ pub struct AnalyzeSynapsesInput {
     /// will explore different candidates over time.
     #[serde(default)]
     pub random_seed: Option<u64>,
+    /// Historical per-module outcome tracker for add-synapse gating (Issue #1057).
+    ///
+    /// When provided with sufficient history, the tracker's success rate for
+    /// add-synapse candidates is checked. If the rate falls below the
+    /// configurable threshold, add-synapse generation is skipped entirely.
+    #[serde(default)]
+    pub module_outcome_tracker: Option<analysis::module_weights::ModuleOutcomeTracker>,
     /// Temperature for exploration-exploitation balance (Issue #1020).
     ///
     /// Default 1.0 preserves existing behaviour. See `AnalyzeParallelInput`

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -109,6 +109,7 @@ fn synapse_analysis_respects_deadline() {
         max_candidates: None,
         analysis_deadline_ms: Some(deadline_ms),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -462,6 +462,7 @@ fn test_synapse_candidates_no_bias_optimisation() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -523,6 +524,7 @@ fn test_synapse_weight_distribution() {
             max_candidates: Some(50),
             analysis_deadline_ms: None,
             random_seed: None,
+            module_outcome_tracker: None,
             temperature: 1.0,
         };
 

--- a/tests/analysis/issue_1057_add_synapse_gating.rs
+++ b/tests/analysis/issue_1057_add_synapse_gating.rs
@@ -1,0 +1,202 @@
+//! Integration tests for add-synapse candidate gating (Issue #1057).
+//!
+//! Tests that add-synapse candidates are skipped when:
+//! 1. `ModuleOutcomeTracker` shows historical success rate below the configurable threshold
+//! 2. The creature's synapse density (synapses/neurons ratio) exceeds the maximum threshold
+//!
+//! These gates reduce wasted compute on add-synapse candidates that have a near-zero
+//! success rate (~0.1-0.3%) across most creatures.
+
+use neat_ai_discovery::analysis::constants::{
+    ADD_SYNAPSE_MAX_DENSITY_RATIO, ADD_SYNAPSE_MIN_SUCCESS_RATE, ADD_SYNAPSE_MODULE_NAME,
+};
+use neat_ai_discovery::analysis::module_weights::ModuleOutcomeTracker;
+use neat_ai_discovery::analysis::synapse::add_synapse_gating::{
+    compute_synapse_density_ratio, should_skip_add_synapse_candidates,
+};
+
+/// Helper to create a tracker with known module history.
+fn tracker_with_history(entries: &[(&str, u32, u32)]) -> ModuleOutcomeTracker {
+    let mut tracker = ModuleOutcomeTracker::new();
+    for &(name, attempts, successes) in entries {
+        for i in 0..attempts {
+            tracker.record(name, i < successes);
+        }
+    }
+    tracker
+}
+
+// =============================================================================
+// Synapse density ratio computation
+// =============================================================================
+
+#[test]
+fn test_density_ratio_basic() {
+    // 100 synapses, 10 neurons → ratio 10.0
+    let ratio = compute_synapse_density_ratio(100, 10);
+    assert!((ratio - 10.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_density_ratio_zero_neurons_returns_zero() {
+    // Edge case: 0 neurons should not panic
+    let ratio = compute_synapse_density_ratio(50, 0);
+    assert!((ratio - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_density_ratio_no_synapses() {
+    let ratio = compute_synapse_density_ratio(0, 10);
+    assert!((ratio - 0.0).abs() < f64::EPSILON);
+}
+
+// =============================================================================
+// ModuleOutcomeTracker gating
+// =============================================================================
+
+#[test]
+fn test_skip_when_tracker_shows_low_success_rate() {
+    // 100 attempts, 0 successes → success rate ≈ 0.01 (Bayesian posterior with Beta(1,1))
+    // With 100 attempts and 0 successes: (0+1)/(100+2) = 0.0098 < 0.01
+    let tracker = tracker_with_history(&[(ADD_SYNAPSE_MODULE_NAME, 100, 0)]);
+    let result = should_skip_add_synapse_candidates(
+        &Some(tracker),
+        5,    // low density
+        50,   // some synapses
+        None, // default threshold
+        None, // default density
+    );
+    assert!(
+        result.skip,
+        "Should skip add-synapse candidates when success rate < 1%"
+    );
+    assert!(
+        result.reason.contains("success rate"),
+        "Reason should mention success rate: {}",
+        result.reason
+    );
+}
+
+#[test]
+fn test_no_skip_when_tracker_shows_acceptable_success_rate() {
+    // 100 attempts, 5 successes → ~5.8% success rate > 1%
+    let tracker = tracker_with_history(&[(ADD_SYNAPSE_MODULE_NAME, 100, 5)]);
+    let result = should_skip_add_synapse_candidates(
+        &Some(tracker),
+        5, // low density
+        50,
+        None,
+        None,
+    );
+    assert!(
+        !result.skip,
+        "Should not skip when success rate is above threshold"
+    );
+}
+
+#[test]
+fn test_no_skip_when_tracker_has_no_data() {
+    // No data for add-synapse module → neutral prior (0.5) → do not skip
+    let tracker = ModuleOutcomeTracker::new();
+    let result = should_skip_add_synapse_candidates(&Some(tracker), 5, 50, None, None);
+    assert!(
+        !result.skip,
+        "Should not skip when no historical data is available"
+    );
+}
+
+#[test]
+fn test_no_skip_when_tracker_has_insufficient_data() {
+    // Only 5 attempts → insufficient data → do not skip
+    let tracker = tracker_with_history(&[(ADD_SYNAPSE_MODULE_NAME, 5, 0)]);
+    let result = should_skip_add_synapse_candidates(&Some(tracker), 5, 50, None, None);
+    assert!(
+        !result.skip,
+        "Should not skip when insufficient data for reliable estimate"
+    );
+}
+
+#[test]
+fn test_no_skip_when_no_tracker() {
+    let result = should_skip_add_synapse_candidates(&None, 5, 50, None, None);
+    assert!(!result.skip, "Should not skip when no tracker provided");
+}
+
+// =============================================================================
+// Synapse density gating
+// =============================================================================
+
+#[test]
+fn test_skip_when_density_too_high() {
+    // 200 synapses / 10 neurons = ratio 20 > default threshold (14)
+    let result = should_skip_add_synapse_candidates(&None, 10, 200, None, None);
+    assert!(
+        result.skip,
+        "Should skip when synapse density ratio exceeds threshold"
+    );
+    assert!(
+        result.reason.contains("density"),
+        "Reason should mention density: {}",
+        result.reason
+    );
+}
+
+#[test]
+fn test_no_skip_when_density_below_threshold() {
+    // 30 synapses / 10 neurons = ratio 3 < default threshold (14)
+    let result = should_skip_add_synapse_candidates(&None, 10, 30, None, None);
+    assert!(
+        !result.skip,
+        "Should not skip when density is below threshold"
+    );
+}
+
+// =============================================================================
+// Custom thresholds
+// =============================================================================
+
+#[test]
+fn test_custom_success_rate_threshold() {
+    // 100 attempts, 3 successes → ~3.9% success rate
+    // With custom threshold of 5%, this should be skipped
+    let tracker = tracker_with_history(&[(ADD_SYNAPSE_MODULE_NAME, 100, 3)]);
+    let result = should_skip_add_synapse_candidates(&Some(tracker), 10, 30, Some(0.05), None);
+    assert!(
+        result.skip,
+        "Should skip when success rate is below custom threshold of 5%"
+    );
+}
+
+#[test]
+fn test_custom_density_threshold() {
+    // 60 synapses / 10 neurons = ratio 6
+    // With custom density threshold of 5, this should be skipped
+    let result = should_skip_add_synapse_candidates(&None, 10, 60, None, Some(5.0));
+    assert!(
+        result.skip,
+        "Should skip when density exceeds custom threshold"
+    );
+}
+
+// =============================================================================
+// Constants validation
+// =============================================================================
+
+#[test]
+fn test_default_constants_are_sensible() {
+    // Verify constants are in expected ranges at runtime (not const-evaluable due to f64 ops)
+    let min_rate = ADD_SYNAPSE_MIN_SUCCESS_RATE;
+    let max_density = ADD_SYNAPSE_MAX_DENSITY_RATIO;
+    assert!(
+        min_rate > 0.0 && min_rate < 0.1,
+        "Default success rate threshold should be between 0% and 10%, got {min_rate}"
+    );
+    assert!(
+        max_density > 5.0 && max_density < 30.0,
+        "Default density ratio threshold should be between 5 and 30, got {max_density}"
+    );
+    assert!(
+        !ADD_SYNAPSE_MODULE_NAME.is_empty(),
+        "Module name must not be empty"
+    );
+}

--- a/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
+++ b/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
@@ -98,6 +98,7 @@ fn issue_199_low_variance_sources_use_default_threshold() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -201,6 +202,7 @@ fn issue_199_high_variance_sources_scale_threshold() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -302,6 +304,7 @@ fn issue_199_env_var_override_takes_precedence() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -383,6 +386,7 @@ fn issue_199_env_var_zero_disables_folding() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/issue_221_sample_locality.rs
+++ b/tests/analysis/issue_221_sample_locality.rs
@@ -344,6 +344,7 @@ fn sample_locality_batching_produces_results() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -415,6 +416,7 @@ fn sample_locality_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -463,6 +465,7 @@ fn source_batching_90_percent_overlap_produces_results() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -228,6 +228,7 @@ fn synapse_diagnostics_include_rejection_reasons_for_unpromising_targets() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -412,6 +413,7 @@ fn multiple_focus_targets_each_get_separate_diagnostic_entry() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -474,6 +476,7 @@ fn fully_connected_neuron_reports_no_eligible_sources() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -15,6 +15,7 @@ mod impact_squash;
 mod issue_1003_parallel_candidate_compression;
 mod issue_1004_overlap_compression_discovery;
 mod issue_1020_temperature_scheduling;
+mod issue_1057_add_synapse_gating;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;

--- a/tests/analysis/target_map_optimization.rs
+++ b/tests/analysis/target_map_optimization.rs
@@ -83,6 +83,7 @@ fn synapse_analysis_with_target_map_optimization_succeeds() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -162,6 +163,7 @@ fn multiple_focus_neurons_share_target_map_optimization() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -262,6 +264,7 @@ fn target_map_filters_non_finite_values() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -333,6 +336,7 @@ fn empty_target_records_skips_source_processing() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/focus/issue_182_focus_unused_observations.rs
+++ b/tests/focus/issue_182_focus_unused_observations.rs
@@ -210,6 +210,7 @@ fn issue_182_focus_unused_observations_prioritises_inputs_without_synapses() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(5000), // Short deadline to test prioritisation
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -282,6 +283,7 @@ fn issue_182_without_env_var_no_prioritisation() {
         max_candidates: Some(10),
         analysis_deadline_ms: None, // No deadline - process all
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -85,6 +85,7 @@ fn synapse_analysis_works_with_gpu_work_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -262,6 +263,7 @@ fn multiple_focus_neurons_work_with_shared_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -346,6 +348,7 @@ fn harmful_synapse_detection_works_with_queue() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -117,6 +117,7 @@ fn synapse_analysis_with_deadline_completes() {
         // Issue #953: Set a 2-minute deadline
         analysis_deadline_ms: Some(120_000),
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -123,6 +123,7 @@ fn timing_enabled_via_env_var() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -184,6 +185,7 @@ fn per_shader_timing_collected() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/infrastructure/issue_196_cache_locality_benchmark.rs
+++ b/tests/infrastructure/issue_196_cache_locality_benchmark.rs
@@ -134,6 +134,7 @@ fn cache_locality_optimization_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -153,6 +154,7 @@ fn cache_locality_optimization_preserves_correctness() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(123),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/infrastructure/issue_228_zero_copy_buffer.rs
+++ b/tests/infrastructure/issue_228_zero_copy_buffer.rs
@@ -205,6 +205,7 @@ fn zero_copy_produces_correct_results() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
     let result_zero_copy =
@@ -224,6 +225,7 @@ fn zero_copy_produces_correct_results() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
     let result_copy = analyze_synapses(&input).expect("Analysis with copy should succeed");
@@ -324,6 +326,7 @@ fn metadata_includes_zero_copy_status() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -410,6 +413,7 @@ fn zero_copy_no_data_corruption() {
             max_candidates: Some(20),
             analysis_deadline_ms: None,
             random_seed: Some(seed),
+            module_outcome_tracker: None,
             temperature: 1.0,
         };
 

--- a/tests/infrastructure/issue_718_bug_comment_error_handling.rs
+++ b/tests/infrastructure/issue_718_bug_comment_error_handling.rs
@@ -71,6 +71,7 @@ fn target_with_only_constant_upstream_returns_empty_results() {
         max_candidates: None,
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/infrastructure/observability.rs
+++ b/tests/infrastructure/observability.rs
@@ -374,6 +374,7 @@ fn integration_timing_output() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -442,6 +443,7 @@ fn integration_gpu_metrics() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/neuron/issue_134_direction_flip.rs
+++ b/tests/neuron/issue_134_direction_flip.rs
@@ -79,6 +79,7 @@ fn issue_134_bent_identity_target_simulation_rejects_linear_false_positive() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -148,6 +149,7 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
@@ -78,6 +78,7 @@ fn issue_178_constant_source_becomes_setbias_candidate() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/neuron/issue_180_setweight_operation.rs
+++ b/tests/neuron/issue_180_setweight_operation.rs
@@ -106,6 +106,7 @@ fn issue_180_setweight_replaces_remove_add_pattern() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/scoring/issue_192_error_distribution_analysis.rs
+++ b/tests/scoring/issue_192_error_distribution_analysis.rs
@@ -458,6 +458,7 @@ fn test_synapse_analysis_includes_error_distribution() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -569,6 +570,7 @@ fn test_candidate_includes_outlier_info_when_enabled() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -670,6 +672,7 @@ fn test_bimodal_error_pattern_detection() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
+++ b/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
@@ -210,6 +210,7 @@ fn test_issue_506_synapse_candidates_have_pessimism_discount() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
+++ b/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
@@ -132,6 +132,7 @@ fn test_issue_413_add_synapse_hard_tanh_prediction_not_inverted() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -212,6 +213,7 @@ fn test_issue_413_add_synapse_prediction_direction_correct() {
         max_candidates: Some(10),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/issue_416_harmful_synapse_threshold.rs
+++ b/tests/synapse/issue_416_harmful_synapse_threshold.rs
@@ -141,6 +141,7 @@ fn test_harmful_synapse_candidates_must_have_positive_expected_gain() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -238,6 +239,7 @@ fn test_helpful_synapse_is_not_marked_as_harmful() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -366,6 +368,7 @@ fn test_mixed_helpful_and_harmful_synapses() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/issue_522_synapse_post_processing.rs
+++ b/tests/synapse/issue_522_synapse_post_processing.rs
@@ -126,6 +126,7 @@ fn output_targets_have_full_impact_hidden_targets_are_discounted() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -254,6 +255,7 @@ fn candidates_sorted_by_expected_score_gain_descending() {
         max_candidates: Some(100),
         analysis_deadline_ms: None, // No deadline = no diversification shuffle
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -366,6 +368,7 @@ fn max_candidates_limits_total_output() {
         max_candidates: Some(max_limit),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -457,6 +460,7 @@ fn pipeline_applies_pessimism_discount_to_candidates() {
         max_candidates: Some(100),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -560,6 +564,7 @@ fn metadata_contains_candidate_counts_and_timing() {
         max_candidates: Some(50),
         analysis_deadline_ms: None,
         random_seed: Some(42),
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -228,6 +228,7 @@ fn test_remove_harmful_synapse_discovery() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -355,6 +356,7 @@ fn test_harmful_synapse_identifies_correct_neurons() {
         max_candidates: Some(100),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/sample_matching.rs
+++ b/tests/synapse/sample_matching.rs
@@ -74,6 +74,7 @@ fn analysis_handles_non_finite_values_gracefully() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -137,6 +138,7 @@ fn analysis_pairs_samples_by_obs_index() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -202,6 +204,7 @@ fn analysis_skips_neurons_without_errors() {
         max_candidates: None,
         analysis_deadline_ms: None,
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/synapse_candidate_indices.rs
+++ b/tests/synapse/synapse_candidate_indices.rs
@@ -105,6 +105,7 @@ fn synapse_candidates_populate_from_and_to_indices() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 

--- a/tests/synapse/synapse_impact_discounting.rs
+++ b/tests/synapse/synapse_impact_discounting.rs
@@ -179,6 +179,7 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -294,6 +295,7 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 
@@ -384,6 +386,7 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
         max_candidates: Some(10),
         analysis_deadline_ms: Some(30000),
         random_seed: None,
+        module_outcome_tracker: None,
         temperature: 1.0,
     };
 


### PR DESCRIPTION
## Summary

Gate add-synapse candidate generation behind historical success rate and synapse
density checks to reduce wasted compute. Closes #1057.

GRQ-sampler discovery cache shows add-synapse candidates have a near-zero success
rate (~0.1-0.3%) across most creatures — only 3 of 43 creatures have any successes.
This change skips add-synapse generation when:

1. **ModuleOutcomeTracker shows <1% historical success rate** (configurable via
   `ADD_SYNAPSE_MIN_SUCCESS_RATE`): When sufficient history exists (>=10 attempts)
   and the Bayesian success rate falls below the threshold, helpful add-synapse
   candidates are cleared before post-processing.

2. **Synapse density ratio exceeds threshold** (configurable via
   `ADD_SYNAPSE_MAX_DENSITY_RATIO`): When synapse_count/neuron_count > 14,
   adding one synapse has minimal structural impact and generation is skipped.

### Changes

- **New module**: `src/analysis/synapse/add_synapse_gating.rs` — `should_skip_add_synapse_candidates()` and `compute_synapse_density_ratio()`
- **New constants**: `ADD_SYNAPSE_MODULE_NAME`, `ADD_SYNAPSE_MIN_SUCCESS_RATE`, `ADD_SYNAPSE_MAX_DENSITY_RATIO`
- **Extended `AnalyzeSynapsesInput`** with optional `module_outcome_tracker` field
- **Gating wired into `results.rs`**: Checks run before post-processing; when triggered, helpful candidates are cleared with diagnostic logging

## Evidence

All 13 new tests pass, covering density ratio computation, success rate gating (low rate, acceptable rate, no data, insufficient data, no tracker), density gating, custom threshold overrides, and constant range validation.

## Test Plan

- Added `tests/analysis/issue_1057_add_synapse_gating.rs` with 13 unit tests
- All 528+ existing tests continue to pass
- `./quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)