### PR TITLE
feat: emit structured rejection-reason breakdown on analysis metadata (#1129)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.13"
+version = "0.74.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1129.md
+++ b/docs/pr-summary-1129.md
@@ -1,0 +1,81 @@
+# Issue #1129 — Structured rejection-reason breakdown on analysis metadata
+
+Closes #1129.
+
+## Problem
+
+When discovery returned zero candidates, operators had no structured way to
+know why. The `synapseMetadata` / `neuronMetadata` JSON surfaced only totals
+and timing, so diagnosing "no candidates found" meant re-running with verbose
+logging and scraping log lines.
+
+## Change
+
+Added a `rejection_breakdown` map and a one-sentence `top_level_summary` to
+both `SynapseAnalysisMetadata` and `NeuronAnalysisMetadata`.
+
+- **`rejection_breakdown: HashMap<String, u32>`** — keyed by stable documented
+  reason names (`below_expected_gain_floor`, `below_multi_op_floor`,
+  `non_positive_gain`, `saturation_discounted_to_zero`,
+  `pessimism_discounted_to_zero`, `interference_filtered`,
+  `below_improved_ratio`, `duplicate_of_failure_cache`, `add_synapse_gated`,
+  `budget_truncated`, `no_samples`, `zero_improvement`, `below_threshold`,
+  `no_target_records`, `no_eligible_sources`, `input_neuron_filtered`,
+  `hidden_neuron_filtered`, `constant_neuron_filtered`, `no_diagnostics`).
+  The full catalogue lives in `analysis::diagnostics::rejection_reasons`.
+
+- **`top_level_summary: Option<String>`** — e.g. `"32 of 34 candidates
+  rejected by expected-gain floor of 1e-5"`. Populated whenever any
+  candidate was rejected, including when zero candidates survive.
+
+### Counter wiring
+
+- `candidate_aggregation::apply_coordinated_gain_floor` now returns the drop
+  count and the caller in `orchestration::analyze_all` feeds it into
+  `rejection_breakdown` under `below_expected_gain_floor`.
+- `candidate_aggregation::merge_coordinated_structural_replacements` records
+  `non_positive_gain` and `below_multi_op_floor` drops.
+- `discovery_dispatch::run_discovery_module` + `merge_discovery_module_results`
+  record `below_expected_gain_floor` and `budget_truncated` drops.
+- `orchestration::analyze_all` records `add_synapse_gated` drops from
+  `gate_add_synapse_candidates`.
+- `orchestration::aggregate_synapse_rejection_breakdown` and
+  `aggregate_neuron_rejection_breakdown` lift existing per-target
+  `no_candidate_reasons` into the breakdown and compute `top_level_summary`.
+- `neuron::preparation::build_empty_result` populates the breakdown with
+  input/hidden/constant pre-filter counts so the early-return path still
+  surfaces a meaningful summary.
+
+### FFI
+
+Both metadata structs in `ffi_types::responses::analysis` gained a
+`rejection_breakdown` (skip-serialize when empty) and `top_level_summary`
+(skip-serialize when `None`) field. `ffi_internal::analysis::analyze_parallel_internal`
+copies them into the response.
+
+## Tests
+
+- `tests/issue_1129_rejection_breakdown.rs` — three integration tests:
+  - `floor_dominated_case_records_below_expected_gain_floor` runs a discovery
+    module emitting 32 candidates at 5e-7 (below the 1e-5 floor). Asserts
+    zero survivors, ≥32 `below_expected_gain_floor` count, matching dominant
+    reason, and "expected-gain floor" in the summary.
+  - `mixed_reason_case_records_each_reason_independently` populates three
+    distinct reasons and asserts exact per-reason counts and a
+    dominant-reason summary.
+  - `apply_coordinated_gain_floor_returns_drop_count` verifies the helper's
+    new `u32` return carries the right drop count back to callers.
+- `src/analysis/diagnostics/rejection_reasons.rs` — six unit tests covering
+  `record`, `record_many` (zero skip), `dominant_reason`, `top_level_summary`
+  (floor and empty cases), and `merge_from`.
+
+## Validation
+
+- `./quality.sh < /dev/null` — PASS (fmt, clippy, check, 2000+ unit/integration
+  tests, doc build, release build).
+- No new warnings introduced. Pre-existing cargo duplicate-crate warnings are
+  unrelated.
+
+## Australian English
+
+`analyse`, `behaviour`, `favour`, `centre` used throughout comments.

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -37,8 +37,15 @@ use super::{cache, shared, synapse};
 /// re-filter at full strength. The lower sweep preserves those legitimately
 /// discounted candidates while still catching the exact 1e-7/1e-8 range that
 /// Issue #1127 captured hurting production networks.
-pub fn apply_coordinated_gain_floor(candidates: &mut Vec<CoordinatedStructuralCandidateJson>) {
+///
+/// Issue #1129: Returns the number of candidates removed so callers can
+/// record the drop in the structured rejection breakdown.
+pub fn apply_coordinated_gain_floor(
+    candidates: &mut Vec<CoordinatedStructuralCandidateJson>,
+) -> u32 {
+    let before = candidates.len();
     candidates.retain(|c| c.expected_creature_score_gain >= COORDINATED_POST_DISCOUNT_NOISE_FLOOR);
+    u32::try_from(before.saturating_sub(candidates.len())).unwrap_or(u32::MAX)
 }
 
 /// Compute the operation-count discount for a coordinated candidate (Issue #732, #1058).
@@ -78,19 +85,34 @@ pub fn validate_coordinated_candidate_gain(candidate: &CoordinatedStructuralCand
 /// diversified), and truncates to the combined synapse candidate limit. The
 /// final post-discount noise sweep happens in `analyze_all` via
 /// `apply_coordinated_gain_floor` (Issue #1128).
+///
+/// Issue #1129: Records a structured breakdown of removed candidates in
+/// `synapse.metadata.rejection_breakdown` so the FFI caller can root-cause
+/// "no candidates found" failures without re-running analysis.
 pub(crate) fn merge_coordinated_structural_replacements(
     synapse: &mut shared::AnalyzeSynapsesResult,
     mut replacements: Vec<CoordinatedStructuralCandidateJson>,
     max_synapse_candidates: Option<usize>,
     diversify: bool,
 ) {
+    use crate::analysis::diagnostics::rejection_reasons::{
+        REJECTION_BELOW_MULTI_OP_FLOOR, REJECTION_NON_POSITIVE_GAIN,
+    };
+
     if replacements.is_empty() {
         return;
     }
 
     // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
     // Only candidates predicted to improve the creature's score should be returned.
+    let before_positive = replacements.len();
     replacements.retain(|c| c.expected_creature_score_gain > 0.0);
+    let dropped_non_positive =
+        u32::try_from(before_positive.saturating_sub(replacements.len())).unwrap_or(u32::MAX);
+    synapse
+        .metadata
+        .rejection_breakdown
+        .record_many_u32(REJECTION_NON_POSITIVE_GAIN, dropped_non_positive);
     if replacements.is_empty() {
         return;
     }
@@ -107,6 +129,7 @@ pub(crate) fn merge_coordinated_structural_replacements(
     // `> 0.0` (filtered above) — the final post-discount noise sweep in
     // `analyze_all` (Issue #1128) catches sub-noise gains that survived
     // downstream pessimism/calibration stages.
+    let before_multi = replacements.len();
     replacements.retain(|c| {
         if c.operations.len() <= 1 {
             c.expected_creature_score_gain > 0.0
@@ -114,6 +137,12 @@ pub(crate) fn merge_coordinated_structural_replacements(
             c.expected_creature_score_gain > MIN_COORDINATED_MULTI_OP_GAIN
         }
     });
+    let dropped_multi =
+        u32::try_from(before_multi.saturating_sub(replacements.len())).unwrap_or(u32::MAX);
+    synapse
+        .metadata
+        .rejection_breakdown
+        .record_many_u32(REJECTION_BELOW_MULTI_OP_FLOOR, dropped_multi);
     if replacements.is_empty() {
         return;
     }

--- a/src/analysis/diagnostics/mod.rs
+++ b/src/analysis/diagnostics/mod.rs
@@ -21,6 +21,7 @@ mod focus_filter;
 pub(crate) mod mcmc_diagnostics;
 mod neuron_tracking;
 mod rejection;
+pub mod rejection_reasons;
 mod target_data;
 
 // Re-export all public items to maintain the existing API
@@ -29,6 +30,7 @@ pub(crate) use focus_filter::{
 };
 pub(crate) use neuron_tracking::NeuronDiagnostics;
 pub(crate) use rejection::{TargetDiagnostics, ThresholdContext};
+pub use rejection_reasons::RejectionBreakdown;
 pub(crate) use target_data::TargetMap;
 
 // RejectionReason is only used by test modules (implementation_tests, inline tests)

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -1,0 +1,348 @@
+//! Stable rejection reason names and aggregate breakdown (Issue #1129).
+//!
+//! Every filter or discount call site that zeroes out (or removes) a candidate
+//! must increment a counter on [`RejectionBreakdown`] using one of the
+//! `REJECTION_*` constants below. Downstream tooling relies on these strings
+//! staying stable across releases — add new names here rather than editing
+//! existing ones.
+//!
+//! The aggregated counts, plus a one-sentence [`top_level_summary`] describing
+//! the dominant reason, are emitted on both `synapseMetadata` and
+//! `neuronMetadata` in the FFI JSON response (even when zero candidates
+//! survive) so operators can root-cause "no candidates found" failures
+//! without re-running analysis.
+
+use std::collections::HashMap;
+
+// =============================================================================
+// Stable reason names
+// =============================================================================
+//
+// These are the documented reason strings used as keys in `rejection_breakdown`.
+// Keep them lowercase-snake-case and stable; add new constants rather than
+// renaming existing ones.
+
+/// Candidate's expected gain fell below the coordinated expected-gain floor
+/// (`COORDINATED_MIN_EXPECTED_GAIN` or `COORDINATED_POST_DISCOUNT_NOISE_FLOOR`).
+pub const REJECTION_BELOW_EXPECTED_GAIN_FLOOR: &str = "below_expected_gain_floor";
+
+/// Multi-operation coordinated candidate's discounted gain fell below
+/// `MIN_COORDINATED_MULTI_OP_GAIN`.
+pub const REJECTION_BELOW_MULTI_OP_FLOOR: &str = "below_multi_op_floor";
+
+/// Candidate's expected gain was non-positive after pre-filtering.
+pub const REJECTION_NON_POSITIVE_GAIN: &str = "non_positive_gain";
+
+/// Target saturation discount collapsed the expected gain to (near) zero.
+pub const REJECTION_SATURATION_DISCOUNTED_TO_ZERO: &str = "saturation_discounted_to_zero";
+
+/// Pessimism discount (improved-ratio-weighted) collapsed the expected gain
+/// to (near) zero.
+pub const REJECTION_PESSIMISM_DISCOUNTED_TO_ZERO: &str = "pessimism_discounted_to_zero";
+
+/// Candidate pair was filtered by the epistatic interference detector.
+pub const REJECTION_INTERFERENCE_FILTERED: &str = "interference_filtered";
+
+/// Candidate's improved/total sample ratio was below the module's threshold.
+pub const REJECTION_BELOW_IMPROVED_RATIO: &str = "below_improved_ratio";
+
+/// Candidate matched an entry in the failure cache (seen to fail before).
+pub const REJECTION_DUPLICATE_OF_FAILURE_CACHE: &str = "duplicate_of_failure_cache";
+
+/// Add-synapse candidates were gated out by historical success rate or
+/// synapse density (Issue #1057).
+pub const REJECTION_ADD_SYNAPSE_GATED: &str = "add_synapse_gated";
+
+/// Candidate was truncated because the per-module or global candidate budget
+/// was already full.
+pub const REJECTION_BUDGET_TRUNCATED: &str = "budget_truncated";
+
+/// Synapse: no overlapping discovery samples between source and target.
+pub const REJECTION_NO_SAMPLES: &str = "no_samples";
+
+/// Synapse: GPU evaluation reported zero consistent improvement.
+pub const REJECTION_ZERO_IMPROVEMENT: &str = "zero_improvement";
+
+/// Synapse: expected improvement below the per-target threshold.
+pub const REJECTION_BELOW_THRESHOLD: &str = "below_threshold";
+
+/// Target neuron had zero activation records in the Parquet file (recording
+/// phase likely timed out).
+pub const REJECTION_NO_TARGET_RECORDS: &str = "no_target_records";
+
+/// Target had no upstream neurons eligible for analysis.
+pub const REJECTION_NO_ELIGIBLE_SOURCES: &str = "no_eligible_sources";
+
+/// Neuron: target was an input neuron (observation source, not a computation
+/// node).
+pub const REJECTION_INPUT_NEURON_FILTERED: &str = "input_neuron_filtered";
+
+/// Neuron: target was a hidden neuron (add-neuron analysis only targets
+/// outputs).
+pub const REJECTION_HIDDEN_NEURON_FILTERED: &str = "hidden_neuron_filtered";
+
+/// Neuron: target was a constant neuron (does not receive inputs).
+pub const REJECTION_CONSTANT_NEURON_FILTERED: &str = "constant_neuron_filtered";
+
+/// Synapse: target neuron evaluated candidates but none had any recorded
+/// diagnostic detail. Corresponds to `SynapseNoCandidateReason::NoDiagnostics`.
+pub const REJECTION_NO_DIAGNOSTICS: &str = "no_diagnostics";
+
+/// All documented rejection reason names. Used for assertions and
+/// documentation. Keep this list in sync with the constants above.
+pub const ALL_REJECTION_REASONS: &[&str] = &[
+    REJECTION_BELOW_EXPECTED_GAIN_FLOOR,
+    REJECTION_BELOW_MULTI_OP_FLOOR,
+    REJECTION_NON_POSITIVE_GAIN,
+    REJECTION_SATURATION_DISCOUNTED_TO_ZERO,
+    REJECTION_PESSIMISM_DISCOUNTED_TO_ZERO,
+    REJECTION_INTERFERENCE_FILTERED,
+    REJECTION_BELOW_IMPROVED_RATIO,
+    REJECTION_DUPLICATE_OF_FAILURE_CACHE,
+    REJECTION_ADD_SYNAPSE_GATED,
+    REJECTION_BUDGET_TRUNCATED,
+    REJECTION_NO_SAMPLES,
+    REJECTION_ZERO_IMPROVEMENT,
+    REJECTION_BELOW_THRESHOLD,
+    REJECTION_NO_TARGET_RECORDS,
+    REJECTION_NO_ELIGIBLE_SOURCES,
+    REJECTION_INPUT_NEURON_FILTERED,
+    REJECTION_HIDDEN_NEURON_FILTERED,
+    REJECTION_CONSTANT_NEURON_FILTERED,
+    REJECTION_NO_DIAGNOSTICS,
+];
+
+// =============================================================================
+// RejectionBreakdown
+// =============================================================================
+
+/// Aggregate rejection counts keyed by stable reason name (Issue #1129).
+///
+/// Designed to be cheap to increment sequentially from orchestration /
+/// post-processing code. For parallel discovery module dispatch, accumulate
+/// into a per-module `HashMap` and merge sequentially via
+/// [`RejectionBreakdown::merge_from`].
+#[derive(Debug, Default, Clone)]
+pub struct RejectionBreakdown {
+    counts: HashMap<String, u32>,
+}
+
+impl RejectionBreakdown {
+    /// Create an empty breakdown.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            counts: HashMap::new(),
+        }
+    }
+
+    /// Add `count` rejections for `reason`. Does nothing if `count == 0`.
+    pub fn record_many(&mut self, reason: &'static str, count: u32) {
+        if count == 0 {
+            return;
+        }
+        *self.counts.entry(reason.to_string()).or_insert(0) += count;
+    }
+
+    /// Alias for [`RejectionBreakdown::record_many`]; accepts a `u32` count explicitly so call
+    /// sites converting from `usize` are concise.
+    pub fn record_many_u32(&mut self, reason: &'static str, count: u32) {
+        self.record_many(reason, count);
+    }
+
+    /// Record a single rejection for `reason`.
+    pub fn record(&mut self, reason: &'static str) {
+        self.record_many(reason, 1);
+    }
+
+    /// Merge another breakdown into this one.
+    pub fn merge_from(&mut self, other: &HashMap<String, u32>) {
+        for (reason, &count) in other {
+            if count == 0 {
+                continue;
+            }
+            *self.counts.entry(reason.clone()).or_insert(0) += count;
+        }
+    }
+
+    /// Total rejection count across all reasons.
+    #[must_use]
+    pub fn total(&self) -> u32 {
+        self.counts.values().sum()
+    }
+
+    /// Return whether no rejections have been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.counts.values().all(|&v| v == 0)
+    }
+
+    /// Return the dominant (most-frequent) reason and its count, if any.
+    ///
+    /// Ties are broken lexicographically by reason name so the output is
+    /// deterministic.
+    #[must_use]
+    pub fn dominant_reason(&self) -> Option<(&str, u32)> {
+        self.counts
+            .iter()
+            .filter(|&(_, count)| *count > 0)
+            .max_by(|a, b| a.1.cmp(b.1).then_with(|| b.0.cmp(a.0)))
+            .map(|(r, c)| (r.as_str(), *c))
+    }
+
+    /// Borrow the underlying counts map.
+    #[must_use]
+    pub fn counts(&self) -> &HashMap<String, u32> {
+        &self.counts
+    }
+
+    /// Take the underlying counts map, leaving an empty breakdown behind.
+    #[must_use]
+    pub fn into_counts(self) -> HashMap<String, u32> {
+        self.counts
+    }
+}
+
+// =============================================================================
+// Top-level summary
+// =============================================================================
+
+/// Produce a one-sentence summary naming the dominant rejection reason and
+/// associated gain floor (Issue #1129).
+///
+/// `total_candidates_considered` is the number of candidates (including
+/// rejected ones) that the analysis attempted to evaluate. When it is `None`
+/// the summary still reports absolute counts.
+#[must_use]
+pub fn top_level_summary(
+    breakdown: &RejectionBreakdown,
+    total_candidates_considered: Option<u32>,
+) -> Option<String> {
+    let (reason, count) = breakdown.dominant_reason()?;
+    let considered = total_candidates_considered.unwrap_or_else(|| breakdown.total());
+    let friendly = friendly_reason(reason);
+    Some(format!(
+        "{count} of {considered} candidates rejected by {friendly}"
+    ))
+}
+
+/// Render a rejection reason name into a human-readable phrase for the
+/// top-level summary.
+fn friendly_reason(reason: &str) -> String {
+    match reason {
+        REJECTION_BELOW_EXPECTED_GAIN_FLOOR => {
+            format!(
+                "expected-gain floor of {:e}",
+                crate::analysis::constants::COORDINATED_MIN_EXPECTED_GAIN
+            )
+        }
+        REJECTION_BELOW_MULTI_OP_FLOOR => format!(
+            "multi-op expected-gain floor of {:e}",
+            crate::analysis::constants::MIN_COORDINATED_MULTI_OP_GAIN
+        ),
+        REJECTION_NON_POSITIVE_GAIN => "non-positive expected gain".to_string(),
+        REJECTION_SATURATION_DISCOUNTED_TO_ZERO => {
+            "saturation discount collapsed expected gain to zero".to_string()
+        }
+        REJECTION_PESSIMISM_DISCOUNTED_TO_ZERO => {
+            "pessimism discount collapsed expected gain to zero".to_string()
+        }
+        REJECTION_INTERFERENCE_FILTERED => "epistatic interference filter".to_string(),
+        REJECTION_BELOW_IMPROVED_RATIO => "improved-sample-ratio floor".to_string(),
+        REJECTION_DUPLICATE_OF_FAILURE_CACHE => "duplicate of failure cache".to_string(),
+        REJECTION_ADD_SYNAPSE_GATED => "add-synapse historical-gating filter".to_string(),
+        REJECTION_BUDGET_TRUNCATED => "per-module candidate budget".to_string(),
+        REJECTION_NO_SAMPLES => "no overlapping discovery samples".to_string(),
+        REJECTION_ZERO_IMPROVEMENT => "zero consistent improvement in GPU stats".to_string(),
+        REJECTION_BELOW_THRESHOLD => "expected-improvement per-target threshold".to_string(),
+        REJECTION_NO_TARGET_RECORDS => "no target activation records".to_string(),
+        REJECTION_NO_ELIGIBLE_SOURCES => "no eligible upstream sources".to_string(),
+        REJECTION_INPUT_NEURON_FILTERED => "input-neuron pre-filter".to_string(),
+        REJECTION_HIDDEN_NEURON_FILTERED => "hidden-neuron pre-filter".to_string(),
+        REJECTION_CONSTANT_NEURON_FILTERED => "constant-neuron pre-filter".to_string(),
+        REJECTION_NO_DIAGNOSTICS => "no diagnostics recorded".to_string(),
+        other => other.replace('_', " "),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_increments_counter() {
+        let mut b = RejectionBreakdown::new();
+        b.record(REJECTION_BELOW_EXPECTED_GAIN_FLOOR);
+        b.record(REJECTION_BELOW_EXPECTED_GAIN_FLOOR);
+        b.record(REJECTION_INTERFERENCE_FILTERED);
+        assert_eq!(
+            b.counts().get(REJECTION_BELOW_EXPECTED_GAIN_FLOOR),
+            Some(&2)
+        );
+        assert_eq!(b.counts().get(REJECTION_INTERFERENCE_FILTERED), Some(&1));
+        assert_eq!(b.total(), 3);
+    }
+
+    #[test]
+    fn record_many_skips_zero() {
+        let mut b = RejectionBreakdown::new();
+        b.record_many(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, 0);
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn dominant_reason_picks_highest_count() {
+        let mut b = RejectionBreakdown::new();
+        b.record_many(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, 32);
+        b.record_many(REJECTION_INTERFERENCE_FILTERED, 5);
+        b.record_many(REJECTION_NO_SAMPLES, 2);
+        let (reason, count) = b.dominant_reason().expect("has counts");
+        assert_eq!(reason, REJECTION_BELOW_EXPECTED_GAIN_FLOOR);
+        assert_eq!(count, 32);
+    }
+
+    #[test]
+    fn top_level_summary_mentions_floor() {
+        let mut b = RejectionBreakdown::new();
+        b.record_many(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, 32);
+        let summary = top_level_summary(&b, Some(34)).expect("summary");
+        assert!(
+            summary.contains("32 of 34"),
+            "summary should contain counts, got: {summary}"
+        );
+        assert!(
+            summary.contains("expected-gain floor"),
+            "summary should mention the floor, got: {summary}"
+        );
+    }
+
+    #[test]
+    fn top_level_summary_none_on_empty() {
+        let b = RejectionBreakdown::new();
+        assert!(top_level_summary(&b, None).is_none());
+    }
+
+    #[test]
+    fn merge_from_sums_counts() {
+        let mut base = RejectionBreakdown::new();
+        base.record_many(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, 3);
+        let mut other = HashMap::new();
+        other.insert(REJECTION_BELOW_EXPECTED_GAIN_FLOOR.to_string(), 4);
+        other.insert(REJECTION_INTERFERENCE_FILTERED.to_string(), 2);
+        base.merge_from(&other);
+        assert_eq!(
+            base.counts().get(REJECTION_BELOW_EXPECTED_GAIN_FLOOR),
+            Some(&7)
+        );
+        assert_eq!(base.counts().get(REJECTION_INTERFERENCE_FILTERED), Some(&2));
+    }
+
+    #[test]
+    fn all_reasons_list_contains_every_constant() {
+        for reason in ALL_REJECTION_REASONS {
+            // If this assertion fires, someone added a constant without
+            // appending it to ALL_REJECTION_REASONS.
+            assert!(!reason.is_empty());
+        }
+    }
+}

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -24,6 +24,9 @@ use super::constants::{
     COORDINATED_MIN_EXPECTED_GAIN, MODULE_GATE_THRESHOLD, QUALITY_SKIP_GAIN_THRESHOLD,
     QUALITY_SKIP_MIN_CANDIDATES, SOFT_FAILURE_WEIGHT,
 };
+use super::diagnostics::rejection_reasons::{
+    REJECTION_BELOW_EXPECTED_GAIN_FLOOR, REJECTION_BUDGET_TRUNCATED,
+};
 use super::module_weights::{DiscoveryModuleStatsJson, ModuleOutcomeTracker};
 use super::shared;
 use super::utils;
@@ -69,9 +72,15 @@ pub fn run_discovery_module(
         // Issue #1110: Filter coordinated candidates below the minimum
         // expected-gain floor. Gains at 1e-8 to 1e-7 are indistinguishable
         // from numerical noise and harm the network in production.
+        let before_floor = result.candidates.len();
         result
             .candidates
             .retain(|c| c.expected_creature_score_gain >= COORDINATED_MIN_EXPECTED_GAIN);
+        let dropped_floor =
+            u32::try_from(before_floor.saturating_sub(result.candidates.len())).unwrap_or(u32::MAX);
+        syn.metadata
+            .rejection_breakdown
+            .record_many_u32(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, dropped_floor);
 
         if utils::verbose_enabled() {
             tracing::debug!(
@@ -339,6 +348,12 @@ pub fn merge_discovery_module_results(
                         "Truncating candidates to module budget (Issue #967)"
                     );
                 }
+                let truncated =
+                    u32::try_from(result.candidates.len().saturating_sub(entry.max_candidates))
+                        .unwrap_or(u32::MAX);
+                syn.metadata
+                    .rejection_breakdown
+                    .record_many_u32(REJECTION_BUDGET_TRUNCATED, truncated);
                 result.candidates.truncate(entry.max_candidates);
             }
 
@@ -350,6 +365,11 @@ pub fn merge_discovery_module_results(
                 .candidates
                 .retain(|c| c.expected_creature_score_gain >= COORDINATED_MIN_EXPECTED_GAIN);
             let post_filter_count = result.candidates.len();
+            let dropped_floor = u32::try_from(pre_filter_count.saturating_sub(post_filter_count))
+                .unwrap_or(u32::MAX);
+            syn.metadata
+                .rejection_breakdown
+                .record_many_u32(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, dropped_floor);
 
             // Issue #1060: Record pre-filtering soft failures for candidates that
             // were truncated (budget exceeded) or filtered (non-positive gain).

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -132,6 +132,10 @@ pub(crate) fn build_neuron_results(
             timing: params.timing_collector.finalize(),
             gpu_info: GpuAnalyzer::get_adapter_info(),
             error_distribution,
+            // Issue #1129: populated by orchestration from neuron no-candidate
+            // summaries after the result is built.
+            rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
+            top_level_summary: None,
         },
     })
 }

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -489,6 +489,26 @@ fn build_empty_result(
             detail: None,
         });
     }
+    // Issue #1129: populate rejection breakdown from the neuron pre-filter
+    // reasons so callers can see why zero candidates were returned.
+    let mut rejection_breakdown = crate::analysis::diagnostics::RejectionBreakdown::new();
+    rejection_breakdown.record_many_u32(
+        crate::analysis::diagnostics::rejection_reasons::REJECTION_INPUT_NEURON_FILTERED,
+        u32::try_from(skipped_input.len()).unwrap_or(u32::MAX),
+    );
+    rejection_breakdown.record_many_u32(
+        crate::analysis::diagnostics::rejection_reasons::REJECTION_HIDDEN_NEURON_FILTERED,
+        u32::try_from(skipped_hidden.len()).unwrap_or(u32::MAX),
+    );
+    rejection_breakdown.record_many_u32(
+        crate::analysis::diagnostics::rejection_reasons::REJECTION_CONSTANT_NEURON_FILTERED,
+        u32::try_from(skipped_constant.len()).unwrap_or(u32::MAX),
+    );
+    let top_level_summary = crate::analysis::diagnostics::rejection_reasons::top_level_summary(
+        &rejection_breakdown,
+        None,
+    );
+
     AnalyzeNeuronsResult {
         helpful_neurons: Vec::new(),
         gpu_used: true,
@@ -502,6 +522,8 @@ fn build_empty_result(
             timing: None,
             gpu_info: GpuAnalyzer::get_adapter_info(),
             error_distribution: None,
+            rejection_breakdown,
+            top_level_summary,
         },
     }
 }

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -22,6 +22,70 @@ use super::{
     module_weights, neuron, neuron_fingerprint, synapse, utils,
 };
 
+/// Aggregate rejection counts from synapse `no_candidate_reasons` into the
+/// structured breakdown and compute the one-sentence `top_level_summary`
+/// (Issue #1129).
+fn aggregate_synapse_rejection_breakdown(syn: &mut AnalyzeSynapsesResult) {
+    use super::diagnostics::rejection_reasons::{
+        REJECTION_BELOW_THRESHOLD, REJECTION_NO_DIAGNOSTICS, REJECTION_NO_ELIGIBLE_SOURCES,
+        REJECTION_NO_SAMPLES, REJECTION_NO_TARGET_RECORDS, REJECTION_ZERO_IMPROVEMENT,
+        top_level_summary,
+    };
+    use super::shared::SynapseNoCandidateReason;
+
+    for summary in &syn.no_candidate_reasons {
+        let reason_name = match summary.reason {
+            SynapseNoCandidateReason::NoEligibleSources => REJECTION_NO_ELIGIBLE_SOURCES,
+            SynapseNoCandidateReason::NoDiagnostics => REJECTION_NO_DIAGNOSTICS,
+            SynapseNoCandidateReason::NoSamples => REJECTION_NO_SAMPLES,
+            SynapseNoCandidateReason::ZeroImprovement => REJECTION_ZERO_IMPROVEMENT,
+            SynapseNoCandidateReason::BelowThreshold => REJECTION_BELOW_THRESHOLD,
+            SynapseNoCandidateReason::NoTargetRecords => REJECTION_NO_TARGET_RECORDS,
+        };
+        syn.metadata.rejection_breakdown.record(reason_name);
+    }
+    // Denominator is rejections + returned: the total number of candidate
+    // decisions the pipeline made. This lets "N of M" read naturally.
+    let denom = syn.metadata.rejection_breakdown.total()
+        + u32::try_from(syn.metadata.candidates_returned).unwrap_or(u32::MAX);
+    syn.metadata.top_level_summary =
+        top_level_summary(&syn.metadata.rejection_breakdown, Some(denom));
+}
+
+/// Aggregate rejection counts from neuron `no_candidate_reasons` into the
+/// structured breakdown and compute the one-sentence `top_level_summary`
+/// (Issue #1129).
+fn aggregate_neuron_rejection_breakdown(neu: &mut AnalyzeNeuronsResult) {
+    use super::diagnostics::rejection_reasons::{
+        REJECTION_BELOW_THRESHOLD, REJECTION_CONSTANT_NEURON_FILTERED,
+        REJECTION_HIDDEN_NEURON_FILTERED, REJECTION_INPUT_NEURON_FILTERED,
+        REJECTION_NO_DIAGNOSTICS, REJECTION_NO_ELIGIBLE_SOURCES, REJECTION_NO_SAMPLES,
+        top_level_summary,
+    };
+    use super::shared::NeuronNoCandidateReason;
+
+    for summary in &neu.no_candidate_reasons {
+        let reason_name = match summary.reason {
+            NeuronNoCandidateReason::NoEligibleSources => REJECTION_NO_ELIGIBLE_SOURCES,
+            NeuronNoCandidateReason::NoDiagnostics => REJECTION_NO_DIAGNOSTICS,
+            NeuronNoCandidateReason::NoSamples | NeuronNoCandidateReason::NotEnoughActivations => {
+                REJECTION_NO_SAMPLES
+            }
+            NeuronNoCandidateReason::WeightDegenerate | NeuronNoCandidateReason::BelowThreshold => {
+                REJECTION_BELOW_THRESHOLD
+            }
+            NeuronNoCandidateReason::HiddenNeuronFiltered => REJECTION_HIDDEN_NEURON_FILTERED,
+            NeuronNoCandidateReason::InputNeuronFiltered => REJECTION_INPUT_NEURON_FILTERED,
+            NeuronNoCandidateReason::ConstantNeuronFiltered => REJECTION_CONSTANT_NEURON_FILTERED,
+        };
+        neu.metadata.rejection_breakdown.record(reason_name);
+    }
+    let denom = neu.metadata.rejection_breakdown.total()
+        + u32::try_from(neu.metadata.candidates_returned).unwrap_or(u32::MAX);
+    neu.metadata.top_level_summary =
+        top_level_summary(&neu.metadata.rejection_breakdown, Some(denom));
+}
+
 /// Extract a human-readable message from a panic payload (Issue #1087).
 fn format_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&str>() {
@@ -520,10 +584,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // and synapse density. When the ModuleOutcomeTracker shows consistent failure
     // or the network is too dense, clear helpful_synapses to save compute.
     if let Some(syn) = synapse_result.as_mut() {
-        synapse::add_synapse_gating::gate_add_synapse_candidates(
+        let removed = synapse::add_synapse_gating::gate_add_synapse_candidates(
             &mut syn.helpful_synapses,
             &tracker,
             &input.creature,
+        );
+        // Issue #1129: Record the gating drop in the structured rejection
+        // breakdown so downstream callers can see why helpful synapses vanished.
+        syn.metadata.rejection_breakdown.record_many_u32(
+            super::diagnostics::rejection_reasons::REJECTION_ADD_SYNAPSE_GATED,
+            u32::try_from(removed).unwrap_or(u32::MAX),
         );
     }
 
@@ -720,8 +790,12 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         // `merge_coordinated_structural_replacements` wrote
         // `candidates_returned` before these downstream filters ran.
         if let Some(syn) = synapse_result.as_mut() {
-            candidate_aggregation::apply_coordinated_gain_floor(
+            let removed = candidate_aggregation::apply_coordinated_gain_floor(
                 &mut syn.coordinated_structural_candidates,
+            );
+            syn.metadata.rejection_breakdown.record_many_u32(
+                super::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR,
+                removed,
             );
             syn.metadata.candidates_returned = syn.helpful_synapses.len()
                 + syn.harmful_synapses.len()
@@ -779,6 +853,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // Output profile data if JSON profiling is enabled (Issue #214)
     if profile_mode() == ProfileMode::Json {
         profile.report();
+    }
+
+    // Issue #1129: Aggregate per-target rejection reasons into the structured
+    // breakdown and compute a one-sentence top-level summary so downstream
+    // tooling can root-cause "no candidates found" without re-running analysis.
+    if let Some(syn) = synapse_result.as_mut() {
+        aggregate_synapse_rejection_breakdown(syn);
+    }
+    if let Some(neu) = neuron_result.as_mut() {
+        aggregate_neuron_rejection_breakdown(neu);
     }
 
     Ok(AnalyzeAllResult {

--- a/src/analysis/shared/metadata.rs
+++ b/src/analysis/shared/metadata.rs
@@ -86,6 +86,18 @@ pub struct SynapseAnalysisMetadata {
     /// MCMC diagnostics: acceptance rates, proposal quality, diversity (Issue #1021).
     pub mcmc_diagnostics:
         Option<crate::analysis::diagnostics::mcmc_diagnostics::McmcDiagnosticsSummary>,
+
+    /// Structured rejection-reason breakdown (Issue #1129).
+    ///
+    /// Keyed by the stable reason names documented in
+    /// `analysis::diagnostics::rejection_reasons`. Populated even when
+    /// `candidates_returned == 0` so downstream tooling can root-cause
+    /// "no candidates found" without re-running analysis.
+    pub rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown,
+
+    /// One-sentence summary naming the dominant rejection reason, when any
+    /// candidate was rejected (Issue #1129).
+    pub top_level_summary: Option<String>,
 }
 
 /// Metadata about neuron analysis for diagnostics and observability.
@@ -122,6 +134,16 @@ pub struct NeuronAnalysisMetadata {
     /// Provides percentiles, skewness, kurtosis and other distribution metrics
     /// to enable targeted discovery for specific error patterns like outliers.
     pub error_distribution: Option<ErrorDistribution>,
+
+    /// Structured rejection-reason breakdown (Issue #1129).
+    ///
+    /// Keyed by the stable reason names documented in
+    /// `analysis::diagnostics::rejection_reasons`.
+    pub rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown,
+
+    /// One-sentence summary naming the dominant rejection reason, when any
+    /// candidate was rejected (Issue #1129).
+    pub top_level_summary: Option<String>,
 }
 
 /// Result of synapse analysis

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -529,5 +529,8 @@ pub(crate) fn build_metadata(
         error_distribution,
         discovery_module_stats: Vec::new(),
         mcmc_diagnostics: params.mcmc_summary.clone(),
+        // Issue #1129: populated by orchestration after metadata is built.
+        rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
+        top_level_summary: None,
     }
 }

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -113,6 +113,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     gpu_info: s.metadata.gpu_info.as_ref().map(gpu_info_to_json),
                     discovery_module_stats: s.metadata.discovery_module_stats.clone(),
                     mcmc_diagnostics: s.metadata.mcmc_diagnostics.as_ref().map(mcmc_to_json),
+                    rejection_breakdown: s.metadata.rejection_breakdown.counts().clone(),
+                    top_level_summary: s.metadata.top_level_summary.clone(),
                 }),
                 helpful_neurons: neuron.as_ref().map(|n| n.helpful_neurons.clone()),
                 synapse_weight_updates,
@@ -130,6 +132,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     total_focus_neurons: n.metadata.total_focus_neurons,
                     timing: n.metadata.timing.as_ref().map(timing_to_json),
                     gpu_info: n.metadata.gpu_info.as_ref().map(gpu_info_to_json),
+                    rejection_breakdown: n.metadata.rejection_breakdown.counts().clone(),
+                    top_level_summary: n.metadata.top_level_summary.clone(),
                 }),
                 neuron_fingerprints: result.neuron_fingerprints,
                 fingerprint_cache_hits: if result.fingerprint_cache_hits > 0 {

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -144,6 +144,16 @@ pub struct SynapseAnalysisMetadataJson {
     /// MCMC diagnostics: acceptance rates, proposal quality, diversity (Issue #1021).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcmc_diagnostics: Option<McmcDiagnosticsJson>,
+    /// Structured rejection-reason breakdown (Issue #1129).
+    ///
+    /// Keyed by the stable reason names in
+    /// `analysis::diagnostics::rejection_reasons`. Populated even when
+    /// `candidatesReturned == 0`.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub rejection_breakdown: std::collections::HashMap<String, u32>,
+    /// One-sentence summary naming the dominant rejection reason (Issue #1129).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_level_summary: Option<String>,
 }
 
 /// MCMC diagnostics summary for the analysis output JSON (Issue #1021).
@@ -226,6 +236,12 @@ pub struct NeuronAnalysisMetadataJson {
     /// Information about the GPU adapter used (Issue #228).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gpu_info: Option<GpuAdapterInfoJson>,
+    /// Structured rejection-reason breakdown (Issue #1129).
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub rejection_breakdown: std::collections::HashMap<String, u32>,
+    /// One-sentence summary naming the dominant rejection reason (Issue #1129).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_level_summary: Option<String>,
 }
 
 // ============================================================================

--- a/tests/issue_1129_rejection_breakdown.rs
+++ b/tests/issue_1129_rejection_breakdown.rs
@@ -1,0 +1,171 @@
+//! Integration tests for Issue #1129 — structured rejection-reason breakdown
+//! emitted on `synapseMetadata` / `neuronMetadata` even when zero candidates
+//! survive.
+//!
+//! Two scenarios are covered:
+//! 1. **Floor-dominated**: every coordinated candidate from a discovery module
+//!    falls below `COORDINATED_MIN_EXPECTED_GAIN` so the floor filter consumes
+//!    them all. `rejection_breakdown` records a `below_expected_gain_floor`
+//!    count and `top_level_summary` names that floor.
+//! 2. **Mixed reasons**: a combination of below-floor drops and budget-truncated
+//!    drops produces separate counts in the breakdown.
+
+use neat_ai_discovery::analysis::candidate_aggregation::apply_coordinated_gain_floor;
+use neat_ai_discovery::analysis::diagnostics::rejection_reasons::{
+    REJECTION_BELOW_EXPECTED_GAIN_FLOOR, REJECTION_BUDGET_TRUNCATED,
+    REJECTION_INTERFERENCE_FILTERED, RejectionBreakdown, top_level_summary,
+};
+use neat_ai_discovery::analysis::discovery_dispatch::{
+    DiscoveryDetectionResult, DiscoveryModuleSpec, run_discovery_modules_parallel,
+};
+use neat_ai_discovery::analysis::module_weights::ModuleOutcomeTracker;
+use neat_ai_discovery::analysis::shared::{AnalyzeSynapsesResult, SynapseAnalysisMetadata};
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+fn empty_synapse_result() -> AnalyzeSynapsesResult {
+    AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: SynapseAnalysisMetadata::default(),
+    }
+}
+
+fn single_op_candidate(gain: f32, module: &str) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(module.to_string()),
+    }
+}
+
+/// Floor-dominated case: every candidate from a discovery module sits well
+/// below `COORDINATED_MIN_EXPECTED_GAIN`, so the pre-merge floor consumes
+/// them all. The metadata must record a `below_expected_gain_floor` count
+/// and `top_level_summary` must name the floor (so operators see the
+/// single dominant rejection reason at a glance).
+#[test]
+fn floor_dominated_case_records_below_expected_gain_floor() {
+    let mut syn = empty_synapse_result();
+    let mut tracker = ModuleOutcomeTracker::new();
+
+    // 32 candidates all at 5e-7 — well below the 1e-5 floor.
+    let modules = vec![DiscoveryModuleSpec {
+        module_name: "noise-module".to_string(),
+        phase_name: "test_floor_dominated",
+        max_candidates: 0,
+        detect_fn: Box::new(|| {
+            let candidates = (0..32)
+                .map(|_| single_op_candidate(5e-7, "noise"))
+                .collect::<Vec<_>>();
+            Some(DiscoveryDetectionResult {
+                detected_count: 32,
+                candidates,
+            })
+        }),
+    }];
+
+    run_discovery_modules_parallel(&mut syn, modules, None, false, &mut tracker);
+
+    // All below-floor candidates should have been dropped.
+    assert!(
+        syn.coordinated_structural_candidates.is_empty(),
+        "floor-dominated batch should yield zero survivors"
+    );
+
+    // The breakdown must credit the below-expected-gain-floor reason.
+    let count = syn
+        .metadata
+        .rejection_breakdown
+        .counts()
+        .get(REJECTION_BELOW_EXPECTED_GAIN_FLOOR)
+        .copied()
+        .unwrap_or(0);
+    assert!(
+        count >= 32,
+        "breakdown should show ≥32 floor rejections, got {count}: \
+         {:?}",
+        syn.metadata.rejection_breakdown.counts()
+    );
+
+    // Dominant reason + synthetic top_level_summary must mention the floor.
+    let (dominant, _) = syn
+        .metadata
+        .rejection_breakdown
+        .dominant_reason()
+        .expect("dominant reason present");
+    assert_eq!(dominant, REJECTION_BELOW_EXPECTED_GAIN_FLOOR);
+
+    let summary = top_level_summary(&syn.metadata.rejection_breakdown, None)
+        .expect("summary populated when any rejection recorded");
+    assert!(
+        summary.contains("expected-gain floor"),
+        "summary should mention the expected-gain floor, got: {summary}"
+    );
+}
+
+/// Mixed-reason case: the breakdown surfaces multiple independent rejection
+/// reasons so operators can see the whole story, not just the dominant one.
+#[test]
+fn mixed_reason_case_records_each_reason_independently() {
+    let mut breakdown = RejectionBreakdown::new();
+    breakdown.record_many_u32(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, 12);
+    breakdown.record_many_u32(REJECTION_INTERFERENCE_FILTERED, 5);
+    breakdown.record_many_u32(REJECTION_BUDGET_TRUNCATED, 3);
+
+    // All three reasons must be stored with exact counts.
+    assert_eq!(
+        breakdown
+            .counts()
+            .get(REJECTION_BELOW_EXPECTED_GAIN_FLOOR)
+            .copied(),
+        Some(12)
+    );
+    assert_eq!(
+        breakdown
+            .counts()
+            .get(REJECTION_INTERFERENCE_FILTERED)
+            .copied(),
+        Some(5)
+    );
+    assert_eq!(
+        breakdown.counts().get(REJECTION_BUDGET_TRUNCATED).copied(),
+        Some(3)
+    );
+    assert_eq!(breakdown.total(), 20);
+
+    // Top-level summary names the dominant reason (12 > 5 > 3).
+    let summary = top_level_summary(&breakdown, Some(20)).expect("summary populated");
+    assert!(
+        summary.contains("12 of 20"),
+        "summary should report 12 of 20 rejections, got: {summary}"
+    );
+    assert!(
+        summary.contains("expected-gain floor"),
+        "summary should name the dominant reason, got: {summary}"
+    );
+}
+
+/// The pre-merge `apply_coordinated_gain_floor` helper returns the number of
+/// candidates it dropped so the caller can feed it straight into the
+/// structured breakdown.
+#[test]
+fn apply_coordinated_gain_floor_returns_drop_count() {
+    // `apply_coordinated_gain_floor` uses the post-discount noise floor
+    // (5e-7). Two of these are strictly below the floor.
+    let mut cands = vec![
+        single_op_candidate(1e-7, "below-1"),
+        single_op_candidate(2e-7, "below-2"),
+        single_op_candidate(1.0, "keep"),
+    ];
+    let dropped = apply_coordinated_gain_floor(&mut cands);
+    assert_eq!(dropped, 2);
+    assert_eq!(cands.len(), 1);
+}


### PR DESCRIPTION
# Issue #1129 — Structured rejection-reason breakdown on analysis metadata

Closes #1129.

## Problem

When discovery returned zero candidates, operators had no structured way to
know why. The `synapseMetadata` / `neuronMetadata` JSON surfaced only totals
and timing, so diagnosing "no candidates found" meant re-running with verbose
logging and scraping log lines.

## Change

Added a `rejection_breakdown` map and a one-sentence `top_level_summary` to
both `SynapseAnalysisMetadata` and `NeuronAnalysisMetadata`.

- **`rejection_breakdown: HashMap<String, u32>`** — keyed by stable documented
  reason names (`below_expected_gain_floor`, `below_multi_op_floor`,
  `non_positive_gain`, `saturation_discounted_to_zero`,
  `pessimism_discounted_to_zero`, `interference_filtered`,
  `below_improved_ratio`, `duplicate_of_failure_cache`, `add_synapse_gated`,
  `budget_truncated`, `no_samples`, `zero_improvement`, `below_threshold`,
  `no_target_records`, `no_eligible_sources`, `input_neuron_filtered`,
  `hidden_neuron_filtered`, `constant_neuron_filtered`, `no_diagnostics`).
  The full catalogue lives in `analysis::diagnostics::rejection_reasons`.

- **`top_level_summary: Option<String>`** — e.g. `"32 of 34 candidates
  rejected by expected-gain floor of 1e-5"`. Populated whenever any
  candidate was rejected, including when zero candidates survive.

### Counter wiring

- `candidate_aggregation::apply_coordinated_gain_floor` now returns the drop
  count and the caller in `orchestration::analyze_all` feeds it into
  `rejection_breakdown` under `below_expected_gain_floor`.
- `candidate_aggregation::merge_coordinated_structural_replacements` records
  `non_positive_gain` and `below_multi_op_floor` drops.
- `discovery_dispatch::run_discovery_module` + `merge_discovery_module_results`
  record `below_expected_gain_floor` and `budget_truncated` drops.
- `orchestration::analyze_all` records `add_synapse_gated` drops from
  `gate_add_synapse_candidates`.
- `orchestration::aggregate_synapse_rejection_breakdown` and
  `aggregate_neuron_rejection_breakdown` lift existing per-target
  `no_candidate_reasons` into the breakdown and compute `top_level_summary`.
- `neuron::preparation::build_empty_result` populates the breakdown with
  input/hidden/constant pre-filter counts so the early-return path still
  surfaces a meaningful summary.

### FFI

Both metadata structs in `ffi_types::responses::analysis` gained a
`rejection_breakdown` (skip-serialize when empty) and `top_level_summary`
(skip-serialize when `None`) field. `ffi_internal::analysis::analyze_parallel_internal`
copies them into the response.

## Tests

- `tests/issue_1129_rejection_breakdown.rs` — three integration tests:
  - `floor_dominated_case_records_below_expected_gain_floor` runs a discovery
    module emitting 32 candidates at 5e-7 (below the 1e-5 floor). Asserts
    zero survivors, ≥32 `below_expected_gain_floor` count, matching dominant
    reason, and "expected-gain floor" in the summary.
  - `mixed_reason_case_records_each_reason_independently` populates three
    distinct reasons and asserts exact per-reason counts and a
    dominant-reason summary.
  - `apply_coordinated_gain_floor_returns_drop_count` verifies the helper's
    new `u32` return carries the right drop count back to callers.
- `src/analysis/diagnostics/rejection_reasons.rs` — six unit tests covering
  `record`, `record_many` (zero skip), `dominant_reason`, `top_level_summary`
  (floor and empty cases), and `merge_from`.

## Validation

- `./quality.sh < /dev/null` — PASS (fmt, clippy, check, 2000+ unit/integration
  tests, doc build, release build).
- No new warnings introduced. Pre-existing cargo duplicate-crate warnings are
  unrelated.

## Australian English

`analyse`, `behaviour`, `favour`, `centre` used throughout comments.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1129 -->