### PR TITLE
ci: add ShellCheck lint workflow (#1121)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: .
+          severity: warning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.7"
+version = "0.74.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1121.md
+++ b/docs/pr-summary-1121.md
@@ -1,0 +1,12 @@
+## Summary
+Added `.github/workflows/shellcheck.yml` to lint all bash scripts with ShellCheck on every pull request, filling the gap left by the existing `shell-checks` CI job that only performs `bash -n` syntax validation. Closes #1121.
+
+## Evidence
+Ran `shellcheck --severity=warning` locally against every `*.sh` file in the repository (`quality.sh`, `benchmark.sh`, `benchmark_compare.sh`, and the scripts under `scripts/` and `tests/`). All files pass cleanly, so the new workflow will be green on the current codebase.
+
+This is a CI-only change; there is no UI to screenshot and no performance impact.
+
+## Test Plan
+- [x] Verified all existing shell scripts pass `shellcheck --severity=warning` with no findings
+- [x] Validated `shellcheck.yml` parses as valid YAML
+- [ ] Confirm the `ShellCheck` job runs and passes on this PR


### PR DESCRIPTION
## Summary
Added `.github/workflows/shellcheck.yml` to lint all bash scripts with ShellCheck on every pull request, filling the gap left by the existing `shell-checks` CI job that only performs `bash -n` syntax validation. Closes #1121.

## Evidence
Ran `shellcheck --severity=warning` locally against every `*.sh` file in the repository (`quality.sh`, `benchmark.sh`, `benchmark_compare.sh`, and the scripts under `scripts/` and `tests/`). All files pass cleanly, so the new workflow will be green on the current codebase.

This is a CI-only change; there is no UI to screenshot and no performance impact.

## Test Plan
- [x] Verified all existing shell scripts pass `shellcheck --severity=warning` with no findings
- [x] Validated `shellcheck.yml` parses as valid YAML
- [ ] Confirm the `ShellCheck` job runs and passes on this PR



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1121 -->