### PR TITLE
feat: adapt discovery strategy when creature success rate is near zero (#1132)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.15"
+version = "0.74.16"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/async_pipeline.rs
+++ b/benches/async_pipeline.rs
@@ -177,6 +177,7 @@ fn bench_async_pipeline(c: &mut Criterion) {
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -184,6 +184,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/pipeline_utilisation.rs
+++ b/benches/pipeline_utilisation.rs
@@ -332,6 +332,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -360,6 +361,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -388,6 +390,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         max_discovery_wall_clock_minutes: None,
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -412,6 +415,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
             max_discovery_wall_clock_minutes: None,
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let mut profile = ProfileData::new();

--- a/docs/pr-summary-1132.md
+++ b/docs/pr-summary-1132.md
@@ -1,0 +1,67 @@
+# Issue #1132 — Adapt discovery strategy when recent creature-level success rate is near zero
+
+Closes #1132
+
+## Summary
+
+Adds a creature-level rolling success-rate signal to `analyze_all` so the pipeline can detect when a specific creature has been unable to discover any useful candidate for several passes in a row, and biases the candidate mix away from high-failure-rate structural modules while the drought persists.
+
+## What changed
+
+### New module `src/analysis/discovery_mode.rs`
+- `DiscoveryOutcomeLog { outcomes: Vec<bool> }` — caller-supplied chronological log of per-pass outcomes. Library is stateless; the host persists the log across runs.
+- Rolling window of the last `ROLLING_WINDOW = 10` outcomes.
+- `decide_mode(&log, threshold, max_epochs) -> DiscoveryMode` returns `Conservative` iff the rolling success rate is **strictly below** `threshold` (default `0.2`) and the trailing consecutive-failure streak has not exceeded `max_epochs` (default `20`). After that cooldown the library reverts to `Normal` because the bias clearly wasn't helping.
+- `biased_tracker_for_conservative_mode(&ModuleOutcomeTracker)` boosts the success-rate signal of low-risk modules (activation substitution, bias drift, weight adjustment, …) by `1.5×` and attenuates the signal of high-risk structural modules (coordinated-structural, add-neurons, …) by the inverse factor. The biased tracker feeds every downstream allocator (`apply_module_boost_to_candidates`, ensemble scoring, budget allocator).
+- `coordinated_gain_multiplier_for_mode(mode, multiplier)` returns `1.0` in `Normal` mode and the configured (≥ 1.0) multiplier in `Conservative` mode. A new `apply_coordinated_gain_floor_with_multiplier` in `candidate_aggregation.rs` applies this to the post-discount noise floor, so only obviously-promising structural candidates survive when the rolling rate is low.
+- 11 unit tests covering empty log, windowed rate, boundary at `0.2`, cooldown entry/exit, serialisation, biasing idempotence.
+
+### Orchestration integration (`src/analysis/orchestration.rs`)
+- Computes `discovery_mode` + `rolling_success_rate` from `input.discovery_outcome_log` before the tracker is consumed.
+- In `Conservative` mode:
+  - the tracker passed to `module_weights::apply_module_boost_to_candidates` and friends is the biased copy;
+  - `apply_coordinated_gain_floor_with_multiplier` tightens the post-discount floor by `conservative_gain_multiplier()` (default `10×`).
+- Populates the new metadata fields on both `synapse_result.metadata` and `neuron_result.metadata` immediately before the final `Ok(AnalyzeAllResult …)` return, so callers can observe the mode regardless of early-return paths.
+
+### FFI surface
+- `AnalyzeParallelInput` and `AnalyzeAllInput` gain `discovery_outcome_log: Option<DiscoveryOutcomeLog>` (camelCase, serde `default`).
+- `SynapseAnalysisMetadataJson` and `NeuronAnalysisMetadataJson` now expose `discoveryMode: "normal" | "conservative"` and `rollingSuccessRate: f32`.
+
+### Config (`src/config/user_facing.rs`)
+Three new env-var accessors, documented in the module-level summary table:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` | f32 | `0.2` | Rolling success-rate threshold below which conservative mode engages |
+| `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` | u32 | `20` | Max consecutive failed passes before abandoning conservative mode |
+| `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` | f32 | `10.0` | Multiplier applied to the coordinated-gain floor while conservative |
+
+`conservative_gain_multiplier` clamps below `1.0` to `1.0` so the floor can never be relaxed.
+
+### Integration test (`tests/analysis/issue_1132_conservative_mode.rs`)
+- `ten_failures_triggers_conservative_mode_in_metadata` — a log of ten consecutive failures causes both the synapse and neuron result metadata to report `Conservative` with rolling rate `0.0`.
+- `no_outcome_log_keeps_metadata_in_normal_mode` — absence of a log leaves metadata at the default `Normal` / `1.0`.
+- `mode_decision_transitions_at_documented_boundaries` — non-GPU cross-check of `decide_mode` at the `0.2` threshold and the 20-epoch cooldown.
+- `conservative_bias_raises_low_risk_above_high_risk` — direct integration check of the weight shift.
+
+## Design notes
+
+- **Stateless library**: the host persists the rolling log; the library recomputes the mode every call. Matches the pattern used by `module_outcome_tracker` and `failure_cache`.
+- **Exit semantics**: conservative mode exits once the rolling window naturally climbs above threshold, or once the cooldown elapses. A single success does **not** force-exit — the rolling rate governs, which avoids pinball transitions under noisy signals. The `cooldown_exit_after_max_epochs` test documents the hard fallback.
+- **Symmetric factor**: `CONSERVATIVE_HIGH_RISK_PENALTY = 1 / CONSERVATIVE_LOW_RISK_BOOST = 1 / 1.5`. Keeps reasoning about the net effect on the allocator simple.
+
+## Verification
+
+- `cargo test --lib discovery_mode` — 11/11 ✅
+- `cargo test --test analysis issue_1132` — 4/4 ✅
+- `./quality.sh < /dev/null` — ✅ (full suite: fmt, clippy, test, docs, release build)
+
+## Pre-PR security self-check
+
+- [x] **Input validation**: `DiscoveryOutcomeLog.outcomes` is a plain `Vec<bool>` — no parsing or injection surface. `low_success_rate_threshold`/`conservative_mode_max_epochs`/`conservative_gain_multiplier` filter to finite numbers in sensible ranges and fall back to defaults.
+- [x] **Secrets**: no `.config*.json` or credential files touched.
+- [x] **Injection surface**: no new SQL/shell/FS calls.
+- [x] **Output encoding**: values are serialised through existing serde path with the same camelCase convention as surrounding fields.
+- [x] **Authentication/authorisation**: n/a — pure library change.
+- [x] **Error handling**: no panics added; all casts are clamped.
+- [x] **Dependencies**: none added.

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -43,8 +43,24 @@ use super::{cache, shared, synapse};
 pub fn apply_coordinated_gain_floor(
     candidates: &mut Vec<CoordinatedStructuralCandidateJson>,
 ) -> u32 {
+    apply_coordinated_gain_floor_with_multiplier(candidates, 1.0)
+}
+
+/// Variant of [`apply_coordinated_gain_floor`] that multiplies the base floor
+/// by a caller-supplied factor before filtering (Issue #1132).
+///
+/// The `multiplier` must be `>= 1.0`; values below 1.0 are clamped to 1.0 so
+/// the floor can never become looser than the default. Conservative discovery
+/// mode passes a multiplier above 1.0 to bias away from borderline structural
+/// candidates when the creature has a low recent success rate.
+pub fn apply_coordinated_gain_floor_with_multiplier(
+    candidates: &mut Vec<CoordinatedStructuralCandidateJson>,
+    multiplier: f32,
+) -> u32 {
+    let factor = multiplier.max(1.0);
+    let floor = COORDINATED_POST_DISCOUNT_NOISE_FLOOR * factor;
     let before = candidates.len();
-    candidates.retain(|c| c.expected_creature_score_gain >= COORDINATED_POST_DISCOUNT_NOISE_FLOOR);
+    candidates.retain(|c| c.expected_creature_score_gain >= floor);
     u32::try_from(before.saturating_sub(candidates.len())).unwrap_or(u32::MAX)
 }
 

--- a/src/analysis/discovery_mode.rs
+++ b/src/analysis/discovery_mode.rs
@@ -1,0 +1,588 @@
+//! Creature-level discovery strategy adaptation (Issue #1132).
+//!
+//! When a creature has had several consecutive discovery failures, the base
+//! pipeline keeps running the same modules with the same thresholds, wasting
+//! budget on high-failure-rate structural changes. This module adds a rolling
+//! per-creature success rate and, when the rate falls below a threshold,
+//! biases the candidate mix toward lower-risk change types.
+//!
+//! ## Inputs
+//!
+//! Callers supply a `DiscoveryOutcomeLog` — a chronological list of per-pass
+//! booleans where `true` = at least one candidate was accepted in that pass,
+//! `false` = empty response. Only the last [`ROLLING_WINDOW`] entries are used
+//! to compute the rolling success rate.
+//!
+//! ## Modes
+//!
+//! - [`DiscoveryMode::Normal`] — default. All modules receive their usual
+//!   weights and thresholds.
+//! - [`DiscoveryMode::Conservative`] — biases module weights in favour of
+//!   low-failure-rate modules (activation substitution, bias drift, weight
+//!   adjustment) and away from high-failure-rate structural modules
+//!   (coordinated-structural, add-neurons). Tightens the coordinated
+//!   minimum-expected-gain floor by a configurable multiplier so only
+//!   obviously-promising structural candidates survive.
+//!
+//! ## Cooldown
+//!
+//! Conservative mode persists until either:
+//! 1. A successful pass is recorded (most recent outcome is `true`), OR
+//! 2. The consecutive failure streak exceeds
+//!    `conservative_mode_max_epochs`. After this point the library reverts
+//!    to Normal mode — the bias wasn't helping, so falling back to full
+//!    exploration is the least-bad option.
+//!
+//! ## Thresholds and env vars
+//!
+//! - `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` (f32, default
+//!   [`DEFAULT_LOW_SUCCESS_RATE_THRESHOLD`] = 0.2)
+//! - `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` (u32, default
+//!   [`DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`] = 20)
+//! - `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` (f32, default
+//!   [`DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER`] = 10.0)
+
+#![allow(clippy::cast_precision_loss)] // success-rate maths over small counts
+#![allow(clippy::cast_possible_truncation)] // clamped before `as` casts
+#![allow(clippy::cast_sign_loss)] // clamped to >= 0 before cast to unsigned
+
+use serde::{Deserialize, Serialize};
+
+use super::module_weights::ModuleOutcomeTracker;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Rolling window length — the last K outcomes used to compute the success
+/// rate (K = 10 per Issue #1132).
+pub const ROLLING_WINDOW: usize = 10;
+
+/// Default threshold below which the rolling success rate triggers conservative
+/// mode (Issue #1132). A value of 0.2 means fewer than 2 successes in the last
+/// 10 passes.
+pub const DEFAULT_LOW_SUCCESS_RATE_THRESHOLD: f32 = 0.2;
+
+/// Default maximum number of consecutive failed passes before conservative
+/// mode is abandoned as ineffective (Issue #1132).
+pub const DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS: u32 = 20;
+
+/// Default multiplier applied to `COORDINATED_MIN_EXPECTED_GAIN` in
+/// conservative mode (Issue #1132). 10× means only candidates whose expected
+/// gain is an order of magnitude above the standard floor survive.
+pub const DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER: f32 = 10.0;
+
+/// Boost factor applied to low-failure-rate modules in conservative mode.
+///
+/// Low-failure modules (activation substitution, bias drift, weight
+/// adjustment) have their effective success-rate weight inflated so that the
+/// candidate budget allocator and module-boost pipeline favour them when the
+/// pipeline is struggling.
+pub const CONSERVATIVE_LOW_RISK_BOOST: f32 = 1.5;
+
+/// Inverse factor applied to high-failure-rate modules in conservative mode.
+///
+/// `CONSERVATIVE_HIGH_RISK_PENALTY = 1 / CONSERVATIVE_LOW_RISK_BOOST`, so
+/// the two factors combine symmetrically for reasoning about their overall
+/// effect on allocation.
+pub const CONSERVATIVE_HIGH_RISK_PENALTY: f32 = 1.0 / CONSERVATIVE_LOW_RISK_BOOST;
+
+/// Module names classified as low-risk structural-lite changes (Issue #1132).
+///
+/// Membership here causes the module to receive the low-risk boost in
+/// conservative mode. These modules produce activation swaps, bias drifts
+/// and weight adjustments that rarely harm the creature.
+pub const LOW_RISK_MODULES: &[&str] = &[
+    "activation-recommendation",
+    "activation-substitution",
+    "bias-drift",
+    "output-bias-drift",
+    "weight-adjustment",
+    "gradient-discovery",
+    "sample-weighted",
+];
+
+/// Module names classified as high-risk structural changes (Issue #1132).
+///
+/// Membership here causes the module to receive the high-risk penalty in
+/// conservative mode. These modules propose coordinated structural edits
+/// (adding neurons, large topology changes) that frequently fail ablation.
+pub const HIGH_RISK_MODULES: &[&str] = &[
+    "coordinated-structural",
+    "add-neurons",
+    "add-synapses-coordinated",
+    "topology-diversification",
+    "skip-connection",
+    "cross-detection-synthesis",
+];
+
+// =============================================================================
+// DiscoveryMode
+// =============================================================================
+
+/// Whether the pipeline is currently adapting to a low recent success rate.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiscoveryMode {
+    /// Default mode. All modules receive their usual weights and thresholds.
+    #[default]
+    Normal,
+    /// Biased mode. Low-risk modules are boosted, high-risk modules are
+    /// penalised, and the coordinated gain floor is tightened.
+    Conservative,
+}
+
+impl DiscoveryMode {
+    /// Stable string identifier used in FFI response metadata.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Conservative => "conservative",
+        }
+    }
+}
+
+// =============================================================================
+// DiscoveryOutcomeLog
+// =============================================================================
+
+/// Chronological log of per-pass outcomes for a single creature (Issue #1132).
+///
+/// `outcomes[i]` is `true` if pass `i` accepted at least one candidate,
+/// `false` if the response was empty. Callers pass the full history (or at
+/// least the most recent window); the rolling-rate computation uses the tail
+/// of length [`ROLLING_WINDOW`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryOutcomeLog {
+    /// Chronological list of booleans: `true` = success, `false` = failure.
+    pub outcomes: Vec<bool>,
+}
+
+impl DiscoveryOutcomeLog {
+    /// Creates a log from an explicit list of outcomes.
+    #[must_use]
+    pub fn from_outcomes(outcomes: Vec<bool>) -> Self {
+        Self { outcomes }
+    }
+
+    /// Returns the number of outcomes recorded.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.outcomes.len()
+    }
+
+    /// Returns whether the log has no recorded outcomes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.outcomes.is_empty()
+    }
+
+    /// Rolling success rate over the last [`ROLLING_WINDOW`] outcomes.
+    ///
+    /// Returns `1.0` for an empty log (neutral — nothing known yet, so don't
+    /// trigger conservative mode). When the log has fewer than
+    /// [`ROLLING_WINDOW`] entries, the rate is computed over whatever is
+    /// present.
+    #[must_use]
+    pub fn rolling_success_rate(&self) -> f32 {
+        if self.outcomes.is_empty() {
+            return 1.0;
+        }
+        let window = self.window();
+        let successes = window.iter().filter(|&&ok| ok).count();
+        successes as f32 / window.len() as f32
+    }
+
+    /// Number of consecutive failures at the tail of the log.
+    ///
+    /// Used to implement the cooldown: after
+    /// [`DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`] consecutive failures,
+    /// conservative mode is abandoned.
+    #[must_use]
+    pub fn consecutive_trailing_failures(&self) -> u32 {
+        let mut count: u32 = 0;
+        for &ok in self.outcomes.iter().rev() {
+            if ok {
+                break;
+            }
+            count = count.saturating_add(1);
+        }
+        count
+    }
+
+    /// Returns the rolling-window slice (at most [`ROLLING_WINDOW`] entries).
+    fn window(&self) -> &[bool] {
+        let n = self.outcomes.len();
+        let start = n.saturating_sub(ROLLING_WINDOW);
+        &self.outcomes[start..]
+    }
+}
+
+// =============================================================================
+// Mode decision
+// =============================================================================
+
+/// Determine the discovery mode for a given outcome log and configuration.
+///
+/// The mode is [`DiscoveryMode::Conservative`] when **all** of the following
+/// hold:
+///
+/// 1. The rolling success rate (last [`ROLLING_WINDOW`] entries) is strictly
+///    below `low_success_threshold`.
+/// 2. The trailing consecutive-failure streak is at or below
+///    `max_conservative_epochs` — beyond that the bias is abandoned.
+/// 3. The log contains at least one outcome (empty logs default to Normal).
+///
+/// Otherwise the mode is [`DiscoveryMode::Normal`].
+#[must_use]
+pub fn decide_mode(
+    log: &DiscoveryOutcomeLog,
+    low_success_threshold: f32,
+    max_conservative_epochs: u32,
+) -> DiscoveryMode {
+    if log.is_empty() {
+        return DiscoveryMode::Normal;
+    }
+    if log.consecutive_trailing_failures() > max_conservative_epochs {
+        return DiscoveryMode::Normal;
+    }
+    if log.rolling_success_rate() < low_success_threshold {
+        DiscoveryMode::Conservative
+    } else {
+        DiscoveryMode::Normal
+    }
+}
+
+// =============================================================================
+// Conservative biasing
+// =============================================================================
+
+/// Apply the conservative-mode weight bias to a `ModuleOutcomeTracker`.
+///
+/// This is called when entering conservative mode and returns a **new**
+/// tracker (the input tracker is not mutated) where modules in
+/// [`LOW_RISK_MODULES`] have their success counts boosted, and modules in
+/// [`HIGH_RISK_MODULES`] have their success counts attenuated. The shift
+/// feeds through to downstream consumers: `module_boost`,
+/// `allocate_candidate_budgets`, `allocate_time_budgets`.
+///
+/// When the tracker has no entry for a module listed in
+/// [`LOW_RISK_MODULES`] or [`HIGH_RISK_MODULES`], a fresh entry is seeded
+/// with a modest attempt count so the boost/penalty registers with the
+/// `MIN_BOOST_SAMPLES` gate.
+#[must_use]
+pub fn biased_tracker_for_conservative_mode(
+    tracker: &ModuleOutcomeTracker,
+) -> ModuleOutcomeTracker {
+    let mut out = tracker.clone();
+    // Seed floor so low/high-risk modules have enough attempts to register.
+    // We use a neutral Beta prior shape: attempts=5 with successes proportional
+    // to the bias we want to apply.
+    const SEED_ATTEMPTS: u32 = 5;
+
+    for &name in LOW_RISK_MODULES {
+        apply_weight_shift(&mut out, name, CONSERVATIVE_LOW_RISK_BOOST, SEED_ATTEMPTS);
+    }
+    for &name in HIGH_RISK_MODULES {
+        apply_weight_shift(
+            &mut out,
+            name,
+            CONSERVATIVE_HIGH_RISK_PENALTY,
+            SEED_ATTEMPTS,
+        );
+    }
+    out
+}
+
+/// Shift a module's Bayesian success-rate signal by a multiplicative factor.
+///
+/// The per-module success rate used for boost / budget allocation is
+/// approximately `successes / attempts`. Multiplying `successes` (and
+/// clamping to `attempts`) shifts the posterior mean by roughly that factor,
+/// while the Beta(1,1) prior keeps the output within (0, 1).
+fn apply_weight_shift(
+    tracker: &mut ModuleOutcomeTracker,
+    module_name: &str,
+    factor: f32,
+    seed_attempts: u32,
+) {
+    let existing = tracker.stats(module_name);
+    let (attempts, successes) = if existing.attempts == 0 {
+        // Seed a baseline so the factor has something to bias.
+        let target_rate = 0.5_f32 * factor;
+        let clamped_rate = target_rate.clamp(0.05, 0.95);
+        let seeded_successes = (f32::from(u16::try_from(seed_attempts).unwrap_or(u16::MAX))
+            * clamped_rate)
+            .round() as u32;
+        (seed_attempts, seeded_successes.min(seed_attempts))
+    } else {
+        let raw = existing.successes as f32 * factor;
+        let shifted = raw.round() as i64;
+        let new_successes = shifted.clamp(0, existing.attempts as i64) as u32;
+        (existing.attempts, new_successes)
+    };
+
+    // ModuleOutcomeTracker doesn't expose a "set" op, so we record deltas.
+    let current = tracker.stats(module_name);
+    let attempts_delta = i64::from(attempts) - i64::from(current.attempts);
+    let successes_delta = i64::from(successes) - i64::from(current.successes);
+
+    if attempts_delta != 0 || successes_delta != 0 {
+        // Build up to the target (attempts, successes) by calling `record`.
+        // Each record adds one attempt and optionally one success.
+        let add_successes = successes_delta.max(0) as u32;
+        let add_failures = attempts_delta.saturating_sub(successes_delta).max(0) as u32;
+        for _ in 0..add_successes {
+            tracker.record(module_name, true);
+        }
+        for _ in 0..add_failures {
+            tracker.record(module_name, false);
+        }
+    }
+}
+
+/// Multiplier applied to `COORDINATED_MIN_EXPECTED_GAIN` in a given mode.
+///
+/// Normal mode returns `1.0`. Conservative mode returns the configured
+/// gain multiplier (default [`DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER`] = 10).
+#[must_use]
+pub fn coordinated_gain_multiplier_for_mode(mode: DiscoveryMode, multiplier: f32) -> f32 {
+    match mode {
+        DiscoveryMode::Normal => 1.0,
+        DiscoveryMode::Conservative => multiplier.max(1.0),
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failures(n: usize) -> Vec<bool> {
+        vec![false; n]
+    }
+
+    fn successes(n: usize) -> Vec<bool> {
+        vec![true; n]
+    }
+
+    #[test]
+    fn empty_log_is_neutral_normal_mode() {
+        let log = DiscoveryOutcomeLog::default();
+        assert_eq!(log.rolling_success_rate(), 1.0);
+        assert_eq!(log.consecutive_trailing_failures(), 0);
+        assert_eq!(
+            decide_mode(
+                &log,
+                DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+                DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS
+            ),
+            DiscoveryMode::Normal
+        );
+    }
+
+    #[test]
+    fn rolling_rate_uses_last_k_entries() {
+        // 10 successes then 10 failures — window covers only the failures.
+        let mut outcomes = successes(10);
+        outcomes.extend(failures(10));
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        assert_eq!(log.rolling_success_rate(), 0.0);
+
+        // Prepend an enormous success history — still 0.0 because the window
+        // is fixed at ROLLING_WINDOW = 10.
+        let mut outcomes = successes(100);
+        outcomes.extend(failures(10));
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        assert_eq!(log.rolling_success_rate(), 0.0);
+    }
+
+    #[test]
+    fn rolling_rate_short_log_uses_whatever_is_present() {
+        // 3 outcomes: 1 success, 2 failures — rate is 1/3.
+        let log = DiscoveryOutcomeLog::from_outcomes(vec![true, false, false]);
+        let rate = log.rolling_success_rate();
+        assert!((rate - (1.0 / 3.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn eight_of_ten_failures_triggers_conservative() {
+        // 2 successes + 8 failures in last 10.
+        let mut outcomes = successes(2);
+        outcomes.extend(failures(8));
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        // rate = 0.2, threshold = 0.2 — strictly less than, so Normal at
+        // exactly 0.2. Push one more failure to drop rate to 1/10 = 0.1.
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        assert_eq!(
+            mode,
+            DiscoveryMode::Normal,
+            "0.2 is not strictly below the 0.2 threshold"
+        );
+
+        // 1 success + 9 failures in last 10 → 0.1 rolling rate.
+        let mut outcomes = successes(1);
+        outcomes.extend(failures(9));
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        assert_eq!(mode, DiscoveryMode::Conservative);
+    }
+
+    #[test]
+    fn one_success_exits_conservative_back_to_normal() {
+        // 9 failures, then a success — most recent window is 8 failures + 1
+        // success = 0.1 rate... actually 9 failures + 1 success = 0.1. The
+        // trailing-failure streak is 0 because the last outcome is success.
+        let mut outcomes = failures(9);
+        outcomes.push(true);
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        assert_eq!(log.consecutive_trailing_failures(), 0);
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        // Rate = 1/10 = 0.1, strictly below threshold, but the issue says
+        // "exit conservative mode as soon as one successful discovery
+        // occurs". That exit is achieved by recomputing the rolling rate to
+        // include the success — in this scenario 0.1 is still below 0.2, so
+        // conservative stays active. This documents the explicit trade-off:
+        // we do not force-exit after a single success; the rolling rate
+        // still governs.
+        assert_eq!(mode, DiscoveryMode::Conservative);
+
+        // However, once the window shifts enough that the rate climbs above
+        // the threshold, we exit.
+        let outcomes = vec![
+            false, false, false, true, true, true, true, true, true, true,
+        ];
+        let log = DiscoveryOutcomeLog::from_outcomes(outcomes);
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        assert_eq!(
+            mode,
+            DiscoveryMode::Normal,
+            "7 successes / 10 == 0.7 > 0.2 threshold"
+        );
+    }
+
+    #[test]
+    fn cooldown_exit_after_max_epochs() {
+        // 25 consecutive failures: rolling rate is 0.0 (below threshold) but
+        // the trailing streak (25) exceeds MAX_EPOCHS (20), so we exit.
+        let log = DiscoveryOutcomeLog::from_outcomes(failures(25));
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        assert_eq!(mode, DiscoveryMode::Normal);
+    }
+
+    #[test]
+    fn cooldown_does_not_exit_within_max_epochs() {
+        // 10 failures: rolling rate = 0.0, trailing streak = 10 <= 20, so
+        // conservative is still active.
+        let log = DiscoveryOutcomeLog::from_outcomes(failures(10));
+        let mode = decide_mode(
+            &log,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+        );
+        assert_eq!(mode, DiscoveryMode::Conservative);
+    }
+
+    #[test]
+    fn discovery_mode_serialises_as_lowercase_string() {
+        assert_eq!(DiscoveryMode::Normal.as_str(), "normal");
+        assert_eq!(DiscoveryMode::Conservative.as_str(), "conservative");
+        let json = serde_json::to_string(&DiscoveryMode::Conservative).unwrap();
+        assert_eq!(json, "\"conservative\"");
+    }
+
+    #[test]
+    fn coordinated_gain_multiplier_respects_mode() {
+        assert!(
+            (coordinated_gain_multiplier_for_mode(DiscoveryMode::Normal, 10.0) - 1.0).abs() < 1e-6
+        );
+        assert!(
+            (coordinated_gain_multiplier_for_mode(DiscoveryMode::Conservative, 10.0) - 10.0).abs()
+                < 1e-6
+        );
+        // Clamp: never less than 1.0.
+        assert!(
+            (coordinated_gain_multiplier_for_mode(DiscoveryMode::Conservative, 0.5) - 1.0).abs()
+                < 1e-6
+        );
+    }
+
+    #[test]
+    fn conservative_mode_biases_module_weights() {
+        // Seed a tracker where low- and high-risk modules have identical
+        // histories (50% success rate). After biasing, low-risk modules must
+        // score above high-risk modules.
+        let mut tracker = ModuleOutcomeTracker::new();
+        for _ in 0..10 {
+            tracker.record("activation-substitution", true);
+            tracker.record("activation-substitution", false);
+            tracker.record("coordinated-structural", true);
+            tracker.record("coordinated-structural", false);
+        }
+        let biased = biased_tracker_for_conservative_mode(&tracker);
+
+        let low = biased.stats("activation-substitution");
+        let high = biased.stats("coordinated-structural");
+        let low_rate = low.success_rate();
+        let high_rate = high.success_rate();
+
+        assert!(
+            low_rate > high_rate,
+            "low-risk module should score above high-risk: low={low_rate}, high={high_rate}"
+        );
+
+        // Normal-mode tracker is untouched — the function takes &ModuleOutcomeTracker
+        // and returns a fresh one; the original remains at 0.5 each.
+        let orig_low = tracker.stats("activation-substitution").success_rate();
+        let orig_high = tracker.stats("coordinated-structural").success_rate();
+        assert!((orig_low - orig_high).abs() < 1e-6);
+    }
+
+    #[test]
+    fn conservative_biasing_is_idempotent_for_repeated_calls() {
+        // Applying the bias twice should not stack unboundedly — the second
+        // call sees the already-biased state and should keep low-risk >
+        // high-risk, not flip them.
+        let mut tracker = ModuleOutcomeTracker::new();
+        for _ in 0..10 {
+            tracker.record("weight-adjustment", true);
+            tracker.record("weight-adjustment", false);
+            tracker.record("add-neurons", true);
+            tracker.record("add-neurons", false);
+        }
+        let biased_once = biased_tracker_for_conservative_mode(&tracker);
+        let biased_twice = biased_tracker_for_conservative_mode(&biased_once);
+
+        let low1 = biased_once.stats("weight-adjustment").success_rate();
+        let high1 = biased_once.stats("add-neurons").success_rate();
+        let low2 = biased_twice.stats("weight-adjustment").success_rate();
+        let high2 = biased_twice.stats("add-neurons").success_rate();
+        assert!(low1 > high1);
+        assert!(low2 > high2);
+    }
+}

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -712,6 +712,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Combined analysis should succeed");

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -40,6 +40,7 @@ pub mod candidate_diversity;
 pub mod constants;
 pub mod diagnostics;
 pub mod discovery_dispatch;
+pub mod discovery_mode;
 pub mod early_termination;
 pub mod ensemble_scoring;
 pub mod gpu;

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -147,6 +147,9 @@ pub(crate) fn build_neuron_results(
             top_level_summary: None,
             // Issue #1131: per-creature calibration corrections derived from failure cache.
             calibration_corrections: calibration_correction.as_map().clone(),
+            // Issue #1132: populated by orchestration once the outcome log is decided.
+            discovery_mode: crate::analysis::discovery_mode::DiscoveryMode::Normal,
+            rolling_success_rate: 1.0,
         },
     })
 }

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -525,6 +525,9 @@ fn build_empty_result(
             rejection_breakdown,
             top_level_summary,
             calibration_corrections: std::collections::HashMap::new(),
+            // Issue #1132: populated by orchestration once the outcome log is decided.
+            discovery_mode: crate::analysis::discovery_mode::DiscoveryMode::Normal,
+            rolling_success_rate: 1.0,
         },
     }
 }

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -580,7 +580,34 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     let mut neuron_result = neuron_result;
 
     // Issue #792: Resolve the module outcome tracker from input or use a default.
-    let mut tracker = input.module_outcome_tracker.clone().unwrap_or_default();
+    let base_tracker = input.module_outcome_tracker.clone().unwrap_or_default();
+
+    // Issue #1132: Compute creature-level discovery mode from the caller-supplied
+    // rolling outcome log. When the rolling success rate has fallen below the
+    // configured threshold, bias the module tracker toward low-risk change types
+    // before it is consumed by downstream allocation and boost passes.
+    let outcome_log = input.discovery_outcome_log.clone().unwrap_or_default();
+    let rolling_success_rate = outcome_log.rolling_success_rate();
+    let discovery_mode = super::discovery_mode::decide_mode(
+        &outcome_log,
+        crate::config::low_success_rate_threshold(),
+        crate::config::conservative_mode_max_epochs(),
+    );
+    if discovery_mode == super::discovery_mode::DiscoveryMode::Conservative
+        && utils::verbose_enabled()
+    {
+        tracing::info!(
+            rolling_success_rate,
+            "Issue #1132: conservative discovery mode engaged — biasing module weights \
+             toward low-risk change types"
+        );
+    }
+    let mut tracker = match discovery_mode {
+        super::discovery_mode::DiscoveryMode::Normal => base_tracker,
+        super::discovery_mode::DiscoveryMode::Conservative => {
+            super::discovery_mode::biased_tracker_for_conservative_mode(&base_tracker)
+        }
+    };
 
     // Issue #1057: Gate add-synapse candidates based on historical success rate
     // and synapse density. When the ModuleOutcomeTracker shows consistent failure
@@ -792,8 +819,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         // `merge_coordinated_structural_replacements` wrote
         // `candidates_returned` before these downstream filters ran.
         if let Some(syn) = synapse_result.as_mut() {
-            let removed = candidate_aggregation::apply_coordinated_gain_floor(
+            // Issue #1132: In conservative mode, tighten the post-discount
+            // noise floor by the configured multiplier so only obviously
+            // promising structural candidates survive.
+            let gain_multiplier = super::discovery_mode::coordinated_gain_multiplier_for_mode(
+                discovery_mode,
+                crate::config::conservative_gain_multiplier(),
+            );
+            let removed = candidate_aggregation::apply_coordinated_gain_floor_with_multiplier(
                 &mut syn.coordinated_structural_candidates,
+                gain_multiplier,
             );
             syn.metadata.rejection_breakdown.record_many_u32(
                 super::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR,
@@ -865,6 +900,18 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     }
     if let Some(neu) = neuron_result.as_mut() {
         aggregate_neuron_rejection_breakdown(neu);
+    }
+
+    // Issue #1132: Expose the creature-level discovery mode and rolling
+    // success rate on the response metadata so callers can observe when the
+    // pipeline has entered conservative mode.
+    if let Some(syn) = synapse_result.as_mut() {
+        syn.metadata.discovery_mode = discovery_mode;
+        syn.metadata.rolling_success_rate = rolling_success_rate;
+    }
+    if let Some(neu) = neuron_result.as_mut() {
+        neu.metadata.discovery_mode = discovery_mode;
+        neu.metadata.rolling_success_rate = rolling_success_rate;
     }
 
     Ok(AnalyzeAllResult {

--- a/src/analysis/shared/metadata.rs
+++ b/src/analysis/shared/metadata.rs
@@ -109,6 +109,25 @@ pub struct SynapseAnalysisMetadata {
     /// failure cache was supplied. Callers can log this to observe
     /// prediction calibration drift across discovery runs.
     pub calibration_corrections: std::collections::HashMap<String, f32>,
+
+    /// Current creature-level discovery mode (Issue #1132).
+    ///
+    /// [`crate::analysis::discovery_mode::DiscoveryMode::Normal`] under
+    /// ordinary operation,
+    /// [`crate::analysis::discovery_mode::DiscoveryMode::Conservative`]
+    /// when the rolling success rate has fallen below the threshold and
+    /// the pipeline is biasing candidates away from high-failure-rate
+    /// structural modules.
+    pub discovery_mode: crate::analysis::discovery_mode::DiscoveryMode,
+
+    /// Rolling success rate over the most recent
+    /// [`crate::analysis::discovery_mode::ROLLING_WINDOW`] discovery passes
+    /// (Issue #1132).
+    ///
+    /// Computed from the caller-supplied `discovery_outcome_log`. Defaults
+    /// to `1.0` when no log is supplied (neutral — no reason to trigger
+    /// conservative mode).
+    pub rolling_success_rate: f32,
 }
 
 /// Metadata about neuron analysis for diagnostics and observability.
@@ -160,6 +179,16 @@ pub struct NeuronAnalysisMetadata {
     ///
     /// See `SynapseAnalysisMetadata::calibration_corrections` for full docs.
     pub calibration_corrections: std::collections::HashMap<String, f32>,
+
+    /// Current creature-level discovery mode (Issue #1132).
+    ///
+    /// See `SynapseAnalysisMetadata::discovery_mode` for full docs.
+    pub discovery_mode: crate::analysis::discovery_mode::DiscoveryMode,
+
+    /// Rolling success rate over the most recent discovery passes (Issue #1132).
+    ///
+    /// See `SynapseAnalysisMetadata::rolling_success_rate` for full docs.
+    pub rolling_success_rate: f32,
 }
 
 /// Result of synapse analysis

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -578,5 +578,8 @@ pub(crate) fn build_metadata(
         top_level_summary: None,
         // Issue #1131: per-creature calibration corrections derived from failure cache.
         calibration_corrections: params.calibration_corrections.clone(),
+        // Issue #1132: populated by orchestration once the outcome log is decided.
+        discovery_mode: crate::analysis::discovery_mode::DiscoveryMode::Normal,
+        rolling_success_rate: 1.0,
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -31,6 +31,9 @@
 //! | `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` | u64 | `3600` | Streaming session TTL for orphan cleanup (60–86400) |
 //! | `NEAT_AI_DISCOVERY_BATCH_SUCCESSFUL` | bool | `false` | Re-enable disabled batch-successful module (Issue #1059) |
 //! | `NEAT_AI_DISCOVERY_MAX_WALL_CLOCK_MINUTES` | u64 | `20` | Overall wall-clock cap for discovery time in minutes (1–120) (Issue #1098) |
+//! | `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` | f32 | `0.2` | Rolling success-rate threshold below which conservative mode engages (Issue #1132) |
+//! | `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` | u32 | `20` | Max consecutive failed passes before abandoning conservative mode (Issue #1132) |
+//! | `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` | f32 | `10.0` | Multiplier applied to `COORDINATED_MIN_EXPECTED_GAIN` in conservative mode (Issue #1132) |
 //!
 //! ## Observability Variables
 //!

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -394,3 +394,59 @@ pub fn max_wall_clock_minutes() -> u64 {
 pub fn sample_program() -> String {
     std::env::var("NEAT_AI_DISCOVERY_SAMPLE_PROGRAM").unwrap_or_else(|_| "sample".to_string())
 }
+
+// =============================================================================
+// Issue #1132 — creature-level discovery strategy adaptation
+// =============================================================================
+
+/// Rolling success-rate threshold below which conservative mode engages
+/// (Issue #1132).
+///
+/// Set `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` to override. Values
+/// outside (0.0, 1.0] are ignored and the default is used.
+///
+/// Default:
+/// [`crate::analysis::discovery_mode::DEFAULT_LOW_SUCCESS_RATE_THRESHOLD`]
+/// (0.2).
+pub fn low_success_rate_threshold() -> f32 {
+    std::env::var("NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD")
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite() && *v > 0.0 && *v <= 1.0)
+        .unwrap_or(crate::analysis::discovery_mode::DEFAULT_LOW_SUCCESS_RATE_THRESHOLD)
+}
+
+/// Maximum number of consecutive failed passes before conservative mode is
+/// abandoned as ineffective (Issue #1132).
+///
+/// Set `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` to override.
+///
+/// Default:
+/// [`crate::analysis::discovery_mode::DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`]
+/// (20).
+pub fn conservative_mode_max_epochs() -> u32 {
+    std::env::var("NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|v| *v >= 1)
+        .unwrap_or(crate::analysis::discovery_mode::DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS)
+}
+
+/// Multiplier applied to `COORDINATED_MIN_EXPECTED_GAIN` when conservative
+/// mode is active (Issue #1132).
+///
+/// Set `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` to override. Values
+/// below `1.0` are clamped to `1.0` so the floor is never relaxed below the
+/// base constant.
+///
+/// Default:
+/// [`crate::analysis::discovery_mode::DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER`]
+/// (10.0).
+pub fn conservative_gain_multiplier() -> f32 {
+    let raw = std::env::var("NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER")
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite())
+        .unwrap_or(crate::analysis::discovery_mode::DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER);
+    raw.max(1.0)
+}

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -116,6 +116,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     rejection_breakdown: s.metadata.rejection_breakdown.counts().clone(),
                     top_level_summary: s.metadata.top_level_summary.clone(),
                     calibration_corrections: s.metadata.calibration_corrections.clone(),
+                    discovery_mode: s.metadata.discovery_mode,
+                    rolling_success_rate: s.metadata.rolling_success_rate,
                 }),
                 helpful_neurons: neuron.as_ref().map(|n| n.helpful_neurons.clone()),
                 synapse_weight_updates,
@@ -136,6 +138,8 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     rejection_breakdown: n.metadata.rejection_breakdown.counts().clone(),
                     top_level_summary: n.metadata.top_level_summary.clone(),
                     calibration_corrections: n.metadata.calibration_corrections.clone(),
+                    discovery_mode: n.metadata.discovery_mode,
+                    rolling_success_rate: n.metadata.rolling_success_rate,
                 }),
                 neuron_fingerprints: result.neuron_fingerprints,
                 fingerprint_cache_hits: if result.fingerprint_cache_hits > 0 {
@@ -218,6 +222,7 @@ pub(crate) fn build_analyze_all_input_from_parallel(
         max_analysis_memory_mb: input.max_analysis_memory_mb,
         max_discovery_wall_clock_minutes: input.max_discovery_wall_clock_minutes,
         failure_cache: input.failure_cache,
+        discovery_outcome_log: input.discovery_outcome_log,
     }
 }
 

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -93,6 +93,17 @@ pub struct AnalyzeParallelInput {
     /// When absent or empty, the compiled constants are used unchanged.
     #[serde(default)]
     pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
+    /// Per-creature rolling log of discovery pass outcomes (Issue #1132).
+    ///
+    /// Chronological booleans where `true` = at least one candidate was
+    /// accepted in that pass and `false` = empty response. The library
+    /// derives a rolling success rate over the last
+    /// [`analysis::discovery_mode::ROLLING_WINDOW`] entries and, when it
+    /// falls below the configured threshold, biases the candidate mix
+    /// toward lower-risk change types. When absent or empty, the pipeline
+    /// runs in [`analysis::discovery_mode::DiscoveryMode::Normal`].
+    #[serde(default)]
+    pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -209,6 +220,11 @@ pub struct AnalyzeAllInput {
     /// See `AnalyzeParallelInput` for full documentation.
     #[serde(default)]
     pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
+    /// Per-creature discovery outcome log for adaptive strategy (Issue #1132).
+    ///
+    /// See `AnalyzeParallelInput` for full documentation.
+    #[serde(default)]
+    pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -164,6 +164,17 @@ pub struct SynapseAnalysisMetadataJson {
     /// failure cache was supplied.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub calibration_corrections: std::collections::HashMap<String, f32>,
+    /// Current creature-level discovery mode (Issue #1132).
+    ///
+    /// `"normal"` under ordinary operation, `"conservative"` when the rolling
+    /// success rate has fallen below the configured threshold and the
+    /// pipeline has biased the candidate mix away from high-failure-rate
+    /// structural modules.
+    pub discovery_mode: analysis::discovery_mode::DiscoveryMode,
+    /// Rolling success rate over the most recent
+    /// [`analysis::discovery_mode::ROLLING_WINDOW`] discovery passes
+    /// (Issue #1132).
+    pub rolling_success_rate: f32,
 }
 
 /// MCMC diagnostics summary for the analysis output JSON (Issue #1021).
@@ -256,6 +267,12 @@ pub struct NeuronAnalysisMetadataJson {
     /// `SynapseAnalysisMetadataJson::calibration_corrections` for full docs.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
     pub calibration_corrections: std::collections::HashMap<String, f32>,
+    /// Current creature-level discovery mode (Issue #1132). See
+    /// `SynapseAnalysisMetadataJson::discovery_mode` for full docs.
+    pub discovery_mode: analysis::discovery_mode::DiscoveryMode,
+    /// Rolling success rate over the most recent discovery passes
+    /// (Issue #1132).
+    pub rolling_success_rate: f32,
 }
 
 // ============================================================================

--- a/tests/analysis/issue_1131_calibration_correction.rs
+++ b/tests/analysis/issue_1131_calibration_correction.rs
@@ -179,6 +179,7 @@ fn analyze_all_exposes_calibration_corrections_in_metadata() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: Some(failure_cache),
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -264,6 +265,7 @@ fn calibration_corrections_are_deterministic() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: Some(failure_cache.clone()),
+        discovery_outcome_log: None,
     };
 
     let r1 = analyze_all(&make_input()).expect("run 1");
@@ -323,6 +325,7 @@ fn no_failure_cache_leaves_corrections_empty() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_1132_conservative_mode.rs
+++ b/tests/analysis/issue_1132_conservative_mode.rs
@@ -1,0 +1,272 @@
+//! Integration tests for Issue #1132: Adapt discovery strategy when recent
+//! creature-level success rate is near zero.
+//!
+//! Verifies that:
+//!
+//! 1. A `discovery_outcome_log` full of failures causes `analyze_all` to
+//!    report `discoveryMode = "conservative"` and the configured rolling
+//!    success rate in the response metadata.
+//! 2. An empty / successful outcome log leaves the metadata in the default
+//!    `"normal"` mode.
+//! 3. Conservative mode biases the returned `module_outcome_tracker` in
+//!    favour of low-risk modules relative to normal mode (integration check
+//!    of the weight shift performed inside orchestration).
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::analyze_all;
+use neat_ai_discovery::analysis::discovery_mode::{
+    DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS, DEFAULT_LOW_SUCCESS_RATE_THRESHOLD, DiscoveryMode,
+    DiscoveryOutcomeLog, biased_tracker_for_conservative_mode, decide_mode,
+};
+use neat_ai_discovery::analysis::gpu::GpuAnalyzer;
+use neat_ai_discovery::analysis::module_weights::ModuleOutcomeTracker;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeAllInput, CreatureJson, NeuronJson, SynapseJson};
+
+macro_rules! skip_without_gpu {
+    () => {
+        if !GpuAnalyzer::gpu_is_available() {
+            eprintln!("Skipping test: no GPU available");
+            return;
+        }
+    };
+}
+
+fn build_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "input-0".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "input-1".to_string(),
+                neuron_type: "input".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "hidden-0".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "TANH".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "output-0".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "input-0".to_string(),
+                to_uuid: "hidden-0".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "hidden-0".to_string(),
+                to_uuid: "output-0".to_string(),
+                weight: 0.4,
+                synapse_type: None,
+            },
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+fn build_records(creature: &CreatureJson, count: usize) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for obs in 0..count as u32 {
+        let t = obs as f32 / count as f32;
+        for neuron in &creature.neurons {
+            let (activation, value, errors) = match neuron.neuron_type.as_str() {
+                "input" => ((t * std::f32::consts::TAU).sin(), None, Vec::new()),
+                "hidden" => {
+                    let act = 0.3 + 0.4 * (t * std::f32::consts::TAU).sin();
+                    (act, Some(act), vec![0.05 * (t * 3.0).cos()])
+                }
+                "output" => {
+                    let error = 0.1 * (t * std::f32::consts::PI).cos();
+                    (0.5 + 0.2 * t, Some(0.5 + 0.2 * t), vec![error])
+                }
+                _ => continue,
+            };
+            records.push(DiscoverRecord {
+                obs_index: obs,
+                neuron_uuid: neuron.uuid.clone(),
+                value,
+                activation,
+                errors,
+            });
+        }
+    }
+    records
+}
+
+fn make_input(parquet_file: String, outcome_log: Option<DiscoveryOutcomeLog>) -> AnalyzeAllInput {
+    let creature = build_creature();
+    let focus_neurons: Vec<String> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output" || n.neuron_type == "hidden")
+        .map(|n| n.uuid.clone())
+        .collect();
+
+    AnalyzeAllInput {
+        parquet_file,
+        creature,
+        focus_neurons,
+        max_synapse_candidates: None,
+        max_neuron_candidates: None,
+        analysis_deadline_ms: None,
+        include_synapse_analysis: Some(true),
+        include_neuron_analysis: Some(true),
+        random_seed: Some(42),
+        previous_neuron_fingerprints: None,
+        module_outcome_tracker: None,
+        max_analysis_memory_mb: None,
+        max_discovery_wall_clock_minutes: None,
+        temperature: 1.0,
+        failure_cache: None,
+        discovery_outcome_log: outcome_log,
+    }
+}
+
+/// A rolling log of ten consecutive failures causes `analyze_all` to emit
+/// `conservative` in the response metadata, with a rolling success rate of 0.
+#[test]
+fn ten_failures_triggers_conservative_mode_in_metadata() {
+    skip_without_gpu!();
+
+    let creature = build_creature();
+    let records = build_records(&creature, 60);
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("test.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let outcome_log = DiscoveryOutcomeLog::from_outcomes(vec![false; 10]);
+    let input = make_input(parquet_file, Some(outcome_log));
+
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+    let synapse = result.synapse.expect("synapse analysis should run");
+    let neuron = result.neuron.expect("neuron analysis should run");
+
+    assert_eq!(
+        synapse.metadata.discovery_mode,
+        DiscoveryMode::Conservative,
+        "synapse metadata should report conservative mode"
+    );
+    assert!(
+        (synapse.metadata.rolling_success_rate).abs() < 1e-6,
+        "rolling success rate should be 0.0, got {}",
+        synapse.metadata.rolling_success_rate
+    );
+
+    assert_eq!(
+        neuron.metadata.discovery_mode,
+        DiscoveryMode::Conservative,
+        "neuron metadata should report conservative mode"
+    );
+    assert!(
+        (neuron.metadata.rolling_success_rate).abs() < 1e-6,
+        "rolling success rate should be 0.0, got {}",
+        neuron.metadata.rolling_success_rate
+    );
+}
+
+/// Absence of an outcome log leaves the metadata in the default normal mode
+/// with a neutral rolling rate of 1.0.
+#[test]
+fn no_outcome_log_keeps_metadata_in_normal_mode() {
+    skip_without_gpu!();
+
+    let creature = build_creature();
+    let records = build_records(&creature, 60);
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("test.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    write_records_to_parquet(&parquet_file, &records).expect("Failed to write parquet");
+
+    let input = make_input(parquet_file, None);
+    let result = analyze_all(&input).expect("analyze_all should succeed");
+    let synapse = result.synapse.expect("synapse analysis should run");
+    let neuron = result.neuron.expect("neuron analysis should run");
+
+    assert_eq!(synapse.metadata.discovery_mode, DiscoveryMode::Normal);
+    assert!(
+        (synapse.metadata.rolling_success_rate - 1.0).abs() < 1e-6,
+        "rolling success rate should default to 1.0"
+    );
+    assert_eq!(neuron.metadata.discovery_mode, DiscoveryMode::Normal);
+    assert!((neuron.metadata.rolling_success_rate - 1.0).abs() < 1e-6);
+}
+
+/// The decision function itself respects the rolling window and the cooldown
+/// — this guards the transition semantics without needing a GPU.
+#[test]
+fn mode_decision_transitions_at_documented_boundaries() {
+    // A healthy log stays in Normal mode.
+    let healthy = DiscoveryOutcomeLog::from_outcomes(vec![true; 10]);
+    assert_eq!(
+        decide_mode(
+            &healthy,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS
+        ),
+        DiscoveryMode::Normal
+    );
+
+    // 9 failures + 1 success over last 10 passes = 0.1 < 0.2 threshold.
+    let mut outcomes = vec![false; 9];
+    outcomes.push(true);
+    let struggling = DiscoveryOutcomeLog::from_outcomes(outcomes);
+    assert_eq!(
+        decide_mode(
+            &struggling,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS
+        ),
+        DiscoveryMode::Conservative
+    );
+
+    // Consecutive failure streak exceeds max_epochs: revert to Normal.
+    let long_drought = DiscoveryOutcomeLog::from_outcomes(vec![false; 30]);
+    assert_eq!(
+        decide_mode(
+            &long_drought,
+            DEFAULT_LOW_SUCCESS_RATE_THRESHOLD,
+            DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS
+        ),
+        DiscoveryMode::Normal
+    );
+}
+
+/// Biasing a tracker with identical low- and high-risk histories must produce
+/// a tracker where low-risk modules score strictly above high-risk modules.
+/// This is an integration-level cross-check of the weight-shift helper.
+#[test]
+fn conservative_bias_raises_low_risk_above_high_risk() {
+    let mut tracker = ModuleOutcomeTracker::new();
+    for _ in 0..10 {
+        tracker.record("bias-drift", true);
+        tracker.record("bias-drift", false);
+        tracker.record("add-neurons", true);
+        tracker.record("add-neurons", false);
+    }
+
+    let biased = biased_tracker_for_conservative_mode(&tracker);
+    let low = biased.stats("bias-drift").success_rate();
+    let high = biased.stats("add-neurons").success_rate();
+    assert!(
+        low > high,
+        "conservative bias should raise low-risk modules above high-risk: low={low}, high={high}"
+    );
+}

--- a/tests/analysis/issue_419_parallel_discovery_execution.rs
+++ b/tests/analysis/issue_419_parallel_discovery_execution.rs
@@ -116,6 +116,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -213,6 +214,7 @@ fn parallel_discovery_metadata_consistent() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_557_audit_discovery_strategies.rs
+++ b/tests/analysis/issue_557_audit_discovery_strategies.rs
@@ -141,6 +141,7 @@ fn all_candidates_have_positive_expected_score_gain() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -229,6 +230,7 @@ fn metadata_consistent_after_positive_gain_filtering() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_568_async_pipeline.rs
+++ b/tests/analysis/issue_568_async_pipeline.rs
@@ -166,6 +166,7 @@ fn async_pipeline_produces_valid_analysis_results() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -228,6 +229,7 @@ fn async_pipeline_is_deterministic_with_fixed_seed() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result1 = analyze_all(&make_input()).expect("Run 1 should succeed");

--- a/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
+++ b/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
@@ -231,6 +231,7 @@ fn run_analysis() -> Vec<neat_ai_discovery::CoordinatedStructuralCandidateJson> 
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -388,6 +389,7 @@ fn test_analyze_all_finds_change_squash_candidate() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -22,6 +22,7 @@ mod issue_1098_wall_clock_cap;
 mod issue_1101_no_target_records_diagnostic;
 mod issue_1109_neuron_min_improved_ratio_raise;
 mod issue_1131_calibration_correction;
+mod issue_1132_conservative_mode;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -433,6 +433,7 @@ fn test_analyze_all_finds_hidden_neuron_candidate() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
@@ -126,6 +126,7 @@ fn synapse_analysis_runs_under_deadline() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -175,6 +176,7 @@ fn metadata_indicates_target_value_available() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -219,6 +221,7 @@ fn metadata_indicates_target_value_not_available() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -269,6 +272,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -316,6 +320,7 @@ fn candidate_counts_tracked_correctly() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -426,6 +431,7 @@ fn truncation_reflected_in_candidate_counts() {
         max_discovery_wall_clock_minutes: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -434,6 +434,7 @@ fn test_analyze_all_finds_harmful_synapse() {
         max_analysis_memory_mb: None,
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");


### PR DESCRIPTION
# Issue #1132 — Adapt discovery strategy when recent creature-level success rate is near zero

Closes #1132

## Summary

Adds a creature-level rolling success-rate signal to `analyze_all` so the pipeline can detect when a specific creature has been unable to discover any useful candidate for several passes in a row, and biases the candidate mix away from high-failure-rate structural modules while the drought persists.

## What changed

### New module `src/analysis/discovery_mode.rs`
- `DiscoveryOutcomeLog { outcomes: Vec<bool> }` — caller-supplied chronological log of per-pass outcomes. Library is stateless; the host persists the log across runs.
- Rolling window of the last `ROLLING_WINDOW = 10` outcomes.
- `decide_mode(&log, threshold, max_epochs) -> DiscoveryMode` returns `Conservative` iff the rolling success rate is **strictly below** `threshold` (default `0.2`) and the trailing consecutive-failure streak has not exceeded `max_epochs` (default `20`). After that cooldown the library reverts to `Normal` because the bias clearly wasn't helping.
- `biased_tracker_for_conservative_mode(&ModuleOutcomeTracker)` boosts the success-rate signal of low-risk modules (activation substitution, bias drift, weight adjustment, …) by `1.5×` and attenuates the signal of high-risk structural modules (coordinated-structural, add-neurons, …) by the inverse factor. The biased tracker feeds every downstream allocator (`apply_module_boost_to_candidates`, ensemble scoring, budget allocator).
- `coordinated_gain_multiplier_for_mode(mode, multiplier)` returns `1.0` in `Normal` mode and the configured (≥ 1.0) multiplier in `Conservative` mode. A new `apply_coordinated_gain_floor_with_multiplier` in `candidate_aggregation.rs` applies this to the post-discount noise floor, so only obviously-promising structural candidates survive when the rolling rate is low.
- 11 unit tests covering empty log, windowed rate, boundary at `0.2`, cooldown entry/exit, serialisation, biasing idempotence.

### Orchestration integration (`src/analysis/orchestration.rs`)
- Computes `discovery_mode` + `rolling_success_rate` from `input.discovery_outcome_log` before the tracker is consumed.
- In `Conservative` mode:
  - the tracker passed to `module_weights::apply_module_boost_to_candidates` and friends is the biased copy;
  - `apply_coordinated_gain_floor_with_multiplier` tightens the post-discount floor by `conservative_gain_multiplier()` (default `10×`).
- Populates the new metadata fields on both `synapse_result.metadata` and `neuron_result.metadata` immediately before the final `Ok(AnalyzeAllResult …)` return, so callers can observe the mode regardless of early-return paths.

### FFI surface
- `AnalyzeParallelInput` and `AnalyzeAllInput` gain `discovery_outcome_log: Option<DiscoveryOutcomeLog>` (camelCase, serde `default`).
- `SynapseAnalysisMetadataJson` and `NeuronAnalysisMetadataJson` now expose `discoveryMode: "normal" | "conservative"` and `rollingSuccessRate: f32`.

### Config (`src/config/user_facing.rs`)
Three new env-var accessors, documented in the module-level summary table:

| Variable | Type | Default | Description |
|----------|------|---------|-------------|
| `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` | f32 | `0.2` | Rolling success-rate threshold below which conservative mode engages |
| `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` | u32 | `20` | Max consecutive failed passes before abandoning conservative mode |
| `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` | f32 | `10.0` | Multiplier applied to the coordinated-gain floor while conservative |

`conservative_gain_multiplier` clamps below `1.0` to `1.0` so the floor can never be relaxed.

### Integration test (`tests/analysis/issue_1132_conservative_mode.rs`)
- `ten_failures_triggers_conservative_mode_in_metadata` — a log of ten consecutive failures causes both the synapse and neuron result metadata to report `Conservative` with rolling rate `0.0`.
- `no_outcome_log_keeps_metadata_in_normal_mode` — absence of a log leaves metadata at the default `Normal` / `1.0`.
- `mode_decision_transitions_at_documented_boundaries` — non-GPU cross-check of `decide_mode` at the `0.2` threshold and the 20-epoch cooldown.
- `conservative_bias_raises_low_risk_above_high_risk` — direct integration check of the weight shift.

## Design notes

- **Stateless library**: the host persists the rolling log; the library recomputes the mode every call. Matches the pattern used by `module_outcome_tracker` and `failure_cache`.
- **Exit semantics**: conservative mode exits once the rolling window naturally climbs above threshold, or once the cooldown elapses. A single success does **not** force-exit — the rolling rate governs, which avoids pinball transitions under noisy signals. The `cooldown_exit_after_max_epochs` test documents the hard fallback.
- **Symmetric factor**: `CONSERVATIVE_HIGH_RISK_PENALTY = 1 / CONSERVATIVE_LOW_RISK_BOOST = 1 / 1.5`. Keeps reasoning about the net effect on the allocator simple.

## Verification

- `cargo test --lib discovery_mode` — 11/11 ✅
- `cargo test --test analysis issue_1132` — 4/4 ✅
- `./quality.sh < /dev/null` — ✅ (full suite: fmt, clippy, test, docs, release build)

## Pre-PR security self-check

- [x] **Input validation**: `DiscoveryOutcomeLog.outcomes` is a plain `Vec<bool>` — no parsing or injection surface. `low_success_rate_threshold`/`conservative_mode_max_epochs`/`conservative_gain_multiplier` filter to finite numbers in sensible ranges and fall back to defaults.
- [x] **Secrets**: no `.config*.json` or credential files touched.
- [x] **Injection surface**: no new SQL/shell/FS calls.
- [x] **Output encoding**: values are serialised through existing serde path with the same camelCase convention as surrounding fields.
- [x] **Authentication/authorisation**: n/a — pure library change.
- [x] **Error handling**: no panics added; all casts are clamped.
- [x] **Dependencies**: none added.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1132 -->