### PR TITLE
ci: complete cargo security audit workflow (#1122)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,22 +9,34 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
 jobs:
   security:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      
+
     - name: Install cargo-audit
       run: cargo install cargo-audit
-      
+
     - name: Run security audit
       run: cargo audit
-      
+
+    - name: RustSec audit-check
+      # Official RustSec GitHub Action — wraps cargo-audit and annotates
+      # PRs / opens issues for newly disclosed advisories.
+      uses: rustsec/audit-check@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Dependency review
       if: ${{ inputs.include-dependency-review && github.event_name == 'pull_request' }}
       uses: actions/dependency-review-action@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.9"
+version = "0.74.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1122.md
+++ b/docs/pr-summary-1122.md
@@ -1,0 +1,29 @@
+## Summary
+Completed the Cargo Security Audit workflow by adding the missing
+`rustsec/audit-check` detection pattern. The reusable workflow at
+`.github/workflows/security.yml` now runs the official RustSec GitHub
+Action alongside the existing `cargo install cargo-audit` + `cargo audit`
+steps, and is granted the `issues: write` / `checks: write` permissions
+the action needs to annotate PRs and open advisory issues. Closes #1122.
+
+A small pre-existing clippy lint (`map(...).unwrap_or(...)` on a `Result`)
+surfaced by the newer toolchain in `src/debug.rs` was also fixed so
+`quality.sh` passes cleanly — the change is a one-line rewrite to
+`map_or(...)`.
+
+## Evidence
+This is a CI/workflow change with no user interface. Verification:
+
+- New TDD test `tests/test_security_workflow_validation.sh` asserts the
+  workflow contains all three canonical patterns: `cargo audit`,
+  `cargo-audit`, and `rustsec/audit-check`. Red→green confirmed:
+  - Before the workflow edit: `1 failed` (missing `rustsec/audit-check`).
+  - After the workflow edit: `3 passed, 0 failed`.
+- Full `./quality.sh` run passes end-to-end (fmt, clippy, check, tests,
+  docs, release build).
+
+## Test Plan
+- Added `tests/test_security_workflow_validation.sh` covering the three
+  required cargo-audit patterns in `.github/workflows/security.yml`.
+- Ran `./quality.sh < /dev/null` — all checks pass.
+- Ran the new test directly — 3 passed, 0 failed.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -380,8 +380,7 @@ fn run_sample_command(pid: u32) {
         "neat_ai_discovery.sample.{pid}.{}.txt",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis())
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_millis())
     ));
     let out_path_str = out_path.to_string_lossy().to_string();
 

--- a/tests/test_security_workflow_validation.sh
+++ b/tests/test_security_workflow_validation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Test script for Cargo Security Audit workflow completeness (Issue #1122).
+#
+# The VibeCoding workflow sync expects `.github/workflows/security.yml` to
+# reference all three canonical cargo-audit patterns so the audit is fully
+# covered:
+#   1. `cargo audit`          — invocation of the audit tool
+#   2. `cargo-audit`          — crate name (install or reference)
+#   3. `rustsec/audit-check`  — official GitHub Action from RustSec
+#
+# These tests read the real workflow file and assert each pattern is present.
+
+set -euo pipefail
+
+WORKFLOW_FILE=".github/workflows/security.yml"
+PASS=0
+FAIL=0
+
+assert_pattern_present() {
+  local description="$1"
+  local pattern="$2"
+  local file="$3"
+
+  if grep -qE "$pattern" "$file"; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $description — expected pattern '$pattern' in $file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Test: workflow file exists ---
+if [ ! -f "$WORKFLOW_FILE" ]; then
+  echo "FAIL: $WORKFLOW_FILE not found"
+  exit 1
+fi
+
+# --- Test: all three cargo audit patterns are present ---
+assert_pattern_present \
+  "cargo audit invocation present" \
+  "cargo[[:space:]]+audit" \
+  "$WORKFLOW_FILE"
+
+assert_pattern_present \
+  "cargo-audit crate reference present" \
+  "cargo-audit" \
+  "$WORKFLOW_FILE"
+
+assert_pattern_present \
+  "rustsec/audit-check action reference present" \
+  "rustsec/audit-check" \
+  "$WORKFLOW_FILE"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "❌ Security workflow validation failed"
+  exit 1
+fi
+
+echo "✅ All security workflow validation tests passed"


### PR DESCRIPTION
## Summary
Completed the Cargo Security Audit workflow by adding the missing
`rustsec/audit-check` detection pattern. The reusable workflow at
`.github/workflows/security.yml` now runs the official RustSec GitHub
Action alongside the existing `cargo install cargo-audit` + `cargo audit`
steps, and is granted the `issues: write` / `checks: write` permissions
the action needs to annotate PRs and open advisory issues. Closes #1122.

A small pre-existing clippy lint (`map(...).unwrap_or(...)` on a `Result`)
surfaced by the newer toolchain in `src/debug.rs` was also fixed so
`quality.sh` passes cleanly — the change is a one-line rewrite to
`map_or(...)`.

## Evidence
This is a CI/workflow change with no user interface. Verification:

- New TDD test `tests/test_security_workflow_validation.sh` asserts the
  workflow contains all three canonical patterns: `cargo audit`,
  `cargo-audit`, and `rustsec/audit-check`. Red→green confirmed:
  - Before the workflow edit: `1 failed` (missing `rustsec/audit-check`).
  - After the workflow edit: `3 passed, 0 failed`.
- Full `./quality.sh` run passes end-to-end (fmt, clippy, check, tests,
  docs, release build).

## Test Plan
- Added `tests/test_security_workflow_validation.sh` covering the three
  required cargo-audit patterns in `.github/workflows/security.yml`.
- Ran `./quality.sh < /dev/null` — all checks pass.
- Ran the new test directly — 3 passed, 0 failed.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1122 -->