### PR TITLE
feat: enrich error context in analysis pipeline paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.51"
+version = "0.72.52"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1086.md
+++ b/docs/pr-summary-1086.md
@@ -1,0 +1,30 @@
+## Summary
+
+Enrich error context across the analysis pipeline by adding `.context()` annotations to all major phase transitions, GPU queue creation, parquet cache loading, and per-neuron/synapse analysis paths. This produces readable error chains (e.g., "failed during synapse analysis phase: GPU batch evaluation timed out") that help the TypeScript host trace error origins through the multi-stage pipeline. Closes #1086.
+
+No new dependencies added — uses existing `anyhow::Context`.
+
+## Changes
+
+- **`src/analysis/orchestration.rs`** — Added context to `run_optional_analysis` (phase name in errors), `dispatch_analyses` (synapse/neuron phase identification), GPU queue creation, parquet cache loading, and analysis dispatch error paths.
+- **`src/analysis/neuron/mod.rs`** — Added context to input validation, parquet cache loading, GPU queue creation, analysis preparation, source record loading (includes neuron UUID), and GPU evaluation (includes neuron UUID).
+- **`src/analysis/synapse/mod.rs`** — Added context to input validation, parquet cache loading, and GPU queue creation.
+- **`src/analysis/synapse/orchestration.rs`** — Added context to input validation and per-target synapse analysis (includes target neuron UUID).
+- **`src/analysis/gpu/queue/scheduling.rs`** — Added context to GPU analyser initialisation failure path.
+- **`src/analysis/gpu/queue/mod.rs`** — Improved error message for disconnected GPU response channel.
+- **`src/analysis/implementation_tests/synapse_analysis_tests.rs`** — Updated three existing tests to use `{err:#}` (alternate display) so they check the full error chain rather than just the outermost context message.
+
+## Evidence
+
+This is a backend/library change with no visual output. Correctness verified via:
+- Two new unit tests for `run_optional_analysis` error context enrichment
+- All 758 existing tests pass (3 tests updated to use `{err:#}` for full chain assertions)
+- Full `./quality.sh` passes cleanly
+
+## Test Plan
+
+- Added `run_optional_analysis_error_includes_phase_context` — verifies phase name appears in error chain
+- Added `run_optional_analysis_success_does_not_add_spurious_context` — verifies successful phases return clean results
+- Updated `analyze_neurons_rejects_duplicate_focus_targets` to check full error chain
+- Updated `analyze_synapses_rejects_duplicate_focus_targets` to check full error chain
+- Updated `analyze_synapses_requires_focus_targets` to check full error chain

--- a/src/analysis/gpu/queue/mod.rs
+++ b/src/analysis/gpu/queue/mod.rs
@@ -81,9 +81,10 @@ impl<T> GpuFuture<T> {
                 "GPU batch evaluation timed out after {timeout_secs}s. \
                  The GPU may be unresponsive. Consider reducing batch size or restarting."
             )),
-            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                Err(anyhow::anyhow!("GPU response channel closed unexpectedly"))
-            }
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
+                "GPU response channel closed unexpectedly — \
+                 the GPU thread may have exited or panicked"
+            )),
         }
     }
 }

--- a/src/analysis/gpu/queue/scheduling.rs
+++ b/src/analysis/gpu/queue/scheduling.rs
@@ -3,7 +3,7 @@
 //! This module handles GPU thread lifecycle management including creation,
 //! initialisation with timeout, graceful shutdown, and cleanup via Drop.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use crossbeam_channel::{Receiver, Sender, bounded};
 use std::thread;
 use std::time::Duration;
@@ -73,7 +73,9 @@ impl GpuWorkQueue {
         let init_timeout = Duration::from_secs(GPU_INIT_TIMEOUT_SECS);
         match init_rx.recv_timeout(init_timeout) {
             Ok(Ok(())) => {} // Success
-            Ok(Err(e)) => return Err(e),
+            Ok(Err(e)) => {
+                return Err(e).context("GPU analyser initialisation failed on GPU thread");
+            }
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
                 return Err(anyhow!(
                     "GPU initialisation timed out after {GPU_INIT_TIMEOUT_SECS}s. \

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -75,7 +75,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
 
     let err =
         analyze_neurons(&input).expect_err("Neuron analysis should refuse duplicate focus neurons");
-    let message = format!("{err}");
+    let message = format!("{err:#}");
     assert!(
         message.contains("duplicate focus neurons"),
         "Expected duplicate focus error, got: {message}",
@@ -149,7 +149,7 @@ fn analyze_synapses_rejects_duplicate_focus_targets() {
 
     let err = analyze_synapses(&input)
         .expect_err("Synapse analysis should refuse duplicate focus neurons");
-    let message = format!("{err}");
+    let message = format!("{err:#}");
     assert!(
         message.contains("duplicate focus neurons"),
         "Expected duplicate focus error, got: {message}",
@@ -450,7 +450,7 @@ fn analyze_synapses_requires_focus_targets() {
 
     let err =
         analyze_synapses(&input).expect_err("Synapse analysis should refuse empty focus lists");
-    let message = format!("{err}");
+    let message = format!("{err:#}");
     assert!(
         message.contains("at least one focus neuron"),
         "Expected missing focus error, got: {message}",

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -323,3 +323,59 @@ fn merge_coordinated_structural_filters_zero_gain_candidates() {
     assert!(syn.coordinated_structural_candidates[0].expected_creature_score_gain > 0.0);
     assert_eq!(syn.metadata.candidates_returned, 1);
 }
+
+// =============================================================================
+// Issue #1086: Error context enrichment tests
+// =============================================================================
+
+#[test]
+fn run_optional_analysis_error_includes_phase_context() {
+    // When a phase closure returns an error, the propagated error chain should
+    // include the phase name so callers can identify which analysis phase failed.
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let result: Result<Option<()>> = run_optional_analysis(
+        true,
+        "starting",
+        "finished",
+        "skipped",
+        "synapse_analysis",
+        || Err(anyhow::anyhow!("inner GPU error")),
+    );
+
+    let err = result.expect_err("should propagate the error");
+    let err_chain = format!("{err:#}");
+    assert!(
+        err_chain.contains("synapse_analysis"),
+        "error chain should include the phase name, got: {err_chain}"
+    );
+    assert!(
+        err_chain.contains("inner GPU error"),
+        "error chain should preserve the original error, got: {err_chain}"
+    );
+}
+
+#[test]
+fn run_optional_analysis_success_does_not_add_spurious_context() {
+    // Successful phases should not wrap the result in extra error context.
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let result: Result<Option<i32>> = run_optional_analysis(
+        true,
+        "starting",
+        "finished",
+        "skipped",
+        "test_phase",
+        || Ok(42),
+    );
+
+    assert_eq!(result.unwrap(), Some(42));
+}

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -17,7 +17,7 @@ mod post_processing;
 mod preparation;
 
 use crate::{AnalyzeNeuronsInput, CandidateNeuronJson};
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 // Import shared types from the analysis module structure
 use crate::analysis::shared::{AnalyzeNeuronsResult, TimingScope};
@@ -52,10 +52,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// This is the public entry point for neuron analysis.
 pub fn analyze_neurons(input: &AnalyzeNeuronsInput) -> Result<AnalyzeNeuronsResult> {
     // Validate focus_neurons before expensive pre-loading
-    require_unique_focus(&input.focus_neurons, "Neuron analysis")?;
+    require_unique_focus(&input.focus_neurons, "Neuron analysis")
+        .context("neuron analysis input validation failed")?;
 
     // Pre-load all records for faster analysis (1 scan vs ~2000 scans)
-    let cache = Arc::new(RecordCache::new_adaptive(&input.parquet_file)?);
+    let cache = Arc::new(
+        RecordCache::new_adaptive(&input.parquet_file)
+            .context("failed to load parquet record cache for neuron analysis")?,
+    );
     analyze_neurons_with_cache(input, cache)
 }
 
@@ -67,7 +71,11 @@ pub(crate) fn analyze_neurons_with_cache(
     cache: Arc<RecordCache>,
 ) -> Result<AnalyzeNeuronsResult> {
     let deadline = build_deadline(input.analysis_deadline_ms);
-    let gpu_queue = Arc::new(GpuWorkQueue::new()?.with_deadline(deadline));
+    let gpu_queue = Arc::new(
+        GpuWorkQueue::new()
+            .context("failed to create GPU work queue for neuron analysis")?
+            .with_deadline(deadline),
+    );
     analyze_neurons_with_cache_and_gpu_queue(input, cache, gpu_queue)
 }
 
@@ -87,7 +95,8 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
     let ordered_neurons = build_ordered_neurons(&input.creature);
 
     // Build lookup maps and filter focus targets
-    let prep = preparation::prepare_neuron_analysis(input, &ordered_neurons, &cache)?;
+    let prep = preparation::prepare_neuron_analysis(input, &ordered_neurons, &cache)
+        .context("failed to prepare neuron analysis")?;
 
     // If no output neurons remain after filtering, return early with empty results
     if let Some(early_return) = prep.early_return {
@@ -254,7 +263,10 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
                 &deadline,
                 &analysis_timed_out,
                 &diagnostics,
-            )?;
+            )
+            .with_context(|| {
+                format!("failed to load source records for neuron {target_uuid}")
+            })?;
 
             // Check if timed out during pre-filtering
             if analysis_timed_out.load(Ordering::Relaxed) {
@@ -328,7 +340,10 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
                     &eval_ctx,
                     &deadline,
                     &analysis_timed_out,
-                )?;
+                )
+                .with_context(|| {
+                    format!("failed during GPU evaluation for neuron {target_uuid}")
+                })?;
             }
 
             // Track completion of this focus neuron for timeout reporting.

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::cast_possible_truncation)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::observability::{
     PhaseTimer, ProfileData, ProfileMode, global_gpu_metrics, profile_mode,
@@ -32,7 +32,7 @@ pub(crate) fn run_optional_analysis<T>(
     if enabled {
         crate::watchdog::beat(starting);
         let _timer = PhaseTimer::new(phase_name);
-        let result = f()?;
+        let result = f().with_context(|| format!("failed during {phase_name} phase"))?;
         crate::watchdog::beat(finished);
         Ok(Some(result))
     } else {
@@ -98,7 +98,10 @@ fn dispatch_analyses(
                 )
             },
         );
-        Ok((syn_result?, neu_result?))
+        Ok((
+            syn_result.context("failed during synapse analysis phase")?,
+            neu_result.context("failed during neuron analysis phase")?,
+        ))
     } else {
         // Only one (or neither) analysis is enabled — run sequentially.
         let synapse_result = run_optional_analysis(
@@ -280,7 +283,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_outcome_tracker: input.module_outcome_tracker.clone().unwrap_or_default(),
             });
         }
-        Err(e) => return Err(e),
+        Err(e) => return Err(e).context("failed to load parquet record cache for analysis"),
     };
     profile.record_phase(
         "parquet_loading",
@@ -341,8 +344,11 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // The GpuWorkQueue is designed for concurrent submitters via crossbeam_channel,
     // so a single GPU thread serves both synapse and neuron analyses.
     let loading_deadline_for_gpu = utils::build_deadline(input.analysis_deadline_ms);
-    let shared_gpu_queue =
-        Arc::new(super::gpu::GpuWorkQueue::new()?.with_deadline(loading_deadline_for_gpu));
+    let shared_gpu_queue = Arc::new(
+        super::gpu::GpuWorkQueue::new()
+            .context("failed to create GPU work queue for analysis dispatch")?
+            .with_deadline(loading_deadline_for_gpu),
+    );
 
     // Issue #1002: Both analyses run concurrently via rayon::join when both are
     // enabled, so randomised ordering is no longer needed — both get the full
@@ -371,7 +377,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                 module_outcome_tracker: input.module_outcome_tracker.clone().unwrap_or_default(),
             });
         }
-        Err(e) => return Err(e),
+        Err(e) => return Err(e).context("failed during analysis dispatch"),
     };
 
     // Issue #1028: Check memory budget after GPU analysis. If exceeded, skip

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -98,7 +98,7 @@ pub(crate) use scoring::{
 // =============================================================================
 
 use crate::AnalyzeSynapsesInput;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::analysis::diagnostics::require_unique_focus;
 use crate::analysis::gpu::GpuWorkQueue;
@@ -116,10 +116,14 @@ use std::sync::Arc;
 /// This is the public entry point for synapse analysis.
 pub fn analyze_synapses(input: &AnalyzeSynapsesInput) -> Result<AnalyzeSynapsesResult> {
     // Validate focus_neurons before expensive pre-loading
-    require_unique_focus(&input.focus_neurons, "Synapse analysis")?;
+    require_unique_focus(&input.focus_neurons, "Synapse analysis")
+        .context("synapse analysis input validation failed")?;
 
     // Pre-load all records for faster analysis (1 scan vs ~2000 scans)
-    let cache = Arc::new(RecordCache::new_adaptive(&input.parquet_file)?);
+    let cache = Arc::new(
+        RecordCache::new_adaptive(&input.parquet_file)
+            .context("failed to load parquet record cache for synapse analysis")?,
+    );
     analyze_synapses_with_cache(input, cache)
 }
 
@@ -133,7 +137,11 @@ pub(crate) fn analyze_synapses_with_cache(
     // Issue #953: Propagate the analysis deadline so GpuEvaluator trait calls use
     // adaptive timeouts, preventing liveness stalls on slow GPU responses.
     let deadline = crate::analysis::utils::build_deadline(input.analysis_deadline_ms);
-    let gpu_queue = Arc::new(GpuWorkQueue::new()?.with_deadline(deadline));
+    let gpu_queue = Arc::new(
+        GpuWorkQueue::new()
+            .context("failed to create GPU work queue for synapse analysis")?
+            .with_deadline(deadline),
+    );
     orchestration::analyze_synapses_with_cache_impl(input, cache, gpu_queue)
 }
 

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -5,7 +5,7 @@
 //! up focus targets, running parallel per-target analysis, and assembling results.
 
 use crate::AnalyzeSynapsesInput;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::analysis::diagnostics::{TargetDiagnostics, require_unique_focus};
 use crate::analysis::gpu::{GpuAnalyzer, GpuWorkQueue};
@@ -41,7 +41,8 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     let lookups = preparation::build_creature_lookups(input);
 
     // Phase 2: Focus target and diagnostics setup
-    let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_synapses")?;
+    let unique_focus = require_unique_focus(&input.focus_neurons, "analyse_synapses")
+        .context("synapse analysis input validation failed")?;
     let diagnostics = Arc::new(TargetDiagnostics::new(&unique_focus));
     let timing_collector = Arc::new(crate::analysis::shared::TimingCollector::new(
         crate::analysis::utils::gpu_timing_enabled(),
@@ -130,7 +131,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
                 cache.as_ref(),
                 &gpu_queue,
                 &ctx,
-            )?;
+            )
+            .with_context(|| {
+                format!("failed during synapse analysis for target neuron {target_uuid}")
+            })?;
 
             // Update lock-free atomic metadata
             metadata.merge_atomic(&target_results);


### PR DESCRIPTION
## Summary

Enrich error context across the analysis pipeline by adding `.context()` annotations to all major phase transitions, GPU queue creation, parquet cache loading, and per-neuron/synapse analysis paths. This produces readable error chains (e.g., "failed during synapse analysis phase: GPU batch evaluation timed out") that help the TypeScript host trace error origins through the multi-stage pipeline. Closes #1086.

No new dependencies added — uses existing `anyhow::Context`.

## Changes

- **`src/analysis/orchestration.rs`** — Added context to `run_optional_analysis` (phase name in errors), `dispatch_analyses` (synapse/neuron phase identification), GPU queue creation, parquet cache loading, and analysis dispatch error paths.
- **`src/analysis/neuron/mod.rs`** — Added context to input validation, parquet cache loading, GPU queue creation, analysis preparation, source record loading (includes neuron UUID), and GPU evaluation (includes neuron UUID).
- **`src/analysis/synapse/mod.rs`** — Added context to input validation, parquet cache loading, and GPU queue creation.
- **`src/analysis/synapse/orchestration.rs`** — Added context to input validation and per-target synapse analysis (includes target neuron UUID).
- **`src/analysis/gpu/queue/scheduling.rs`** — Added context to GPU analyser initialisation failure path.
- **`src/analysis/gpu/queue/mod.rs`** — Improved error message for disconnected GPU response channel.
- **`src/analysis/implementation_tests/synapse_analysis_tests.rs`** — Updated three existing tests to use `{err:#}` (alternate display) so they check the full error chain rather than just the outermost context message.

## Evidence

This is a backend/library change with no visual output. Correctness verified via:
- Two new unit tests for `run_optional_analysis` error context enrichment
- All 758 existing tests pass (3 tests updated to use `{err:#}` for full chain assertions)
- Full `./quality.sh` passes cleanly

## Test Plan

- Added `run_optional_analysis_error_includes_phase_context` — verifies phase name appears in error chain
- Added `run_optional_analysis_success_does_not_add_spurious_context` — verifies successful phases return clean results
- Updated `analyze_neurons_rejects_duplicate_focus_targets` to check full error chain
- Updated `analyze_synapses_rejects_duplicate_focus_targets` to check full error chain
- Updated `analyze_synapses_requires_focus_targets` to check full error chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)