### PR TITLE
fix: quality gate shellcheck, bash 3.2 benchmark scripts, Taplo lint schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.72.56"
+version = "0.73.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benchmark_compare.sh
+++ b/benchmark_compare.sh
@@ -87,10 +87,15 @@ discover_benchmarks() {
             in_bench_block=false
         fi
     done < Cargo.toml
-    echo "${benchmarks[@]}"
+    if [[ ${#benchmarks[@]} -gt 0 ]]; then
+        printf '%s\n' "${benchmarks[@]}"
+    fi
 }
 
-BENCHMARKS=($(discover_benchmarks))
+BENCHMARKS=()
+while IFS= read -r line; do
+    BENCHMARKS+=("$line")
+done < <(discover_benchmarks)
 
 if [[ "$LIST_ONLY" == true ]]; then
     echo "Available benchmark suites (${#BENCHMARKS[@]}):"

--- a/quality.sh
+++ b/quality.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Source cargo environment if available (needed for non-login shells)
 if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
     source "$HOME/.cargo/env"
 fi
 
@@ -13,6 +14,24 @@ echo "================================"
 # Check bash script syntax
 echo "📝 Checking bash script syntax..."
 find . -name "*.sh" -type f -not -path "./target/*" -not -path "./.git/*" -exec bash -n {} \;
+
+echo "Running shellcheck on bash scripts..."
+if ! command -v shellcheck &> /dev/null; then
+    echo "shellcheck is required — install: https://github.com/koalaman/shellcheck#installing"
+    exit 1
+fi
+SHELLCHECK_FAILED=0
+while IFS= read -r script; do
+    echo "  shellcheck: $script"
+    if ! shellcheck -s bash "$script"; then
+        SHELLCHECK_FAILED=1
+    fi
+done < <(find . -name "*.sh" -type f -not -path "./target/*" -not -path "./.git/*")
+if [[ "$SHELLCHECK_FAILED" -ne 0 ]]; then
+    echo "shellcheck: FAILED"
+    exit 1
+fi
+echo "shellcheck: all scripts passed"
 
 # Update dependencies to latest versions (including incompatible upgrades)
 echo "📦 Upgrading Rust library dependencies..."

--- a/scripts/benchmark-ci.sh
+++ b/scripts/benchmark-ci.sh
@@ -108,11 +108,14 @@ discover_benchmarks() {
         fi
     done < "$PROJECT_ROOT/Cargo.toml"
     if [[ ${#benchmarks[@]} -gt 0 ]]; then
-        echo "${benchmarks[@]}"
+        printf '%s\n' "${benchmarks[@]}"
     fi
 }
 
-BENCHMARKS=($(discover_benchmarks))
+BENCHMARKS=()
+while IFS= read -r line; do
+    BENCHMARKS+=("$line")
+done < <(discover_benchmarks)
 
 if [[ ${#BENCHMARKS[@]} -eq 0 ]]; then
     echo "Error: No benchmark targets found in Cargo.toml"

--- a/scripts/runlib.sh
+++ b/scripts/runlib.sh
@@ -8,11 +8,11 @@ RUST_MSRV="1.92.0"
 # Returns 0 if v1 >= v2 (semver-style), 1 otherwise.
 _version_ge() {
   local v1="$1" v2="$2"
-  local IFS=.
   local i
   local -a a b
-  a=(${v1%%-*})  # strip any -pre suffix
-  b=(${v2%%-*})
+  local IFS='.'
+  read -r -a a <<< "${v1%%-*}"  # strip any -pre suffix
+  read -r -a b <<< "${v2%%-*}"
   for ((i=0; i<${#a[@]} || i<${#b[@]}; i++)); do
     local x=${a[i]:-0} y=${b[i]:-0}
     ((10#$x > 10#$y)) && return 0
@@ -95,12 +95,15 @@ _require_tools() {
     export PATH="$HOME/.cargo/bin:$PATH"
     # Ensure PATH is set for future invocations
     if [[ -f "$HOME/.bashrc" ]] && ! grep -q "\.cargo/bin" "$HOME/.bashrc" 2>/dev/null; then
+      # shellcheck disable=SC2016
       echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.bashrc"
     fi
     if [[ -f "$HOME/.zshrc" ]] && ! grep -q "\.cargo/bin" "$HOME/.zshrc" 2>/dev/null; then
+      # shellcheck disable=SC2016
       echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.zshrc"
     fi
     if [[ -f "$HOME/.bash_profile" ]] && ! grep -q "\.cargo/bin" "$HOME/.bash_profile" 2>/dev/null; then
+      # shellcheck disable=SC2016
       echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$HOME/.bash_profile"
     fi
     echo "Rust installed successfully" >&2

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,8 @@
+# JSON Schema for `lints` in published Cargo.toml schemas is wrong for `[lints.*]`
+# (rust-lang/cargo#15030). Skip schema validation for those keys only.
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["lints", "lints.*"]
+
+[rule.schema]
+enabled = false


### PR DESCRIPTION
## Summary

This PR tightens local quality checks and fixes editor/Taplo validation for `[lints.*]` without changing Cargo behaviour.

## Changes

- **quality.sh**: Run `shellcheck -s bash` on all repository `*.sh` files after `bash -n`. Exits with install instructions if `shellcheck` is missing.
- **scripts/benchmark-ci.sh** / **benchmark_compare.sh**: Replace word-splitting benchmark discovery with newline-oriented output and a `while read` loop (fixes SC2207; avoids `mapfile`, which is unavailable on macOS `/bin/bash` 3.2).
- **scripts/runlib.sh**: Use `read -r -a` for semver tokenisation (SC2206); `shellcheck disable=SC2016` for intentional literal `$HOME` in profile snippets.
- **taplo.toml**: Disable JSON Schema validation only for `lints` keys in `Cargo.toml`. Published schemas incorrectly reject valid `[lints.clippy]` tables (`anyOf` / rust-lang/cargo#15030 class of issue); Cargo continues to accept the manifest.
- **Cargo.toml**: Patch version `0.73.2`.

## Verification

- `cargo metadata` / `cargo check`
- `taplo lint Cargo.toml --schema https://json.schemastore.org/cargo.json` (with repo `taplo.toml`)
- `tests/benchmark_ci_test.sh`

Made with [Cursor](https://cursor.com)