### PR TITLE
feat: apply saturation-aware prediction discount for neuron candidates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.6"
+version = "0.74.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1112.md
+++ b/docs/pr-summary-1112.md
@@ -1,0 +1,28 @@
+## Summary
+
+Apply saturation-aware prediction discount for neuron candidates targeting near-saturated neurons. Production data shows predictions of ~0.01 for candidates targeting `HARD_TANH` at full activation range, while actual results are ~-0.00005 (100-200x overestimation beyond existing calibration). The discount is applied after pessimism discounting and before logistic calibration, linearly interpolating from 1.0 (at saturation threshold 0.9) to the aggressive floor of 0.15 (at full saturation). Closes #1112.
+
+## Changes
+
+- **`src/analysis/constants/candidate_scoring.rs`**: Added `SATURATION_DISCOUNT_AGGRESSIVE` constant (0.15) as the discount floor for fully saturated targets.
+- **`src/analysis/synapse/scoring/discounting.rs`**: Added `saturation_discount()` helper and public `apply_saturation_prediction_discount()` function.
+- **`src/analysis/neuron/post_processing.rs`**: Applied saturation discount in `apply_impact_discounting()` between pessimism discount and logistic calibration.
+- **`src/analysis/synapse/scoring/mod.rs`** and **`src/analysis/synapse/mod.rs`**: Re-exported the new function.
+
+## Evidence
+
+Backend/scoring change with no web interface. Verified via unit tests:
+
+- All 7 new tests pass (`cargo test --test scoring -- issue_1112`)
+- `./quality.sh` passes cleanly (fmt, clippy, check, tests, doc build, release build)
+
+## Test Plan
+
+- `tests/scoring/issue_1112_saturation_prediction_discount.rs` — 7 tests:
+  - `saturated_hard_tanh_target_gets_heavy_discount`: HARD_TANH at [-1, 1] (factor=1.0) reduces prediction by >= 60%
+  - `non_saturated_identity_target_unchanged`: IDENTITY (None) receives no discount
+  - `threshold_boundary_gets_no_discount`: factor=0.9 (threshold) returns unchanged gain
+  - `below_threshold_gets_no_discount`: factor=0.5 returns unchanged gain
+  - `discount_is_proportional_to_saturation`: factor=0.95 retains more gain than factor=1.0
+  - `zero_gain_remains_zero`: zero input produces zero output
+  - `negative_gain_preserves_sign`: negative gains remain negative after discount

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -300,6 +300,29 @@ pub const ACTIVATION_BOOST_MIN: f64 = 0.5;
 pub const ACTIVATION_BOOST_MAX: f64 = 2.0;
 
 // =============================================================================
+// Saturation-Aware Prediction Discount (Issue #1112)
+// =============================================================================
+
+/// Discount floor for predictions targeting near-saturated neurons (Issue #1112).
+///
+/// When a target neuron is operating near its activation saturation bounds
+/// (e.g., `HARD_TANH` at [-1, 1]), its output physically cannot move much in
+/// response to small perturbations, so predictions are heavily over-estimated.
+///
+/// Production data shows predictions of ~0.01 for neuron candidates targeting
+/// `HARD_TANH` at full range, while actual results are ~-0.00005 (negative —
+/// making things worse). This discount is applied multiplicatively after
+/// pessimism discounting and before logistic calibration.
+///
+/// The discount interpolates linearly from 1.0 (at the saturation threshold)
+/// down to this floor (at full saturation, factor = 1.0).
+///
+/// ## Valid Range
+/// Must be in (0.0, 0.5). Values below 0.05 risk zeroing-out all saturated
+/// candidates. Values above 0.5 provide insufficient correction.
+pub const SATURATION_DISCOUNT_AGGRESSIVE: f32 = 0.15;
+
+// =============================================================================
 // Pessimism Discount (Issue #506)
 // =============================================================================
 

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -16,6 +16,7 @@ use crate::analysis::gpu::GpuAnalyzer;
 use crate::analysis::shared::AnalyzeNeuronsResult;
 use crate::analysis::synapse::{
     apply_logistic_prediction_calibration, apply_neuron_pessimism_discount,
+    apply_saturation_prediction_discount,
 };
 use crate::analysis::utils::{
     lock_or_bail, log_analysis_timeout, shuffle_within_top_k, verbose_enabled,
@@ -184,6 +185,14 @@ fn apply_impact_discounting(
             candidate.expected_creature_score_gain,
             candidate.improved_count,
             candidate.total_count,
+        );
+
+        // Issue #1112: Apply saturation-aware prediction discount.
+        // Targets near activation saturation bounds cannot respond to perturbations,
+        // so predictions are heavily over-estimated and need proportional discounting.
+        candidate.expected_creature_score_gain = apply_saturation_prediction_discount(
+            candidate.expected_creature_score_gain,
+            candidate.target_saturation_factor,
         );
 
         // Issue #1056: Apply logistic prediction calibration to correct ~18× overestimation.

--- a/src/analysis/synapse/mod.rs
+++ b/src/analysis/synapse/mod.rs
@@ -55,7 +55,8 @@ mod target_analysis;
 pub use scoring::{
     apply_activation_neuron_boost, apply_logistic_prediction_calibration,
     apply_neuron_pessimism_discount, apply_pessimism_discount, apply_prediction_calibration,
-    apply_source_type_boost, apply_synapse_pessimism_discount, apply_target_type_boost,
+    apply_saturation_prediction_discount, apply_source_type_boost,
+    apply_synapse_pessimism_discount, apply_target_type_boost,
 };
 
 pub(crate) use candidate_generation::{

--- a/src/analysis/synapse/scoring/discounting.rs
+++ b/src/analysis/synapse/scoring/discounting.rs
@@ -7,7 +7,8 @@
 use crate::analysis::constants::{
     LOGISTIC_CALIBRATION_FLOOR, LOGISTIC_CALIBRATION_MIDPOINT, LOGISTIC_CALIBRATION_STEEPNESS,
     NEURON_PESSIMISM_CURVE_EXPONENT, NEURON_PESSIMISM_DISCOUNT_FLOOR, PESSIMISM_CURVE_EXPONENT,
-    PESSIMISM_DISCOUNT_FLOOR, SYNAPSE_PESSIMISM_CURVE_EXPONENT, SYNAPSE_PESSIMISM_DISCOUNT_FLOOR,
+    PESSIMISM_DISCOUNT_FLOOR, SATURATION_DISCOUNT_AGGRESSIVE, SYNAPSE_PESSIMISM_CURVE_EXPONENT,
+    SYNAPSE_PESSIMISM_DISCOUNT_FLOOR,
 };
 
 // =============================================================================
@@ -187,4 +188,57 @@ pub fn apply_logistic_prediction_calibration(
         / (1.0 + (-LOGISTIC_CALIBRATION_STEEPNESS * (ratio - LOGISTIC_CALIBRATION_MIDPOINT)).exp());
     let modulator = LOGISTIC_CALIBRATION_FLOOR + (1.0 - LOGISTIC_CALIBRATION_FLOOR) * sigmoid;
     gain * base_calibration * modulator
+}
+
+// =============================================================================
+// Saturation-Aware Prediction Discount (Issue #1112)
+// =============================================================================
+
+/// Compute the saturation discount multiplier for a given saturation factor.
+///
+/// Linearly interpolates from 1.0 (no discount) at the saturation threshold
+/// (0.9) down to `SATURATION_DISCOUNT_AGGRESSIVE` at full saturation (1.0).
+///
+/// Returns 1.0 for non-saturated targets (factor ≤ threshold or `None`).
+#[inline]
+fn saturation_discount(factor: f32) -> f32 {
+    // Threshold matches TARGET_SATURATION_RANGE_THRESHOLD in preparation.rs
+    const THRESHOLD: f32 = 0.90;
+
+    if factor <= THRESHOLD {
+        return 1.0;
+    }
+
+    // Normalise to [0, 1] within the saturated range
+    let normalised = ((factor - THRESHOLD) / (1.0 - THRESHOLD)).clamp(0.0, 1.0);
+
+    // Interpolate from 1.0 down to the aggressive floor
+    1.0 - normalised * (1.0 - SATURATION_DISCOUNT_AGGRESSIVE)
+}
+
+/// Apply saturation-aware prediction discount for neuron candidates (Issue #1112).
+///
+/// When the target neuron is operating near its activation saturation bounds,
+/// predictions are heavily over-estimated because the target physically cannot
+/// move much in response to small perturbations. This function applies an
+/// additional multiplicative discount proportional to the saturation level.
+///
+/// ## Arguments
+///
+/// * `gain` — The expected creature score gain after pessimism discounting
+/// * `target_saturation_factor` — The saturation factor from candidate
+///   preparation (`None` for non-saturated targets)
+///
+/// ## Returns
+///
+/// The discounted gain. Non-saturated targets (factor = `None`) are returned
+/// unchanged.
+pub fn apply_saturation_prediction_discount(
+    gain: f32,
+    target_saturation_factor: Option<f32>,
+) -> f32 {
+    match target_saturation_factor {
+        Some(factor) => gain * saturation_discount(factor),
+        None => gain,
+    }
 }

--- a/src/analysis/synapse/scoring/mod.rs
+++ b/src/analysis/synapse/scoring/mod.rs
@@ -22,7 +22,8 @@ pub use boost_functions::{
 };
 pub use discounting::{
     apply_logistic_prediction_calibration, apply_neuron_pessimism_discount,
-    apply_pessimism_discount, apply_prediction_calibration, apply_synapse_pessimism_discount,
+    apply_pessimism_discount, apply_prediction_calibration, apply_saturation_prediction_discount,
+    apply_synapse_pessimism_discount,
 };
 
 pub(crate) use improvement::upsert_candidate;

--- a/tests/scoring/issue_1112_saturation_prediction_discount.rs
+++ b/tests/scoring/issue_1112_saturation_prediction_discount.rs
@@ -1,0 +1,123 @@
+//! Issue #1112: Saturation-aware prediction discount for neuron candidates.
+//!
+//! Production data shows predictions of ~0.01 for neuron candidates targeting
+//! `HARD_TANH` at full activation range, while actual results are ~-0.00005.
+//! Saturation resistance means the target cannot move much in response to
+//! perturbations, so predictions must be discounted proportionally.
+
+use neat_ai_discovery::analysis::constants::SATURATION_DISCOUNT_AGGRESSIVE;
+use neat_ai_discovery::analysis::synapse::apply_saturation_prediction_discount;
+
+// =============================================================================
+// Compile-time constant validation
+// =============================================================================
+
+const _: () = assert!(SATURATION_DISCOUNT_AGGRESSIVE > 0.0);
+const _: () = assert!(SATURATION_DISCOUNT_AGGRESSIVE < 0.5);
+
+// =============================================================================
+// Unit tests
+// =============================================================================
+
+/// Candidate targeting `HARD_TANH` at [-1, 1] (fully saturated, factor = 1.0)
+/// should have prediction reduced by ≥60%.
+#[test]
+fn saturated_hard_tanh_target_gets_heavy_discount() {
+    let raw_gain = 0.01_f32;
+    // `HARD_TANH` at [-1, 1] → saturation_factor ≈ 1.0
+    let discounted = apply_saturation_prediction_discount(raw_gain, Some(1.0));
+
+    let reduction = 1.0 - (discounted / raw_gain);
+    assert!(
+        reduction >= 0.60,
+        "Saturated target prediction should be reduced by ≥60%, but reduction was {:.1}%",
+        reduction * 100.0,
+    );
+    assert!(
+        discounted > 0.0,
+        "Discounted gain should remain positive, got {discounted}",
+    );
+}
+
+/// Candidate targeting IDENTITY (unbounded, no saturation factor) should
+/// receive no additional discount.
+#[test]
+fn non_saturated_identity_target_unchanged() {
+    let raw_gain = 0.01_f32;
+    // IDENTITY → unbounded → target_saturation_factor = None
+    let discounted = apply_saturation_prediction_discount(raw_gain, None);
+
+    assert!(
+        (discounted - raw_gain).abs() < 1e-10,
+        "Non-saturated target should be unchanged: expected {raw_gain}, got {discounted}",
+    );
+}
+
+/// Targets at the saturation threshold boundary (0.9) should receive no discount.
+#[test]
+fn threshold_boundary_gets_no_discount() {
+    let raw_gain = 0.05_f32;
+    let discounted = apply_saturation_prediction_discount(raw_gain, Some(0.90));
+
+    assert!(
+        (discounted - raw_gain).abs() < 1e-6,
+        "Target at threshold (0.9) should get no discount: expected {raw_gain}, got {discounted}",
+    );
+}
+
+/// Targets below the saturation threshold should receive no discount even
+/// when a saturation factor is provided.
+#[test]
+fn below_threshold_gets_no_discount() {
+    let raw_gain = 0.05_f32;
+    let discounted = apply_saturation_prediction_discount(raw_gain, Some(0.5));
+
+    assert!(
+        (discounted - raw_gain).abs() < 1e-6,
+        "Target below threshold should get no discount: expected {raw_gain}, got {discounted}",
+    );
+}
+
+/// Discount should be proportional to saturation — a target at 0.95 should
+/// receive less discount than a fully saturated target (1.0).
+#[test]
+fn discount_is_proportional_to_saturation() {
+    let raw_gain = 0.01_f32;
+    let at_95 = apply_saturation_prediction_discount(raw_gain, Some(0.95));
+    let at_100 = apply_saturation_prediction_discount(raw_gain, Some(1.0));
+
+    assert!(
+        at_95 > at_100,
+        "Partially saturated ({at_95}) should retain more gain than fully saturated ({at_100})",
+    );
+    assert!(
+        at_95 < raw_gain,
+        "Partially saturated target should still receive some discount",
+    );
+}
+
+/// Zero gain should remain zero after saturation discount.
+#[test]
+fn zero_gain_remains_zero() {
+    let discounted = apply_saturation_prediction_discount(0.0, Some(1.0));
+    assert!(
+        discounted.abs() < 1e-15,
+        "Zero gain should remain zero, got {discounted}",
+    );
+}
+
+/// Negative gain should preserve sign after saturation discount.
+#[test]
+fn negative_gain_preserves_sign() {
+    let raw_gain = -0.03_f32;
+    let discounted = apply_saturation_prediction_discount(raw_gain, Some(1.0));
+
+    assert!(
+        discounted < 0.0,
+        "Negative gain should remain negative after discount",
+    );
+    assert!(
+        discounted.abs() < raw_gain.abs(),
+        "Absolute value should decrease: |{discounted}| should be < |{raw_gain}|",
+    );
+}

--- a/tests/scoring/main.rs
+++ b/tests/scoring/main.rs
@@ -5,6 +5,7 @@ mod common;
 
 mod cross_validation_test;
 mod issue_1056_logistic_prediction_calibration;
+mod issue_1112_saturation_prediction_discount;
 mod issue_192_error_distribution_analysis;
 mod issue_465_candidate_outcome_cache;
 mod issue_465_source_type_scoring;


### PR DESCRIPTION
## Summary

Apply saturation-aware prediction discount for neuron candidates targeting near-saturated neurons. Production data shows predictions of ~0.01 for candidates targeting `HARD_TANH` at full activation range, while actual results are ~-0.00005 (100-200x overestimation beyond existing calibration). The discount is applied after pessimism discounting and before logistic calibration, linearly interpolating from 1.0 (at saturation threshold 0.9) to the aggressive floor of 0.15 (at full saturation). Closes #1112.

## Changes

- **`src/analysis/constants/candidate_scoring.rs`**: Added `SATURATION_DISCOUNT_AGGRESSIVE` constant (0.15) as the discount floor for fully saturated targets.
- **`src/analysis/synapse/scoring/discounting.rs`**: Added `saturation_discount()` helper and public `apply_saturation_prediction_discount()` function.
- **`src/analysis/neuron/post_processing.rs`**: Applied saturation discount in `apply_impact_discounting()` between pessimism discount and logistic calibration.
- **`src/analysis/synapse/scoring/mod.rs`** and **`src/analysis/synapse/mod.rs`**: Re-exported the new function.

## Evidence

Backend/scoring change with no web interface. Verified via unit tests:

- All 7 new tests pass (`cargo test --test scoring -- issue_1112`)
- `./quality.sh` passes cleanly (fmt, clippy, check, tests, doc build, release build)

## Test Plan

- `tests/scoring/issue_1112_saturation_prediction_discount.rs` — 7 tests:
  - `saturated_hard_tanh_target_gets_heavy_discount`: HARD_TANH at [-1, 1] (factor=1.0) reduces prediction by >= 60%
  - `non_saturated_identity_target_unchanged`: IDENTITY (None) receives no discount
  - `threshold_boundary_gets_no_discount`: factor=0.9 (threshold) returns unchanged gain
  - `below_threshold_gets_no_discount`: factor=0.5 returns unchanged gain
  - `discount_is_proportional_to_saturation`: factor=0.95 retains more gain than factor=1.0
  - `zero_gain_remains_zero`: zero input produces zero output
  - `negative_gain_preserves_sign`: negative gains remain negative after discount



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1112 -->