### PR TITLE
perf: add Parquet column pruning for analysis-specific reads (#1073)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.47"
+version = "0.72.48"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/parquet_loading_comparison.rs
+++ b/benches/parquet_loading_comparison.rs
@@ -18,7 +18,9 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use neat_ai_discovery::analysis::cache::{
     LruRecordCache, RecordCache, StreamingRecordCache, TieredRecordCache,
 };
-use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::parquet_format::{
+    ColumnProfile, read_all_records_grouped_by_neuron_with_profile, write_records_to_parquet,
+};
 use neat_ai_discovery::types::DiscoverRecord;
 use std::hint::black_box;
 use tempfile::tempdir;
@@ -222,10 +224,80 @@ fn bench_scaling(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark column pruning: full read vs without-errors read (Issue #1073).
+///
+/// The `errors` column is a `ListArray` requiring full materialisation.
+/// Skipping it when not needed should reduce I/O and deserialisation time.
+fn bench_column_pruning(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parquet_column_pruning");
+
+    // Use larger error arrays to amplify the ListArray deserialisation cost
+    for (neuron_count, records_per_neuron, errors_per_record) in
+        [(50, 200, 5), (100, 500, 10), (200, 500, 20)]
+    {
+        let temp_dir = tempdir().expect("Failed to create temp directory");
+        let parquet_path = temp_dir.path().join("pruning_bench.parquet");
+        let parquet_file = parquet_path.to_str().unwrap().to_string();
+
+        let mut records = Vec::with_capacity(neuron_count * records_per_neuron);
+        for neuron_idx in 0..neuron_count {
+            let neuron_uuid = format!("neuron-{neuron_idx}");
+            for obs_idx in 0..records_per_neuron {
+                let activation = (obs_idx as f32 % 100.0) / 100.0;
+                let errors: Vec<f32> = (0..errors_per_record)
+                    .map(|e| ((obs_idx + e) as f32 % 50.0 - 25.0) / 50.0)
+                    .collect();
+                records.push(DiscoverRecord::new(
+                    obs_idx as u32,
+                    neuron_uuid.clone(),
+                    Some(activation),
+                    activation,
+                    errors,
+                ));
+            }
+        }
+        write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+        let total = neuron_count * records_per_neuron;
+        let id = format!("{neuron_count}n_{records_per_neuron}r_{errors_per_record}e_{total}total");
+
+        group.bench_with_input(
+            BenchmarkId::new("full_read", &id),
+            &parquet_file,
+            |b, pf| {
+                b.iter(|| {
+                    let grouped =
+                        read_all_records_grouped_by_neuron_with_profile(pf, ColumnProfile::Full)
+                            .expect("Failed to read");
+                    black_box(grouped.len());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("without_errors", &id),
+            &parquet_file,
+            |b, pf| {
+                b.iter(|| {
+                    let grouped = read_all_records_grouped_by_neuron_with_profile(
+                        pf,
+                        ColumnProfile::WithoutErrors,
+                    )
+                    .expect("Failed to read");
+                    black_box(grouped.len());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_small_dataset,
     bench_medium_dataset,
-    bench_scaling
+    bench_scaling,
+    bench_column_pruning
 );
 criterion_main!(benches);

--- a/docs/pr-summary-1073.md
+++ b/docs/pr-summary-1073.md
@@ -1,0 +1,34 @@
+## Summary
+
+Add Parquet column pruning via `ProjectionMask` to skip the `errors` `ListArray` column
+when it is not needed by the caller. Introduces a `ColumnProfile` enum with `Full` and
+`WithoutErrors` variants, and new `_with_profile` reader functions that apply column
+projection at the Parquet I/O level. Existing reader functions are unchanged and delegate
+to the profile-aware versions with `ColumnProfile::Full`. Closes #1073.
+
+## Evidence
+
+Benchmark results from `cargo bench --bench parquet_loading_comparison -- parquet_column_pruning`:
+
+| Dataset | Full Read | Without Errors | Speedup |
+|---------|----------|----------------|---------|
+| 50n x 200r x 5 errors (10K records) | 952 us | 488 us | **1.95x (49% faster)** |
+| 100n x 500r x 10 errors (50K records) | 5.27 ms | 2.23 ms | **2.36x (58% faster)** |
+| 200n x 500r x 20 errors (100K records) | 13.46 ms | 4.50 ms | **2.99x (67% faster)** |
+
+The improvement scales with the number of error values per record, confirming that
+`ListArray` deserialisation is the dominant cost being avoided.
+
+## Test Plan
+
+- Added `tests/parquet_column_pruning.rs` with 8 integration tests:
+  - `test_full_profile_returns_errors` — full profile preserves errors
+  - `test_without_errors_profile_returns_empty_errors` — pruned profile returns empty errors
+  - `test_without_errors_preserves_other_fields` — obs_index, value, activation preserved
+  - `test_without_errors_preserves_nullable_value` — nullable value field handled correctly
+  - `test_grouped_read_without_errors` — grouped read with pruning works
+  - `test_grouped_read_full_profile_matches_original` — full profile matches original behaviour
+  - `test_limit_read_without_errors` — limit + pruning combination works
+  - `test_column_profile_debug_display` — enum variant distinction
+- All existing tests pass unchanged
+- `./quality.sh` passes cleanly

--- a/src/parquet_format/mod.rs
+++ b/src/parquet_format/mod.rs
@@ -11,9 +11,12 @@ mod writer;
 
 // Re-export public API at the parquet_format level for backward compatibility
 pub use reader::{
-    read_all_records_from_parquet, read_all_records_grouped_by_neuron,
-    read_all_records_grouped_by_neuron_with_deadline, read_records_from_parquet,
-    read_records_from_parquet_with_limit,
+    ColumnProfile, read_all_records_from_parquet, read_all_records_grouped_by_neuron,
+    read_all_records_grouped_by_neuron_with_deadline,
+    read_all_records_grouped_by_neuron_with_deadline_and_profile,
+    read_all_records_grouped_by_neuron_with_profile, read_records_from_parquet,
+    read_records_from_parquet_with_limit, read_records_from_parquet_with_limit_and_profile,
+    read_records_from_parquet_with_profile,
 };
 pub use schema::create_schema;
 pub use writer::{ParquetRecordWriter, merge_parquet_files, write_records_to_parquet};

--- a/src/parquet_format/reader.rs
+++ b/src/parquet_format/reader.rs
@@ -2,12 +2,42 @@
 
 use anyhow::{Context, Result};
 use arrow::array::{Array, Float32Array, ListArray, StringArray, UInt32Array};
+use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
 use crate::types::DiscoverRecord;
 use std::time::SystemTime;
+
+/// Column projection profiles for Parquet reads (Issue #1073).
+///
+/// Different analysis paths need different subsets of columns.
+/// Skipping unused columns (particularly the `errors` `ListArray`)
+/// reduces I/O and deserialisation overhead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnProfile {
+    /// All columns: `obs_index`, `neuron_uuid`, `value`, `activation`, `errors`.
+    Full,
+    /// Core analysis columns without errors: `obs_index`, `neuron_uuid`, `value`, `activation`.
+    /// Records returned with this profile have an empty `errors` vec.
+    WithoutErrors,
+}
+
+impl ColumnProfile {
+    /// Root column indices for the discovery Parquet schema.
+    fn root_indices(self) -> Vec<usize> {
+        match self {
+            Self::Full => vec![0, 1, 2, 3, 4],
+            Self::WithoutErrors => vec![0, 1, 2, 3],
+        }
+    }
+
+    /// Whether this profile includes the errors column.
+    fn includes_errors(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
 
 /// Open a parquet file, returning a clear "file removed" error if the file
 /// no longer exists on disk (Issue #1049).
@@ -37,6 +67,15 @@ pub fn read_all_records_grouped_by_neuron(
     read_all_records_grouped_by_neuron_with_deadline(file_path, None)
 }
 
+/// Read all records grouped by neuron UUID, using a column projection profile
+/// to skip unnecessary columns (Issue #1073).
+pub fn read_all_records_grouped_by_neuron_with_profile(
+    file_path: &str,
+    profile: ColumnProfile,
+) -> Result<HashMap<String, Vec<DiscoverRecord>>> {
+    read_all_records_grouped_by_neuron_with_deadline_and_profile(file_path, None, profile)
+}
+
 /// Read all discovery records from a Parquet file, grouped by neuron UUID,
 /// with optional deadline checking and watchdog beats (Issue #648).
 ///
@@ -47,6 +86,24 @@ pub fn read_all_records_grouped_by_neuron(
 pub fn read_all_records_grouped_by_neuron_with_deadline(
     file_path: &str,
     deadline: Option<SystemTime>,
+) -> Result<HashMap<String, Vec<DiscoverRecord>>> {
+    read_all_records_grouped_by_neuron_with_deadline_and_profile(
+        file_path,
+        deadline,
+        ColumnProfile::Full,
+    )
+}
+
+/// Read all discovery records grouped by neuron UUID with deadline checking
+/// and column projection (Issue #1073).
+///
+/// When `profile` is `WithoutErrors`, the `errors` `ListArray` column is
+/// skipped entirely during I/O and deserialisation. Records returned with
+/// this profile have an empty `errors` vec.
+pub fn read_all_records_grouped_by_neuron_with_deadline_and_profile(
+    file_path: &str,
+    deadline: Option<SystemTime>,
+    profile: ColumnProfile,
 ) -> Result<HashMap<String, Vec<DiscoverRecord>>> {
     // Check deadline before starting
     if let Some(dl) = deadline
@@ -60,8 +117,13 @@ pub fn read_all_records_grouped_by_neuron_with_deadline(
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
 
-    let reader = builder.build().context("Failed to build Parquet reader")?;
+    let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .context("Failed to build Parquet reader")?;
 
+    let include_errors = profile.includes_errors();
     let mut grouped_records: HashMap<String, Vec<DiscoverRecord>> = HashMap::new();
 
     for (batch_count, batch_result) in reader.enumerate() {
@@ -101,32 +163,52 @@ pub fn read_all_records_grouped_by_neuron_with_deadline(
 
         let batch = batch_result.context("Failed to read record batch")?;
 
-        // Get columns - use schema field names to find correct columns instead of hardcoded indices
+        // Column indices shift when projection is applied — use schema field names
+        let schema = batch.schema();
+        let obs_idx = schema
+            .index_of("obs_index")
+            .context("Missing obs_index column")?;
+        let uuid_idx = schema
+            .index_of("neuron_uuid")
+            .context("Missing neuron_uuid column")?;
+        let value_idx = schema.index_of("value").context("Missing value column")?;
+        let act_idx = schema
+            .index_of("activation")
+            .context("Missing activation column")?;
+
         let obs_index_col = batch
-            .column(0)
+            .column(obs_idx)
             .as_any()
             .downcast_ref::<UInt32Array>()
             .context("Failed to cast obs_index column")?;
         let neuron_uuid_col = batch
-            .column(1)
+            .column(uuid_idx)
             .as_any()
             .downcast_ref::<StringArray>()
             .context("Failed to cast neuron_uuid column")?;
         let value_col = batch
-            .column(2)
+            .column(value_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast value column")?;
         let activation_col = batch
-            .column(3)
+            .column(act_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast activation column")?;
-        let errors_col = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .context("Failed to cast errors column")?;
+
+        let errors_col = if include_errors {
+            let err_idx = schema.index_of("errors").context("Missing errors column")?;
+            Some(
+                batch
+                    .column(err_idx)
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .context("Failed to cast errors column")?,
+            )
+        } else {
+            None
+        };
 
         // Collect all records and group by neuron UUID
         for i in 0..batch.num_rows() {
@@ -139,15 +221,18 @@ pub fn read_all_records_grouped_by_neuron_with_deadline(
             };
             let activation = activation_col.value(i);
 
-            // Extract errors array
-            let errors_list = errors_col.value(i);
-            let errors_array = errors_list
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .context("Failed to cast errors array")?;
-            let errors: Vec<f32> = (0..errors_array.len())
-                .map(|j| errors_array.value(j))
-                .collect();
+            let errors = if let Some(errors_col) = errors_col {
+                let errors_list = errors_col.value(i);
+                let errors_array = errors_list
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .context("Failed to cast errors array")?;
+                (0..errors_array.len())
+                    .map(|j| errors_array.value(j))
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
             let record = DiscoverRecord::new(obs_index, uuid.clone(), value, activation, errors);
             grouped_records.entry(uuid).or_default().push(record);
@@ -164,44 +249,78 @@ pub fn read_records_from_parquet(
     file_path: &str,
     neuron_uuid: &str,
 ) -> Result<Vec<DiscoverRecord>> {
+    read_records_from_parquet_with_profile(file_path, neuron_uuid, ColumnProfile::Full)
+}
+
+/// Read discovery records filtered by neuron UUID, using a column projection
+/// profile to skip unnecessary columns (Issue #1073).
+pub fn read_records_from_parquet_with_profile(
+    file_path: &str,
+    neuron_uuid: &str,
+    profile: ColumnProfile,
+) -> Result<Vec<DiscoverRecord>> {
     let file = open_parquet_file(file_path)?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
 
-    let reader = builder.build().context("Failed to build Parquet reader")?;
+    let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .context("Failed to build Parquet reader")?;
 
+    let include_errors = profile.includes_errors();
     let mut records = Vec::new();
 
     for batch_result in reader {
         let batch = batch_result.context("Failed to read record batch")?;
 
-        // Get columns - use schema field names to find correct columns instead of hardcoded indices
+        let schema = batch.schema();
+        let obs_idx = schema
+            .index_of("obs_index")
+            .context("Missing obs_index column")?;
+        let uuid_idx = schema
+            .index_of("neuron_uuid")
+            .context("Missing neuron_uuid column")?;
+        let value_idx = schema.index_of("value").context("Missing value column")?;
+        let act_idx = schema
+            .index_of("activation")
+            .context("Missing activation column")?;
+
         let obs_index_col = batch
-            .column(0)
+            .column(obs_idx)
             .as_any()
             .downcast_ref::<UInt32Array>()
             .context("Failed to cast obs_index column")?;
         let neuron_uuid_col = batch
-            .column(1)
+            .column(uuid_idx)
             .as_any()
             .downcast_ref::<StringArray>()
             .context("Failed to cast neuron_uuid column")?;
         let value_col = batch
-            .column(2)
+            .column(value_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast value column")?;
         let activation_col = batch
-            .column(3)
+            .column(act_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast activation column")?;
-        let errors_col = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .context("Failed to cast errors column")?;
+
+        let errors_col = if include_errors {
+            let err_idx = schema.index_of("errors").context("Missing errors column")?;
+            Some(
+                batch
+                    .column(err_idx)
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .context("Failed to cast errors column")?,
+            )
+        } else {
+            None
+        };
 
         // Filter by neuron UUID and collect records
         for i in 0..batch.num_rows() {
@@ -215,15 +334,18 @@ pub fn read_records_from_parquet(
                 };
                 let activation = activation_col.value(i);
 
-                // Extract errors array
-                let errors_list = errors_col.value(i);
-                let errors_array = errors_list
-                    .as_any()
-                    .downcast_ref::<Float32Array>()
-                    .context("Failed to cast errors array")?;
-                let errors: Vec<f32> = (0..errors_array.len())
-                    .map(|j| errors_array.value(j))
-                    .collect();
+                let errors = if let Some(errors_col) = errors_col {
+                    let errors_list = errors_col.value(i);
+                    let errors_array = errors_list
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .context("Failed to cast errors array")?;
+                    (0..errors_array.len())
+                        .map(|j| errors_array.value(j))
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
                 records.push(DiscoverRecord::new(
                     obs_index,
@@ -266,6 +388,16 @@ pub fn read_records_from_parquet_with_limit(
     file_path: &str,
     max_obs: Option<u32>,
 ) -> Result<Vec<DiscoverRecord>> {
+    read_records_from_parquet_with_limit_and_profile(file_path, max_obs, ColumnProfile::Full)
+}
+
+/// Read discovery records with optional observation limit and column projection
+/// (Issue #1073).
+pub fn read_records_from_parquet_with_limit_and_profile(
+    file_path: &str,
+    max_obs: Option<u32>,
+    profile: ColumnProfile,
+) -> Result<Vec<DiscoverRecord>> {
     // Edge case: treat max_obs=0 as "return no rows".
     if matches!(max_obs, Some(0)) {
         return Ok(Vec::new());
@@ -276,39 +408,64 @@ pub fn read_records_from_parquet_with_limit(
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
 
-    let reader = builder.build().context("Failed to build Parquet reader")?;
+    let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .context("Failed to build Parquet reader")?;
 
+    let include_errors = profile.includes_errors();
     let mut records = Vec::new();
     let mut accepted_obs_indices: HashSet<u32> = HashSet::new();
 
     for batch_result in reader {
         let batch = batch_result.context("Failed to read record batch")?;
 
+        let schema = batch.schema();
+        let obs_col_idx = schema
+            .index_of("obs_index")
+            .context("Missing obs_index column")?;
+        let uuid_col_idx = schema
+            .index_of("neuron_uuid")
+            .context("Missing neuron_uuid column")?;
+        let value_col_idx = schema.index_of("value").context("Missing value column")?;
+        let act_col_idx = schema
+            .index_of("activation")
+            .context("Missing activation column")?;
+
         let obs_index_col = batch
-            .column(0)
+            .column(obs_col_idx)
             .as_any()
             .downcast_ref::<UInt32Array>()
             .context("Failed to cast obs_index column")?;
         let neuron_uuid_col = batch
-            .column(1)
+            .column(uuid_col_idx)
             .as_any()
             .downcast_ref::<StringArray>()
             .context("Failed to cast neuron_uuid column")?;
         let value_col = batch
-            .column(2)
+            .column(value_col_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast value column")?;
         let activation_col = batch
-            .column(3)
+            .column(act_col_idx)
             .as_any()
             .downcast_ref::<Float32Array>()
             .context("Failed to cast activation column")?;
-        let errors_col = batch
-            .column(4)
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .context("Failed to cast errors column")?;
+
+        let errors_col = if include_errors {
+            let err_idx = schema.index_of("errors").context("Missing errors column")?;
+            Some(
+                batch
+                    .column(err_idx)
+                    .as_any()
+                    .downcast_ref::<ListArray>()
+                    .context("Failed to cast errors column")?,
+            )
+        } else {
+            None
+        };
 
         for i in 0..batch.num_rows() {
             let obs_index = obs_index_col.value(i);
@@ -343,15 +500,18 @@ pub fn read_records_from_parquet_with_limit(
             };
             let activation = activation_col.value(i);
 
-            // Extract errors array
-            let errors_list = errors_col.value(i);
-            let errors_array = errors_list
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .context("Failed to cast errors array")?;
-            let errors: Vec<f32> = (0..errors_array.len())
-                .map(|j| errors_array.value(j))
-                .collect();
+            let errors = if let Some(errors_col) = errors_col {
+                let errors_list = errors_col.value(i);
+                let errors_array = errors_list
+                    .as_any()
+                    .downcast_ref::<Float32Array>()
+                    .context("Failed to cast errors array")?;
+                (0..errors_array.len())
+                    .map(|j| errors_array.value(j))
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
             records.push(DiscoverRecord::new(
                 obs_index,

--- a/tests/parquet_column_pruning.rs
+++ b/tests/parquet_column_pruning.rs
@@ -1,0 +1,162 @@
+//! Integration tests for Parquet column pruning (Issue #1073).
+//!
+//! Verifies that column projection profiles correctly skip the errors
+//! column while preserving all other record fields.
+
+use neat_ai_discovery::parquet_format::{
+    ColumnProfile, read_all_records_grouped_by_neuron_with_profile,
+    read_records_from_parquet_with_limit_and_profile, read_records_from_parquet_with_profile,
+    write_records_to_parquet,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use tempfile::NamedTempFile;
+
+/// Helper: create test records with known errors values.
+fn create_test_records() -> Vec<DiscoverRecord> {
+    vec![
+        DiscoverRecord::new(0, "neuron-a".to_string(), Some(0.5), 0.7, vec![0.1, 0.2]),
+        DiscoverRecord::new(1, "neuron-a".to_string(), Some(0.6), 0.8, vec![0.15, 0.25]),
+        DiscoverRecord::new(0, "neuron-b".to_string(), Some(0.3), 0.5, vec![0.05]),
+        DiscoverRecord::new(1, "neuron-b".to_string(), None, 0.6, vec![0.1]),
+    ]
+}
+
+/// Helper: write test records to a temp parquet file and return the path guard + path string.
+fn write_temp_parquet(records: &[DiscoverRecord]) -> (NamedTempFile, String) {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap().to_string();
+    write_records_to_parquet(&path, records).expect("Failed to write parquet");
+    (temp_file, path)
+}
+
+#[test]
+fn test_full_profile_returns_errors() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let result =
+        read_records_from_parquet_with_profile(&path, "neuron-a", ColumnProfile::Full).unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(
+        !result[0].errors.is_empty(),
+        "Full profile should include errors"
+    );
+    assert_eq!(result[0].errors.len(), 2);
+}
+
+#[test]
+fn test_without_errors_profile_returns_empty_errors() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let result =
+        read_records_from_parquet_with_profile(&path, "neuron-a", ColumnProfile::WithoutErrors)
+            .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(
+        result[0].errors.is_empty(),
+        "WithoutErrors profile should return empty errors vec"
+    );
+    assert!(result[1].errors.is_empty());
+}
+
+#[test]
+fn test_without_errors_preserves_other_fields() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let result =
+        read_records_from_parquet_with_profile(&path, "neuron-a", ColumnProfile::WithoutErrors)
+            .unwrap();
+
+    assert_eq!(result.len(), 2);
+
+    // Verify obs_index, value, and activation are preserved
+    let r0 = &result[0];
+    assert_eq!(r0.obs_index, 0);
+    assert_eq!(r0.value, Some(0.5));
+    assert!((r0.activation - 0.7).abs() < f32::EPSILON);
+
+    let r1 = &result[1];
+    assert_eq!(r1.obs_index, 1);
+    assert_eq!(r1.value, Some(0.6));
+    assert!((r1.activation - 0.8).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_without_errors_preserves_nullable_value() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let result =
+        read_records_from_parquet_with_profile(&path, "neuron-b", ColumnProfile::WithoutErrors)
+            .unwrap();
+
+    // neuron-b record at obs_index=1 has value=None
+    let null_value_record = result.iter().find(|r| r.obs_index == 1).unwrap();
+    assert_eq!(null_value_record.value, None);
+}
+
+#[test]
+fn test_grouped_read_without_errors() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let grouped =
+        read_all_records_grouped_by_neuron_with_profile(&path, ColumnProfile::WithoutErrors)
+            .unwrap();
+
+    assert_eq!(grouped.len(), 2);
+
+    let neuron_a = grouped.get("neuron-a").unwrap();
+    assert_eq!(neuron_a.len(), 2);
+    assert!(neuron_a[0].errors.is_empty());
+
+    let neuron_b = grouped.get("neuron-b").unwrap();
+    assert_eq!(neuron_b.len(), 2);
+    assert!(neuron_b[0].errors.is_empty());
+}
+
+#[test]
+fn test_grouped_read_full_profile_matches_original() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let grouped =
+        read_all_records_grouped_by_neuron_with_profile(&path, ColumnProfile::Full).unwrap();
+
+    let neuron_a = grouped.get("neuron-a").unwrap();
+    assert_eq!(neuron_a.len(), 2);
+    assert_eq!(neuron_a[0].errors.len(), 2);
+}
+
+#[test]
+fn test_limit_read_without_errors() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    let result = read_records_from_parquet_with_limit_and_profile(
+        &path,
+        Some(1),
+        ColumnProfile::WithoutErrors,
+    )
+    .unwrap();
+
+    // With max_obs=1, we get records for only one distinct obs_index
+    assert!(!result.is_empty());
+    let obs_indices: std::collections::HashSet<u32> = result.iter().map(|r| r.obs_index).collect();
+    assert_eq!(obs_indices.len(), 1);
+    assert!(result.iter().all(|r| r.errors.is_empty()));
+}
+
+#[test]
+fn test_column_profile_debug_display() {
+    // Verify ColumnProfile derives Debug and the variants are distinct
+    let full = format!("{:?}", ColumnProfile::Full);
+    let without = format!("{:?}", ColumnProfile::WithoutErrors);
+    assert_ne!(full, without);
+    assert!(full.contains("Full"));
+    assert!(without.contains("WithoutErrors"));
+}


### PR DESCRIPTION
## Summary

Add Parquet column pruning via `ProjectionMask` to skip the `errors` `ListArray` column
when it is not needed by the caller. Introduces a `ColumnProfile` enum with `Full` and
`WithoutErrors` variants, and new `_with_profile` reader functions that apply column
projection at the Parquet I/O level. Existing reader functions are unchanged and delegate
to the profile-aware versions with `ColumnProfile::Full`. Closes #1073.

## Evidence

Benchmark results from `cargo bench --bench parquet_loading_comparison -- parquet_column_pruning`:

| Dataset | Full Read | Without Errors | Speedup |
|---------|----------|----------------|---------|
| 50n x 200r x 5 errors (10K records) | 952 us | 488 us | **1.95x (49% faster)** |
| 100n x 500r x 10 errors (50K records) | 5.27 ms | 2.23 ms | **2.36x (58% faster)** |
| 200n x 500r x 20 errors (100K records) | 13.46 ms | 4.50 ms | **2.99x (67% faster)** |

The improvement scales with the number of error values per record, confirming that
`ListArray` deserialisation is the dominant cost being avoided.

## Test Plan

- Added `tests/parquet_column_pruning.rs` with 8 integration tests:
  - `test_full_profile_returns_errors` — full profile preserves errors
  - `test_without_errors_profile_returns_empty_errors` — pruned profile returns empty errors
  - `test_without_errors_preserves_other_fields` — obs_index, value, activation preserved
  - `test_without_errors_preserves_nullable_value` — nullable value field handled correctly
  - `test_grouped_read_without_errors` — grouped read with pruning works
  - `test_grouped_read_full_profile_matches_original` — full profile matches original behaviour
  - `test_limit_read_without_errors` — limit + pruning combination works
  - `test_column_profile_debug_display` — enum variant distinction
- All existing tests pass unchanged
- `./quality.sh` passes cleanly

---

## Automated Fix Details
This PR addresses issue #1073: **perf: add Parquet column pruning for analysis-specific reads**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1073
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1073 -->