### PR TITLE
feat: cap add-neuron candidates per target within a batch (#1140)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,6 +608,7 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_SESSION_TTL_SECS` | Streaming session TTL for orphan cleanup (default 3600) |
 | `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | Metropolis-Hastings probabilistic acceptance temperature |
 | `NEAT_AI_DISCOVERY_MAX_WALL_CLOCK_MINUTES` | Overall wall-clock cap for discovery time in minutes (default 20, range 1–120) |
+| `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` | Max add-neuron candidates per target within a single batch (default 3, range 1–32) (Issue #1140) |
 
 See [README.md — Troubleshooting](README.md#troubleshooting) and
 [README.md — GPU Performance Tuning](README.md#gpu-performance-tuning) for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.17"
+version = "0.74.18"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1140.md
+++ b/docs/pr-summary-1140.md
@@ -1,0 +1,55 @@
+## Summary
+
+Cap `add-neurons` candidates per target within a single discovery batch so
+that a clearly-hopeless target cannot consume most of the budget with minor
+variants. GRQ-sampler commit `744ac60d` recorded 17 of 19 `add-neurons`
+failures in one submission against the **same** neuron; the cross-batch
+cooldown added in Issue #1130 cannot fire inside a single batch, so a
+within-batch cap is required.
+
+Closes #1140.
+
+### What changed
+
+- New constant `MAX_ADD_NEURON_CANDIDATES_PER_TARGET` (default `3`) and
+  accessor `max_add_neuron_candidates_per_target()` in
+  `src/analysis/constants/candidate_scoring.rs`. The accessor reads the
+  `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` environment variable and
+  clamps to `[1, 32]`.
+- New rejection reason `REJECTION_PER_TARGET_CAP` in
+  `src/analysis/diagnostics/rejection_reasons.rs`, added to
+  `ALL_REJECTION_REASONS` and mapped in `friendly_reason`.
+- `src/analysis/neuron/post_processing.rs::build_neuron_results` now calls
+  `apply_per_target_cap` after sort-by-gain and the pairing/filter steps but
+  before the shuffle/truncate sweep. The helper:
+  1. Re-sorts candidates by `expected_creature_score_gain` descending via
+     `f32::total_cmp` (deterministic tie breaking).
+  2. Groups by `target_neuron_uuid` and retains only the top-K per target.
+  3. Returns the drop count, which is recorded against
+     `REJECTION_PER_TARGET_CAP` in `metadata.rejection_breakdown`.
+- `AGENTS.md` environment-variable table lists the new override.
+
+### Test plan
+
+- `src/analysis/neuron/post_processing.rs::tests::per_target_cap_*` — four
+  new unit tests covering the acceptance criteria:
+  - `per_target_cap_truncates_target_over_limit` — target with > K
+    candidates is truncated to the K highest-gain ones.
+  - `per_target_cap_leaves_targets_under_limit_unchanged` — targets with
+    ≤ K candidates are untouched.
+  - `per_target_cap_breakdown_reports_drop` — the rejection breakdown
+    surfaces `per_target_cap` with the correct drop count.
+  - `per_target_cap_env_override_controls_limit` — the env override is
+    honoured (`#[serial]` to isolate env state).
+- Existing regression tests updated to raise the cap where the test
+  exercises a single-target creature (the degenerate case for the cap):
+  - `tests/activation/complement_via_identity.rs`
+  - `tests/gpu/gpu_activation_shaders.rs`
+  - `tests/neuron/issue_926_add_neuron_between_hidden.rs`
+  - `tests/synapse/coordinated_structural_replace_synapse_with_relu.rs`
+
+### Evidence
+
+Backend/CLI change only — no UI surface to screenshot. `./quality.sh`
+passes cleanly (fmt, clippy, check, full test suite, doc build, release
+build).

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -20,6 +20,51 @@
 pub const DIVERSIFY_TOP_K: usize = 64;
 
 // =============================================================================
+// Per-Target Add-Neuron Cap (Issue #1140)
+// =============================================================================
+
+/// Default maximum number of `add-neurons` candidates returned per target
+/// neuron in a single discovery batch (Issue #1140).
+///
+/// GRQ-sampler commit `744ac60d` showed 17 of 19 `add-neurons` failures in one
+/// submission targeted the same neuron, differing only by source input. All 17
+/// failed. The cross-batch cooldown (Issue #1130) cannot fire within a single
+/// batch, so a per-target within-batch cap is required to avoid wasting budget
+/// on clearly-hopeless targets.
+///
+/// Overridable via the `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET`
+/// environment variable.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above ~10 defeat the purpose of the cap.
+pub const MAX_ADD_NEURON_CANDIDATES_PER_TARGET: usize = 3;
+
+/// Minimum permitted per-target cap after env-var override clamping.
+pub const MIN_ADD_NEURON_CANDIDATES_PER_TARGET: usize = 1;
+
+/// Maximum permitted per-target cap after env-var override clamping.
+pub const MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING: usize = 32;
+
+/// Return the effective per-target add-neuron cap (Issue #1140).
+///
+/// Reads `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` at call time so tests
+/// can override the default. Values outside the permitted range are clamped
+/// to `[MIN_ADD_NEURON_CANDIDATES_PER_TARGET,
+/// MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING]`. Unparseable or missing
+/// values fall back to `MAX_ADD_NEURON_CANDIDATES_PER_TARGET`.
+#[must_use]
+pub fn max_add_neuron_candidates_per_target() -> usize {
+    std::env::var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(MAX_ADD_NEURON_CANDIDATES_PER_TARGET)
+        .clamp(
+            MIN_ADD_NEURON_CANDIDATES_PER_TARGET,
+            MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING,
+        )
+}
+
+// =============================================================================
 // Source-Type Scoring (Issue #465)
 // =============================================================================
 

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -50,7 +50,7 @@ pub const MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING: usize = 32;
 /// Reads `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` at call time so tests
 /// can override the default. Values outside the permitted range are clamped
 /// to `[MIN_ADD_NEURON_CANDIDATES_PER_TARGET,
-/// MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING]`. Unparseable or missing
+/// MAX_ADD_NEURON_CANDIDATES_PER_TARGET_CEILING]`. Unparsable or missing
 /// values fall back to `MAX_ADD_NEURON_CANDIDATES_PER_TARGET`.
 #[must_use]
 pub fn max_add_neuron_candidates_per_target() -> usize {

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -57,6 +57,11 @@ pub const REJECTION_ADD_SYNAPSE_GATED: &str = "add_synapse_gated";
 /// was already full.
 pub const REJECTION_BUDGET_TRUNCATED: &str = "budget_truncated";
 
+/// Add-neuron candidate was dropped because the per-target cap
+/// (`MAX_ADD_NEURON_CANDIDATES_PER_TARGET`) was already reached for this
+/// target neuron in the current batch (Issue #1140).
+pub const REJECTION_PER_TARGET_CAP: &str = "per_target_cap";
+
 /// Synapse: no overlapping discovery samples between source and target.
 pub const REJECTION_NO_SAMPLES: &str = "no_samples";
 
@@ -101,6 +106,7 @@ pub const ALL_REJECTION_REASONS: &[&str] = &[
     REJECTION_DUPLICATE_OF_FAILURE_CACHE,
     REJECTION_ADD_SYNAPSE_GATED,
     REJECTION_BUDGET_TRUNCATED,
+    REJECTION_PER_TARGET_CAP,
     REJECTION_NO_SAMPLES,
     REJECTION_ZERO_IMPROVEMENT,
     REJECTION_BELOW_THRESHOLD,
@@ -252,6 +258,7 @@ fn friendly_reason(reason: &str) -> String {
         REJECTION_DUPLICATE_OF_FAILURE_CACHE => "duplicate of failure cache".to_string(),
         REJECTION_ADD_SYNAPSE_GATED => "add-synapse historical-gating filter".to_string(),
         REJECTION_BUDGET_TRUNCATED => "per-module candidate budget".to_string(),
+        REJECTION_PER_TARGET_CAP => "per-target add-neuron cap".to_string(),
         REJECTION_NO_SAMPLES => "no overlapping discovery samples".to_string(),
         REJECTION_ZERO_IMPROVEMENT => "zero consistent improvement in GPU stats".to_string(),
         REJECTION_BELOW_THRESHOLD => "expected-improvement per-target threshold".to_string(),

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -95,6 +95,13 @@ pub(crate) fn build_neuron_results(
     // Production guard rail (Dec 2025): only return candidates within sensible parameter ranges.
     helpful_results = crate::analysis::utils::filter_candidates_to_sensible_ranges(helpful_results);
 
+    // Issue #1140: Cap add-neuron candidates per target within a single
+    // discovery batch. Without this cap, a single hopeless target can consume
+    // most of the budget with minor variants (e.g. 17 of 19 failed add-neuron
+    // candidates in GRQ-sampler commit 744ac60d targeted the same neuron).
+    // The cross-batch cooldown (Issue #1130) does not help within a batch.
+    let per_target_cap_drops = apply_per_target_cap(&mut helpful_results);
+
     // Deadline coverage (Jan 2026): diversify within the top-K
     if params.input.analysis_deadline_ms.is_some() {
         use crate::analysis::constants::DIVERSIFY_TOP_K;
@@ -143,7 +150,17 @@ pub(crate) fn build_neuron_results(
             error_distribution,
             // Issue #1129: populated by orchestration from neuron no-candidate
             // summaries after the result is built.
-            rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
+            rejection_breakdown: {
+                let mut breakdown = crate::analysis::diagnostics::RejectionBreakdown::new();
+                // Issue #1140: surface per-target cap drops in the structured
+                // rejection breakdown so operators can see why candidates
+                // were removed.
+                breakdown.record_many_u32(
+                    crate::analysis::diagnostics::rejection_reasons::REJECTION_PER_TARGET_CAP,
+                    u32::try_from(per_target_cap_drops).unwrap_or(u32::MAX),
+                );
+                breakdown
+            },
             top_level_summary: None,
             // Issue #1131: per-creature calibration corrections derived from failure cache.
             calibration_corrections: calibration_correction.as_map().clone(),
@@ -239,5 +256,190 @@ fn apply_impact_discounting(
                 "Neuron candidate impact discount applied"
             );
         }
+    }
+}
+
+/// Cap add-neuron candidates per target neuron within a single discovery
+/// batch (Issue #1140).
+///
+/// Sorts `candidates` by `expected_creature_score_gain` descending (NaN-safe
+/// via `total_cmp`), then retains only the top-K candidates per
+/// `target_neuron_uuid`, where K is
+/// [`max_add_neuron_candidates_per_target`]. The retained candidates remain
+/// in gain-descending order. Returns the number of candidates dropped by the
+/// cap so callers can record it in the rejection breakdown.
+pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) -> usize {
+    let cap = crate::analysis::constants::max_add_neuron_candidates_per_target();
+    if candidates.is_empty() || cap == 0 {
+        return 0;
+    }
+
+    // Sort by gain descending so that retained candidates per target are the
+    // highest-gain ones. `total_cmp` provides a total order including NaN,
+    // breaking ties deterministically.
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    let original_len = candidates.len();
+    let mut per_target: HashMap<String, usize> = HashMap::new();
+    candidates.retain(|candidate| {
+        let count = per_target
+            .entry(candidate.target_neuron_uuid.clone())
+            .or_insert(0);
+        if *count < cap {
+            *count += 1;
+            true
+        } else {
+            false
+        }
+    });
+    original_len - candidates.len()
+}
+
+// =============================================================================
+// Tests (Issue #1140)
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::apply_per_target_cap;
+    use crate::CandidateNeuronJson;
+    use serial_test::serial;
+
+    fn test_candidate(target_uuid: &str, gain: f32) -> CandidateNeuronJson {
+        CandidateNeuronJson {
+            source_neuron_uuid: format!("source-{gain}"),
+            target_neuron_uuid: target_uuid.to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
+            incoming_weight: 1.0,
+            outgoing_weight: 1.0,
+            squash: "TANH".to_string(),
+            bias: 0.0,
+            comment: None,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: gain,
+            expected_creature_score_gain: gain,
+            improved_count: 10,
+            total_count: 10,
+            target_neuron_stats: None,
+            prediction_confidence: 0.5,
+            expected_score_gain_confidence_interval: [gain, gain],
+            target_saturation_factor: None,
+        }
+    }
+
+    #[test]
+    fn per_target_cap_truncates_target_over_limit() {
+        // Seven candidates for one target; cap defaults to 3.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.1),
+            test_candidate("target-A", 0.5),
+            test_candidate("target-A", 0.2),
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.3),
+            test_candidate("target-A", 0.7),
+            test_candidate("target-A", 0.4),
+        ];
+
+        let dropped = apply_per_target_cap(&mut candidates);
+
+        assert_eq!(candidates.len(), 3, "target-A should be capped to 3");
+        assert_eq!(dropped, 4, "four candidates should be dropped");
+
+        // Retained candidates must be the highest-gain ones (0.9, 0.7, 0.5).
+        let retained_gains: Vec<f32> = candidates
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        assert_eq!(retained_gains, vec![0.9, 0.7, 0.5]);
+    }
+
+    #[test]
+    fn per_target_cap_leaves_targets_under_limit_unchanged() {
+        // Two candidates for target-A, one for target-B; both under the cap of 3.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.5),
+            test_candidate("target-A", 0.2),
+            test_candidate("target-B", 0.8),
+        ];
+
+        let dropped = apply_per_target_cap(&mut candidates);
+
+        assert_eq!(candidates.len(), 3, "no candidate should be dropped");
+        assert_eq!(dropped, 0, "zero candidates should be dropped");
+
+        // Per-target counts must be preserved.
+        let target_a: Vec<f32> = candidates
+            .iter()
+            .filter(|c| c.target_neuron_uuid == "target-A")
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        assert_eq!(target_a.len(), 2);
+        let target_b: Vec<f32> = candidates
+            .iter()
+            .filter(|c| c.target_neuron_uuid == "target-B")
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        assert_eq!(target_b.len(), 1);
+    }
+
+    #[test]
+    fn per_target_cap_breakdown_reports_drop() {
+        // Build a mix: target-A exceeds the cap, target-B is under it.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.8),
+            test_candidate("target-A", 0.7),
+            test_candidate("target-A", 0.6),
+            test_candidate("target-A", 0.5),
+            test_candidate("target-B", 0.4),
+        ];
+
+        let dropped = apply_per_target_cap(&mut candidates);
+        assert_eq!(dropped, 2, "two target-A candidates should be dropped");
+
+        // Feed into a RejectionBreakdown exactly as build_neuron_results does.
+        let mut breakdown = crate::analysis::diagnostics::RejectionBreakdown::new();
+        breakdown.record_many_u32(
+            crate::analysis::diagnostics::rejection_reasons::REJECTION_PER_TARGET_CAP,
+            u32::try_from(dropped).expect("fits in u32"),
+        );
+
+        assert_eq!(
+            breakdown
+                .counts()
+                .get(crate::analysis::diagnostics::rejection_reasons::REJECTION_PER_TARGET_CAP,),
+            Some(&2),
+            "rejection breakdown should report two per-target-cap drops"
+        );
+        assert_eq!(breakdown.total(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn per_target_cap_env_override_controls_limit() {
+        // SAFETY: env access is serialised via `#[serial]`.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET", "1");
+        }
+
+        let mut candidates = vec![
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.8),
+            test_candidate("target-A", 0.7),
+        ];
+        let dropped = apply_per_target_cap(&mut candidates);
+
+        // SAFETY: env access is serialised via `#[serial]`.
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET");
+        }
+
+        assert_eq!(candidates.len(), 1, "cap=1 should leave only one candidate");
+        assert_eq!(dropped, 2);
+        assert!((candidates[0].expected_creature_score_gain - 0.9).abs() < f32::EPSILON);
     }
 }

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -12,11 +12,35 @@
 use crate::skip_without_gpu;
 use neat_ai_discovery::record_discovery_internal;
 use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson};
+use serial_test::serial;
 use tempfile::TempDir;
 
 #[test]
+#[serial]
 fn test_complement_is_discovered_as_identity_not_inverse() {
     skip_without_gpu!();
+
+    // Issue #1140: This test exercises a single-output creature so every
+    // candidate targets the same neuron. The new per-target add-neuron cap
+    // (default 3) would drop the IDENTITY candidate in favour of higher-gain
+    // activations (Mish, SOFTSIGN) and prevent this regression from being
+    // exercised. Raise the cap for this test so the full candidate pool is
+    // available to search for an IDENTITY representation of complement.
+    // SAFETY: env access is serialised via `#[serial]`.
+    unsafe {
+        std::env::set_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET", "32");
+    }
+    // Guard that restores the previous behaviour if the test panics.
+    struct EnvGuard;
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: env access is serialised via `#[serial]`.
+            unsafe {
+                std::env::remove_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET");
+            }
+        }
+    }
+    let _guard = EnvGuard;
 
     let temp_dir = TempDir::new().expect("Failed to create temporary directory");
     let temp_path = temp_dir.path();

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -22,6 +22,7 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_neurons};
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
 use tempfile::NamedTempFile;
 
 /// Skip test if no GPU available
@@ -168,8 +169,29 @@ fn test_mish_gpu_shader_produces_correct_results() {
 /// some candidates, which wouldn't happen if the GPU shader fell back to
 /// IDENTITY and produced nonsensical weight calculations.
 #[test]
+#[serial]
 fn test_all_new_activations_produce_candidates() {
     skip_without_gpu!();
+
+    // Issue #1140: This test uses a single-output creature so every
+    // candidate targets the same neuron. The default per-target add-neuron
+    // cap (3) would drop most activations and defeat the purpose of this
+    // test (verifying 3+ distinct activations produce candidates). Raise the
+    // cap for this test so the full candidate pool is preserved.
+    // SAFETY: env access is serialised via `#[serial]`.
+    unsafe {
+        std::env::set_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET", "32");
+    }
+    struct EnvGuard;
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: env access is serialised via `#[serial]`.
+            unsafe {
+                std::env::remove_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET");
+            }
+        }
+    }
+    let _guard = EnvGuard;
 
     let creature = create_test_creature(
         vec![

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -25,7 +25,32 @@ use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_neurons};
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeNeuronsInput, CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
 use tempfile::NamedTempFile;
+
+/// RAII guard (Issue #1140) that raises the per-target add-neuron cap so that
+/// tests with a small number of target neurons can still exercise diverse
+/// activation proposals. Removes the override when dropped.
+struct PerTargetCapOverride;
+
+impl PerTargetCapOverride {
+    fn new(cap: &str) -> Self {
+        // SAFETY: env access is serialised via `#[serial]` on the call site.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET", cap);
+        }
+        Self
+    }
+}
+
+impl Drop for PerTargetCapOverride {
+    fn drop(&mut self) {
+        // SAFETY: env access is serialised via `#[serial]` on the call site.
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET");
+        }
+    }
+}
 
 /// Skip test if no GPU available.
 macro_rules! skip_without_gpu {
@@ -404,8 +429,17 @@ fn test_hidden_neuron_candidate_properties() {
 /// Verify that the full analysis pipeline (`analyze_all`) also finds hidden-to-hidden
 /// neuron candidates through the combined synapse + neuron analysis path.
 #[test]
+#[serial]
 fn test_analyze_all_finds_hidden_neuron_candidate() {
     skip_without_gpu!();
+
+    // Issue #1140: Raise the per-target cap so the test's tiny creature
+    // (2 focus targets) can still see the hidden-C candidates that
+    // `convert_neurons_to_coordinated_replacements` may convert to
+    // coordinated candidates. At the default cap of 3 the hidden-C slots
+    // are exhausted before the conversion step, leaving no hidden-C
+    // candidates in `helpful_neurons`.
+    let _cap_guard = PerTargetCapOverride::new("32");
 
     use neat_ai_discovery::AnalyzeAllInput;
     use neat_ai_discovery::analysis::analyze_all;

--- a/tests/synapse/coordinated_structural_replace_synapse_with_relu.rs
+++ b/tests/synapse/coordinated_structural_replace_synapse_with_relu.rs
@@ -3,6 +3,7 @@ use neat_ai_discovery::analysis::GpuAnalyzer;
 use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson, analyze_parallel_internal};
+use serial_test::serial;
 
 /// Regression/integration test for Issue #173 (7-Jan-2026).
 ///
@@ -13,11 +14,31 @@ use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson, analyze_parallel_
 /// - addSynapse(source -> hidden)
 /// - addSynapse(hidden -> target)
 #[test]
+#[serial]
 fn coordinated_structural_can_replace_synapse_with_hidden_relu_neuron() {
     // Discovery is GPU-only. On machines without GPU, we skip.
     if !GpuAnalyzer::gpu_is_available() {
         return;
     }
+
+    // Issue #1140: Single-output creature → all add-neuron candidates target
+    // output-0. The default per-target cap of 3 can drop the ReLU candidate
+    // in favour of boosted activations (GELU 2.0×, ABSOLUTE 1.95×) before
+    // the coordinated-structural conversion runs.
+    // SAFETY: env access is serialised via `#[serial]`.
+    unsafe {
+        std::env::set_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET", "32");
+    }
+    struct EnvGuard;
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: env access is serialised via `#[serial]`.
+            unsafe {
+                std::env::remove_var("NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET");
+            }
+        }
+    }
+    let _guard = EnvGuard;
 
     let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
     let parquet_file = temp_dir


### PR DESCRIPTION
## Summary

Cap `add-neurons` candidates per target within a single discovery batch so
that a clearly-hopeless target cannot consume most of the budget with minor
variants. GRQ-sampler commit `744ac60d` recorded 17 of 19 `add-neurons`
failures in one submission against the **same** neuron; the cross-batch
cooldown added in Issue #1130 cannot fire inside a single batch, so a
within-batch cap is required.

Closes #1140.

### What changed

- New constant `MAX_ADD_NEURON_CANDIDATES_PER_TARGET` (default `3`) and
  accessor `max_add_neuron_candidates_per_target()` in
  `src/analysis/constants/candidate_scoring.rs`. The accessor reads the
  `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` environment variable and
  clamps to `[1, 32]`.
- New rejection reason `REJECTION_PER_TARGET_CAP` in
  `src/analysis/diagnostics/rejection_reasons.rs`, added to
  `ALL_REJECTION_REASONS` and mapped in `friendly_reason`.
- `src/analysis/neuron/post_processing.rs::build_neuron_results` now calls
  `apply_per_target_cap` after sort-by-gain and the pairing/filter steps but
  before the shuffle/truncate sweep. The helper:
  1. Re-sorts candidates by `expected_creature_score_gain` descending via
     `f32::total_cmp` (deterministic tie breaking).
  2. Groups by `target_neuron_uuid` and retains only the top-K per target.
  3. Returns the drop count, which is recorded against
     `REJECTION_PER_TARGET_CAP` in `metadata.rejection_breakdown`.
- `AGENTS.md` environment-variable table lists the new override.

### Test plan

- `src/analysis/neuron/post_processing.rs::tests::per_target_cap_*` — four
  new unit tests covering the acceptance criteria:
  - `per_target_cap_truncates_target_over_limit` — target with > K
    candidates is truncated to the K highest-gain ones.
  - `per_target_cap_leaves_targets_under_limit_unchanged` — targets with
    ≤ K candidates are untouched.
  - `per_target_cap_breakdown_reports_drop` — the rejection breakdown
    surfaces `per_target_cap` with the correct drop count.
  - `per_target_cap_env_override_controls_limit` — the env override is
    honoured (`#[serial]` to isolate env state).
- Existing regression tests updated to raise the cap where the test
  exercises a single-target creature (the degenerate case for the cap):
  - `tests/activation/complement_via_identity.rs`
  - `tests/gpu/gpu_activation_shaders.rs`
  - `tests/neuron/issue_926_add_neuron_between_hidden.rs`
  - `tests/synapse/coordinated_structural_replace_synapse_with_relu.rs`

### Evidence

Backend/CLI change only — no UI surface to screenshot. `./quality.sh`
passes cleanly (fmt, clippy, check, full test suite, doc build, release
build).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1140 -->