### PR TITLE
fix: apply coordinated-structural gain floor unconditionally (#1139)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.16"
+version = "0.74.17"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1139.md
+++ b/docs/pr-summary-1139.md
@@ -1,0 +1,83 @@
+## Summary
+
+Closes #1139.
+
+Applied the coordinated-structural gain floor unconditionally after variant
+generation so sub-floor `Gentle Nudge` / `Micro Nudge` variants can no longer
+leak to the FFI response when the memory budget is exceeded or the
+post-processing deadline passes.
+
+Root cause: `pair_coordinated_structural_with_weight_variants` scales the base
+candidate's `expected_creature_score_gain` by `0.75×` / `0.5×` / `0.25×` /
+`0.1×`, producing variants below `COORDINATED_POST_DISCOUNT_NOISE_FLOOR`
+(`5e-7`). The final sweep that removed those variants
+(`apply_coordinated_gain_floor_with_multiplier`) lived **inside** the
+`!memory_budget_exceeded && !post_processing_deadline_passed` guard in
+`analyze_all`, so whenever either condition tripped the filter was skipped.
+GRQ-sampler commit `744ac60d` (discoveryVersion `0.74.16`) captured two such
+variants with gains of `1.4e-7` / `1.3e-7` damaging the creature when tested.
+
+Changes:
+
+- Added `apply_final_coordinated_gain_floor(syn, mode, multiplier)` in
+  `src/analysis/candidate_aggregation.rs`. It computes the mode-aware
+  multiplier, applies the floor, records the drop in
+  `metadata.rejection_breakdown[REJECTION_BELOW_EXPECTED_GAIN_FLOOR]`, and
+  refreshes `metadata.candidates_returned`. All three updates happen together
+  so the FFI caller sees consistent metadata in either code path.
+- `analyze_all` now calls the helper **outside** the memory/deadline guard,
+  unconditionally, right after the guarded post-processing block closes. The
+  duplicated inline block inside the guard was removed.
+- Bumped `Cargo.toml` to `0.74.17` so remote workers pick up the fix.
+
+## Evidence
+
+This is a backend/FFI change with no web interface. Verification was via the
+new TDD regression tests plus the existing floor suite, all green:
+
+```
+cargo test --test issue_1139_coordinated_floor_always_applied
+  running 4 tests ... 4 passed
+cargo test --test coordinated_min_gain_floor
+  running 5 tests ... 5 passed
+./quality.sh
+  ✅ All quality checks passed!
+```
+
+The new precondition test (`variant_generation_can_produce_subfloor_gains`)
+directly reproduces the leak by feeding a `1.9e-6` base candidate through
+`pair_coordinated_structural_with_weight_variants` and asserting that at
+least one of the six paired variants lands below `5e-7` — demonstrating the
+bug mechanism captured by the GRQ-sampler failure cache.
+
+## Test Plan
+
+New file `tests/issue_1139_coordinated_floor_always_applied.rs`:
+
+- `variant_generation_can_produce_subfloor_gains` — reproduces the
+  precondition for the Issue #1139 leak.
+- `final_floor_removes_subfloor_variants_and_updates_metadata` — exercises
+  the helper against a populated `AnalyzeSynapsesResult`, asserting no
+  sub-floor candidate survives, that the rejection-breakdown count matches
+  the removed count, and that `candidates_returned` is refreshed.
+- `final_floor_honours_conservative_multiplier` — the conservative-mode `10×`
+  multiplier drops a candidate exactly at the normal-mode floor.
+- `final_floor_noop_when_all_above_floor` — no false-positive removals and
+  `candidates_returned` still refreshed when nothing is filtered.
+
+Existing suites continue to pass:
+
+- `tests/coordinated_min_gain_floor.rs` (5 tests)
+- Full `./quality.sh` (fmt, clippy, check, test, docs, release build)
+
+## Security Self-Check
+
+- [x] Input validation — new helper accepts only internal types; `multiplier`
+      is clamped to `>= 1.0` by the downstream floor helper so a misconfigured
+      env var cannot relax the floor.
+- [x] No secrets staged.
+- [x] No new SQL / shell / filesystem / HTTP surface.
+- [x] No output encoding changes; metadata fields use existing typed structs.
+- [x] No new authentication / authorisation surface.
+- [x] No change to user-facing error messages; existing tracing remains.
+- [x] No new third-party dependency.

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -64,6 +64,55 @@ pub fn apply_coordinated_gain_floor_with_multiplier(
     u32::try_from(before.saturating_sub(candidates.len())).unwrap_or(u32::MAX)
 }
 
+/// Apply the final coordinated-structural gain floor to a synapse result and
+/// refresh dependent metadata (Issue #1139).
+///
+/// This is the FFI-facing safety net: it must always run after variant
+/// generation (`pair_coordinated_structural_with_weight_variants`) because the
+/// `0.75×`/`0.5×`/`0.25×`/`0.1×` expected-gain multipliers can pull a variant
+/// below `COORDINATED_POST_DISCOUNT_NOISE_FLOOR` even when its base candidate
+/// is above the floor. Production evidence (GRQ-sampler discoveryVersion
+/// 0.74.16) captured `Gentle Nudge` variants with gains of ~1.3e-7 damaging
+/// creatures when tested.
+///
+/// The floor was previously applied only inside the
+/// `!memory_budget_exceeded && !post_processing_deadline_passed` fast-path
+/// guard in `analyze_all`, so sub-floor variants leaked whenever the memory
+/// budget or deadline was exceeded. Moving the call out of that guard means:
+///
+/// - `expected_creature_score_gain` is screened in both the fast-path and the
+///   skipped-post-processing fallback.
+/// - `metadata.rejection_breakdown[REJECTION_BELOW_EXPECTED_GAIN_FLOOR]` is
+///   updated with the drop count.
+/// - `metadata.candidates_returned` is refreshed so the FFI caller sees an
+///   accurate total after filtering.
+///
+/// Returns the number of coordinated-structural candidates removed.
+pub fn apply_final_coordinated_gain_floor(
+    synapse: &mut shared::AnalyzeSynapsesResult,
+    discovery_mode: super::discovery_mode::DiscoveryMode,
+    conservative_multiplier: f32,
+) -> u32 {
+    use super::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR;
+
+    let gain_multiplier = super::discovery_mode::coordinated_gain_multiplier_for_mode(
+        discovery_mode,
+        conservative_multiplier,
+    );
+    let removed = apply_coordinated_gain_floor_with_multiplier(
+        &mut synapse.coordinated_structural_candidates,
+        gain_multiplier,
+    );
+    synapse
+        .metadata
+        .rejection_breakdown
+        .record_many_u32(REJECTION_BELOW_EXPECTED_GAIN_FLOOR, removed);
+    synapse.metadata.candidates_returned = synapse.helpful_synapses.len()
+        + synapse.harmful_synapses.len()
+        + synapse.coordinated_structural_candidates.len();
+    removed
+}
+
 /// Compute the operation-count discount for a coordinated candidate (Issue #732, #1058).
 ///
 /// Issue #1058: Replaced the three-layer compound discount (per-op exponential ×

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -810,40 +810,32 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             module_dispatch_specs::apply_diversity_reranking(syn);
         }
 
-        // Issue #1110, #1128: Final coordinated-structural gain floor.
-        // Applied AFTER module boost and diversity reranking so that gains
-        // which started above the floor but were discounted by those steps
-        // cannot reach the FFI response. Production failure evidence
-        // (GRQ-sampler failures cache) shows sub-1e-5 gains harm the network.
-        // Metadata must be refreshed after the sweep since
-        // `merge_coordinated_structural_replacements` wrote
-        // `candidates_returned` before these downstream filters ran.
-        if let Some(syn) = synapse_result.as_mut() {
-            // Issue #1132: In conservative mode, tighten the post-discount
-            // noise floor by the configured multiplier so only obviously
-            // promising structural candidates survive.
-            let gain_multiplier = super::discovery_mode::coordinated_gain_multiplier_for_mode(
-                discovery_mode,
-                crate::config::conservative_gain_multiplier(),
-            );
-            let removed = candidate_aggregation::apply_coordinated_gain_floor_with_multiplier(
-                &mut syn.coordinated_structural_candidates,
-                gain_multiplier,
-            );
-            syn.metadata.rejection_breakdown.record_many_u32(
-                super::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR,
-                removed,
-            );
-            syn.metadata.candidates_returned = syn.helpful_synapses.len()
-                + syn.harmful_synapses.len()
-                + syn.coordinated_structural_candidates.len();
-        }
-
         // Issue #224: Candidate clustering to reduce redundant ablation tests.
         if let Some(syn) = synapse_result.as_mut() {
             module_dispatch_specs::cluster_synapse_candidates(syn, &input.creature);
         }
     } // end if !memory_budget_exceeded (Issue #1028)
+
+    // Issue #1110, #1128, #1139: Final coordinated-structural gain floor.
+    //
+    // MUST run unconditionally — outside the memory/deadline guard — because
+    // `pair_coordinated_structural_with_weight_variants` (invoked earlier in
+    // synapse post-processing) produces `Gentle Nudge`/`Micro Nudge` variants
+    // whose `expected_creature_score_gain` is multiplied by 0.25× / 0.1× and
+    // can fall below `COORDINATED_POST_DISCOUNT_NOISE_FLOOR` (5e-7). Running
+    // this filter only in the fast-path guard leaked sub-floor variants to
+    // the FFI response whenever the memory budget or deadline was exceeded
+    // (GRQ-sampler discoveryVersion 0.74.16 captured 1.3e-7 gains damaging
+    // creatures). Applying it here ensures the floor holds in both the
+    // fast-path and the skipped-post-processing fallback, and refreshes
+    // `candidates_returned` + the rejection breakdown in either path.
+    if let Some(syn) = synapse_result.as_mut() {
+        candidate_aggregation::apply_final_coordinated_gain_floor(
+            syn,
+            discovery_mode,
+            crate::config::conservative_gain_multiplier(),
+        );
+    }
 
     // Collect final profile data (Issue #214)
     let synapse_candidates = synapse_result.as_ref().map_or(0, |s| {

--- a/tests/issue_1139_coordinated_floor_always_applied.rs
+++ b/tests/issue_1139_coordinated_floor_always_applied.rs
@@ -1,0 +1,203 @@
+//! Regression tests for Issue #1139 — apply the coordinated-structural gain
+//! floor unconditionally after variant generation.
+//!
+//! ## Bug evidence
+//!
+//! GRQ-sampler commit `744ac60d` (`2026-04-22T22:31:14.839Z`,
+//! discoveryVersion `0.74.16`) captured two `Gentle Nudge` variants with
+//! `expectedCreatureScoreGain` below `COORDINATED_POST_DISCOUNT_NOISE_FLOOR`
+//! (5e-7) reaching the FFI response and damaging the creature when tested.
+//!
+//! ## Root cause
+//!
+//! `pair_coordinated_structural_with_weight_variants` multiplies the base
+//! candidate's `expected_creature_score_gain` by 0.75 / 0.5 / 0.25 / 0.1 for
+//! the paired variants, so a base candidate just above the floor produces
+//! sub-floor variants. The final cleanup filter
+//! (`apply_coordinated_gain_floor_with_multiplier`) only ran inside the
+//! `!memory_budget_exceeded && !post_processing_deadline_passed` guard, so
+//! whenever either condition tripped the sub-floor variants leaked out.
+//!
+//! ## Fix
+//!
+//! The final floor sweep is now driven through
+//! `apply_final_coordinated_gain_floor` and called unconditionally after the
+//! guarded post-processing block. This test exercises the helper against a
+//! `AnalyzeSynapsesResult` populated with freshly generated variants to
+//! verify:
+//!
+//! 1. No coordinated-structural candidate below the floor remains.
+//! 2. The rejection breakdown records the drop.
+//! 3. `candidates_returned` is refreshed.
+
+use neat_ai_discovery::analysis::candidate_aggregation::apply_final_coordinated_gain_floor;
+use neat_ai_discovery::analysis::constants::COORDINATED_POST_DISCOUNT_NOISE_FLOOR;
+use neat_ai_discovery::analysis::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR;
+use neat_ai_discovery::analysis::discovery_mode::DiscoveryMode;
+use neat_ai_discovery::analysis::shared::{AnalyzeSynapsesResult, SynapseAnalysisMetadata};
+use neat_ai_discovery::analysis::utils::pair_coordinated_structural_with_weight_variants;
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+fn empty_synapse_result() -> AnalyzeSynapsesResult {
+    AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: SynapseAnalysisMetadata::default(),
+    }
+}
+
+/// Build an `AddSynapse`-only coordinated candidate whose variant generation
+/// will produce sub-floor expected-gain values.
+fn add_synapse_candidate(weight: f32, gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+            from_neuron_uuid: "src".to_string(),
+            to_neuron_uuid: "dst".to_string(),
+            weight,
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some("base".to_string()),
+    }
+}
+
+/// Verify that variant generation can indeed push a base candidate below the
+/// floor. This reproduces the precondition for the Issue #1139 leak.
+#[test]
+fn variant_generation_can_produce_subfloor_gains() {
+    // Base gain 1.9e-6 × gentle-nudge multiplier (0.25) = 4.75e-7, below the
+    // 5e-7 floor. The GRQ-sampler failure cache captured ~1.3e-7 `Gentle
+    // Nudge` variants — same mechanism, lower base gain.
+    let base_gain = 1.9e-6_f32;
+    let base = add_synapse_candidate(0.1, base_gain);
+    let variants = pair_coordinated_structural_with_weight_variants(vec![base], None);
+
+    let any_subfloor = variants
+        .iter()
+        .any(|c| c.expected_creature_score_gain < COORDINATED_POST_DISCOUNT_NOISE_FLOOR);
+    assert!(
+        any_subfloor,
+        "precondition: at least one variant should fall below the floor, \
+         got gains {:?}",
+        variants
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The helper must strip every sub-floor coordinated candidate and refresh
+/// the rejection breakdown plus `candidates_returned`. This is the core
+/// guarantee the orchestration relies on in the fast-path and the
+/// skipped-post-processing fallback alike.
+#[test]
+fn final_floor_removes_subfloor_variants_and_updates_metadata() {
+    let mut syn = empty_synapse_result();
+
+    // Simulate what `apply_post_processing` produces just before the guard:
+    // the base plus its paired variants including sub-floor `Gentle Nudge`.
+    let base = add_synapse_candidate(0.1, 1.9e-6);
+    syn.coordinated_structural_candidates =
+        pair_coordinated_structural_with_weight_variants(vec![base], None);
+
+    let total_before = syn.coordinated_structural_candidates.len();
+    let subfloor_before = syn
+        .coordinated_structural_candidates
+        .iter()
+        .filter(|c| c.expected_creature_score_gain < COORDINATED_POST_DISCOUNT_NOISE_FLOOR)
+        .count();
+    assert!(
+        subfloor_before > 0,
+        "precondition: at least one sub-floor variant must be present"
+    );
+
+    let removed = apply_final_coordinated_gain_floor(&mut syn, DiscoveryMode::Normal, 1.0);
+
+    assert_eq!(
+        removed as usize, subfloor_before,
+        "removed count must equal the number of sub-floor variants"
+    );
+    assert!(
+        syn.coordinated_structural_candidates
+            .iter()
+            .all(|c| c.expected_creature_score_gain >= COORDINATED_POST_DISCOUNT_NOISE_FLOOR),
+        "no sub-floor coordinated candidate should survive, got gains {:?}",
+        syn.coordinated_structural_candidates
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        syn.coordinated_structural_candidates.len(),
+        total_before - subfloor_before,
+        "kept count must equal total minus sub-floor"
+    );
+
+    // Rejection breakdown must reflect the drop.
+    let recorded = syn
+        .metadata
+        .rejection_breakdown
+        .counts()
+        .get(REJECTION_BELOW_EXPECTED_GAIN_FLOOR)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        recorded, removed,
+        "rejection breakdown must record the removed count, got {recorded}"
+    );
+
+    // `candidates_returned` must be refreshed to reflect the post-filter total.
+    let expected_returned = syn.helpful_synapses.len()
+        + syn.harmful_synapses.len()
+        + syn.coordinated_structural_candidates.len();
+    assert_eq!(
+        syn.metadata.candidates_returned, expected_returned,
+        "candidates_returned must be refreshed after filtering"
+    );
+}
+
+/// In conservative mode the configured multiplier must tighten the floor.
+/// A candidate at exactly the normal-mode floor survives Normal mode but is
+/// dropped by Conservative mode with a 10× multiplier.
+#[test]
+fn final_floor_honours_conservative_multiplier() {
+    let mut syn = empty_synapse_result();
+    syn.coordinated_structural_candidates
+        .push(add_synapse_candidate(
+            0.1,
+            COORDINATED_POST_DISCOUNT_NOISE_FLOOR,
+        ));
+
+    let removed_normal = apply_final_coordinated_gain_floor(&mut syn, DiscoveryMode::Normal, 10.0);
+    assert_eq!(removed_normal, 0);
+    assert_eq!(syn.coordinated_structural_candidates.len(), 1);
+
+    // Same candidate, Conservative mode with 10× multiplier — now dropped.
+    let removed_conservative =
+        apply_final_coordinated_gain_floor(&mut syn, DiscoveryMode::Conservative, 10.0);
+    assert_eq!(removed_conservative, 1);
+    assert!(syn.coordinated_structural_candidates.is_empty());
+}
+
+/// When no sub-floor candidates exist the helper must be a no-op on the
+/// candidate list while still refreshing `candidates_returned` (important
+/// when the skipped-post-processing path never wrote it earlier).
+#[test]
+fn final_floor_noop_when_all_above_floor() {
+    let mut syn = empty_synapse_result();
+    syn.coordinated_structural_candidates
+        .push(add_synapse_candidate(0.1, 1.0));
+    syn.coordinated_structural_candidates
+        .push(add_synapse_candidate(0.1, 0.5));
+    syn.metadata.candidates_returned = 0;
+
+    let removed = apply_final_coordinated_gain_floor(&mut syn, DiscoveryMode::Normal, 1.0);
+
+    assert_eq!(removed, 0);
+    assert_eq!(syn.coordinated_structural_candidates.len(), 2);
+    assert_eq!(syn.metadata.candidates_returned, 2);
+}


### PR DESCRIPTION
## Summary

Closes #1139.

Applied the coordinated-structural gain floor unconditionally after variant
generation so sub-floor `Gentle Nudge` / `Micro Nudge` variants can no longer
leak to the FFI response when the memory budget is exceeded or the
post-processing deadline passes.

Root cause: `pair_coordinated_structural_with_weight_variants` scales the base
candidate's `expected_creature_score_gain` by `0.75×` / `0.5×` / `0.25×` /
`0.1×`, producing variants below `COORDINATED_POST_DISCOUNT_NOISE_FLOOR`
(`5e-7`). The final sweep that removed those variants
(`apply_coordinated_gain_floor_with_multiplier`) lived **inside** the
`!memory_budget_exceeded && !post_processing_deadline_passed` guard in
`analyze_all`, so whenever either condition tripped the filter was skipped.
GRQ-sampler commit `744ac60d` (discoveryVersion `0.74.16`) captured two such
variants with gains of `1.4e-7` / `1.3e-7` damaging the creature when tested.

Changes:

- Added `apply_final_coordinated_gain_floor(syn, mode, multiplier)` in
  `src/analysis/candidate_aggregation.rs`. It computes the mode-aware
  multiplier, applies the floor, records the drop in
  `metadata.rejection_breakdown[REJECTION_BELOW_EXPECTED_GAIN_FLOOR]`, and
  refreshes `metadata.candidates_returned`. All three updates happen together
  so the FFI caller sees consistent metadata in either code path.
- `analyze_all` now calls the helper **outside** the memory/deadline guard,
  unconditionally, right after the guarded post-processing block closes. The
  duplicated inline block inside the guard was removed.
- Bumped `Cargo.toml` to `0.74.17` so remote workers pick up the fix.

## Evidence

This is a backend/FFI change with no web interface. Verification was via the
new TDD regression tests plus the existing floor suite, all green:

```
cargo test --test issue_1139_coordinated_floor_always_applied
  running 4 tests ... 4 passed
cargo test --test coordinated_min_gain_floor
  running 5 tests ... 5 passed
./quality.sh
  ✅ All quality checks passed!
```

The new precondition test (`variant_generation_can_produce_subfloor_gains`)
directly reproduces the leak by feeding a `1.9e-6` base candidate through
`pair_coordinated_structural_with_weight_variants` and asserting that at
least one of the six paired variants lands below `5e-7` — demonstrating the
bug mechanism captured by the GRQ-sampler failure cache.

## Test Plan

New file `tests/issue_1139_coordinated_floor_always_applied.rs`:

- `variant_generation_can_produce_subfloor_gains` — reproduces the
  precondition for the Issue #1139 leak.
- `final_floor_removes_subfloor_variants_and_updates_metadata` — exercises
  the helper against a populated `AnalyzeSynapsesResult`, asserting no
  sub-floor candidate survives, that the rejection-breakdown count matches
  the removed count, and that `candidates_returned` is refreshed.
- `final_floor_honours_conservative_multiplier` — the conservative-mode `10×`
  multiplier drops a candidate exactly at the normal-mode floor.
- `final_floor_noop_when_all_above_floor` — no false-positive removals and
  `candidates_returned` still refreshed when nothing is filtered.

Existing suites continue to pass:

- `tests/coordinated_min_gain_floor.rs` (5 tests)
- Full `./quality.sh` (fmt, clippy, check, test, docs, release build)

## Security Self-Check

- [x] Input validation — new helper accepts only internal types; `multiplier`
      is clamped to `>= 1.0` by the downstream floor helper so a misconfigured
      env var cannot relax the floor.
- [x] No secrets staged.
- [x] No new SQL / shell / filesystem / HTTP surface.
- [x] No output encoding changes; metadata fields use existing typed structs.
- [x] No new authentication / authorisation surface.
- [x] No change to user-facing error messages; existing tracing remains.
- [x] No new third-party dependency.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1139 -->