### PR TITLE
fix: compute analysis deadline once and share across all sub-phases (#1097)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.56"
+version = "0.72.57"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1097.md
+++ b/docs/pr-summary-1097.md
@@ -1,0 +1,32 @@
+## Summary
+
+Fixed the analysis timeout guard being bypassed when `analysis_deadline_ms` is a relative duration. Each analysis sub-phase (parquet loading, synapse analysis, neuron analysis, discovery modules) was calling `build_deadline()` independently. When the deadline was a relative duration (e.g., `600_000ms` = 10 minutes), each call created a fresh deadline from "now", allowing total analysis to exceed 24 minutes on a 10-minute budget. Closes #1097.
+
+### Root Cause
+
+`build_deadline(Some(600_000))` creates a `SystemTime` 10 minutes in the future. When called at the start of parquet loading, synapse analysis, neuron analysis, and discovery modules independently, each phase got its own 10-minute window rather than sharing a single deadline.
+
+### Fix
+
+- Added `deadline_to_absolute_ms()` utility to convert a `SystemTime` deadline back to an absolute millisecond timestamp (always `>= YEAR_2000_MS`, so `build_deadline` treats it as absolute rather than relative).
+- In `analyze_all()`, the deadline is now built **once** at the start and converted to an absolute timestamp. All sub-phases (synapse input, neuron input, GPU queue, discovery modules) receive this shared absolute deadline.
+- Added a deadline check before the post-processing phase (compression, discovery modules, reranking) so that when the analysis phases consume the entire time budget, heavyweight post-processing is skipped.
+
+## Evidence
+
+This is a backend/CLI fix with no visual output. Evidence is provided by the test suite:
+
+- Unit tests verify `deadline_to_absolute_ms` correctness and round-trip consistency
+- Integration test `issue_1097_shared_deadline` verifies that converting a relative deadline to absolute and rebuilding produces a consistent point in time (no drift)
+- All 783 existing unit tests continue to pass
+- `quality.sh` passes cleanly
+
+## Test Plan
+
+- Added unit tests in `src/analysis/utils/deadline_tests.rs`:
+  - `deadline_to_absolute_ms_returns_none_for_none` — None input returns None
+  - `deadline_to_absolute_ms_returns_absolute_timestamp` — valid deadline returns correct absolute ms
+  - `shared_deadline_does_not_reset_on_rebuild` — round-trip relative → absolute → rebuild produces consistent deadline (no drift)
+- Added integration test `tests/analysis/issue_1097_shared_deadline.rs`:
+  - `relative_deadline_round_trip_does_not_drift` — verifies the fix prevents deadline reset
+  - `deadline_to_absolute_ms_always_above_year_2000_threshold` — ensures absolute values are always treated as absolute timestamps

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -315,10 +315,19 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
 
     crate::watchdog::beat("analysis::analyze_all → loading parquet cache");
 
+    // Issue #1097: Build the overall deadline ONCE and convert to an absolute
+    // timestamp. All sub-phases share this single deadline so that a relative
+    // duration (e.g., 600_000ms = 10 minutes) is not re-interpreted as "10
+    // minutes from now" by each phase independently. Without this, parquet
+    // loading, synapse analysis, and neuron analysis each got a fresh 10-minute
+    // window, allowing total analysis to exceed 24 minutes on a 10-minute budget.
+    let overall_deadline = utils::build_deadline(input.analysis_deadline_ms);
+    let shared_deadline_abs_ms = utils::deadline_to_absolute_ms(&overall_deadline);
+
     // Pre-load ALL records from parquet in one pass. This is MUCH faster than
     // lazy-loading each neuron separately (1 scan vs ~2000 scans for large creatures).
     // Issue #648: Pass the analysis deadline so loading can abort early if time runs out.
-    let loading_deadline = utils::build_deadline(input.analysis_deadline_ms);
+    let loading_deadline = overall_deadline;
     let parquet_loading_start = std::time::Instant::now();
     let cache_result =
         cache::RecordCache::new_adaptive_with_deadline(&input.parquet_file, loading_deadline);
@@ -388,13 +397,15 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         });
     }
 
+    // Issue #1097: Pass the shared absolute deadline to sub-phases so they
+    // all count down from the same point in time.
     let synapse_input = if include_synapse {
         Some(AnalyzeSynapsesInput {
             parquet_file: input.parquet_file.clone(),
             creature: input.creature.clone(),
             focus_neurons: effective_focus_neurons.clone(),
             max_candidates: input.max_synapse_candidates,
-            analysis_deadline_ms: input.analysis_deadline_ms,
+            analysis_deadline_ms: shared_deadline_abs_ms,
             random_seed: input.random_seed,
             temperature: input.temperature,
         })
@@ -408,7 +419,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             creature: input.creature.clone(),
             focus_neurons: effective_focus_neurons,
             max_candidates: input.max_neuron_candidates,
-            analysis_deadline_ms: input.analysis_deadline_ms,
+            analysis_deadline_ms: shared_deadline_abs_ms,
             random_seed: input.random_seed,
             temperature: input.temperature,
         })
@@ -419,7 +430,9 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Issue #1002: Create a shared GPU work queue for both analyses.
     // The GpuWorkQueue is designed for concurrent submitters via crossbeam_channel,
     // so a single GPU thread serves both synapse and neuron analyses.
-    let loading_deadline_for_gpu = utils::build_deadline(input.analysis_deadline_ms);
+    // Issue #1097: Reuse the already-computed overall deadline instead of
+    // building a new one (which would reset a relative duration).
+    let loading_deadline_for_gpu = overall_deadline;
     let shared_gpu_queue = Arc::new(
         super::gpu::GpuWorkQueue::new()
             .context("failed to create GPU work queue for analysis dispatch")?
@@ -503,11 +516,23 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         );
     }
 
+    // Issue #1097: Check overall deadline before post-processing. If the
+    // analysis phases consumed the entire time budget, skip the heavyweight
+    // post-processing to stay within the configured timeout.
+    let post_processing_deadline_passed = utils::deadline_passed(&overall_deadline);
+    if post_processing_deadline_passed {
+        tracing::info!(
+            "Analysis deadline reached before post-processing — skipping discovery \
+             modules, compression, and reranking to stay within timeout (Issue #1097)"
+        );
+    }
+
     // Issue #1028: Skip post-processing when memory budget is exceeded.
+    // Issue #1097: Also skip when the analysis deadline has passed.
     // The candidates from GPU analysis are still returned, but compression,
     // discovery module detection, and reranking are skipped to avoid further
-    // memory growth.
-    if !memory_budget_exceeded {
+    // memory growth or exceeding the timeout.
+    if !memory_budget_exceeded && !post_processing_deadline_passed {
         // Issue #1004: Overlap candidate compression with discovery module detection.
         //
         // Both compression (reads `helpful_synapses` immutably) and discovery module
@@ -588,7 +613,8 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                         // Issue #375 / #419: Discovery module detection phase only.
                         // Issue #1029: Pass the analysis deadline so detection modules
                         // are skipped when time runs out, preventing lockups.
-                        let discovery_deadline = utils::build_deadline(input.analysis_deadline_ms);
+                        // Issue #1097: Use the shared absolute deadline.
+                        let discovery_deadline = utils::build_deadline(shared_deadline_abs_ms);
                         module_dispatch_specs::prepare_and_detect_discovery_modules(
                             &creature,
                             &hidden_neurons,

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -125,6 +125,20 @@ pub fn build_deadline(deadline_ms: Option<u64>) -> Option<SystemTime> {
         .and_then(|validated_ms| SystemTime::now().checked_add(Duration::from_millis(validated_ms)))
 }
 
+/// Convert a `SystemTime` deadline to an absolute millisecond timestamp (Issue #1097).
+///
+/// This is the inverse of `build_deadline`: given a `SystemTime`, return the
+/// equivalent absolute milliseconds since UNIX epoch. This allows the deadline
+/// to be shared across sub-phases without each phase re-interpreting a relative
+/// duration as "N milliseconds from now" (which would reset the deadline).
+pub fn deadline_to_absolute_ms(deadline: &Option<SystemTime>) -> Option<u64> {
+    deadline.as_ref().and_then(|d| {
+        d.duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|dur| dur.as_millis() as u64)
+    })
+}
+
 /// Check if the deadline has passed or cancellation has been requested.
 ///
 /// Returns `true` if:

--- a/src/analysis/utils/deadline_tests.rs
+++ b/src/analysis/utils/deadline_tests.rs
@@ -588,3 +588,86 @@ fn order_eligible_sources_no_op_for_single_element() {
     assert_eq!(sources.len(), 1);
     assert_eq!(sources[0].uuid, "single");
 }
+
+// ============================================================================
+// deadline_to_absolute_ms tests (Issue #1097)
+// ============================================================================
+
+#[test]
+fn deadline_to_absolute_ms_returns_none_for_none() {
+    assert!(
+        deadline_to_absolute_ms(&None).is_none(),
+        "None deadline should return None"
+    );
+}
+
+#[test]
+fn deadline_to_absolute_ms_returns_absolute_timestamp() {
+    let now = SystemTime::now();
+    let deadline = Some(now + Duration::from_secs(300));
+    let abs_ms = deadline_to_absolute_ms(&deadline);
+    assert!(abs_ms.is_some(), "Valid deadline should return Some");
+
+    let now_ms = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let result = abs_ms.unwrap();
+    // Should be approximately now + 300 seconds
+    assert!(
+        result >= now_ms + 299_000 && result <= now_ms + 301_000,
+        "Absolute ms should be ~300s in the future, got delta {}ms",
+        result.saturating_sub(now_ms)
+    );
+}
+
+/// Issue #1097: Verify that converting a relative deadline to absolute ms and
+/// then rebuilding the deadline produces a consistent point in time, rather
+/// than re-adding the original duration again.
+#[test]
+fn shared_deadline_does_not_reset_on_rebuild() {
+    // Simulate the original relative duration (10 minutes).
+    let relative_ms = 600_000u64;
+
+    // Step 1: Build the overall deadline once (as analyze_all does).
+    let overall_deadline = build_deadline(Some(relative_ms));
+    assert!(overall_deadline.is_some());
+
+    // Step 2: Convert to absolute ms (the fix from Issue #1097).
+    let abs_ms = deadline_to_absolute_ms(&overall_deadline);
+    assert!(abs_ms.is_some());
+    let abs_ms_value = abs_ms.unwrap();
+
+    // The absolute value must be >= YEAR_2000_MS so that build_deadline treats
+    // it as an absolute timestamp rather than a relative duration.
+    assert!(
+        abs_ms_value >= YEAR_2000_MS,
+        "Absolute ms ({abs_ms_value}) should be >= YEAR_2000_MS ({YEAR_2000_MS})"
+    );
+
+    // Step 3: Rebuild the deadline from the absolute ms (as sub-phases do).
+    let rebuilt_deadline = build_deadline(abs_ms);
+    assert!(rebuilt_deadline.is_some());
+
+    // Step 4: The rebuilt deadline should be close to the original, NOT
+    // an additional 10 minutes in the future.
+    let original_ms = overall_deadline
+        .unwrap()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let rebuilt_ms = rebuilt_deadline
+        .unwrap()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    let drift = rebuilt_ms.abs_diff(original_ms);
+
+    // Allow up to 2 seconds of drift from timing variance.
+    assert!(
+        drift < 2_000,
+        "Rebuilt deadline drifted {drift}ms from the original — the absolute \
+         timestamp should NOT re-add the duration (Issue #1097)"
+    );
+}

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -59,9 +59,10 @@ pub use platform::{ensure_xdg_runtime_dir, suppress_mesa_warnings_if_requested};
 pub use deadline::{
     DEFAULT_DURATION_MS, GPU_QUEUE_TIMEOUT_MAX_SECS, GPU_QUEUE_TIMEOUT_MIN_SECS, MAX_DURATION_MS,
     MIN_DURATION_MS, OrderedNeuron, YEAR_2000_MS, build_deadline, calculate_effective_timeout_ms,
-    calculate_gpu_batch_timeout, deadline_passed, derive_seed, focus_unused_observations_from_env,
-    log_analysis_start, log_analysis_timeout, order_eligible_sources, order_focus_targets,
-    parse_input_index, shuffle_slice, shuffle_within_top_k, source_input_index_bias_from_env,
+    calculate_gpu_batch_timeout, deadline_passed, deadline_to_absolute_ms, derive_seed,
+    focus_unused_observations_from_env, log_analysis_start, log_analysis_timeout,
+    order_eligible_sources, order_focus_targets, parse_input_index, shuffle_slice,
+    shuffle_within_top_k, source_input_index_bias_from_env,
 };
 
 // Re-export deadline override for tests

--- a/tests/analysis/issue_1097_shared_deadline.rs
+++ b/tests/analysis/issue_1097_shared_deadline.rs
@@ -1,0 +1,78 @@
+//! Issue #1097: Verify that the analysis deadline is computed once and shared
+//! across all sub-phases.
+//!
+//! Before this fix, each sub-phase called `build_deadline(analysis_deadline_ms)`
+//! independently. When `analysis_deadline_ms` was a relative duration (e.g.,
+//! `600_000ms` = 10 minutes), each call created a fresh deadline from "now",
+//! allowing total analysis to exceed the intended timeout (24+ minutes on a
+//! 10-minute budget).
+//!
+//! The fix converts the relative duration to an absolute timestamp once at the
+//! top of `analyze_all()` and passes that to all sub-phases.
+
+#![allow(clippy::cast_possible_truncation)]
+
+use neat_ai_discovery::analysis::utils::{YEAR_2000_MS, build_deadline, deadline_to_absolute_ms};
+
+/// Verify the round-trip: relative ms → `build_deadline` → absolute ms → `build_deadline`
+/// produces a consistent deadline that does not drift forward.
+#[test]
+fn relative_deadline_round_trip_does_not_drift() {
+    let relative_ms = 300_000u64; // 5 minutes
+
+    // Build initial deadline from relative duration
+    let initial = build_deadline(Some(relative_ms)).expect("should produce a deadline");
+
+    // Convert to absolute ms
+    let abs_ms = deadline_to_absolute_ms(&Some(initial)).expect("should produce absolute ms");
+
+    // Verify it's treated as an absolute timestamp
+    assert!(
+        abs_ms >= YEAR_2000_MS,
+        "Absolute timestamp should be >= YEAR_2000_MS"
+    );
+
+    // Rebuild from absolute ms — should NOT add another 5 minutes
+    let rebuilt = build_deadline(Some(abs_ms)).expect("should produce a deadline from absolute ms");
+
+    let initial_epoch_ms = initial
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let rebuilt_epoch_ms = rebuilt
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    let drift = initial_epoch_ms.abs_diff(rebuilt_epoch_ms);
+    assert!(
+        drift < 2_000,
+        "Rebuilt deadline drifted {drift}ms — should be near-identical to original. \
+         A large drift means the absolute timestamp was re-interpreted as relative."
+    );
+}
+
+/// Verify that `deadline_to_absolute_ms` always produces values above
+/// the `YEAR_2000_MS` threshold so they are treated as absolute timestamps
+/// by `calculate_effective_timeout_ms`.
+#[test]
+fn deadline_to_absolute_ms_always_above_year_2000_threshold() {
+    // Even a very short relative deadline should produce an absolute timestamp
+    // well above YEAR_2000_MS when converted.
+    let short_deadline = build_deadline(Some(3_000)); // 3 seconds (minimum)
+    let abs_ms =
+        deadline_to_absolute_ms(&short_deadline).expect("short deadline should be convertible");
+    assert!(
+        abs_ms >= YEAR_2000_MS,
+        "Even a 3-second deadline should produce an absolute ms ({abs_ms}) >= YEAR_2000_MS ({YEAR_2000_MS})"
+    );
+
+    // A long relative deadline should also be above the threshold
+    let long_deadline = build_deadline(Some(3_600_000)); // 1 hour (maximum)
+    let abs_ms =
+        deadline_to_absolute_ms(&long_deadline).expect("long deadline should be convertible");
+    assert!(
+        abs_ms >= YEAR_2000_MS,
+        "A 1-hour deadline should produce an absolute ms ({abs_ms}) >= YEAR_2000_MS ({YEAR_2000_MS})"
+    );
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -17,6 +17,7 @@ mod issue_1004_overlap_compression_discovery;
 mod issue_1020_temperature_scheduling;
 mod issue_1057_add_synapse_gating;
 mod issue_1060_prefilter_learning;
+mod issue_1097_shared_deadline;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Fixed the analysis timeout guard being bypassed when `analysis_deadline_ms` is a relative duration. Each analysis sub-phase (parquet loading, synapse analysis, neuron analysis, discovery modules) was calling `build_deadline()` independently. When the deadline was a relative duration (e.g., `600_000ms` = 10 minutes), each call created a fresh deadline from "now", allowing total analysis to exceed 24 minutes on a 10-minute budget. Closes #1097.

### Root Cause

`build_deadline(Some(600_000))` creates a `SystemTime` 10 minutes in the future. When called at the start of parquet loading, synapse analysis, neuron analysis, and discovery modules independently, each phase got its own 10-minute window rather than sharing a single deadline.

### Fix

- Added `deadline_to_absolute_ms()` utility to convert a `SystemTime` deadline back to an absolute millisecond timestamp (always `>= YEAR_2000_MS`, so `build_deadline` treats it as absolute rather than relative).
- In `analyze_all()`, the deadline is now built **once** at the start and converted to an absolute timestamp. All sub-phases (synapse input, neuron input, GPU queue, discovery modules) receive this shared absolute deadline.
- Added a deadline check before the post-processing phase (compression, discovery modules, reranking) so that when the analysis phases consume the entire time budget, heavyweight post-processing is skipped.

## Evidence

This is a backend/CLI fix with no visual output. Evidence is provided by the test suite:

- Unit tests verify `deadline_to_absolute_ms` correctness and round-trip consistency
- Integration test `issue_1097_shared_deadline` verifies that converting a relative deadline to absolute and rebuilding produces a consistent point in time (no drift)
- All 783 existing unit tests continue to pass
- `quality.sh` passes cleanly

## Test Plan

- Added unit tests in `src/analysis/utils/deadline_tests.rs`:
  - `deadline_to_absolute_ms_returns_none_for_none` — None input returns None
  - `deadline_to_absolute_ms_returns_absolute_timestamp` — valid deadline returns correct absolute ms
  - `shared_deadline_does_not_reset_on_rebuild` — round-trip relative → absolute → rebuild produces consistent deadline (no drift)
- Added integration test `tests/analysis/issue_1097_shared_deadline.rs`:
  - `relative_deadline_round_trip_does_not_drift` — verifies the fix prevents deadline reset
  - `deadline_to_absolute_ms_always_above_year_2000_threshold` — ensures absolute values are always treated as absolute timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)