### PR TITLE
feat: add periodic cleanup of orphaned streaming sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -605,6 +605,7 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_SOURCE_INPUT_INDEX_BIAS` | Bias toward newer inputs |
 | `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY` | Output-only focus targets |
 | `NEAT_AI_DISCOVERY_CONSTANT_SOURCE_EFFECT_THRESHOLD` | Constant source folding threshold |
+| `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` | Streaming session TTL for orphan cleanup (default 3600) |
 | `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | Metropolis-Hastings probabilistic acceptance temperature |
 
 See [README.md — Troubleshooting](README.md#troubleshooting) and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.48"
+version = "0.72.49"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1084.md
+++ b/docs/pr-summary-1084.md
@@ -1,0 +1,24 @@
+## Summary
+
+Add periodic cleanup of orphaned streaming sessions to prevent memory leaks when the host process crashes or fails to call `finish_discovery_session()` / `cancel_discovery_session()`. Closes #1084.
+
+**Changes:**
+
+- Added `created_at: Instant` field to `RecordingSession` to track session creation time
+- Added `cleanup_stale_sessions()` function that removes sessions exceeding the configurable TTL
+- Call `cleanup_stale_sessions()` at the start of `start_session()` (piggybacks on existing calls)
+- Added `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` environment variable (default 3600s / 1 hour, clamped to 60-86400)
+- Stale sessions are logged at `warn` level with session ID and age before removal
+- Temp files are cleaned up via the existing `Drop` implementation on `RecordingSession`
+- No impact on normal session lifecycle (finish/cancel still work as before)
+
+## Evidence
+All existing streaming tests continue to pass unchanged. Four new unit tests verify the cleanup behaviour.
+
+## Test Plan
+- `test_cleanup_stale_sessions_removes_expired` — verifies sessions older than TTL are removed
+- `test_cleanup_stale_sessions_preserves_fresh` — verifies fresh sessions survive cleanup
+- `test_cleanup_stale_sessions_cleans_temp_files` — verifies temp files are cleaned up when stale sessions are removed
+- `test_start_session_triggers_cleanup` — verifies cleanup is automatically triggered when starting a new session
+- `session_ttl_default_values` — verifies config constants
+- `session_ttl_returns_valid_value` — verifies config accessor returns a value within valid range

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,7 @@
 //! | `NEAT_AI_DISCOVERY_ZERO_COPY` | Option\<bool\> | auto | Force-enable/disable zero-copy buffers |
 //! | `NEAT_AI_DISCOVERY_QUIET_GPU` | bool | `false` | Suppress Mesa/libEGL debug output (Linux) |
 //! | `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | f32 | disabled | Metropolis-Hastings temperature for probabilistic acceptance (0.01–5.0) |
+//! | `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` | u64 | `3600` | Streaming session TTL for orphan cleanup (60–86400) |
 //! | `NEAT_AI_DISCOVERY_BATCH_SUCCESSFUL` | bool | `false` | Re-enable disabled batch-successful module (Issue #1059) |
 //!
 //! ## Observability Variables
@@ -127,6 +128,20 @@ mod tests {
         // (This test relies on the env var NOT being set in the test environment)
         let result = outlier_percentile();
         assert!(result > 0 && result < 100);
+    }
+
+    #[test]
+    fn session_ttl_default_values() {
+        assert_eq!(DEFAULT_SESSION_TTL_SECS, 3600);
+        assert_eq!(MIN_SESSION_TTL_SECS, 60);
+        assert_eq!(MAX_SESSION_TTL_SECS, 86400);
+    }
+
+    #[test]
+    fn session_ttl_returns_valid_value() {
+        // When no env var is set, should return the default (3600)
+        let result = session_ttl_secs();
+        assert!((MIN_SESSION_TTL_SECS..=MAX_SESSION_TTL_SECS).contains(&result));
     }
 
     #[test]

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -337,6 +337,31 @@ pub fn batch_successful_enabled() -> bool {
     parse_bool_env("NEAT_AI_DISCOVERY_BATCH_SUCCESSFUL")
 }
 
+/// Default streaming session TTL in seconds (1 hour).
+pub const DEFAULT_SESSION_TTL_SECS: u64 = 3600;
+
+/// Minimum streaming session TTL in seconds (60 seconds).
+pub const MIN_SESSION_TTL_SECS: u64 = 60;
+
+/// Maximum streaming session TTL in seconds (24 hours).
+pub const MAX_SESSION_TTL_SECS: u64 = 86400;
+
+/// Get the streaming session TTL (time-to-live) in seconds.
+///
+/// Set `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` to control how long orphaned
+/// streaming sessions are kept before automatic cleanup. Sessions older than
+/// this threshold are removed at the start of each new `start_discovery_session()`
+/// call.
+///
+/// Default: 3600 (1 hour). Clamped to 60–86400.
+pub fn session_ttl_secs() -> u64 {
+    std::env::var("NEAT_AI_DISCOVERY_SESSION_TTL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SESSION_TTL_SECS)
+        .clamp(MIN_SESSION_TTL_SECS, MAX_SESSION_TTL_SECS)
+}
+
 /// Get the macOS `sample` program path for thread dumps.
 ///
 /// Set `NEAT_AI_DISCOVERY_SAMPLE_PROGRAM` to override.

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -36,6 +36,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
+use std::time::Instant;
 
 use crate::parquet_format::ParquetRecordWriter;
 use crate::types::DiscoverRecord;
@@ -60,6 +61,7 @@ pub struct RecordingSession {
     parquet_path: String,
     records_written: u64,
     finished: bool,
+    created_at: Instant,
 }
 
 impl RecordingSession {
@@ -82,6 +84,7 @@ impl RecordingSession {
             parquet_path: parquet_path.to_string(),
             records_written: 0,
             finished: false,
+            created_at: Instant::now(),
         })
     }
 }
@@ -105,10 +108,46 @@ impl Drop for RecordingSession {
     }
 }
 
+/// Remove streaming sessions that have exceeded the configured TTL.
+///
+/// This is called automatically at the start of each `start_session()` call
+/// to prevent orphaned sessions from leaking memory when the host process
+/// crashes or fails to call finish/cancel. Stale sessions are logged at
+/// `warn` level before removal; their temp files are cleaned up via the
+/// `Drop` implementation on `RecordingSession`.
+pub fn cleanup_stale_sessions() {
+    let ttl_secs = crate::config::session_ttl_secs();
+    let ttl = std::time::Duration::from_secs(ttl_secs);
+    let mut sessions = SESSIONS.lock();
+
+    let stale_ids: Vec<String> = sessions
+        .iter()
+        .filter_map(|(id, session)| {
+            let age = session.created_at.elapsed();
+            if age > ttl { Some(id.clone()) } else { None }
+        })
+        .collect();
+
+    for id in stale_ids {
+        if let Some(session) = sessions.remove(&id) {
+            let age_secs = session.created_at.elapsed().as_secs();
+            tracing::warn!(
+                session_id = %id,
+                age_secs = age_secs,
+                ttl_secs = ttl_secs,
+                "Removing stale streaming session (exceeded TTL)"
+            );
+            // Session `Drop` cleans up the incomplete temporary file
+        }
+    }
+}
+
 /// Start a new recording session
 ///
 /// Creates a Parquet file and returns a session ID for subsequent append/finish calls.
 pub fn start_session(creature: CreatureJson, temp_dir: String) -> Result<String> {
+    // Clean up any orphaned sessions that have exceeded the TTL
+    cleanup_stale_sessions();
     // Create temp directory
     let temp_path = Path::new(&temp_dir);
     fs::create_dir_all(temp_path)
@@ -284,6 +323,7 @@ pub fn active_session_count() -> usize {
 mod tests {
     use super::*;
     use crate::{NeuronData, NeuronJson};
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn session_exists(session_id: &str) -> bool {
@@ -632,5 +672,137 @@ mod tests {
 
         let (_, _, total) = finish_session(&session_id).unwrap();
         assert_eq!(total, written);
+    }
+
+    #[test]
+    fn test_cleanup_stale_sessions_removes_expired() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        // Start a session and manually backdate its creation time
+        let session_id = start_session(creature, temp_path).unwrap();
+        assert!(session_exists(&session_id));
+
+        // Backdate the session's created_at to be well past any TTL
+        {
+            let mut sessions = SESSIONS.lock();
+            if let Some(session) = sessions.get_mut(&session_id) {
+                // Set created_at to 2 hours ago (exceeds default 1-hour TTL)
+                session.created_at = Instant::now() - Duration::from_secs(7200);
+            }
+        }
+
+        // Run cleanup — should remove the stale session
+        cleanup_stale_sessions();
+
+        assert!(
+            !session_exists(&session_id),
+            "expected stale session to be removed after cleanup"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_stale_sessions_preserves_fresh() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        // Start a fresh session (created_at is now)
+        let session_id = start_session(creature, temp_path).unwrap();
+        assert!(session_exists(&session_id));
+
+        // Run cleanup — fresh session should survive
+        cleanup_stale_sessions();
+
+        assert!(
+            session_exists(&session_id),
+            "expected fresh session to survive cleanup"
+        );
+
+        // Clean up
+        cancel_session(&session_id).unwrap();
+    }
+
+    #[test]
+    fn test_cleanup_stale_sessions_cleans_temp_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let creature = create_test_creature();
+        let temp_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let session_id = start_session(creature, temp_path.clone()).unwrap();
+
+        // Write some records so a temp file exists on disk
+        let batch = vec![(
+            0u32,
+            vec![NeuronData {
+                neuron_uuid: "hidden-1".to_string(),
+                activation: 0.5,
+                value: Some(0.4),
+                errors: vec![0.1],
+            }],
+            vec![0.1, 0.2],
+        )];
+        append_records(&session_id, batch).unwrap();
+
+        let tmp_file = Path::new(&temp_path).join("discovery_data.parquet.tmp");
+        assert!(
+            tmp_file.exists(),
+            "expected tmp file to exist before cleanup"
+        );
+
+        // Backdate the session
+        {
+            let mut sessions = SESSIONS.lock();
+            if let Some(session) = sessions.get_mut(&session_id) {
+                session.created_at = Instant::now() - Duration::from_secs(7200);
+            }
+        }
+
+        // Run cleanup — should remove the session and its temp file via Drop
+        cleanup_stale_sessions();
+
+        assert!(
+            !session_exists(&session_id),
+            "expected stale session to be removed"
+        );
+        assert!(
+            !tmp_file.exists(),
+            "expected tmp file to be cleaned up when stale session is removed"
+        );
+    }
+
+    #[test]
+    fn test_start_session_triggers_cleanup() {
+        let temp_dir1 = TempDir::new().unwrap();
+        let temp_dir2 = TempDir::new().unwrap();
+        let creature1 = create_test_creature();
+        let creature2 = create_test_creature();
+
+        // Start first session and backdate it
+        let session_id1 =
+            start_session(creature1, temp_dir1.path().to_str().unwrap().to_string()).unwrap();
+        {
+            let mut sessions = SESSIONS.lock();
+            if let Some(session) = sessions.get_mut(&session_id1) {
+                session.created_at = Instant::now() - Duration::from_secs(7200);
+            }
+        }
+
+        // Starting a new session should trigger cleanup of the stale one
+        let session_id2 =
+            start_session(creature2, temp_dir2.path().to_str().unwrap().to_string()).unwrap();
+
+        assert!(
+            !session_exists(&session_id1),
+            "expected stale session to be cleaned up when starting new session"
+        );
+        assert!(
+            session_exists(&session_id2),
+            "expected new session to exist"
+        );
+
+        // Clean up
+        cancel_session(&session_id2).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Add periodic cleanup of orphaned streaming sessions to prevent memory leaks when the host process crashes or fails to call `finish_discovery_session()` / `cancel_discovery_session()`. Closes #1084.

**Changes:**

- Added `created_at: Instant` field to `RecordingSession` to track session creation time
- Added `cleanup_stale_sessions()` function that removes sessions exceeding the configurable TTL
- Call `cleanup_stale_sessions()` at the start of `start_session()` (piggybacks on existing calls)
- Added `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` environment variable (default 3600s / 1 hour, clamped to 60-86400)
- Stale sessions are logged at `warn` level with session ID and age before removal
- Temp files are cleaned up via the existing `Drop` implementation on `RecordingSession`
- No impact on normal session lifecycle (finish/cancel still work as before)

## Evidence
All existing streaming tests continue to pass unchanged. Four new unit tests verify the cleanup behaviour.

## Test Plan
- `test_cleanup_stale_sessions_removes_expired` — verifies sessions older than TTL are removed
- `test_cleanup_stale_sessions_preserves_fresh` — verifies fresh sessions survive cleanup
- `test_cleanup_stale_sessions_cleans_temp_files` — verifies temp files are cleaned up when stale sessions are removed
- `test_start_session_triggers_cleanup` — verifies cleanup is automatically triggered when starting a new session
- `session_ttl_default_values` — verifies config constants
- `session_ttl_returns_valid_value` — verifies config accessor returns a value within valid range

---

## Automated Fix Details
This PR addresses issue #1084: **Add periodic cleanup of orphaned streaming sessions**


## Quality Checks
- Followed TDD methodology
- All new functionality has corresponding tests
- Ran `./quality.sh` - all checks pass

## Notes
- No existing tests were removed or commented out
- If any test modifications were required due to business logic changes, they are documented in the commits

Closes #1084
---

🤖 Processed by: stservice
<!-- vibe-worker-issue-1084 -->