### PR TITLE
feat: reduce GPU batch size on memory exhaustion before retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.50"
+version = "0.72.51"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1083.md
+++ b/docs/pr-summary-1083.md
@@ -1,0 +1,33 @@
+## Summary
+
+Reduce GPU batch size on memory exhaustion before retry. When an OOM error occurs during GPU execution, the retry loop now halves the batch size (down to a minimum floor of 64 samples) before re-initialising the `GpuAnalyzer`. This makes GPU recovery more likely to succeed on memory-constrained systems. Closes #1083.
+
+## Changes
+
+- **`src/analysis/gpu/queue/recovery.rs`**: Added `is_memory_exhaustion_error()` to detect OOM-specific errors (subset of `is_device_lost_error`), and `MINIMUM_GPU_BATCH_SIZE` constant (64) as the reduction floor
+- **`src/analysis/gpu/analyzer.rs`**: Added `new_with_batch_size()` to create a `GpuAnalyzer` with an overridden batch size, and `batch_size()` accessor
+- **`src/analysis/gpu/queue/execution.rs`**: Modified the retry loop to halve batch size on OOM, enforce the minimum floor, and use `new_with_batch_size()` for recovery. The reduced batch size persists for subsequent requests
+- **`src/observability/gpu_metrics.rs`**: Added `effective_batch_size` and `batch_size_reductions` tracking, exposed in the metrics report
+- **`src/analysis/gpu/mod.rs`**: Re-exported new public symbols
+
+## Evidence
+
+This is a backend change with no UI. Verified via:
+- 9 new integration tests all passing
+- 17 unit tests in recovery module all passing
+- Full quality gate (`./quality.sh`) passes cleanly
+
+## Test Plan
+
+- Added `tests/gpu/issue_1083_gpu_batch_size_reduction.rs` with 9 tests:
+  - `test_memory_exhaustion_detects_oom_patterns` — OOM pattern detection
+  - `test_memory_exhaustion_ignores_non_memory_errors` — non-OOM errors not matched
+  - `test_memory_exhaustion_detection_is_case_insensitive` — case insensitivity
+  - `test_minimum_batch_size_is_64` — constant verification
+  - `test_batch_size_halving_above_minimum` — halving stays above floor
+  - `test_batch_size_halving_reaches_minimum` — iterative halving reaches floor
+  - `test_batch_size_below_minimum_cannot_reduce` — below-floor detection
+  - `test_batch_size_reduction_from_large_value` — reduction from 1024
+  - `test_gpu_metrics_tracks_batch_size_reduction` — metrics tracking
+- Added 4 unit tests in `recovery.rs` for `is_memory_exhaustion_error` and `MINIMUM_GPU_BATCH_SIZE`
+- Existing GPU recovery tests (issue #647) continue to pass

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -457,6 +457,22 @@ impl GpuAnalyzer {
             batch_size,
         })
     }
+
+    /// Create a new `GpuAnalyzer` with all pipelines initialised, overriding
+    /// the auto-detected batch size (Issue #1083).
+    ///
+    /// Used by the GPU recovery loop to re-initialise with a reduced batch size
+    /// after memory exhaustion.
+    pub fn new_with_batch_size(batch_size_override: usize) -> Result<Self> {
+        let mut analyzer = Self::new()?;
+        analyzer.batch_size = batch_size_override;
+        Ok(analyzer)
+    }
+
+    /// Return the current effective batch size.
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
 }
 
 #[cfg(test)]

--- a/src/analysis/gpu/mod.rs
+++ b/src/analysis/gpu/mod.rs
@@ -61,7 +61,8 @@ pub use analyzer::{GPU_MAX_BATCH_ALLOC_BYTES, GpuAnalyzer, GpuEvaluator};
 pub use queue::GpuWorkQueue;
 pub use queue::recovery::{
     DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, DEFAULT_GPU_RETRY_LIMIT,
-    GPU_RETRY_LIMIT_ENV, backoff_delay_ms, get_gpu_retry_limit, is_device_lost_error,
+    GPU_RETRY_LIMIT_ENV, MINIMUM_GPU_BATCH_SIZE, backoff_delay_ms, get_gpu_retry_limit,
+    is_device_lost_error, is_memory_exhaustion_error,
 };
 
 // Re-export shader module contents (Issue #277)

--- a/src/analysis/gpu/queue/execution.rs
+++ b/src/analysis/gpu/queue/execution.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use super::recovery::{
-    DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, backoff_delay_ms, get_gpu_retry_limit,
-    is_device_lost_error,
+    DEFAULT_BACKOFF_INITIAL_MS, DEFAULT_BACKOFF_MAX_MS, MINIMUM_GPU_BATCH_SIZE, backoff_delay_ms,
+    get_gpu_retry_limit, is_device_lost_error, is_memory_exhaustion_error,
 };
 use super::{GpuWorkQueue, GpuWorkRequest};
 use crate::analysis::gpu::analyzer::{GpuAnalyzer, GpuEvaluator};
@@ -297,12 +297,50 @@ impl GpuWorkQueue {
                     }
                 }
                 Err(device_err) => {
-                    // Device-lost detected — attempt recovery
+                    let is_oom = is_memory_exhaustion_error(&device_err);
+
                     tracing::warn!(
                         error = %device_err,
                         retry_limit = retry_limit,
+                        is_memory_exhaustion = is_oom,
                         "GPU device-lost detected — attempting recovery"
                     );
+
+                    // Issue #1083: On OOM, halve the batch size for retry.
+                    // Track the effective batch size so subsequent requests
+                    // also use the reduced value.
+                    let mut effective_batch_size = analyzer.batch_size();
+                    if is_oom {
+                        let new_size = effective_batch_size / 2;
+                        if new_size < MINIMUM_GPU_BATCH_SIZE {
+                            tracing::warn!(
+                                current_batch_size = effective_batch_size,
+                                minimum_batch_size = MINIMUM_GPU_BATCH_SIZE,
+                                "GPU batch size already at or below minimum — \
+                                 cannot reduce further, propagating OOM error"
+                            );
+                            send_error_to_request(
+                                &request,
+                                &format!(
+                                    "GPU memory exhaustion with batch size {effective_batch_size} \
+                                     (minimum {MINIMUM_GPU_BATCH_SIZE}) — cannot reduce further: \
+                                     {device_err}"
+                                ),
+                            );
+                            continue;
+                        }
+                        effective_batch_size = new_size;
+                        tracing::warn!(
+                            previous_batch_size = effective_batch_size * 2,
+                            new_batch_size = effective_batch_size,
+                            "Reducing GPU batch size due to memory exhaustion — \
+                             consider tuning NEAT_AI_DISCOVERY_GPU_BATCH_SIZE"
+                        );
+                        if track_metrics {
+                            let metrics = global_gpu_metrics();
+                            metrics.record_batch_size_reduction(effective_batch_size);
+                        }
+                    }
 
                     let mut recovered = false;
                     for attempt in 1..=retry_limit {
@@ -315,25 +353,33 @@ impl GpuWorkQueue {
                             attempt = attempt,
                             max_attempts = retry_limit,
                             backoff_ms = delay_ms,
+                            effective_batch_size = effective_batch_size,
                             error = %device_err,
                             "GPU recovery attempt {attempt}/{retry_limit} — \
                              waiting {delay_ms}ms before re-initialising GpuAnalyzer"
                         );
                         std::thread::sleep(Duration::from_millis(delay_ms));
 
-                        match GpuAnalyzer::new() {
+                        let init_result = if is_oom {
+                            GpuAnalyzer::new_with_batch_size(effective_batch_size)
+                        } else {
+                            GpuAnalyzer::new()
+                        };
+
+                        match init_result {
                             Ok(new_analyzer) => {
                                 analyzer = new_analyzer;
                                 tracing::warn!(
                                     attempt = attempt,
+                                    batch_size = analyzer.batch_size(),
                                     "GPU device recovered — retrying failed work item"
                                 );
 
-                                // Retry the failed request with the new analyser
                                 match execute_request(&analyzer, &request, track_metrics) {
                                     Ok(()) => {
                                         tracing::warn!(
                                             attempt = attempt,
+                                            batch_size = analyzer.batch_size(),
                                             "GPU work item succeeded after recovery"
                                         );
                                         recovered = true;
@@ -345,7 +391,6 @@ impl GpuWorkQueue {
                                             error = %retry_err,
                                             "GPU work item failed again after recovery"
                                         );
-                                        // Continue to next attempt
                                     }
                                 }
                             }
@@ -355,7 +400,6 @@ impl GpuWorkQueue {
                                     error = %init_err,
                                     "GpuAnalyzer re-initialisation failed"
                                 );
-                                // Continue to next attempt
                             }
                         }
                     }
@@ -366,9 +410,6 @@ impl GpuWorkQueue {
                             "GPU recovery exhausted all {retry_limit} attempts — \
                              error propagated to caller"
                         );
-                        // The error was already sent to the response channel
-                        // in execute_request (or the channel was dropped).
-                        // Send the error back if the response channel is still open.
                         send_error_to_request(
                             &request,
                             &format!(

--- a/src/analysis/gpu/queue/recovery.rs
+++ b/src/analysis/gpu/queue/recovery.rs
@@ -9,6 +9,10 @@
 /// propagating the error to the caller.
 pub const DEFAULT_GPU_RETRY_LIMIT: u32 = 3;
 
+/// Minimum GPU batch size floor (Issue #1083). Below this threshold, memory
+/// exhaustion errors are propagated rather than retrying with a smaller batch.
+pub const MINIMUM_GPU_BATCH_SIZE: usize = 64;
+
 /// Environment variable name for configuring the GPU retry limit.
 pub const GPU_RETRY_LIMIT_ENV: &str = "NEAT_AI_DISCOVERY_GPU_RETRY_LIMIT";
 
@@ -65,6 +69,16 @@ pub fn is_device_lost_error(error: &anyhow::Error) -> bool {
         || msg.contains("device creation failed")
         || msg.contains("gpu driver")
         || msg.contains("driver may be unresponsive")
+}
+
+/// Check whether an error specifically indicates GPU memory exhaustion.
+///
+/// This is a subset of `is_device_lost_error` — it matches only memory-related
+/// patterns ("out of memory", "allocation failed"). Used by the retry loop
+/// (Issue #1083) to decide whether to reduce batch size before retrying.
+pub fn is_memory_exhaustion_error(error: &anyhow::Error) -> bool {
+    let msg = format!("{error:#}").to_lowercase();
+    msg.contains("out of memory") || msg.contains("allocation failed")
 }
 
 #[cfg(test)]
@@ -192,5 +206,50 @@ mod tests {
     fn test_default_backoff_constants() {
         assert_eq!(DEFAULT_BACKOFF_INITIAL_MS, 10);
         assert_eq!(DEFAULT_BACKOFF_MAX_MS, 1_000);
+    }
+
+    #[test]
+    fn test_minimum_gpu_batch_size_constant() {
+        assert_eq!(MINIMUM_GPU_BATCH_SIZE, 64);
+    }
+
+    #[test]
+    fn test_is_memory_exhaustion_error_detects_oom() {
+        let cases = vec![
+            "Out of memory allocating GPU buffer",
+            "wgpu: allocation failed for 256MB buffer",
+            "GPU allocation failed",
+        ];
+        for msg in cases {
+            let err = anyhow::anyhow!("{msg}");
+            assert!(
+                is_memory_exhaustion_error(&err),
+                "Expected memory exhaustion detection for: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_memory_exhaustion_error_ignores_non_memory_errors() {
+        let cases = vec![
+            "Device is lost",
+            "device lost during operation",
+            "Internal error in GPU pipeline",
+            "Too many command buffers in flight",
+            "Invalid input data",
+        ];
+        for msg in cases {
+            let err = anyhow::anyhow!("{msg}");
+            assert!(
+                !is_memory_exhaustion_error(&err),
+                "Should not detect memory exhaustion for: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_memory_exhaustion_error_case_insensitive() {
+        let err = anyhow::anyhow!("OUT OF MEMORY");
+        assert!(is_memory_exhaustion_error(&err));
     }
 }

--- a/src/observability/gpu_metrics.rs
+++ b/src/observability/gpu_metrics.rs
@@ -39,6 +39,8 @@ pub struct GpuMetrics {
     total_samples_processed: AtomicUsize,
     queue_wait_time_us: AtomicU64,
     gpu_busy_time_us: AtomicU64,
+    effective_batch_size: AtomicUsize,
+    batch_size_reductions: AtomicUsize,
 }
 
 impl GpuMetrics {
@@ -49,6 +51,8 @@ impl GpuMetrics {
             total_samples_processed: AtomicUsize::new(0),
             queue_wait_time_us: AtomicU64::new(0),
             gpu_busy_time_us: AtomicU64::new(0),
+            effective_batch_size: AtomicUsize::new(0),
+            batch_size_reductions: AtomicUsize::new(0),
         }
     }
 
@@ -96,6 +100,26 @@ impl GpuMetrics {
         self.gpu_busy_time_us.load(Ordering::Relaxed)
     }
 
+    /// Record a batch size reduction due to memory exhaustion (Issue #1083).
+    #[inline]
+    pub fn record_batch_size_reduction(&self, new_batch_size: usize) {
+        self.effective_batch_size
+            .store(new_batch_size, Ordering::Relaxed);
+        self.batch_size_reductions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Get the current effective batch size (0 if never reduced).
+    #[inline]
+    pub fn effective_batch_size(&self) -> usize {
+        self.effective_batch_size.load(Ordering::Relaxed)
+    }
+
+    /// Get the number of batch size reductions due to memory exhaustion.
+    #[inline]
+    pub fn batch_size_reductions(&self) -> usize {
+        self.batch_size_reductions.load(Ordering::Relaxed)
+    }
+
     /// Calculate GPU utilisation as a percentage.
     ///
     /// Returns the percentage of time the GPU was busy vs total time
@@ -115,10 +139,14 @@ impl GpuMetrics {
     ///
     /// Output format: `[gpu] batches: N, samples: N, utilisation: N.N%`
     pub fn report(&self) {
+        let reductions = self.batch_size_reductions();
+        let effective = self.effective_batch_size();
         tracing::info!(
             batches = self.batch_count(),
             samples = self.total_samples_processed(),
             utilisation_percent = format_args!("{:.1}", self.utilisation_percent()),
+            batch_size_reductions = reductions,
+            effective_batch_size = effective,
             "GPU metrics"
         );
     }

--- a/tests/gpu/issue_1083_gpu_batch_size_reduction.rs
+++ b/tests/gpu/issue_1083_gpu_batch_size_reduction.rs
@@ -1,0 +1,146 @@
+//! Integration tests for GPU batch size reduction on memory exhaustion (Issue #1083)
+//!
+//! Verifies that the memory exhaustion detection correctly identifies OOM errors,
+//! that batch size halving respects the minimum floor, and that the metrics
+//! track batch size reductions.
+
+use neat_ai_discovery::analysis::gpu::{
+    MINIMUM_GPU_BATCH_SIZE, is_device_lost_error, is_memory_exhaustion_error,
+};
+
+// =============================================================================
+// Memory exhaustion detection
+// =============================================================================
+
+#[test]
+fn test_memory_exhaustion_detects_oom_patterns() {
+    let oom_messages = vec![
+        "Out of memory allocating GPU buffer",
+        "wgpu: out of memory when creating staging buffer",
+        "allocation failed for 256MB compute buffer",
+        "GPU allocation failed",
+    ];
+
+    for msg in oom_messages {
+        let err = anyhow::anyhow!("{msg}");
+        assert!(
+            is_memory_exhaustion_error(&err),
+            "Expected memory exhaustion detection for: {msg}"
+        );
+        assert!(
+            is_device_lost_error(&err),
+            "OOM errors should also be detected as device-lost: {msg}"
+        );
+    }
+}
+
+#[test]
+fn test_memory_exhaustion_ignores_non_memory_errors() {
+    let non_memory_errors = vec![
+        "Device is lost",
+        "device lost during operation",
+        "Internal error in GPU pipeline",
+        "Too many command buffers in flight",
+        "Invalid input data",
+        "Channel disconnected",
+        "GPU driver may be unresponsive",
+    ];
+
+    for msg in non_memory_errors {
+        let err = anyhow::anyhow!("{msg}");
+        assert!(
+            !is_memory_exhaustion_error(&err),
+            "Should NOT detect memory exhaustion for: {msg}"
+        );
+    }
+}
+
+#[test]
+fn test_memory_exhaustion_detection_is_case_insensitive() {
+    let variations = vec![
+        "OUT OF MEMORY",
+        "Out Of Memory",
+        "out of memory",
+        "ALLOCATION FAILED",
+        "Allocation Failed",
+    ];
+
+    for msg in variations {
+        let err = anyhow::anyhow!("{msg}");
+        assert!(
+            is_memory_exhaustion_error(&err),
+            "Expected case-insensitive detection for: {msg}"
+        );
+    }
+}
+
+// =============================================================================
+// Batch size reduction logic
+// =============================================================================
+
+#[test]
+fn test_minimum_batch_size_is_64() {
+    assert_eq!(MINIMUM_GPU_BATCH_SIZE, 64);
+}
+
+#[test]
+fn test_batch_size_halving_above_minimum() {
+    let initial = 512_usize;
+    let reduced = initial / 2;
+    assert_eq!(reduced, 256);
+    assert!(reduced >= MINIMUM_GPU_BATCH_SIZE);
+}
+
+#[test]
+fn test_batch_size_halving_reaches_minimum() {
+    let mut batch_size = 512_usize;
+    let mut reductions = 0;
+    while batch_size / 2 >= MINIMUM_GPU_BATCH_SIZE {
+        batch_size /= 2;
+        reductions += 1;
+    }
+    assert_eq!(batch_size, 64);
+    assert_eq!(reductions, 3); // 512 -> 256 -> 128 -> 64
+}
+
+#[test]
+fn test_batch_size_below_minimum_cannot_reduce() {
+    let batch_size = 64_usize;
+    let proposed = batch_size / 2;
+    assert!(
+        proposed < MINIMUM_GPU_BATCH_SIZE,
+        "Halving {batch_size} should fall below minimum {MINIMUM_GPU_BATCH_SIZE}"
+    );
+}
+
+#[test]
+fn test_batch_size_reduction_from_large_value() {
+    let mut batch_size = 1024_usize;
+    let mut reductions = 0;
+    while batch_size / 2 >= MINIMUM_GPU_BATCH_SIZE {
+        batch_size /= 2;
+        reductions += 1;
+    }
+    assert_eq!(batch_size, 64);
+    assert_eq!(reductions, 4); // 1024 -> 512 -> 256 -> 128 -> 64
+}
+
+// =============================================================================
+// GPU metrics batch size tracking
+// =============================================================================
+
+#[test]
+fn test_gpu_metrics_tracks_batch_size_reduction() {
+    let metrics = neat_ai_discovery::observability::GpuMetrics::new();
+
+    assert_eq!(metrics.effective_batch_size(), 0);
+    assert_eq!(metrics.batch_size_reductions(), 0);
+
+    metrics.record_batch_size_reduction(256);
+    assert_eq!(metrics.effective_batch_size(), 256);
+    assert_eq!(metrics.batch_size_reductions(), 1);
+
+    metrics.record_batch_size_reduction(128);
+    assert_eq!(metrics.effective_batch_size(), 128);
+    assert_eq!(metrics.batch_size_reductions(), 2);
+}

--- a/tests/gpu/main.rs
+++ b/tests/gpu/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod gpu_activation_shaders;
 mod gpu_work_queue;
 mod gpu_workgroup_reduction;
+mod issue_1083_gpu_batch_size_reduction;
 mod issue_647_gpu_device_lost_recovery;
 mod issue_713_deduplicate_gpu_env_setup;
 mod issue_807_gpu_queue_tracing;


### PR DESCRIPTION
## Summary

Reduce GPU batch size on memory exhaustion before retry. When an OOM error occurs during GPU execution, the retry loop now halves the batch size (down to a minimum floor of 64 samples) before re-initialising the `GpuAnalyzer`. This makes GPU recovery more likely to succeed on memory-constrained systems. Closes #1083.

## Changes

- **`src/analysis/gpu/queue/recovery.rs`**: Added `is_memory_exhaustion_error()` to detect OOM-specific errors (subset of `is_device_lost_error`), and `MINIMUM_GPU_BATCH_SIZE` constant (64) as the reduction floor
- **`src/analysis/gpu/analyzer.rs`**: Added `new_with_batch_size()` to create a `GpuAnalyzer` with an overridden batch size, and `batch_size()` accessor
- **`src/analysis/gpu/queue/execution.rs`**: Modified the retry loop to halve batch size on OOM, enforce the minimum floor, and use `new_with_batch_size()` for recovery. The reduced batch size persists for subsequent requests
- **`src/observability/gpu_metrics.rs`**: Added `effective_batch_size` and `batch_size_reductions` tracking, exposed in the metrics report
- **`src/analysis/gpu/mod.rs`**: Re-exported new public symbols

## Evidence

This is a backend change with no UI. Verified via:
- 9 new integration tests all passing
- 17 unit tests in recovery module all passing
- Full quality gate (`./quality.sh`) passes cleanly

## Test Plan

- Added `tests/gpu/issue_1083_gpu_batch_size_reduction.rs` with 9 tests:
  - `test_memory_exhaustion_detects_oom_patterns` — OOM pattern detection
  - `test_memory_exhaustion_ignores_non_memory_errors` — non-OOM errors not matched
  - `test_memory_exhaustion_detection_is_case_insensitive` — case insensitivity
  - `test_minimum_batch_size_is_64` — constant verification
  - `test_batch_size_halving_above_minimum` — halving stays above floor
  - `test_batch_size_halving_reaches_minimum` — iterative halving reaches floor
  - `test_batch_size_below_minimum_cannot_reduce` — below-floor detection
  - `test_batch_size_reduction_from_large_value` — reduction from 1024
  - `test_gpu_metrics_tracks_batch_size_reduction` — metrics tracking
- Added 4 unit tests in `recovery.rs` for `is_memory_exhaustion_error` and `MINIMUM_GPU_BATCH_SIZE`
- Existing GPU recovery tests (issue #647) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)