### PR TITLE
feat: calibrate prediction factors from failure cache (#1131)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.14"
+version = "0.74.15"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/async_pipeline.rs
+++ b/benches/async_pipeline.rs
@@ -176,6 +176,7 @@ fn bench_async_pipeline(c: &mut Criterion) {
                         max_analysis_memory_mb: None,
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
+                        failure_cache: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/cache_locality.rs
+++ b/benches/cache_locality.rs
@@ -127,6 +127,7 @@ fn benchmark_cache_locality(c: &mut Criterion) {
                         analysis_deadline_ms: deadline_ms,
                         random_seed: Some(42),
                         temperature: 1.0,
+                        failure_cache: None,
                     };
 
                     let result = analyze_synapses_with_cache_and_gpu_queue(

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -183,6 +183,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         max_analysis_memory_mb: None,
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
+                        failure_cache: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/pipeline_utilisation.rs
+++ b/benches/pipeline_utilisation.rs
@@ -331,6 +331,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_analysis_memory_mb: None,
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
+                        failure_cache: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -358,6 +359,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_analysis_memory_mb: None,
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
+                        failure_cache: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -385,6 +387,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_analysis_memory_mb: None,
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
+                        failure_cache: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -408,6 +411,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
             max_analysis_memory_mb: None,
             max_discovery_wall_clock_minutes: None,
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let mut profile = ProfileData::new();

--- a/benches/sample_locality.rs
+++ b/benches/sample_locality.rs
@@ -146,6 +146,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
                     temperature: 1.0,
+                    failure_cache: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);
@@ -175,6 +176,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
                     temperature: 1.0,
+                    failure_cache: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/benches/zero_copy_buffer.rs
+++ b/benches/zero_copy_buffer.rs
@@ -77,6 +77,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                 analysis_deadline_ms: None,
                 random_seed: Some(42),
                 temperature: 1.0,
+                failure_cache: None,
             };
             let result = analyze_synapses(&input).expect("Analysis should succeed");
             black_box(result);
@@ -98,6 +99,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                     analysis_deadline_ms: None,
                     random_seed: Some(42),
                     temperature: 1.0,
+                    failure_cache: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/docs/pr-summary-1131.md
+++ b/docs/pr-summary-1131.md
@@ -1,0 +1,32 @@
+## Summary
+
+Calibrates the per-prediction factors using actual outcomes from a supplied failure cache. Closes #1131.
+
+The compiled `NEURON_PREDICTION_CALIBRATION`, `SYNAPSE_PREDICTION_CALIBRATION`, and `COORDINATED_PREDICTION_CALIBRATION` constants are global averages. A single creature can drift from that average — for example, one whose recent failure cache shows ~1000× over-estimation for `add-neurons` should discount that class more than the global constant does. This change computes a per-change-type correction factor from a creature's failure cache and applies it multiplicatively to the base calibration constant before prediction scoring.
+
+### Changes
+
+- **New module** `src/analysis/scoring/calibration_correction.rs` defining:
+  - `FailureCacheEntry { change_type, expected_error_reduction, actual_error_reduction }` (camelCase at the FFI boundary).
+  - `CalibrationCorrection::from_failure_cache(&[FailureCacheEntry])` which groups entries by `change_type`, skips zero-predicted / non-finite ratios, computes an EWMA of `actual / expected` with `α = 0.3`, and clamps to `[MIN_CALIBRATION_CORRECTION = 0.001, NEUTRAL_CORRECTION = 1.0]`.
+  - Stable change-type keys: `add-neurons`, `add-synapses`, `coordinated-structural`.
+- **Input plumbing** — `failure_cache: Option<Vec<FailureCacheEntry>>` added to `AnalyzeParallelInput`, `AnalyzeAllInput`, `AnalyzeSynapsesInput`, and `AnalyzeNeuronsInput` with `#[serde(default)]` for backwards compatibility.
+- **Synapse post-processing** (`src/analysis/synapse/post_processing.rs`) — builds the correction once from the input failure cache and applies it multiplicatively to `SYNAPSE_PREDICTION_CALIBRATION` (helpful + harmful) and `COORDINATED_PREDICTION_CALIBRATION` before invoking the logistic / flat calibration.
+- **Neuron post-processing** (`src/analysis/neuron/post_processing.rs`) — same pattern, applied to `NEURON_PREDICTION_CALIBRATION`.
+- **Metadata** — `calibration_corrections: HashMap<String, f32>` added to both `SynapseAnalysisMetadata` and `NeuronAnalysisMetadata`, and surfaced on the FFI JSON types (`SynapseAnalysisMetadataJson`, `NeuronAnalysisMetadataJson`, skipped when empty).
+
+### Safety characteristics
+
+- **Never inflates predictions** — upper clamp of 1.0 means the correction can only ever discount.
+- **Never collapses to zero** — lower clamp of 0.001 preserves exploration for change-types that have been consistently over-estimating.
+- **Deterministic** — same cache in, same corrections out; verified by an integration test asserting byte-equal correction maps across two runs.
+
+## Test plan
+
+- [x] Unit tests in `src/analysis/scoring/calibration_correction.rs` (9 tests): empty cache → neutral, all-negative → min, uniform cache returns mean ratio (20 entries of `0.000001/0.001` clamped to `0.001`), mixed cache → expected EWMA, zero-predicted skipped, non-finite ratios skipped, change-types independent, correction above 1.0 clamps to neutral, deterministic output.
+- [x] Integration tests in `tests/analysis/issue_1131_calibration_correction.rs` (4 tests):
+  - `twenty_over_estimations_clamp_to_minimum_correction` — acceptance criterion from the issue.
+  - `analyze_all_exposes_calibration_corrections_in_metadata` — end-to-end through `analyze_all`, asserting synapse + neuron metadata carry the per-change-type corrections at the expected floor.
+  - `calibration_corrections_are_deterministic` — repeated runs produce identical corrections, and they match a direct-compute against the same cache.
+  - `no_failure_cache_leaves_corrections_empty` — absence of cache leaves the map empty (no behaviour change for existing callers).
+- [x] `./quality.sh` passes cleanly (all existing tests green).

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -71,6 +71,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let err =
@@ -145,6 +146,7 @@ fn analyze_synapses_rejects_duplicate_focus_targets() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let err = analyze_synapses(&input)
@@ -255,6 +257,7 @@ fn analyze_synapses_reports_eligible_sources_correctly_for_non_input_neurons() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -395,6 +398,7 @@ fn analyze_synapses_reports_fully_connected_neuron_explicitly() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -446,6 +450,7 @@ fn analyze_synapses_requires_focus_targets() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let err =
@@ -499,6 +504,7 @@ fn analyze_synapses_reports_diagnostics_when_no_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result =
@@ -610,6 +616,7 @@ fn analyze_synapses_stops_harmful_processing_after_deadline() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = pool
@@ -704,6 +711,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         module_outcome_tracker: None,
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Combined analysis should succeed");
@@ -761,6 +769,7 @@ fn analyze_neurons_reports_diagnostics_when_no_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result =
@@ -872,6 +881,7 @@ fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         analysis_deadline_ms: Some(1_000_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = pool
@@ -1006,6 +1016,7 @@ fn analyze_synapses_uses_vertical_timeout_with_randomized_order() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = pool
@@ -1103,6 +1114,7 @@ fn analyze_synapses_accepts_positive_improvements_below_threshold() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1201,6 +1213,7 @@ fn analyze_synapses_rejects_non_positive_improvements() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1275,6 +1288,7 @@ fn analyze_synapses_accepts_positive_improvements_above_threshold() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -13,6 +13,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::analysis::cache::RecordCache;
 use crate::analysis::diagnostics::{NeuronDiagnostics, compute_impact_scores_for_discounting};
 use crate::analysis::gpu::GpuAnalyzer;
+use crate::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_ADD_NEURONS, CalibrationCorrection,
+};
 use crate::analysis::shared::AnalyzeNeuronsResult;
 use crate::analysis::synapse::{
     apply_logistic_prediction_calibration, apply_neuron_pessimism_discount,
@@ -59,6 +62,11 @@ pub(crate) fn build_neuron_results(
 
     let mut helpful_results: Vec<CandidateNeuronJson> = helpful_map.into_values().collect();
 
+    // Issue #1131: Derive per-creature calibration correction from the failure cache.
+    let calibration_correction = CalibrationCorrection::from_failure_cache(
+        params.input.failure_cache.as_deref().unwrap_or(&[]),
+    );
+
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     apply_impact_discounting(
         &mut helpful_results,
@@ -66,6 +74,7 @@ pub(crate) fn build_neuron_results(
         params.neuron_type_map,
         params.input,
         params.cache,
+        &calibration_correction,
     );
 
     // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
@@ -136,6 +145,8 @@ pub(crate) fn build_neuron_results(
             // summaries after the result is built.
             rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
             top_level_summary: None,
+            // Issue #1131: per-creature calibration corrections derived from failure cache.
+            calibration_corrections: calibration_correction.as_map().clone(),
         },
     })
 }
@@ -150,6 +161,7 @@ fn apply_impact_discounting(
     neuron_type_map: &HashMap<super::preparation::SharedUuid, String>,
     input: &AnalyzeNeuronsInput,
     cache: &Arc<RecordCache>,
+    calibration_correction: &CalibrationCorrection,
 ) {
     let impact_scores = compute_impact_scores_for_discounting(&input.creature, cache.as_ref());
     for candidate in helpful_results.iter_mut() {
@@ -202,11 +214,17 @@ fn apply_impact_discounting(
         // Issue #1056: Apply logistic prediction calibration to correct ~18× overestimation.
         // The non-linear calibration uses the improved ratio to modulate the base
         // factor, matching GRQ-sampler data showing ~2.7% actual success rate (28/1028).
+        //
+        // Issue #1131: Multiplied by the per-creature calibration correction derived
+        // from the failure cache so creatures with poor recent prediction accuracy
+        // receive additional discounting.
+        let neuron_calibration = crate::analysis::constants::NEURON_PREDICTION_CALIBRATION
+            * calibration_correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
         candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
             candidate.expected_creature_score_gain,
             candidate.improved_count,
             candidate.total_count,
-            crate::analysis::constants::NEURON_PREDICTION_CALIBRATION,
+            neuron_calibration,
         );
 
         if verbose_enabled() && is_hidden {

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -524,6 +524,7 @@ fn build_empty_result(
             error_distribution: None,
             rejection_breakdown,
             top_level_summary,
+            calibration_corrections: std::collections::HashMap::new(),
         },
     }
 }

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -494,6 +494,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             analysis_deadline_ms: shared_deadline_abs_ms,
             random_seed: input.random_seed,
             temperature: input.temperature,
+            failure_cache: input.failure_cache.clone(),
         })
     } else {
         None
@@ -508,6 +509,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             analysis_deadline_ms: shared_deadline_abs_ms,
             random_seed: input.random_seed,
             temperature: input.temperature,
+            failure_cache: input.failure_cache.clone(),
         })
     } else {
         None

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -1,0 +1,380 @@
+//! Per-change-type prediction calibration correction (Issue #1131).
+//!
+//! The compiled calibration constants (`NEURON_PREDICTION_CALIBRATION`,
+//! `SYNAPSE_PREDICTION_CALIBRATION`, `COORDINATED_PREDICTION_CALIBRATION`) are
+//! fixed at build time and reflect the historical average over-estimation gap
+//! between `expectedCreatureScoreGain` and the actual post-apply creature
+//! score delta. Individual creatures can drift from that average: a creature
+//! whose recent failure cache shows a 1300× over-estimate for `add-neurons`
+//! should discount neuron predictions more than the global constant does.
+//!
+//! This module computes a scalar correction factor per change-type (e.g.,
+//! `add-neurons`, `add-synapses`, `coordinated-structural`) from recent
+//! entries of the failure cache. The correction is applied
+//! **multiplicatively** to the existing calibration constant — it never
+//! overrides the constant, and it is floored at
+//! [`MIN_CALIBRATION_CORRECTION`] so a run of failures cannot collapse
+//! predictions to zero.
+//!
+//! # Formula
+//!
+//! Given failure cache entries with `expected_error_reduction` and
+//! `actual_error_reduction`, the per-entry ratio is
+//! `actual / expected`. An exponentially-weighted moving average (EWMA)
+//! of these ratios is computed so recent outcomes dominate the estimate.
+//! The EWMA is then clamped to
+//! `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]` (= `[0.001, 1.0]`).
+//!
+//! Entries where `expected_error_reduction == 0` are skipped.
+//!
+//! # Integration
+//!
+//! The correction is loaded at the FFI entry point (`analyze_parallel_internal`)
+//! and plumbed through `analyze_all` into the post-processing passes in
+//! `synapse::post_processing` and `neuron::post_processing`. Each call site
+//! multiplies the base calibration constant by
+//! `correction.get_correction(change_type)` before invoking the logistic /
+//! flat calibration function.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Minimum correction factor (lower clamp).
+///
+/// A run of failures with `actual / expected` at or near zero clamps to this
+/// floor rather than collapsing predictions to zero. 0.001 means a creature
+/// whose whole recent history shows ~1000× over-estimates still receives a
+/// small non-zero prediction — enough for exploration, while staying far
+/// below the neutral factor of 1.0.
+pub const MIN_CALIBRATION_CORRECTION: f32 = 0.001;
+
+/// Neutral correction factor (upper clamp, returned for empty / unknown caches).
+///
+/// Predictions are only ever discounted further by this correction — never
+/// inflated. The upper clamp of 1.0 ensures the correction can never make the
+/// calibration constant larger than its compiled value.
+pub const NEUTRAL_CORRECTION: f32 = 1.0;
+
+/// EWMA smoothing coefficient applied to each successive entry (0 < α ≤ 1).
+///
+/// `α = 0.3` gives recent outcomes roughly 3× the weight of outcomes 3 entries
+/// ago. A full-cache override only happens with ~20 entries all moving in the
+/// same direction.
+pub const CALIBRATION_CORRECTION_EWMA_ALPHA: f32 = 0.3;
+
+// =============================================================================
+// Change-type identifiers
+// =============================================================================
+
+/// Change-type key for `add-neurons` candidates.
+pub const CHANGE_TYPE_ADD_NEURONS: &str = "add-neurons";
+
+/// Change-type key for `add-synapses` candidates.
+pub const CHANGE_TYPE_ADD_SYNAPSES: &str = "add-synapses";
+
+/// Change-type key for `coordinated-structural` candidates.
+pub const CHANGE_TYPE_COORDINATED_STRUCTURAL: &str = "coordinated-structural";
+
+// =============================================================================
+// Failure cache entry
+// =============================================================================
+
+/// A single failure-cache record: what we predicted vs what actually happened.
+///
+/// `change_type` identifies which prediction bucket this outcome belongs to.
+/// Stable keys (see the `CHANGE_TYPE_*` constants) let the same cache feed
+/// back into the correction for the same class of candidate next run.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureCacheEntry {
+    /// Candidate classification (e.g., `add-neurons`, `add-synapses`,
+    /// `coordinated-structural`). Used as the correction key.
+    pub change_type: String,
+
+    /// What we predicted — the `expectedErrorReduction` at the time of proposal.
+    pub expected_error_reduction: f32,
+
+    /// What actually happened — the post-apply `actualErrorReduction`. May be
+    /// negative for candidates that harmed the network.
+    pub actual_error_reduction: f32,
+}
+
+// =============================================================================
+// CalibrationCorrection
+// =============================================================================
+
+/// Per-change-type scalar correction factors derived from recent outcomes.
+///
+/// A value of 1.0 means "apply the compiled calibration constant as-is".
+/// A value of 0.001 (the floor) means "this change-type has been over-estimating
+/// so much recently that predictions should be heavily discounted beyond
+/// the compiled constant".
+#[derive(Debug, Clone, Default)]
+pub struct CalibrationCorrection {
+    corrections: HashMap<String, f32>,
+}
+
+impl CalibrationCorrection {
+    /// Returns a neutral correction where every change-type maps to 1.0.
+    #[must_use]
+    pub fn neutral() -> Self {
+        Self::default()
+    }
+
+    /// Builds a correction map from the supplied failure cache.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Group entries by `change_type`.
+    /// 2. Skip entries with `expected_error_reduction == 0` (undefined ratio).
+    /// 3. For each group, compute an EWMA of `actual / expected` in the order
+    ///    supplied. Callers pass entries oldest-first; the final EWMA value
+    ///    therefore reflects the most recent outcomes most strongly.
+    /// 4. Clamp the EWMA to `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]`.
+    ///
+    /// Empty caches, or caches with no usable entries for a change-type,
+    /// produce a [`Self::neutral`] correction for that change-type on lookup.
+    #[must_use]
+    pub fn from_failure_cache(cache: &[FailureCacheEntry]) -> Self {
+        // Group entries by change_type, preserving supplied order within each group.
+        let mut grouped: HashMap<&str, Vec<f32>> = HashMap::new();
+        for entry in cache {
+            // Skip entries with undefined ratios.
+            if entry.expected_error_reduction == 0.0 {
+                continue;
+            }
+            let ratio = entry.actual_error_reduction / entry.expected_error_reduction;
+            // Guard against NaN or infinities leaking into the EWMA.
+            if !ratio.is_finite() {
+                continue;
+            }
+            grouped
+                .entry(entry.change_type.as_str())
+                .or_default()
+                .push(ratio);
+        }
+
+        let mut corrections: HashMap<String, f32> = HashMap::new();
+        for (change_type, ratios) in grouped {
+            let ewma = ewma(&ratios, CALIBRATION_CORRECTION_EWMA_ALPHA);
+            let clamped = ewma.clamp(MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION);
+            corrections.insert(change_type.to_string(), clamped);
+        }
+
+        Self { corrections }
+    }
+
+    /// Look up the correction factor for a given change-type.
+    ///
+    /// Returns [`NEUTRAL_CORRECTION`] (1.0) when the change-type is absent —
+    /// this preserves the compiled calibration constant unchanged for
+    /// change-types with no recent failure data.
+    #[must_use]
+    pub fn get_correction(&self, change_type: &str) -> f32 {
+        self.corrections
+            .get(change_type)
+            .copied()
+            .unwrap_or(NEUTRAL_CORRECTION)
+    }
+
+    /// Returns a reference to the underlying correction map, for metadata
+    /// export at the FFI boundary.
+    #[must_use]
+    pub fn as_map(&self) -> &HashMap<String, f32> {
+        &self.corrections
+    }
+
+    /// True when no change-type has a correction recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.corrections.is_empty()
+    }
+}
+
+// =============================================================================
+// EWMA helper
+// =============================================================================
+
+/// Compute the exponentially-weighted moving average of a slice.
+///
+/// Starts from the first observation (no seed bias) and applies
+/// `ewma = (1 - α) * prev + α * x` for each subsequent observation. Returns
+/// [`NEUTRAL_CORRECTION`] for empty input.
+fn ewma(values: &[f32], alpha: f32) -> f32 {
+    if values.is_empty() {
+        return NEUTRAL_CORRECTION;
+    }
+    let mut acc = values[0];
+    for &x in &values[1..] {
+        acc = (1.0 - alpha) * acc + alpha * x;
+    }
+    acc
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(change_type: &str, predicted: f32, actual: f32) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: change_type.to_string(),
+            expected_error_reduction: predicted,
+            actual_error_reduction: actual,
+        }
+    }
+
+    #[test]
+    fn empty_cache_returns_neutral_correction() {
+        let correction = CalibrationCorrection::from_failure_cache(&[]);
+        assert!(correction.is_empty());
+        assert!(
+            (correction.get_correction(CHANGE_TYPE_ADD_NEURONS) - NEUTRAL_CORRECTION).abs() < 1e-9
+        );
+        assert!(
+            (correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES) - NEUTRAL_CORRECTION).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn all_negative_actuals_clamp_to_minimum() {
+        // Every entry is a net-harm outcome; raw ratio is negative.
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| entry(CHANGE_TYPE_ADD_NEURONS, 0.001, -0.0005))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!(
+            (value - MIN_CALIBRATION_CORRECTION).abs() < 1e-9,
+            "expected MIN_CALIBRATION_CORRECTION (={MIN_CALIBRATION_CORRECTION}), got {value}"
+        );
+    }
+
+    #[test]
+    fn uniform_cache_returns_that_mean_ratio() {
+        // 20 entries with identical ratio of 1/1000. EWMA of a constant sequence
+        // is that constant.
+        let cache: Vec<FailureCacheEntry> = (0..20)
+            .map(|_| entry(CHANGE_TYPE_ADD_NEURONS, 0.001, 0.000_001))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        // Expected ratio = 0.000001 / 0.001 = 0.001, which equals the floor.
+        assert!(
+            (value - 0.001).abs() < 1e-6,
+            "expected ≈ 0.001, got {value}"
+        );
+    }
+
+    #[test]
+    fn mixed_cache_returns_ewma_of_ratios() {
+        // Alternating entries: ratios of 0.5 and 0.1. Final EWMA value with
+        // α = 0.3 is deterministic and can be recomputed here.
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.1),
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.1),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+
+        // Manual EWMA with α = 0.3:
+        //   start = 0.5
+        //   step1 = 0.7*0.5 + 0.3*0.1 = 0.38
+        //   step2 = 0.7*0.38 + 0.3*0.5 = 0.416
+        //   step3 = 0.7*0.416 + 0.3*0.1 = 0.3212
+        let expected = 0.321_2_f32;
+        assert!(
+            (value - expected).abs() < 1e-4,
+            "expected ≈ {expected}, got {value}"
+        );
+    }
+
+    #[test]
+    fn zero_predicted_entries_are_skipped() {
+        // A zero-predicted entry has an undefined ratio and must not affect the
+        // correction. Mix one in amongst legitimate entries.
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.0, 0.0),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.005),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.005),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        // Both usable entries have ratio 0.5, so EWMA = 0.5.
+        assert!((value - 0.5).abs() < 1e-6, "expected 0.5, got {value}");
+    }
+
+    #[test]
+    fn non_finite_ratios_are_ignored() {
+        // Infinite or NaN ratios (e.g., extremely tiny predicted near-zero) must
+        // not contaminate the EWMA.
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, f32::MIN_POSITIVE, f32::MAX),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.002),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.002),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!((value - 0.2).abs() < 1e-6, "expected 0.2, got {value}");
+    }
+
+    #[test]
+    fn different_change_types_are_independent() {
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.2),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.2),
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.8),
+            entry(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.8),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        assert!((correction.get_correction(CHANGE_TYPE_ADD_NEURONS) - 0.2).abs() < 1e-6);
+        assert!((correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES) - 0.8).abs() < 1e-6);
+        // Unknown change-type falls back to neutral.
+        assert!(
+            (correction.get_correction(CHANGE_TYPE_COORDINATED_STRUCTURAL) - NEUTRAL_CORRECTION)
+                .abs()
+                < 1e-9
+        );
+    }
+
+    #[test]
+    fn correction_above_one_clamps_to_neutral() {
+        // A lucky run where actual exceeded predicted must never inflate the
+        // base calibration constant — the correction only ever discounts.
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.001, 0.01),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.001, 0.01),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION (=1.0), got {value}"
+        );
+    }
+
+    #[test]
+    fn deterministic_for_same_cache() {
+        let cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.001),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.002),
+            entry(CHANGE_TYPE_ADD_NEURONS, 0.01, 0.001),
+        ];
+        let a = CalibrationCorrection::from_failure_cache(&cache);
+        let b = CalibrationCorrection::from_failure_cache(&cache);
+        assert!(
+            (a.get_correction(CHANGE_TYPE_ADD_NEURONS) - b.get_correction(CHANGE_TYPE_ADD_NEURONS))
+                .abs()
+                < 1e-12
+        );
+    }
+}

--- a/src/analysis/scoring/mod.rs
+++ b/src/analysis/scoring/mod.rs
@@ -4,6 +4,7 @@
 //! metrics, weight calculations, error distribution analysis, and
 //! cross-validation scoring.
 
+pub mod calibration_correction;
 pub mod confidence;
 pub mod cross_validation;
 pub mod error_distribution;

--- a/src/analysis/shared/metadata.rs
+++ b/src/analysis/shared/metadata.rs
@@ -98,6 +98,17 @@ pub struct SynapseAnalysisMetadata {
     /// One-sentence summary naming the dominant rejection reason, when any
     /// candidate was rejected (Issue #1129).
     pub top_level_summary: Option<String>,
+
+    /// Per-change-type calibration correction factors derived from the
+    /// failure cache (Issue #1131).
+    ///
+    /// Keys are the stable change-type identifiers (`add-neurons`,
+    /// `add-synapses`, `coordinated-structural`, ...). Values are the
+    /// scalar correction factors that multiplied the compiled
+    /// `*_PREDICTION_CALIBRATION` constants for this run. Empty when no
+    /// failure cache was supplied. Callers can log this to observe
+    /// prediction calibration drift across discovery runs.
+    pub calibration_corrections: std::collections::HashMap<String, f32>,
 }
 
 /// Metadata about neuron analysis for diagnostics and observability.
@@ -144,6 +155,11 @@ pub struct NeuronAnalysisMetadata {
     /// One-sentence summary naming the dominant rejection reason, when any
     /// candidate was rejected (Issue #1129).
     pub top_level_summary: Option<String>,
+
+    /// Per-change-type calibration correction factors (Issue #1131).
+    ///
+    /// See `SynapseAnalysisMetadata::calibration_corrections` for full docs.
+    pub calibration_corrections: std::collections::HashMap<String, f32>,
 }
 
 /// Result of synapse analysis

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -16,6 +16,9 @@ use super::scoring::{
 };
 use crate::analysis::cache::RecordCache;
 use crate::analysis::samples::EPSILON;
+use crate::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_ADD_SYNAPSES, CHANGE_TYPE_COORDINATED_STRUCTURAL, CalibrationCorrection,
+};
 
 /// Log the distribution of synapse candidates by source type (Issue #910).
 ///
@@ -127,6 +130,7 @@ fn apply_impact_to_helpful(
     order_map: &HashMap<String, usize>,
     target_error_sq: f32,
     total_error_sq: f32,
+    calibration_correction: &CalibrationCorrection,
 ) {
     // Populate indices for debugging/analysis (consistent with CandidateNeuronJson).
     candidate.from_neuron_index = order_map.get(&candidate.from_neuron_uuid).copied();
@@ -192,11 +196,17 @@ fn apply_impact_to_helpful(
     // The non-linear (logistic) calibration uses the improved ratio to modulate the
     // base calibration factor, providing better correction than a flat multiplier.
     // GRQ-sampler data shows add-synapses has ~0.1% actual success rate (3/1001).
+    //
+    // Issue #1131: Multiplied by the per-creature calibration correction derived
+    // from the failure cache, so creatures drifting from the global baseline
+    // receive additional per-creature discounting.
+    let synapse_calibration = crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION
+        * calibration_correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
     candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
         candidate.total_count,
-        crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION,
+        synapse_calibration,
     );
 
     if verbose_enabled() && is_hidden {
@@ -216,6 +226,7 @@ fn apply_impact_to_harmful(
     impact_scores: &HashMap<String, f32>,
     neuron_type_map: &HashMap<&str, &str>,
     order_map: &HashMap<String, usize>,
+    calibration_correction: &CalibrationCorrection,
 ) {
     candidate.from_neuron_index = order_map.get(&candidate.from_neuron_uuid).copied();
     candidate.to_neuron_index = order_map.get(&candidate.to_neuron_uuid).copied();
@@ -246,11 +257,14 @@ fn apply_impact_to_harmful(
     );
 
     // Issue #1056: Apply logistic prediction calibration to harmful candidates.
+    // Issue #1131: Scaled by the per-creature failure-cache correction.
+    let synapse_calibration = crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION
+        * calibration_correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
     candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
         candidate.total_count,
-        crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION,
+        synapse_calibration,
     );
 }
 
@@ -268,6 +282,7 @@ fn apply_impact_to_coordinated(
     candidate: &mut crate::CoordinatedStructuralCandidateJson,
     impact_scores: &HashMap<String, f32>,
     neuron_type_map: &HashMap<&str, &str>,
+    calibration_correction: &CalibrationCorrection,
 ) {
     let target_uuid = candidate
         .operations
@@ -314,9 +329,12 @@ fn apply_impact_to_coordinated(
 
     // Issue #1056: Apply coordinated prediction calibration.
     // Coordinated candidates lack per-sample improved counts, so use flat calibration.
+    // Issue #1131: Scaled by the per-creature failure-cache correction.
+    let coordinated_calibration = crate::analysis::constants::COORDINATED_PREDICTION_CALIBRATION
+        * calibration_correction.get_correction(CHANGE_TYPE_COORDINATED_STRUCTURAL);
     candidate.expected_creature_score_gain = apply_prediction_calibration(
         candidate.expected_creature_score_gain,
-        crate::analysis::constants::COORDINATED_PREDICTION_CALIBRATION,
+        coordinated_calibration,
     );
 }
 
@@ -346,6 +364,13 @@ pub(crate) fn apply_post_processing(
     let error_sq_map = compute_neuron_error_sq_map(input, cache);
     let total_error_sq: f32 = error_sq_map.values().sum();
 
+    // Issue #1131: Derive per-creature calibration correction from the failure cache.
+    // This scales the global *_PREDICTION_CALIBRATION constants multiplicatively so
+    // creatures whose recent predictions over-estimated actual outcomes receive
+    // additional discounting on subsequent candidates.
+    let calibration_correction =
+        CalibrationCorrection::from_failure_cache(input.failure_cache.as_deref().unwrap_or(&[]));
+
     // Apply impact discounting to helpful synapse candidates
     for candidate in helpful_results.iter_mut() {
         let target_error_sq = error_sq_map
@@ -359,17 +384,29 @@ pub(crate) fn apply_post_processing(
             order_map,
             target_error_sq,
             total_error_sq,
+            &calibration_correction,
         );
     }
 
     // Apply impact discounting to harmful synapse candidates
     for candidate in harmful_results.iter_mut() {
-        apply_impact_to_harmful(candidate, &impact_scores, &neuron_type_map, order_map);
+        apply_impact_to_harmful(
+            candidate,
+            &impact_scores,
+            &neuron_type_map,
+            order_map,
+            &calibration_correction,
+        );
     }
 
     // Apply impact discounting to coordinated candidates
     for candidate in coordinated_structural_results.iter_mut() {
-        apply_impact_to_coordinated(candidate, &impact_scores, &neuron_type_map);
+        apply_impact_to_coordinated(
+            candidate,
+            &impact_scores,
+            &neuron_type_map,
+            &calibration_correction,
+        );
     }
 
     // Issue #557: Filter out candidates with non-positive expected_creature_score_gain.
@@ -467,6 +504,7 @@ pub(crate) fn apply_post_processing(
     PostProcessingMetrics {
         candidates_found,
         candidates_returned,
+        calibration_corrections: calibration_correction.as_map().clone(),
     }
 }
 
@@ -474,6 +512,10 @@ pub(crate) fn apply_post_processing(
 pub(crate) struct PostProcessingMetrics {
     pub candidates_found: usize,
     pub candidates_returned: usize,
+    /// Issue #1131: Per-change-type calibration corrections derived from the
+    /// failure cache and applied multiplicatively to the global prediction
+    /// calibration constants. Exposed via analysis metadata for observability.
+    pub calibration_corrections: HashMap<String, f32>,
 }
 
 /// Parameters for building analysis metadata.
@@ -493,6 +535,8 @@ pub(crate) struct MetadataParams<'a> {
     /// Issue #1021: MCMC diagnostics summary.
     pub mcmc_summary:
         Option<crate::analysis::diagnostics::mcmc_diagnostics::McmcDiagnosticsSummary>,
+    /// Issue #1131: Per-change-type calibration corrections from the failure cache.
+    pub calibration_corrections: HashMap<String, f32>,
 }
 
 /// Build the analysis metadata from collected atomic flags and timing data.
@@ -532,5 +576,7 @@ pub(crate) fn build_metadata(
         // Issue #1129: populated by orchestration after metadata is built.
         rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
         top_level_summary: None,
+        // Issue #1131: per-creature calibration corrections derived from failure cache.
+        calibration_corrections: params.calibration_corrections.clone(),
     }
 }

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -238,6 +238,7 @@ mod tests {
             random_seed: Some(42),
             temperature: 1.0,
             analysis_deadline_ms: None,
+            failure_cache: None,
         }
     }
 
@@ -312,6 +313,7 @@ mod tests {
             random_seed: None,
             temperature: 1.0,
             analysis_deadline_ms: None,
+            failure_cache: None,
         };
         let lookups = build_creature_lookups(&input);
 

--- a/src/analysis/synapse/results.rs
+++ b/src/analysis/synapse/results.rs
@@ -87,6 +87,7 @@ pub(super) fn finalise_synapse_results(
         error_values: &error_values,
         timing_collector: &params.timing_collector,
         mcmc_summary: Some(params.mcmc_summary),
+        calibration_corrections: pp_metrics.calibration_corrections,
     });
 
     Ok(AnalyzeSynapsesResult {

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -115,6 +115,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     mcmc_diagnostics: s.metadata.mcmc_diagnostics.as_ref().map(mcmc_to_json),
                     rejection_breakdown: s.metadata.rejection_breakdown.counts().clone(),
                     top_level_summary: s.metadata.top_level_summary.clone(),
+                    calibration_corrections: s.metadata.calibration_corrections.clone(),
                 }),
                 helpful_neurons: neuron.as_ref().map(|n| n.helpful_neurons.clone()),
                 synapse_weight_updates,
@@ -134,6 +135,7 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     gpu_info: n.metadata.gpu_info.as_ref().map(gpu_info_to_json),
                     rejection_breakdown: n.metadata.rejection_breakdown.counts().clone(),
                     top_level_summary: n.metadata.top_level_summary.clone(),
+                    calibration_corrections: n.metadata.calibration_corrections.clone(),
                 }),
                 neuron_fingerprints: result.neuron_fingerprints,
                 fingerprint_cache_hits: if result.fingerprint_cache_hits > 0 {
@@ -215,6 +217,7 @@ pub(crate) fn build_analyze_all_input_from_parallel(
         temperature: input.temperature,
         max_analysis_memory_mb: input.max_analysis_memory_mb,
         max_discovery_wall_clock_minutes: input.max_discovery_wall_clock_minutes,
+        failure_cache: input.failure_cache,
     }
 }
 

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -82,6 +82,17 @@ pub struct AnalyzeParallelInput {
     /// When `None`, no overall cap is enforced (backwards compatible).
     #[serde(default)]
     pub max_discovery_wall_clock_minutes: Option<u64>,
+    /// Per-creature failure cache feeding the prediction calibration
+    /// correction (Issue #1131).
+    ///
+    /// Each entry records what the library predicted vs what actually
+    /// happened post-apply, keyed by change-type (`add-neurons`,
+    /// `add-synapses`, `coordinated-structural`, ...). When supplied, the
+    /// calibration pipeline computes a per-change-type correction factor
+    /// that multiplies the compiled `*_PREDICTION_CALIBRATION` constants.
+    /// When absent or empty, the compiled constants are used unchanged.
+    #[serde(default)]
+    pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -108,6 +119,9 @@ pub struct AnalyzeSynapsesInput {
     /// for full documentation.
     #[serde(default = "default_temperature")]
     pub temperature: f32,
+    /// Per-creature failure cache (Issue #1131). See `AnalyzeParallelInput`.
+    #[serde(default)]
+    pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
 }
 
 /// Internal input structure for neuron analysis (used by `analyze_all`)
@@ -134,6 +148,9 @@ pub struct AnalyzeNeuronsInput {
     /// for full documentation.
     #[serde(default = "default_temperature")]
     pub temperature: f32,
+    /// Per-creature failure cache (Issue #1131). See `AnalyzeParallelInput`.
+    #[serde(default)]
+    pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
 }
 
 /// Internal input structure for combined analysis (used by `analyze_parallel`)
@@ -187,6 +204,11 @@ pub struct AnalyzeAllInput {
     /// See `AnalyzeParallelInput` for full documentation.
     #[serde(default)]
     pub max_discovery_wall_clock_minutes: Option<u64>,
+    /// Per-creature failure cache feeding calibration correction (Issue #1131).
+    ///
+    /// See `AnalyzeParallelInput` for full documentation.
+    #[serde(default)]
+    pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -154,6 +154,16 @@ pub struct SynapseAnalysisMetadataJson {
     /// One-sentence summary naming the dominant rejection reason (Issue #1129).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_level_summary: Option<String>,
+    /// Per-change-type calibration correction factors derived from the
+    /// failure cache (Issue #1131).
+    ///
+    /// Keyed by the stable change-type identifiers (`add-neurons`,
+    /// `add-synapses`, `coordinated-structural`, ...). Values are scalar
+    /// correction factors that multiplied the compiled
+    /// `*_PREDICTION_CALIBRATION` constants for this run. Empty when no
+    /// failure cache was supplied.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub calibration_corrections: std::collections::HashMap<String, f32>,
 }
 
 /// MCMC diagnostics summary for the analysis output JSON (Issue #1021).
@@ -242,6 +252,10 @@ pub struct NeuronAnalysisMetadataJson {
     /// One-sentence summary naming the dominant rejection reason (Issue #1129).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_level_summary: Option<String>,
+    /// Per-change-type calibration correction factors (Issue #1131). See
+    /// `SynapseAnalysisMetadataJson::calibration_corrections` for full docs.
+    #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub calibration_corrections: std::collections::HashMap<String, f32>,
 }
 
 // ============================================================================

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -101,6 +101,7 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/leaky_relu_filtered.rs
+++ b/tests/activation/leaky_relu_filtered.rs
@@ -72,6 +72,7 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/relu_adjacent_filtered.rs
+++ b/tests/activation/relu_adjacent_filtered.rs
@@ -76,6 +76,7 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/step_hidden_neuron_prediction.rs
+++ b/tests/activation/step_hidden_neuron_prediction.rs
@@ -171,6 +171,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -262,6 +263,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -367,6 +369,7 @@ fn test_step_output_neuron_no_identity_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -110,6 +110,7 @@ fn synapse_analysis_respects_deadline() {
         analysis_deadline_ms: Some(deadline_ms),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let start = Instant::now();
@@ -199,6 +200,7 @@ fn neuron_analysis_respects_deadline() {
         analysis_deadline_ms: Some(deadline_ms),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let start = Instant::now();
@@ -283,6 +285,7 @@ fn focus_neurons_are_randomised_across_runs() {
             analysis_deadline_ms: Some(60_000), // 1 minute - enough to complete
             random_seed: None,
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_neurons(&input).expect("Analysis should complete successfully");

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -154,6 +154,7 @@ fn test_optimised_params_vary_by_sample() {
             analysis_deadline_ms: None,
             random_seed: None,
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -232,6 +233,7 @@ fn test_conservative_params_more_stable_across_samples() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let subset_result = analyze_neurons(&subset_input).unwrap();
@@ -365,6 +367,7 @@ fn test_relu_fixed_params_consistent_across_samples() {
             analysis_deadline_ms: None,
             random_seed: None,
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -463,6 +466,7 @@ fn test_synapse_candidates_no_bias_optimisation() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).unwrap();
@@ -524,6 +528,7 @@ fn test_synapse_weight_distribution() {
             analysis_deadline_ms: None,
             random_seed: None,
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_synapses(&input).unwrap();

--- a/tests/analysis/issue_1101_no_target_records_diagnostic.rs
+++ b/tests/analysis/issue_1101_no_target_records_diagnostic.rs
@@ -78,6 +78,7 @@ fn zero_target_records_reports_no_target_records_reason() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/analysis/issue_1131_calibration_correction.rs
+++ b/tests/analysis/issue_1131_calibration_correction.rs
@@ -1,0 +1,334 @@
+//! Integration tests for Issue #1131: Calibrate prediction factors using the
+//! failure cache.
+//!
+//! Verifies that when a creature-specific `failure_cache` is supplied to
+//! `analyze_all`, the derived per-change-type calibration corrections:
+//!
+//! 1. Appear in the returned metadata (synapse + neuron paths).
+//! 2. Clamp to `MIN_CALIBRATION_CORRECTION` for a 20-entry over-estimation
+//!    history of 1000× (expected 0.001, actual 0.000001).
+//! 3. Are deterministic across repeated runs with the same input.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::analyze_all;
+use neat_ai_discovery::analysis::gpu::GpuAnalyzer;
+use neat_ai_discovery::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_ADD_NEURONS, CHANGE_TYPE_ADD_SYNAPSES, CHANGE_TYPE_COORDINATED_STRUCTURAL,
+    CalibrationCorrection, FailureCacheEntry, MIN_CALIBRATION_CORRECTION,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeAllInput, CreatureJson, NeuronJson, SynapseJson};
+
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+/// Build a small creature mirroring the shape used by other integration tests.
+fn build_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-1".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.4,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+fn build_records(creature: &CreatureJson, count: usize) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for obs in 0..count as u32 {
+        let t = obs as f32 / count as f32;
+        for neuron in &creature.neurons {
+            let (activation, value, errors) = match neuron.neuron_type.as_str() {
+                "input" => ((t * std::f32::consts::TAU).sin(), None, Vec::new()),
+                "hidden" => {
+                    let act = 0.3 + 0.4 * (t * std::f32::consts::TAU).sin();
+                    (act, Some(act), vec![0.05 * (t * 3.0).cos()])
+                }
+                "output" => {
+                    let error = 0.1 * (t * std::f32::consts::PI).cos();
+                    (0.5 + 0.2 * t, Some(0.5 + 0.2 * t), vec![error])
+                }
+                _ => continue,
+            };
+            records.push(DiscoverRecord {
+                obs_index: obs,
+                neuron_uuid: neuron.uuid.clone(),
+                value,
+                activation,
+                errors,
+            });
+        }
+    }
+    records
+}
+
+/// Acceptance criterion: 20 entries of expected=0.001, actual=0.000001
+/// yield a correction factor at the lower clamp (≈ 0.001).
+#[test]
+fn twenty_over_estimations_clamp_to_minimum_correction() {
+    let cache: Vec<FailureCacheEntry> = (0..20)
+        .map(|_| FailureCacheEntry {
+            change_type: CHANGE_TYPE_ADD_NEURONS.to_string(),
+            expected_error_reduction: 0.001,
+            actual_error_reduction: 0.000_001,
+        })
+        .collect();
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+    let value = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+    assert!(
+        (value - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+        "expected ≈ {MIN_CALIBRATION_CORRECTION}, got {value}"
+    );
+}
+
+/// With the same 20-entry failure cache, the `analyze_all` synapse metadata
+/// exposes the derived per-change-type correction factors.
+#[test]
+fn analyze_all_exposes_calibration_corrections_in_metadata() {
+    skip_without_gpu!();
+
+    let creature = build_creature();
+    let records = build_records(&creature, 60);
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("test.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    // Seed failure cache: heavy over-estimation across all three change types.
+    let mut failure_cache = Vec::new();
+    for change_type in [
+        CHANGE_TYPE_ADD_NEURONS,
+        CHANGE_TYPE_ADD_SYNAPSES,
+        CHANGE_TYPE_COORDINATED_STRUCTURAL,
+    ] {
+        for _ in 0..20 {
+            failure_cache.push(FailureCacheEntry {
+                change_type: change_type.to_string(),
+                expected_error_reduction: 0.001,
+                actual_error_reduction: 0.000_001,
+            });
+        }
+    }
+
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output" || n.neuron_type == "hidden")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons,
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+        random_seed: Some(42),
+        previous_neuron_fingerprints: None,
+        module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
+        max_discovery_wall_clock_minutes: None,
+        temperature: 1.0,
+        failure_cache: Some(failure_cache),
+    };
+
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+
+    let synapse = result.synapse.expect("synapse analysis should run");
+    let neuron = result.neuron.expect("neuron analysis should run");
+
+    // Synapse path: both add-synapses and coordinated-structural corrections
+    // should be at the floor.
+    let synapse_corrections = &synapse.metadata.calibration_corrections;
+    let syn_add = synapse_corrections
+        .get(CHANGE_TYPE_ADD_SYNAPSES)
+        .copied()
+        .unwrap_or(1.0);
+    let syn_coord = synapse_corrections
+        .get(CHANGE_TYPE_COORDINATED_STRUCTURAL)
+        .copied()
+        .unwrap_or(1.0);
+    assert!(
+        (syn_add - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+        "expected add-synapses correction ≈ {MIN_CALIBRATION_CORRECTION}, got {syn_add}"
+    );
+    assert!(
+        (syn_coord - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+        "expected coordinated-structural correction ≈ {MIN_CALIBRATION_CORRECTION}, got {syn_coord}"
+    );
+
+    // Neuron path: add-neurons correction should be at the floor too.
+    let neuron_corrections = &neuron.metadata.calibration_corrections;
+    let neu_add = neuron_corrections
+        .get(CHANGE_TYPE_ADD_NEURONS)
+        .copied()
+        .unwrap_or(1.0);
+    assert!(
+        (neu_add - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+        "expected add-neurons correction ≈ {MIN_CALIBRATION_CORRECTION}, got {neu_add}"
+    );
+}
+
+/// Two back-to-back `analyze_all` invocations with the same seed and the same
+/// failure cache must produce identical calibration corrections.
+#[test]
+fn calibration_corrections_are_deterministic() {
+    skip_without_gpu!();
+
+    let creature = build_creature();
+    let records = build_records(&creature, 40);
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("test.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let failure_cache: Vec<FailureCacheEntry> = (0..15)
+        .map(|i| FailureCacheEntry {
+            change_type: CHANGE_TYPE_ADD_SYNAPSES.to_string(),
+            expected_error_reduction: 0.01,
+            // Vary slightly so the EWMA is a non-trivial value.
+            actual_error_reduction: 0.002 + (i as f32) * 0.000_05,
+        })
+        .collect();
+
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    let make_input = || AnalyzeAllInput {
+        parquet_file: parquet_file.clone(),
+        creature: creature.clone(),
+        focus_neurons: focus_neurons.clone(),
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(false),
+        random_seed: Some(12345),
+        previous_neuron_fingerprints: None,
+        module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
+        max_discovery_wall_clock_minutes: None,
+        temperature: 1.0,
+        failure_cache: Some(failure_cache.clone()),
+    };
+
+    let r1 = analyze_all(&make_input()).expect("run 1");
+    let r2 = analyze_all(&make_input()).expect("run 2");
+
+    let c1 = &r1.synapse.unwrap().metadata.calibration_corrections;
+    let c2 = &r2.synapse.unwrap().metadata.calibration_corrections;
+    assert_eq!(c1, c2, "corrections must be deterministic across runs");
+
+    // And must match a fresh direct-compute against the same cache.
+    let direct = CalibrationCorrection::from_failure_cache(&failure_cache);
+    let direct_value = direct.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+    let metadata_value = c1
+        .get(CHANGE_TYPE_ADD_SYNAPSES)
+        .copied()
+        .expect("add-synapses correction should be present");
+    assert!(
+        (direct_value - metadata_value).abs() < 1e-6,
+        "metadata value {metadata_value} should match direct compute {direct_value}"
+    );
+}
+
+/// With no failure cache supplied, the metadata's `calibration_corrections` map
+/// is empty and predictions fall through to the compiled constants unchanged.
+#[test]
+fn no_failure_cache_leaves_corrections_empty() {
+    skip_without_gpu!();
+
+    let creature = build_creature();
+    let records = build_records(&creature, 40);
+
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("test.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    let input = AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons,
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(false),
+        random_seed: Some(42),
+        previous_neuron_fingerprints: None,
+        module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
+        max_discovery_wall_clock_minutes: None,
+        temperature: 1.0,
+        failure_cache: None,
+    };
+
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+    let synapse = result.synapse.expect("synapse analysis should run");
+    assert!(
+        synapse.metadata.calibration_corrections.is_empty(),
+        "expected empty corrections map when no failure cache is supplied"
+    );
+}

--- a/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
+++ b/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
@@ -99,6 +99,7 @@ fn issue_199_low_variance_sources_use_default_threshold() {
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -202,6 +203,7 @@ fn issue_199_high_variance_sources_scale_threshold() {
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -303,6 +305,7 @@ fn issue_199_env_var_override_takes_precedence() {
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -384,6 +387,7 @@ fn issue_199_env_var_zero_disables_folding() {
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/analysis/issue_221_sample_locality.rs
+++ b/tests/analysis/issue_221_sample_locality.rs
@@ -345,6 +345,7 @@ fn sample_locality_batching_produces_results() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs
@@ -416,6 +417,7 @@ fn sample_locality_preserves_correctness() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -464,6 +466,7 @@ fn source_batching_90_percent_overlap_produces_results() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs

--- a/tests/analysis/issue_419_parallel_discovery_execution.rs
+++ b/tests/analysis/issue_419_parallel_discovery_execution.rs
@@ -115,6 +115,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -211,6 +212,7 @@ fn parallel_discovery_metadata_consistent() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -104,6 +104,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -158,6 +159,7 @@ fn input_neuron_reported_as_filtered_in_neuron_diagnostics() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -229,6 +231,7 @@ fn synapse_diagnostics_include_rejection_reasons_for_unpromising_targets() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("synapse analysis should succeed");
@@ -413,6 +416,7 @@ fn multiple_focus_targets_each_get_separate_diagnostic_entry() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -475,6 +479,7 @@ fn fully_connected_neuron_reports_no_eligible_sources() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/analysis/issue_557_audit_discovery_strategies.rs
+++ b/tests/analysis/issue_557_audit_discovery_strategies.rs
@@ -140,6 +140,7 @@ fn all_candidates_have_positive_expected_score_gain() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -227,6 +228,7 @@ fn metadata_consistent_after_positive_gain_filtering() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_568_async_pipeline.rs
+++ b/tests/analysis/issue_568_async_pipeline.rs
@@ -165,6 +165,7 @@ fn async_pipeline_produces_valid_analysis_results() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -226,6 +227,7 @@ fn async_pipeline_is_deterministic_with_fixed_seed() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result1 = analyze_all(&make_input()).expect("Run 1 should succeed");

--- a/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
+++ b/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
@@ -230,6 +230,7 @@ fn run_analysis() -> Vec<neat_ai_discovery::CoordinatedStructuralCandidateJson> 
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -386,6 +387,7 @@ fn test_analyze_all_finds_change_squash_candidate() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -21,6 +21,7 @@ mod issue_1097_shared_deadline;
 mod issue_1098_wall_clock_cap;
 mod issue_1101_no_target_records_diagnostic;
 mod issue_1109_neuron_min_improved_ratio_raise;
+mod issue_1131_calibration_correction;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;

--- a/tests/analysis/split_error_all_activations.rs
+++ b/tests/analysis/split_error_all_activations.rs
@@ -150,6 +150,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -282,6 +283,7 @@ fn test_skewed_errors_return_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/split_error_fallback_candidates.rs
+++ b/tests/analysis/split_error_fallback_candidates.rs
@@ -155,6 +155,7 @@ fn regression_split_error_must_return_fallback_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -331,6 +332,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/target_map_optimization.rs
+++ b/tests/analysis/target_map_optimization.rs
@@ -84,6 +84,7 @@ fn synapse_analysis_with_target_map_optimization_succeeds() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -163,6 +164,7 @@ fn multiple_focus_neurons_share_target_map_optimization() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result =
@@ -263,6 +265,7 @@ fn target_map_filters_non_finite_values() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Analysis should complete without errors from non-finite values
@@ -334,6 +337,7 @@ fn empty_target_records_skips_source_processing() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Should complete quickly without processing sources

--- a/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
@@ -124,6 +124,7 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/focus/issue_182_focus_unused_observations.rs
+++ b/tests/focus/issue_182_focus_unused_observations.rs
@@ -211,6 +211,7 @@ fn issue_182_focus_unused_observations_prioritises_inputs_without_synapses() {
         analysis_deadline_ms: Some(5000), // Short deadline to test prioritisation
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -283,6 +284,7 @@ fn issue_182_without_env_var_no_prioritisation() {
         analysis_deadline_ms: None, // No deadline - process all
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -131,6 +131,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -240,6 +241,7 @@ fn test_all_new_activations_produce_candidates() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -86,6 +86,7 @@ fn synapse_analysis_works_with_gpu_work_queue() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -153,6 +154,7 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -263,6 +265,7 @@ fn multiple_focus_neurons_work_with_shared_queue() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Run analysis with multiple focus neurons
@@ -347,6 +350,7 @@ fn harmful_synapse_detection_works_with_queue() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Run analysis

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -89,6 +89,7 @@ fn neuron_analysis_with_deadline_completes() {
         analysis_deadline_ms: Some(120_000),
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis with deadline should succeed");
@@ -118,6 +119,7 @@ fn synapse_analysis_with_deadline_completes() {
         analysis_deadline_ms: Some(120_000),
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis with deadline should succeed");
@@ -154,6 +156,7 @@ fn analysis_with_expired_deadline_returns_promptly() {
         analysis_deadline_ms: Some(1),
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let start = std::time::Instant::now();

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -124,6 +124,7 @@ fn timing_enabled_via_env_var() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -185,6 +186,7 @@ fn per_shader_timing_collected() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -325,6 +327,7 @@ fn neuron_analysis_timing_collected() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_196_cache_locality_benchmark.rs
+++ b/tests/infrastructure/issue_196_cache_locality_benchmark.rs
@@ -135,6 +135,7 @@ fn cache_locality_optimization_preserves_correctness() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -154,6 +155,7 @@ fn cache_locality_optimization_preserves_correctness() {
         analysis_deadline_ms: None,
         random_seed: Some(123),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result2 = analyze_synapses(&input2).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_228_zero_copy_buffer.rs
+++ b/tests/infrastructure/issue_228_zero_copy_buffer.rs
@@ -206,6 +206,7 @@ fn zero_copy_produces_correct_results() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
     let result_zero_copy =
         analyze_synapses(&input).expect("Analysis with zero-copy should succeed");
@@ -225,6 +226,7 @@ fn zero_copy_produces_correct_results() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
     let result_copy = analyze_synapses(&input).expect("Analysis with copy should succeed");
     unsafe {
@@ -325,6 +327,7 @@ fn metadata_includes_zero_copy_status() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -411,6 +414,7 @@ fn zero_copy_no_data_corruption() {
             analysis_deadline_ms: None,
             random_seed: Some(seed),
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_718_bug_comment_error_handling.rs
+++ b/tests/infrastructure/issue_718_bug_comment_error_handling.rs
@@ -72,6 +72,7 @@ fn target_with_only_constant_upstream_returns_empty_results() {
         analysis_deadline_ms: Some(60_000),
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input);

--- a/tests/infrastructure/observability.rs
+++ b/tests/infrastructure/observability.rs
@@ -375,6 +375,7 @@ fn integration_timing_output() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result =
@@ -443,6 +444,7 @@ fn integration_gpu_metrics() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result =

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -509,6 +509,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -605,6 +606,7 @@ fn test_bias_values_are_activation_specific() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -875,6 +877,7 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -984,6 +987,7 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1083,6 +1087,7 @@ fn test_bias_improves_neuron_performance() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1213,6 +1218,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1376,6 +1382,7 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/neuron/issue_134_direction_flip.rs
+++ b/tests/neuron/issue_134_direction_flip.rs
@@ -80,6 +80,7 @@ fn issue_134_bent_identity_target_simulation_rejects_linear_false_positive() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -149,6 +150,7 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
@@ -79,6 +79,7 @@ fn issue_178_constant_source_becomes_setbias_candidate() {
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_180_setweight_operation.rs
+++ b/tests/neuron/issue_180_setweight_operation.rs
@@ -107,6 +107,7 @@ fn issue_180_setweight_replaces_remove_add_pattern() {
         analysis_deadline_ms: Some(30_000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_834_lock_free_error_collection.rs
+++ b/tests/neuron/issue_834_lock_free_error_collection.rs
@@ -160,6 +160,7 @@ fn test_lock_free_error_collection_many_targets() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -218,6 +218,7 @@ fn test_add_neuron_between_hidden_neurons() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -328,6 +329,7 @@ fn test_hidden_neuron_candidate_properties() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -430,6 +432,7 @@ fn test_analyze_all_finds_hidden_neuron_candidate() {
         module_outcome_tracker: None,
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/regression/regression_v0_1_123.rs
+++ b/tests/regression/regression_v0_1_123.rs
@@ -136,6 +136,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -268,6 +269,7 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -535,6 +537,7 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -716,6 +719,7 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_192_error_distribution_analysis.rs
+++ b/tests/scoring/issue_192_error_distribution_analysis.rs
@@ -459,6 +459,7 @@ fn test_synapse_analysis_includes_error_distribution() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -570,6 +571,7 @@ fn test_candidate_includes_outlier_info_when_enabled() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -671,6 +673,7 @@ fn test_bimodal_error_pattern_detection() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/scoring/issue_486_neuron_error_distribution.rs
+++ b/tests/scoring/issue_486_neuron_error_distribution.rs
@@ -98,6 +98,7 @@ fn test_neuron_analysis_populates_error_distribution() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -197,6 +198,7 @@ fn test_neuron_analysis_no_errors_returns_none() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -302,6 +304,7 @@ fn test_neuron_analysis_error_distribution_multiple_targets() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
+++ b/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
@@ -211,6 +211,7 @@ fn test_issue_506_synapse_candidates_have_pessimism_discount() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
@@ -125,6 +125,7 @@ fn synapse_analysis_runs_under_deadline() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -173,6 +174,7 @@ fn metadata_indicates_target_value_available() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -216,6 +218,7 @@ fn metadata_indicates_target_value_not_available() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -265,6 +268,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -311,6 +315,7 @@ fn candidate_counts_tracked_correctly() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -420,6 +425,7 @@ fn truncation_reflected_in_candidate_counts() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");

--- a/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
+++ b/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
@@ -133,6 +133,7 @@ fn test_issue_413_add_synapse_hard_tanh_prediction_not_inverted() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();
@@ -213,6 +214,7 @@ fn test_issue_413_add_synapse_prediction_direction_correct() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_416_harmful_synapse_threshold.rs
+++ b/tests/synapse/issue_416_harmful_synapse_threshold.rs
@@ -142,6 +142,7 @@ fn test_harmful_synapse_candidates_must_have_positive_expected_gain() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -239,6 +240,7 @@ fn test_helpful_synapse_is_not_marked_as_harmful() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -367,6 +369,7 @@ fn test_mixed_helpful_and_harmful_synapses() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/synapse/issue_522_synapse_post_processing.rs
+++ b/tests/synapse/issue_522_synapse_post_processing.rs
@@ -127,6 +127,7 @@ fn output_targets_have_full_impact_hidden_targets_are_discounted() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -255,6 +256,7 @@ fn candidates_sorted_by_expected_score_gain_descending() {
         analysis_deadline_ms: None, // No deadline = no diversification shuffle
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -367,6 +369,7 @@ fn max_candidates_limits_total_output() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -458,6 +461,7 @@ fn pipeline_applies_pessimism_discount_to_candidates() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -561,6 +565,7 @@ fn metadata_contains_candidate_counts_and_timing() {
         analysis_deadline_ms: None,
         random_seed: Some(42),
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -229,6 +229,7 @@ fn test_remove_harmful_synapse_discovery() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -356,6 +357,7 @@ fn test_harmful_synapse_identifies_correct_neurons() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -431,6 +433,7 @@ fn test_analyze_all_finds_harmful_synapse() {
         module_outcome_tracker: None,
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
+        failure_cache: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/synapse/sample_matching.rs
+++ b/tests/synapse/sample_matching.rs
@@ -75,6 +75,7 @@ fn analysis_handles_non_finite_values_gracefully() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Should complete without error
@@ -138,6 +139,7 @@ fn analysis_pairs_samples_by_obs_index() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Should complete successfully with 5 matching sample pairs
@@ -203,6 +205,7 @@ fn analysis_skips_neurons_without_errors() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     // Should complete and find candidates using input-0 as source

--- a/tests/synapse/source_variance_discounting.rs
+++ b/tests/synapse/source_variance_discounting.rs
@@ -131,6 +131,7 @@ fn test_constant_source_gives_zero_improvement() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -232,6 +233,7 @@ fn test_low_variance_source_discounts_prediction() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -333,6 +335,7 @@ fn test_high_variance_source_not_discounted() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -441,6 +444,7 @@ fn test_constant_vs_varying_source_comparison() {
         analysis_deadline_ms: None,
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/synapse/synapse_candidate_indices.rs
+++ b/tests/synapse/synapse_candidate_indices.rs
@@ -106,6 +106,7 @@ fn synapse_candidates_populate_from_and_to_indices() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/synapse/synapse_impact_discounting.rs
+++ b/tests/synapse/synapse_impact_discounting.rs
@@ -180,6 +180,7 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -295,6 +296,7 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -385,6 +387,7 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
         analysis_deadline_ms: Some(30000),
         random_seed: None,
         temperature: 1.0,
+        failure_cache: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -829,6 +829,7 @@ Pages speculative:                        12345.
             analysis_deadline_ms: None,
             random_seed: Some(123),
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;
@@ -922,6 +923,7 @@ Pages speculative:                        12345.
             analysis_deadline_ms: None,
             random_seed: Some(123),
             temperature: 1.0,
+            failure_cache: None,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;


### PR DESCRIPTION
## Summary

Calibrates the per-prediction factors using actual outcomes from a supplied failure cache. Closes #1131.

The compiled `NEURON_PREDICTION_CALIBRATION`, `SYNAPSE_PREDICTION_CALIBRATION`, and `COORDINATED_PREDICTION_CALIBRATION` constants are global averages. A single creature can drift from that average — for example, one whose recent failure cache shows ~1000× over-estimation for `add-neurons` should discount that class more than the global constant does. This change computes a per-change-type correction factor from a creature's failure cache and applies it multiplicatively to the base calibration constant before prediction scoring.

### Changes

- **New module** `src/analysis/scoring/calibration_correction.rs` defining:
  - `FailureCacheEntry { change_type, expected_error_reduction, actual_error_reduction }` (camelCase at the FFI boundary).
  - `CalibrationCorrection::from_failure_cache(&[FailureCacheEntry])` which groups entries by `change_type`, skips zero-predicted / non-finite ratios, computes an EWMA of `actual / expected` with `α = 0.3`, and clamps to `[MIN_CALIBRATION_CORRECTION = 0.001, NEUTRAL_CORRECTION = 1.0]`.
  - Stable change-type keys: `add-neurons`, `add-synapses`, `coordinated-structural`.
- **Input plumbing** — `failure_cache: Option<Vec<FailureCacheEntry>>` added to `AnalyzeParallelInput`, `AnalyzeAllInput`, `AnalyzeSynapsesInput`, and `AnalyzeNeuronsInput` with `#[serde(default)]` for backwards compatibility.
- **Synapse post-processing** (`src/analysis/synapse/post_processing.rs`) — builds the correction once from the input failure cache and applies it multiplicatively to `SYNAPSE_PREDICTION_CALIBRATION` (helpful + harmful) and `COORDINATED_PREDICTION_CALIBRATION` before invoking the logistic / flat calibration.
- **Neuron post-processing** (`src/analysis/neuron/post_processing.rs`) — same pattern, applied to `NEURON_PREDICTION_CALIBRATION`.
- **Metadata** — `calibration_corrections: HashMap<String, f32>` added to both `SynapseAnalysisMetadata` and `NeuronAnalysisMetadata`, and surfaced on the FFI JSON types (`SynapseAnalysisMetadataJson`, `NeuronAnalysisMetadataJson`, skipped when empty).

### Safety characteristics

- **Never inflates predictions** — upper clamp of 1.0 means the correction can only ever discount.
- **Never collapses to zero** — lower clamp of 0.001 preserves exploration for change-types that have been consistently over-estimating.
- **Deterministic** — same cache in, same corrections out; verified by an integration test asserting byte-equal correction maps across two runs.

## Test plan

- [x] Unit tests in `src/analysis/scoring/calibration_correction.rs` (9 tests): empty cache → neutral, all-negative → min, uniform cache returns mean ratio (20 entries of `0.000001/0.001` clamped to `0.001`), mixed cache → expected EWMA, zero-predicted skipped, non-finite ratios skipped, change-types independent, correction above 1.0 clamps to neutral, deterministic output.
- [x] Integration tests in `tests/analysis/issue_1131_calibration_correction.rs` (4 tests):
  - `twenty_over_estimations_clamp_to_minimum_correction` — acceptance criterion from the issue.
  - `analyze_all_exposes_calibration_corrections_in_metadata` — end-to-end through `analyze_all`, asserting synapse + neuron metadata carry the per-change-type corrections at the expected floor.
  - `calibration_corrections_are_deterministic` — repeated runs produce identical corrections, and they match a direct-compute against the same cache.
  - `no_failure_cache_leaves_corrections_empty` — absence of cache leaves the map empty (no behaviour change for existing callers).
- [x] `./quality.sh` passes cleanly (all existing tests green).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1131 -->