### PR TITLE
feat: raise NEURON_MIN_IMPROVED_RATIO from 0.4 to 0.55 (#1109)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.2"
+version = "0.74.3"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1109.md
+++ b/docs/pr-summary-1109.md
@@ -1,0 +1,55 @@
+## Summary
+
+Raised `NEURON_MIN_IMPROVED_RATIO` from `0.4` to `0.55` in
+`src/analysis/constants/detection_thresholds.rs`. GRQ-sampler production failure
+data (commit [50a2909](https://github.com/stSoftwareAU/GRQ-sampler/commit/50a2909eb04ab912804979d7e056e96350e1d8df))
+showed neuron candidates with improved ratios of 52–54% (267–274 out of 510)
+consistently produced negative actual error reductions despite positive
+predictions. The previous `0.4` threshold let near-random candidates through,
+wasting evaluation budget; raising to `0.55` filters these while still staying
+below the synapse threshold (`MIN_IMPROVED_RATIO = 0.6`) because neuron
+candidates are inherently noisier (two new connections rather than one).
+
+Closes #1109.
+
+## Changes
+
+- `src/analysis/constants/detection_thresholds.rs`: bumped
+  `NEURON_MIN_IMPROVED_RATIO` to `0.55` and documented the Issue #1109
+  rationale with the production evidence.
+- `tests/analysis/issue_938_constants_submodule_organisation.rs`: updated the
+  accessibility assertion to the new value.
+- `tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs`: new
+  regression tests covering the raised threshold, the 52–54% production
+  failure pattern rejection, the 55% boundary acceptance, and the invariant
+  that the neuron threshold remains below the synapse threshold.
+- `tests/analysis/main.rs`: registered the new test module.
+- `Cargo.toml`: bumped patch version `0.74.2` → `0.74.3` (remote machines cache
+  the library by version).
+
+## Evidence
+
+CLI/library change only — no UI. `./quality.sh` passes cleanly, including:
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --lib --tests --all-features -- --test-threads=2`
+- release build
+
+`passes_neuron_improved_ratio()` in `src/analysis/neuron/evaluation.rs` uses the
+constant directly and required no code changes — the function's `>=` comparison
+still works correctly with the new value, and no temperature scaling is applied
+at this filter (temperature scheduling in Issue #1020 operates on acceptance
+probabilities downstream, not on this gating threshold).
+
+## Test Plan
+
+- [x] `cargo test --lib --tests --all-features -- --test-threads=2` (via
+  `./quality.sh`)
+- [x] New tests in `tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs`
+  verify the 0.55 value, rejection of 52–54% production failure ratios,
+  acceptance at exactly 55%, and the neuron-below-synapse invariant.
+- [x] Existing constant assertion in
+  `tests/analysis/issue_938_constants_submodule_organisation.rs` updated.
+- [x] Existing Issue #733 tests continue to pass (the "55% good / 20% bad"
+  boundary checks remain valid under the new threshold).

--- a/src/analysis/constants/detection_thresholds.rs
+++ b/src/analysis/constants/detection_thresholds.rs
@@ -31,10 +31,20 @@ pub const MIN_IMPROVED_RATIO: f32 = 0.6;
 /// than `MIN_IMPROVED_RATIO` allows moderate-quality candidates through while
 /// still filtering out clearly bad ones.
 ///
+/// Issue #1109: Raised from 0.4 to 0.55. Production failure data from GRQ-sampler
+/// (commit 50a2909) showed neuron candidates with improved ratios of 52-54%
+/// (267-274 out of 510) consistently producing negative actual error reductions
+/// despite positive predictions. The previous 0.4 threshold was too permissive —
+/// candidates barely above 50/50 are indistinguishable from random chance and
+/// waste evaluation budget. Raising the neuron threshold to 0.55 aligns with the
+/// observed failure patterns while still allowing moderately confident candidates
+/// through (it remains below `MIN_IMPROVED_RATIO = 0.6` because neuron candidates
+/// are noisier than synapse candidates).
+///
 /// ## Valid Range
 /// Must be in (0.0, 1.0). Values below 0.3 provide insufficient filtering.
 /// Values above `MIN_IMPROVED_RATIO` may be too strict for neuron candidates.
-pub const NEURON_MIN_IMPROVED_RATIO: f32 = 0.4;
+pub const NEURON_MIN_IMPROVED_RATIO: f32 = 0.55;
 
 // =============================================================================
 // Remove-Low-Impact Candidate Thresholds (Issue #892)

--- a/src/analysis/scoring/error_distribution.rs
+++ b/src/analysis/scoring/error_distribution.rs
@@ -381,7 +381,7 @@ fn detect_modes_histogram(errors: &[f32]) -> Vec<ErrorMode> {
     modes.retain(|m| m.proportion >= 0.05);
 
     // Sort by sample count (largest first)
-    modes.sort_by(|a, b| b.sample_count.cmp(&a.sample_count));
+    modes.sort_by_key(|b| std::cmp::Reverse(b.sample_count));
 
     modes
 }

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -250,8 +250,7 @@ pub fn log_analysis_start(
     {
         let now_ms = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_millis() as u64);
         if raw_ms >= YEAR_2000_MS {
             // Absolute timestamp
             let elapsed_secs =

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -341,8 +341,7 @@ pub fn validate_parquet_memory_requirements(
 /// This is a public function so it can be used by focus.rs and analysis.rs.
 pub fn check_memory_for_parquet(parquet_file: &str) -> Result<()> {
     let file_size_bytes = std::fs::metadata(parquet_file)
-        .map(|m| m.len())
-        .unwrap_or(0);
+        .map_or(0, |m| m.len());
 
     let (available_bytes, total_bytes) = get_memory_info();
 

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -340,8 +340,7 @@ pub fn validate_parquet_memory_requirements(
 ///
 /// This is a public function so it can be used by focus.rs and analysis.rs.
 pub fn check_memory_for_parquet(parquet_file: &str) -> Result<()> {
-    let file_size_bytes = std::fs::metadata(parquet_file)
-        .map_or(0, |m| m.len());
+    let file_size_bytes = std::fs::metadata(parquet_file).map_or(0, |m| m.len());
 
     let (available_bytes, total_bytes) = get_memory_info();
 

--- a/src/discovery_history.rs
+++ b/src/discovery_history.rs
@@ -172,7 +172,7 @@ impl CalibrationTracker {
             })
             .collect();
 
-        entries.sort_by(|a, b| b.sample_count.cmp(&a.sample_count));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.sample_count));
         entries
     }
 }

--- a/src/ffi/helpers.rs
+++ b/src/ffi/helpers.rs
@@ -35,8 +35,7 @@ pub fn to_ffi_json<T: Serialize>(value: &T) -> *mut std::ffi::c_char {
 /// empty string, which is safer than unwinding across the FFI boundary.
 pub fn ffi_error_literal(msg: &str) -> *mut std::ffi::c_char {
     CString::new(msg)
-        .map(CString::into_raw)
-        .unwrap_or(std::ptr::null_mut())
+        .map_or(std::ptr::null_mut(), CString::into_raw)
 }
 
 /// Build an FFI-safe error response from a caught panic.

--- a/src/ffi/helpers.rs
+++ b/src/ffi/helpers.rs
@@ -34,8 +34,7 @@ pub fn to_ffi_json<T: Serialize>(value: &T) -> *mut std::ffi::c_char {
 /// a null pointer as a last resort — the Deno FFI layer treats null as an
 /// empty string, which is safer than unwinding across the FFI boundary.
 pub fn ffi_error_literal(msg: &str) -> *mut std::ffi::c_char {
-    CString::new(msg)
-        .map_or(std::ptr::null_mut(), CString::into_raw)
+    CString::new(msg).map_or(std::ptr::null_mut(), CString::into_raw)
 }
 
 /// Build an FFI-safe error response from a caught panic.

--- a/src/focus/gradient.rs
+++ b/src/focus/gradient.rs
@@ -169,12 +169,11 @@ fn compute_activation_gradient(squash: &str, value: f32) -> (f32, bool) {
             let gradient = sigmoid * (1.0 - sigmoid);
             (gradient, false)
         }
+        "HARD_TANH" | "CLIPPED" if value.abs() >= saturation_thresholds::HARD_TANH_THRESHOLD => {
+            (0.0, false) // Saturated but not "dead"
+        }
         "HARD_TANH" | "CLIPPED" => {
-            if value.abs() >= saturation_thresholds::HARD_TANH_THRESHOLD {
-                (0.0, false) // Saturated but not "dead"
-            } else {
-                (1.0, false)
-            }
+            (1.0, false)
         }
         "BIPOLAR_SIGMOID" => {
             // 2 * sigmoid(x) - 1, derivative = 2 * sigmoid(x) * (1 - sigmoid(x))

--- a/src/focus/gradient.rs
+++ b/src/focus/gradient.rs
@@ -172,9 +172,7 @@ fn compute_activation_gradient(squash: &str, value: f32) -> (f32, bool) {
         "HARD_TANH" | "CLIPPED" if value.abs() >= saturation_thresholds::HARD_TANH_THRESHOLD => {
             (0.0, false) // Saturated but not "dead"
         }
-        "HARD_TANH" | "CLIPPED" => {
-            (1.0, false)
-        }
+        "HARD_TANH" | "CLIPPED" => (1.0, false),
         "BIPOLAR_SIGMOID" => {
             // 2 * sigmoid(x) - 1, derivative = 2 * sigmoid(x) * (1 - sigmoid(x))
             let sigmoid = if value >= 0.0 {

--- a/tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs
+++ b/tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs
@@ -1,0 +1,51 @@
+//! Issue #1109: Raise `NEURON_MIN_IMPROVED_RATIO` from 0.4 to 0.55.
+//!
+//! Production failure data from GRQ-sampler (commit 50a2909) showed neuron
+//! candidates with improved ratios of 52-54% (267-274 out of 510) consistently
+//! producing negative actual error reductions despite positive predictions.
+//! Raising the threshold from 0.4 to 0.55 filters out these near-random
+//! candidates that waste evaluation budget.
+
+use neat_ai_discovery::analysis::constants::{MIN_IMPROVED_RATIO, NEURON_MIN_IMPROVED_RATIO};
+
+/// Issue #1109: The neuron improved-ratio threshold must be raised to 0.55.
+#[test]
+fn neuron_min_improved_ratio_is_raised_to_0_55() {
+    const {
+        assert!((NEURON_MIN_IMPROVED_RATIO - 0.55_f32).abs() < f32::EPSILON);
+    }
+}
+
+/// Issue #1109: Candidates with the production failure pattern (52-54% improved)
+/// must be rejected by the raised threshold.
+#[test]
+fn production_failure_pattern_is_rejected() {
+    // 267/510 = 0.5235, 274/510 = 0.5372 — the observed failure ratios.
+    let failure_ratios = [267.0_f32 / 510.0, 270.0 / 510.0, 274.0 / 510.0];
+    for ratio in failure_ratios {
+        assert!(
+            ratio < NEURON_MIN_IMPROVED_RATIO,
+            "Production failure ratio {ratio:.4} should be below the raised threshold \
+             {NEURON_MIN_IMPROVED_RATIO}"
+        );
+    }
+}
+
+/// Issue #1109: A candidate with exactly 55% improved must pass.
+#[test]
+fn exactly_55_percent_still_passes() {
+    let ratio = 0.55_f32;
+    assert!(
+        ratio >= NEURON_MIN_IMPROVED_RATIO,
+        "A 55% improved ratio should pass the raised threshold"
+    );
+}
+
+/// Issue #1109: The neuron threshold remains below the synapse threshold
+/// (neuron candidates are inherently noisier and get a small allowance).
+#[test]
+fn neuron_threshold_stays_below_synapse_threshold() {
+    const {
+        assert!(NEURON_MIN_IMPROVED_RATIO < MIN_IMPROVED_RATIO);
+    }
+}

--- a/tests/analysis/issue_938_constants_submodule_organisation.rs
+++ b/tests/analysis/issue_938_constants_submodule_organisation.rs
@@ -153,7 +153,7 @@ fn test_scoring_boosts_accessible() {
 #[test]
 fn test_detection_thresholds_accessible() {
     assert!((constants::MIN_IMPROVED_RATIO - 0.6).abs() < f32::EPSILON);
-    assert!((constants::NEURON_MIN_IMPROVED_RATIO - 0.4).abs() < f32::EPSILON);
+    assert!((constants::NEURON_MIN_IMPROVED_RATIO - 0.55).abs() < f32::EPSILON);
     assert!((constants::REMOVAL_MEAN_ACTIVATION_THRESHOLD - 0.04).abs() < f32::EPSILON);
     assert!((constants::REMOVAL_IMPACT_THRESHOLD - 6e-5).abs() < f32::EPSILON);
     assert!((constants::MAX_INCOMING_WEIGHT - 5.0).abs() < f32::EPSILON);

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -20,6 +20,7 @@ mod issue_1060_prefilter_learning;
 mod issue_1097_shared_deadline;
 mod issue_1098_wall_clock_cap;
 mod issue_1101_no_target_records_diagnostic;
+mod issue_1109_neuron_min_improved_ratio_raise;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Raised `NEURON_MIN_IMPROVED_RATIO` from `0.4` to `0.55` in
`src/analysis/constants/detection_thresholds.rs`. GRQ-sampler production failure
data (commit [50a2909](https://github.com/stSoftwareAU/GRQ-sampler/commit/50a2909eb04ab912804979d7e056e96350e1d8df))
showed neuron candidates with improved ratios of 52–54% (267–274 out of 510)
consistently produced negative actual error reductions despite positive
predictions. The previous `0.4` threshold let near-random candidates through,
wasting evaluation budget; raising to `0.55` filters these while still staying
below the synapse threshold (`MIN_IMPROVED_RATIO = 0.6`) because neuron
candidates are inherently noisier (two new connections rather than one).

Closes #1109.

## Changes

- `src/analysis/constants/detection_thresholds.rs`: bumped
  `NEURON_MIN_IMPROVED_RATIO` to `0.55` and documented the Issue #1109
  rationale with the production evidence.
- `tests/analysis/issue_938_constants_submodule_organisation.rs`: updated the
  accessibility assertion to the new value.
- `tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs`: new
  regression tests covering the raised threshold, the 52–54% production
  failure pattern rejection, the 55% boundary acceptance, and the invariant
  that the neuron threshold remains below the synapse threshold.
- `tests/analysis/main.rs`: registered the new test module.
- `Cargo.toml`: bumped patch version `0.74.2` → `0.74.3` (remote machines cache
  the library by version).

## Evidence

CLI/library change only — no UI. `./quality.sh` passes cleanly, including:

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --tests --all-features -- --test-threads=2`
- release build

`passes_neuron_improved_ratio()` in `src/analysis/neuron/evaluation.rs` uses the
constant directly and required no code changes — the function's `>=` comparison
still works correctly with the new value, and no temperature scaling is applied
at this filter (temperature scheduling in Issue #1020 operates on acceptance
probabilities downstream, not on this gating threshold).

## Test Plan

- [x] `cargo test --lib --tests --all-features -- --test-threads=2` (via
  `./quality.sh`)
- [x] New tests in `tests/analysis/issue_1109_neuron_min_improved_ratio_raise.rs`
  verify the 0.55 value, rejection of 52–54% production failure ratios,
  acceptance at exactly 55%, and the neuron-below-synapse invariant.
- [x] Existing constant assertion in
  `tests/analysis/issue_938_constants_submodule_organisation.rs` updated.
- [x] Existing Issue #733 tests continue to pass (the "55% good / 20% bad"
  boundary checks remain valid under the new threshold).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1109 -->