### PR TITLE
feat: add minimum expected-gain floor for coordinated structural candidates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.3"
+version = "0.74.4"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1110.md
+++ b/docs/pr-summary-1110.md
@@ -1,0 +1,24 @@
+## Summary
+
+Add a minimum expected-gain floor (`COORDINATED_MIN_EXPECTED_GAIN = 1e-5`) for coordinated structural candidates to filter out noise-level proposals. Closes #1110.
+
+Production failure data from GRQ-sampler (commit 50a2909) shows coordinated structural candidates with `expectedCreatureScoreGain` of ~8e-8 and ~4e-8 that produced actual error changes of -0.0008 and -0.0004 respectively -- harming the network. Expected gains at 1e-8 to 1e-7 are indistinguishable from numerical noise and should never be proposed.
+
+## Changes
+
+- Added `COORDINATED_MIN_EXPECTED_GAIN: f32 = 1e-5` constant in `src/analysis/constants/candidate_scoring.rs`
+- Updated both discovery dispatch paths (`run_discovery_module` single-module and `merge_discovery_module_results` parallel) in `src/analysis/discovery_dispatch.rs` to use `>= COORDINATED_MIN_EXPECTED_GAIN` instead of `> 0.0`
+- The filter in `src/analysis/neuron/post_processing.rs` was not changed because it handles neuron candidates, not coordinated structural candidates
+
+## Evidence
+
+No UI changes. Backend-only constant addition and filter update. All 32 discovery dispatch tests pass, including 5 new tests for the threshold behaviour.
+
+## Test Plan
+
+Added 5 unit tests in `src/analysis/discovery_dispatch_tests.rs`:
+- `coordinated_min_expected_gain_constant_is_1e_minus_5` -- verifies constant value
+- `noise_level_gain_8e_minus_8_is_rejected` -- confirms noise-level candidates from production failure data are rejected
+- `genuine_gain_1e_minus_4_is_accepted` -- confirms genuine candidates pass through
+- `gain_exactly_at_threshold_is_accepted` -- boundary: gain == 1e-5 is accepted
+- `gain_just_below_threshold_is_rejected` -- boundary: gain at 9e-6 is rejected

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -538,6 +538,25 @@ pub const ADAPTIVE_PROPOSAL_MAX_SIGMA: f32 = 3.0;
 pub const ADAPTIVE_PROPOSAL_SIGN_FLIP_PROBABILITY: f32 = 0.15;
 
 // =============================================================================
+// Coordinated Candidate Minimum Expected Gain (Issue #1110)
+// =============================================================================
+
+/// Minimum expected-gain floor for coordinated structural candidates (Issue #1110).
+///
+/// Production failure data from GRQ-sampler (commit 50a2909) shows coordinated
+/// structural candidates with `expectedCreatureScoreGain` of ~8e-8 and ~4e-8
+/// (after 0.2× weight scaling) that produced actual error changes of -0.0008
+/// and -0.0004 respectively — harming the network rather than helping.
+///
+/// Expected gains at 1e-8 to 1e-7 are indistinguishable from numerical noise
+/// and should never be proposed. This floor filters noise-level proposals while
+/// preserving genuinely promising candidates.
+///
+/// ## Valid Range
+/// Must be > 0.0. Values above 1e-3 may filter too aggressively.
+pub const COORDINATED_MIN_EXPECTED_GAIN: f32 = 1e-5;
+
+// =============================================================================
 // NaN-safe Floating-Point Comparison Helpers (Issue #483)
 // =============================================================================
 

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -21,8 +21,8 @@ use crate::observability::PhaseTimer;
 use rayon::prelude::*;
 
 use super::constants::{
-    MODULE_GATE_THRESHOLD, QUALITY_SKIP_GAIN_THRESHOLD, QUALITY_SKIP_MIN_CANDIDATES,
-    SOFT_FAILURE_WEIGHT,
+    COORDINATED_MIN_EXPECTED_GAIN, MODULE_GATE_THRESHOLD, QUALITY_SKIP_GAIN_THRESHOLD,
+    QUALITY_SKIP_MIN_CANDIDATES, SOFT_FAILURE_WEIGHT,
 };
 use super::module_weights::{DiscoveryModuleStatsJson, ModuleOutcomeTracker};
 use super::shared;
@@ -63,9 +63,16 @@ pub fn run_discovery_module(
     crate::watchdog::beat(&starting);
     let _timer = PhaseTimer::new(phase_name);
 
-    if let Some(result) = detect_fn()
+    if let Some(mut result) = detect_fn()
         && !result.candidates.is_empty()
     {
+        // Issue #1110: Filter coordinated candidates below the minimum
+        // expected-gain floor. Gains at 1e-8 to 1e-7 are indistinguishable
+        // from numerical noise and harm the network in production.
+        result
+            .candidates
+            .retain(|c| c.expected_creature_score_gain >= COORDINATED_MIN_EXPECTED_GAIN);
+
         if utils::verbose_enabled() {
             tracing::debug!(
                 module = module_name,
@@ -75,12 +82,14 @@ pub fn run_discovery_module(
             );
         }
 
-        super::merge_coordinated_structural_replacements(
-            syn,
-            result.candidates,
-            max_synapse_candidates,
-            diversify,
-        );
+        if !result.candidates.is_empty() {
+            super::merge_coordinated_structural_replacements(
+                syn,
+                result.candidates,
+                max_synapse_candidates,
+                diversify,
+            );
+        }
     }
 
     crate::watchdog::beat(&finished);
@@ -333,11 +342,13 @@ pub fn merge_discovery_module_results(
                 result.candidates.truncate(entry.max_candidates);
             }
 
-            // Issue #1060: Count candidates filtered by positive-gain check before merge.
+            // Issue #1060, #1110: Filter coordinated candidates below the minimum
+            // expected-gain floor. Gains at 1e-8 to 1e-7 are indistinguishable
+            // from numerical noise and harm the network in production.
             let pre_filter_count = result.candidates.len();
             result
                 .candidates
-                .retain(|c| c.expected_creature_score_gain > 0.0);
+                .retain(|c| c.expected_creature_score_gain >= COORDINATED_MIN_EXPECTED_GAIN);
             let post_filter_count = result.candidates.len();
 
             // Issue #1060: Record pre-filtering soft failures for candidates that

--- a/src/analysis/discovery_dispatch_tests.rs
+++ b/src/analysis/discovery_dispatch_tests.rs
@@ -188,6 +188,151 @@ fn run_discovery_module_accumulates_across_multiple_calls() {
 }
 
 // =============================================================================
+// Issue #1110: Coordinated minimum expected-gain floor tests
+// =============================================================================
+
+#[test]
+fn coordinated_min_expected_gain_constant_is_1e_minus_5() {
+    use crate::analysis::constants::COORDINATED_MIN_EXPECTED_GAIN;
+    assert!(
+        (COORDINATED_MIN_EXPECTED_GAIN - 1e-5).abs() < f32::EPSILON,
+        "COORDINATED_MIN_EXPECTED_GAIN should be 1e-5, got {COORDINATED_MIN_EXPECTED_GAIN}",
+    );
+}
+
+/// Production failure data shows gains at ~8e-8 produce negative actual
+/// outcomes. These noise-level candidates must be rejected.
+#[test]
+fn noise_level_gain_8e_minus_8_is_rejected() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "noise level module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 2,
+                candidates: vec![
+                    make_candidate(8e-8), // noise — should be rejected
+                    make_candidate(1e-4), // genuine — should be accepted
+                ],
+            })
+        },
+    );
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        1,
+        "noise-level candidate at 8e-8 should be filtered, genuine at 1e-4 kept"
+    );
+    assert!(syn.coordinated_structural_candidates[0].expected_creature_score_gain >= 1e-5);
+}
+
+/// Candidates at 1e-4 are well above the floor and should be accepted.
+#[test]
+fn genuine_gain_1e_minus_4_is_accepted() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "genuine gain module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(1e-4)],
+            })
+        },
+    );
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        1,
+        "candidate at 1e-4 should be accepted"
+    );
+}
+
+/// Candidates exactly at the threshold (1e-5) should be accepted (>= check).
+#[test]
+fn gain_exactly_at_threshold_is_accepted() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "exact threshold module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(1e-5)],
+            })
+        },
+    );
+
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        1,
+        "candidate exactly at threshold 1e-5 should be accepted"
+    );
+}
+
+/// Candidates just below the threshold should be rejected.
+#[test]
+fn gain_just_below_threshold_is_rejected() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: std::time::Duration::from_secs(60),
+        abort_delay: std::time::Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    run_discovery_module(
+        &mut syn,
+        "below threshold module",
+        "test_phase",
+        None,
+        false,
+        || {
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(9e-6)],
+            })
+        },
+    );
+
+    assert!(
+        syn.coordinated_structural_candidates.is_empty(),
+        "candidate at 9e-6 (below 1e-5 threshold) should be rejected"
+    );
+}
+
+// =============================================================================
 // Issue #557: Positive gain filtering tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Add a minimum expected-gain floor (`COORDINATED_MIN_EXPECTED_GAIN = 1e-5`) for coordinated structural candidates to filter out noise-level proposals. Closes #1110.

Production failure data from GRQ-sampler (commit 50a2909) shows coordinated structural candidates with `expectedCreatureScoreGain` of ~8e-8 and ~4e-8 that produced actual error changes of -0.0008 and -0.0004 respectively -- harming the network. Expected gains at 1e-8 to 1e-7 are indistinguishable from numerical noise and should never be proposed.

## Changes

- Added `COORDINATED_MIN_EXPECTED_GAIN: f32 = 1e-5` constant in `src/analysis/constants/candidate_scoring.rs`
- Updated both discovery dispatch paths (`run_discovery_module` single-module and `merge_discovery_module_results` parallel) in `src/analysis/discovery_dispatch.rs` to use `>= COORDINATED_MIN_EXPECTED_GAIN` instead of `> 0.0`
- The filter in `src/analysis/neuron/post_processing.rs` was not changed because it handles neuron candidates, not coordinated structural candidates

## Evidence

No UI changes. Backend-only constant addition and filter update. All 32 discovery dispatch tests pass, including 5 new tests for the threshold behaviour.

## Test Plan

Added 5 unit tests in `src/analysis/discovery_dispatch_tests.rs`:
- `coordinated_min_expected_gain_constant_is_1e_minus_5` -- verifies constant value
- `noise_level_gain_8e_minus_8_is_rejected` -- confirms noise-level candidates from production failure data are rejected
- `genuine_gain_1e_minus_4_is_accepted` -- confirms genuine candidates pass through
- `gain_exactly_at_threshold_is_accepted` -- boundary: gain == 1e-5 is accepted
- `gain_just_below_threshold_is_rejected` -- boundary: gain at 9e-6 is rejected



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1110 -->