### PR TITLE
fix: use RAII guard for analysis-active tracking to prevent discovery lockup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.46"
+version = "0.72.47"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1077.md
+++ b/docs/pr-summary-1077.md
@@ -1,0 +1,29 @@
+## Summary
+
+Fix discovery lockup where the host process waits forever for analysis to
+complete after an internal panic. Closes #1077.
+
+The root cause: `mark_analysis_started()` and `mark_analysis_finished()` were
+called as a manual pair around each analysis invocation. If the analysis
+panicked (e.g., a rayon thread panic propagating through `rayon::join`),
+`mark_analysis_finished()` was never called. The host process then waited
+indefinitely for `is_analysis_active()` to return false, causing the
+"discovery locked up (never completed)" symptom.
+
+The fix introduces an `AnalysisActiveGuard` RAII struct that increments the
+counter on creation and decrements it on `Drop` — which runs even during
+stack unwinding from a panic. Both `analyze_parallel_internal` and
+`rank_focus_neurons_internal` now use this guard instead of manual calls.
+
+## Evidence
+
+- `test_analysis_active_guard_decrements_on_panic` verifies the counter is
+  decremented even when the guarded scope panics
+- All 739+ existing tests continue to pass
+- `./quality.sh` passes cleanly (clippy, fmt, tests, docs, release build)
+
+## Test Plan
+
+- Added `test_analysis_active_guard_lifecycle` — normal creation and drop
+- Added `test_analysis_active_guard_decrements_on_panic` — panic safety
+- Added `test_analysis_active_guard_multiple_guards` — nested guard correctness

--- a/src/cancellation.rs
+++ b/src/cancellation.rs
@@ -94,9 +94,50 @@ pub fn reset_analysis_active() {
     ANALYSIS_ACTIVE.store(0, Ordering::Release);
 }
 
+// ============================================================================
+// RAII guard for analysis-active tracking (Issue #1077)
+// ============================================================================
+
+/// RAII guard that increments the analysis-active counter on creation and
+/// decrements it on drop, even if the analysis panics.
+///
+/// Previously, `mark_analysis_started()` and `mark_analysis_finished()` were
+/// called manually before and after each analysis invocation. If the analysis
+/// panicked (e.g., from a rayon thread panic propagating through `rayon::join`),
+/// `mark_analysis_finished()` was never called. The host process would then
+/// wait forever for `is_analysis_active()` to return false, causing the
+/// "discovery locked up" symptom described in Issue #1077.
+///
+/// Using this guard ensures the counter is always decremented via the `Drop`
+/// trait, which runs even during stack unwinding from a panic.
+pub struct AnalysisActiveGuard {
+    _private: (),
+}
+
+impl Default for AnalysisActiveGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisActiveGuard {
+    /// Create a new guard, incrementing the analysis-active counter.
+    pub fn new() -> Self {
+        mark_analysis_started();
+        Self { _private: () }
+    }
+}
+
+impl Drop for AnalysisActiveGuard {
+    fn drop(&mut self) {
+        mark_analysis_finished();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_cancellation_flag_lifecycle() {
@@ -111,5 +152,63 @@ mod tests {
         // Reset clears the flag
         reset_cancellation();
         assert!(!is_cancelled());
+    }
+
+    /// Issue #1077: Verify that `AnalysisActiveGuard` increments on creation
+    /// and decrements on drop.
+    #[test]
+    #[serial]
+    fn test_analysis_active_guard_lifecycle() {
+        reset_analysis_active();
+        assert_eq!(analysis_active_count(), 0);
+
+        {
+            let _guard = AnalysisActiveGuard::new();
+            assert_eq!(analysis_active_count(), 1);
+        }
+        // Guard dropped — counter should be back to 0
+        assert_eq!(analysis_active_count(), 0);
+    }
+
+    /// Issue #1077: Verify that `AnalysisActiveGuard` decrements even when
+    /// a panic occurs, preventing the host from waiting forever.
+    #[test]
+    #[serial]
+    fn test_analysis_active_guard_decrements_on_panic() {
+        reset_analysis_active();
+        assert_eq!(analysis_active_count(), 0);
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = AnalysisActiveGuard::new();
+            assert_eq!(analysis_active_count(), 1);
+            panic!("simulated analysis panic");
+        });
+
+        assert!(result.is_err(), "should have caught the panic");
+        // Guard's Drop must have run during unwinding
+        assert_eq!(
+            analysis_active_count(),
+            0,
+            "counter must be decremented even after panic"
+        );
+    }
+
+    /// Issue #1077: Multiple guards can nest correctly.
+    #[test]
+    #[serial]
+    fn test_analysis_active_guard_multiple_guards() {
+        reset_analysis_active();
+
+        let _guard1 = AnalysisActiveGuard::new();
+        assert_eq!(analysis_active_count(), 1);
+
+        {
+            let _guard2 = AnalysisActiveGuard::new();
+            assert_eq!(analysis_active_count(), 2);
+        }
+        assert_eq!(analysis_active_count(), 1);
+
+        drop(_guard1);
+        assert_eq!(analysis_active_count(), 0);
     }
 }

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -46,12 +46,14 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
 
     let combined_input = build_analyze_all_input_from_parallel(input);
 
-    // Issue #1048: Track that an analysis is active so the host knows
-    // not to delete the parquet temp directory until we finish.
-    crate::cancellation::mark_analysis_started();
+    // Issue #1048 / #1077: Track that an analysis is active so the host
+    // knows not to delete the parquet temp directory until we finish.
+    // Uses an RAII guard so the counter is decremented even if the
+    // analysis panics (e.g., rayon thread panic), preventing the host
+    // from waiting forever ("discovery locked up").
+    let _active_guard = crate::cancellation::AnalysisActiveGuard::new();
 
     let analysis_result = analysis::analyze_all(&combined_input);
-    crate::cancellation::mark_analysis_finished();
 
     match analysis_result {
         Ok(result) => {
@@ -230,9 +232,10 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
         }
     };
 
-    // Issue #1048: Track that an analysis is active so the host knows
-    // not to delete the parquet temp directory until we finish.
-    crate::cancellation::mark_analysis_started();
+    // Issue #1048 / #1077: Track that an analysis is active so the host
+    // knows not to delete the parquet temp directory until we finish.
+    // Uses an RAII guard so the counter is decremented even on panic.
+    let _active_guard = crate::cancellation::AnalysisActiveGuard::new();
 
     let rank_result = focus::rank_focus_neurons(
         &input.parquet_file,
@@ -240,7 +243,6 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
         input.max_results,
         input.cost_of_growth,
     );
-    crate::cancellation::mark_analysis_finished();
 
     match rank_result {
         Ok(stats) => {


### PR DESCRIPTION
## Summary

Fix discovery lockup where the host process waits forever for analysis to
complete after an internal panic. Closes #1077.

The root cause: `mark_analysis_started()` and `mark_analysis_finished()` were
called as a manual pair around each analysis invocation. If the analysis
panicked (e.g., a rayon thread panic propagating through `rayon::join`),
`mark_analysis_finished()` was never called. The host process then waited
indefinitely for `is_analysis_active()` to return false, causing the
"discovery locked up (never completed)" symptom.

The fix introduces an `AnalysisActiveGuard` RAII struct that increments the
counter on creation and decrements it on `Drop` — which runs even during
stack unwinding from a panic. Both `analyze_parallel_internal` and
`rank_focus_neurons_internal` now use this guard instead of manual calls.

## Evidence

- `test_analysis_active_guard_decrements_on_panic` verifies the counter is
  decremented even when the guarded scope panics
- All 739+ existing tests continue to pass
- `./quality.sh` passes cleanly (clippy, fmt, tests, docs, release build)

## Test Plan

- Added `test_analysis_active_guard_lifecycle` — normal creation and drop
- Added `test_analysis_active_guard_decrements_on_panic` — panic safety
- Added `test_analysis_active_guard_multiple_guards` — nested guard correctness

---

## Automated Fix Details
This PR addresses issue #1077: **Discovery locked up ( never completed)**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1077
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1077 -->