### PR TITLE
feat: add Parquet file integrity validation on read (#1085)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.52"
+version = "0.72.53"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1085.md
+++ b/docs/pr-summary-1085.md
@@ -1,0 +1,29 @@
+## Summary
+
+Add defence-in-depth integrity validation to the Parquet reading path. Corrupted, truncated, or schema-mismatched files now produce clear `DiscoveryError::Io` errors instead of panicking with unhelpful index-out-of-bounds messages. Incomplete `.parquet.tmp` files are detected and rejected with a warning. Closes #1085.
+
+### Changes
+
+- **Schema validation on file open** (`src/parquet_format/reader.rs`): Added `validate_parquet_schema()` that checks column count, column indices, and column names match the expected discovery schema before applying projection masks. This prevents panics in the `ProjectionMask::roots` call when files have mismatched schemas.
+- **`.parquet.tmp` rejection** (`src/parquet_format/reader.rs`): `open_parquet_file()` now detects `.parquet.tmp` suffix and returns a typed `DiscoveryError::Io` with a clear message about incomplete writes, with a `tracing::warn` log.
+- **Graceful corruption handling**: Truncated and corrupted files already produced errors from the parquet library, but schema mismatches caused panics. All paths now produce `Result::Err` rather than panicking.
+- **No performance regression**: Validation is metadata-only (checks Arrow schema fields), adding negligible overhead to valid file reads.
+
+## Evidence
+
+This is a backend/library change with no UI. Evidence is provided by the test suite:
+
+- `test_truncated_parquet_file_returns_error_not_panic` — truncated file produces error
+- `test_empty_file_returns_error_not_panic` — empty file produces error
+- `test_random_bytes_file_returns_error_not_panic` — garbage bytes produce error
+- `test_schema_mismatch_returns_clear_error` — wrong schema produces error mentioning schema
+- `test_schema_mismatch_with_filtered_read_returns_clear_error` — wrong column types produce error
+- `test_tmp_parquet_file_is_rejected_with_warning` — `.parquet.tmp` file rejected with clear message
+- `test_tmp_parquet_file_detected_by_all_read_functions` — all read functions reject `.tmp` files
+- `test_valid_parquet_file_still_reads_correctly` — no regression on valid files
+
+## Test Plan
+
+- Added `tests/parquet_integrity_validation.rs` with 9 integration tests covering all acceptance criteria
+- All existing tests continue to pass (171 integration tests + existing parquet tests)
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)

--- a/src/parquet_format/reader.rs
+++ b/src/parquet_format/reader.rs
@@ -7,6 +7,7 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
+use crate::DiscoveryError;
 use crate::types::DiscoverRecord;
 use std::time::SystemTime;
 
@@ -42,10 +43,29 @@ impl ColumnProfile {
 /// Open a parquet file, returning a clear "file removed" error if the file
 /// no longer exists on disk (Issue #1049).
 ///
+/// Also rejects `.parquet.tmp` files which indicate incomplete writes from
+/// the streaming writer (Issue #1085).
+///
 /// This distinguishes external deletion (e.g., host cleaned up temp directory)
 /// from other I/O errors such as corruption or permission issues, allowing
 /// callers to return partial results instead of crashing.
 fn open_parquet_file(file_path: &str) -> Result<File> {
+    // Reject .parquet.tmp files — these are incomplete writes (Issue #1085)
+    if file_path.ends_with(".parquet.tmp") {
+        tracing::warn!(
+            file_path,
+            "Skipping incomplete Parquet file (still has .tmp suffix). \
+             This file was likely left behind by an interrupted recording session."
+        );
+        return Err(DiscoveryError::Io {
+            detail: format!(
+                "Parquet file '{file_path}' has a .tmp suffix indicating an incomplete write. \
+                 It may have been left behind by an interrupted recording session."
+            ),
+        }
+        .into());
+    }
+
     File::open(file_path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             anyhow::anyhow!(
@@ -56,6 +76,83 @@ fn open_parquet_file(file_path: &str) -> Result<File> {
             anyhow::anyhow!("Failed to open Parquet file: {file_path}").context(e)
         }
     })
+}
+
+/// Expected column names for the discovery Parquet schema.
+const EXPECTED_COLUMNS: &[&str] = &["obs_index", "neuron_uuid", "value", "activation", "errors"];
+
+/// Validate that the Parquet file's schema matches the expected discovery schema
+/// (Issue #1085). Checks that required columns exist and that the file has the
+/// expected number of root columns for the requested projection profile.
+///
+/// This is a metadata-only check with no performance impact on valid files.
+fn validate_parquet_schema(
+    builder: &ParquetRecordBatchReaderBuilder<File>,
+    file_path: &str,
+    profile: ColumnProfile,
+) -> Result<()> {
+    let parquet_schema = builder.parquet_schema();
+    let num_columns = parquet_schema.num_columns();
+
+    // The discovery schema has 5 root columns (errors has a nested child, so
+    // the Parquet schema may report 6 columns). Check that we have at least
+    // the minimum required columns for the requested profile.
+    let required_count = match profile {
+        ColumnProfile::Full => 5,
+        ColumnProfile::WithoutErrors => 4,
+    };
+
+    if num_columns < required_count {
+        return Err(DiscoveryError::Io {
+            detail: format!(
+                "Parquet file '{file_path}' schema mismatch: expected at least \
+                 {required_count} columns but found {num_columns}. \
+                 The file may not be a valid discovery Parquet file."
+            ),
+        }
+        .into());
+    }
+
+    // Verify that the root column indices we need exist in the schema
+    let root_indices = profile.root_indices();
+    let max_index = root_indices.iter().copied().max().unwrap_or(0);
+
+    // Use the Arrow schema from the builder to check column names
+    let arrow_schema = builder.schema();
+    let field_count = arrow_schema.fields().len();
+
+    if max_index >= field_count {
+        return Err(DiscoveryError::Io {
+            detail: format!(
+                "Parquet file '{file_path}' schema mismatch: expected column index \
+                 {max_index} but file only has {field_count} columns. \
+                 The file may not be a valid discovery Parquet file."
+            ),
+        }
+        .into());
+    }
+
+    // Check that column names match expected names
+    let columns_to_check = match profile {
+        ColumnProfile::Full => EXPECTED_COLUMNS,
+        ColumnProfile::WithoutErrors => &EXPECTED_COLUMNS[..4],
+    };
+
+    for (idx, expected_name) in root_indices.iter().zip(columns_to_check.iter()) {
+        let actual_name = arrow_schema.field(*idx).name();
+        if actual_name != *expected_name {
+            return Err(DiscoveryError::Io {
+                detail: format!(
+                    "Parquet file '{file_path}' schema mismatch: expected column '{expected_name}' \
+                     at index {idx} but found '{actual_name}'. \
+                     The file may not be a valid discovery Parquet file."
+                ),
+            }
+            .into());
+        }
+    }
+
+    Ok(())
 }
 
 /// Read all discovery records from a Parquet file, grouped by neuron UUID.
@@ -116,6 +213,8 @@ pub fn read_all_records_grouped_by_neuron_with_deadline_and_profile(
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
+
+    validate_parquet_schema(&builder, file_path, profile)?;
 
     let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
     let reader = builder
@@ -264,6 +363,8 @@ pub fn read_records_from_parquet_with_profile(
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
 
+    validate_parquet_schema(&builder, file_path, profile)?;
+
     let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
     let reader = builder
         .with_projection(mask)
@@ -407,6 +508,8 @@ pub fn read_records_from_parquet_with_limit_and_profile(
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .context("Failed to create Parquet reader builder")?;
+
+    validate_parquet_schema(&builder, file_path, profile)?;
 
     let mask = ProjectionMask::roots(builder.parquet_schema(), profile.root_indices());
     let reader = builder

--- a/tests/parquet_integrity_validation.rs
+++ b/tests/parquet_integrity_validation.rs
@@ -1,0 +1,271 @@
+//! Integration tests for Parquet file integrity validation (Issue #1085).
+//!
+//! Verifies that corrupted, truncated, and schema-mismatched Parquet files
+//! produce clear errors rather than panics, and that `.parquet.tmp` files
+//! are detected and warned about.
+
+use neat_ai_discovery::parquet_format::{
+    read_all_records_from_parquet, read_all_records_grouped_by_neuron, read_records_from_parquet,
+    write_records_to_parquet,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use std::io::Write;
+use tempfile::{NamedTempFile, TempDir};
+
+/// Helper: create a minimal set of valid test records.
+fn create_test_records() -> Vec<DiscoverRecord> {
+    vec![
+        DiscoverRecord::new(0, "neuron-a".to_string(), Some(0.5), 0.7, vec![0.1, 0.2]),
+        DiscoverRecord::new(1, "neuron-a".to_string(), Some(0.6), 0.8, vec![0.15]),
+    ]
+}
+
+/// Helper: write test records to a temp parquet file and return the path guard + path string.
+fn write_temp_parquet(records: &[DiscoverRecord]) -> (NamedTempFile, String) {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap().to_string();
+    write_records_to_parquet(&path, records).expect("Failed to write parquet");
+    (temp_file, path)
+}
+
+// ============================================================================
+// Truncated / corrupted file tests
+// ============================================================================
+
+#[test]
+fn test_truncated_parquet_file_returns_error_not_panic() {
+    // Write a valid parquet file first, then truncate it
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    // Read the valid file to get its bytes, then write a truncated version
+    let full_bytes = std::fs::read(&path).expect("Failed to read parquet file");
+    assert!(
+        full_bytes.len() > 20,
+        "Valid parquet file should be larger than 20 bytes"
+    );
+
+    // Truncate to half the original size — this destroys the footer
+    let truncated = &full_bytes[..full_bytes.len() / 2];
+    std::fs::write(&path, truncated).expect("Failed to write truncated file");
+
+    // Reading the truncated file should return an error, not panic
+    let result = read_all_records_grouped_by_neuron(&path);
+    assert!(
+        result.is_err(),
+        "Truncated parquet file should produce an error"
+    );
+    let err_msg = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err_msg.contains("parquet") || err_msg.contains("corrupt") || err_msg.contains("footer"),
+        "Error should mention parquet/corruption/footer: {err_msg}"
+    );
+}
+
+#[test]
+fn test_empty_file_returns_error_not_panic() {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap();
+
+    // Write an empty file (0 bytes)
+    std::fs::write(path, b"").expect("Failed to write empty file");
+
+    let result = read_all_records_grouped_by_neuron(path);
+    assert!(result.is_err(), "Empty file should produce an error");
+}
+
+#[test]
+fn test_random_bytes_file_returns_error_not_panic() {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap();
+
+    // Write random (non-parquet) bytes
+    let garbage: Vec<u8> = (0..=255u8)
+        .map(|i| i.wrapping_mul(37).wrapping_add(13))
+        .collect();
+    std::fs::write(path, &garbage).expect("Failed to write garbage file");
+
+    let result = read_records_from_parquet(path, "neuron-a");
+    assert!(
+        result.is_err(),
+        "Random bytes file should produce an error, not panic"
+    );
+}
+
+#[test]
+fn test_truncated_file_with_read_all_returns_error() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    // Truncate to just 8 bytes — smaller than the Parquet magic number
+    std::fs::write(&path, [0u8; 8]).expect("Failed to write truncated file");
+
+    let result = read_all_records_from_parquet(&path);
+    assert!(
+        result.is_err(),
+        "Truncated file should produce an error via read_all_records_from_parquet"
+    );
+}
+
+// ============================================================================
+// Schema mismatch tests
+// ============================================================================
+
+#[test]
+fn test_schema_mismatch_returns_clear_error() {
+    // Create a Parquet file with a different schema (not the discovery schema)
+    use arrow::array::{Int64Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap();
+
+    // Write a parquet file with a completely different schema
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+
+    let ids = Int64Array::from(vec![1, 2, 3]);
+    let names = arrow::array::StringArray::from(vec!["a", "b", "c"]);
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(names)]).unwrap();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    // Attempt to read this as a discovery Parquet file — should get a schema error
+    let result = read_all_records_grouped_by_neuron(path);
+    assert!(
+        result.is_err(),
+        "Schema-mismatched file should produce an error"
+    );
+    let err_msg = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err_msg.contains("schema") || err_msg.contains("missing") || err_msg.contains("column"),
+        "Error should mention schema mismatch: {err_msg}"
+    );
+}
+
+#[test]
+fn test_schema_mismatch_with_filtered_read_returns_clear_error() {
+    use arrow::array::{Float64Array, RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use parquet::arrow::ArrowWriter;
+    use std::sync::Arc;
+
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let path = temp_file.path().to_str().unwrap();
+
+    // Write a parquet file that has obs_index but with wrong type (Float64 instead of UInt32)
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("obs_index", DataType::Float64, false),
+        Field::new("neuron_uuid", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+        Field::new("activation", DataType::Float64, false),
+    ]));
+
+    let obs = Float64Array::from(vec![1.0, 2.0]);
+    let uuids = arrow::array::StringArray::from(vec!["a", "b"]);
+    let values = Float64Array::from(vec![0.5, 0.6]);
+    let activations = Float64Array::from(vec![0.7, 0.8]);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(obs),
+            Arc::new(uuids),
+            Arc::new(values),
+            Arc::new(activations),
+        ],
+    )
+    .unwrap();
+
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    // Attempt to read — should fail because obs_index is Float64, not UInt32
+    let result = read_records_from_parquet(path, "a");
+    assert!(
+        result.is_err(),
+        "Wrong column types should produce an error"
+    );
+}
+
+// ============================================================================
+// .parquet.tmp file detection tests
+// ============================================================================
+
+#[test]
+fn test_tmp_parquet_file_is_rejected_with_warning() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    // Create a .parquet.tmp file (simulates incomplete write)
+    let tmp_path = temp_dir.path().join("discovery_data.parquet.tmp");
+    let mut file = std::fs::File::create(&tmp_path).expect("Failed to create tmp file");
+    file.write_all(b"incomplete parquet data")
+        .expect("Failed to write");
+
+    let path_str = tmp_path.to_str().unwrap();
+
+    // Attempting to read a .parquet.tmp file should produce a clear error
+    let result = read_all_records_grouped_by_neuron(path_str);
+    assert!(result.is_err(), ".parquet.tmp file should produce an error");
+    let err_msg = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err_msg.contains("tmp") || err_msg.contains("incomplete"),
+        "Error should mention tmp/incomplete file: {err_msg}"
+    );
+}
+
+#[test]
+fn test_tmp_parquet_file_detected_by_all_read_functions() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    let tmp_path = temp_dir.path().join("data.parquet.tmp");
+    std::fs::write(&tmp_path, b"garbage").expect("Failed to write");
+
+    let path_str = tmp_path.to_str().unwrap();
+
+    // All read functions should reject .parquet.tmp files
+    assert!(
+        read_all_records_from_parquet(path_str).is_err(),
+        "read_all_records_from_parquet should reject .parquet.tmp"
+    );
+    assert!(
+        read_records_from_parquet(path_str, "neuron-a").is_err(),
+        "read_records_from_parquet should reject .parquet.tmp"
+    );
+    assert!(
+        read_all_records_grouped_by_neuron(path_str).is_err(),
+        "read_all_records_grouped_by_neuron should reject .parquet.tmp"
+    );
+}
+
+// ============================================================================
+// Valid file still works (no regression)
+// ============================================================================
+
+#[test]
+fn test_valid_parquet_file_still_reads_correctly() {
+    let records = create_test_records();
+    let (_tmp, path) = write_temp_parquet(&records);
+
+    // Should still read successfully
+    let result = read_all_records_grouped_by_neuron(&path);
+    assert!(
+        result.is_ok(),
+        "Valid parquet file should read successfully"
+    );
+    let grouped = result.unwrap();
+    assert_eq!(grouped.len(), 1, "Should have 1 neuron group");
+    assert_eq!(
+        grouped.get("neuron-a").unwrap().len(),
+        2,
+        "Should have 2 records for neuron-a"
+    );
+}


### PR DESCRIPTION
## Summary

Add defence-in-depth integrity validation to the Parquet reading path. Corrupted, truncated, or schema-mismatched files now produce clear `DiscoveryError::Io` errors instead of panicking with unhelpful index-out-of-bounds messages. Incomplete `.parquet.tmp` files are detected and rejected with a warning. Closes #1085.

### Changes

- **Schema validation on file open** (`src/parquet_format/reader.rs`): Added `validate_parquet_schema()` that checks column count, column indices, and column names match the expected discovery schema before applying projection masks. This prevents panics in the `ProjectionMask::roots` call when files have mismatched schemas.
- **`.parquet.tmp` rejection** (`src/parquet_format/reader.rs`): `open_parquet_file()` now detects `.parquet.tmp` suffix and returns a typed `DiscoveryError::Io` with a clear message about incomplete writes, with a `tracing::warn` log.
- **Graceful corruption handling**: Truncated and corrupted files already produced errors from the parquet library, but schema mismatches caused panics. All paths now produce `Result::Err` rather than panicking.
- **No performance regression**: Validation is metadata-only (checks Arrow schema fields), adding negligible overhead to valid file reads.

## Evidence

This is a backend/library change with no UI. Evidence is provided by the test suite:

- `test_truncated_parquet_file_returns_error_not_panic` — truncated file produces error
- `test_empty_file_returns_error_not_panic` — empty file produces error
- `test_random_bytes_file_returns_error_not_panic` — garbage bytes produce error
- `test_schema_mismatch_returns_clear_error` — wrong schema produces error mentioning schema
- `test_schema_mismatch_with_filtered_read_returns_clear_error` — wrong column types produce error
- `test_tmp_parquet_file_is_rejected_with_warning` — `.parquet.tmp` file rejected with clear message
- `test_tmp_parquet_file_detected_by_all_read_functions` — all read functions reject `.tmp` files
- `test_valid_parquet_file_still_reads_correctly` — no regression on valid files

## Test Plan

- Added `tests/parquet_integrity_validation.rs` with 9 integration tests covering all acceptance criteria
- All existing tests continue to pass (171 integration tests + existing parquet tests)
- `./quality.sh` passes cleanly (fmt, clippy, check, test, doc, release build)



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1085 -->