### PR TITLE
docs: add Related Repositories section to README (#1147)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.20"
+version = "0.74.21"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -486,6 +486,39 @@ All dependencies build automatically on remote, unattended machines.
   `~/.cargo/lib/.neat_ai_discovery.version`.
 - Do not manually edit version numbers; CI handles patch bumps.
 
+## 🔗 Related Repositories
+
+The NEAT-AI project is split across seven public repositories. Each focuses on one concern and composes with the others as shown below. This repository is **NEAT-AI-Discovery**.
+
+| Repository | Role |
+|------------|------|
+| [NEAT-AI](https://github.com/stSoftwareAU/NEAT-AI) | Primary Deno/TypeScript neural-network engine (evolution, training, WASM activation). |
+| [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) | Shared native Rust library (`neat-core`) with numerics, topology helpers, and the chunked `.bin` training stream. |
+| [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) | Rust discovery module invoked by NEAT-AI via Deno FFI to search architectures and hyper-parameters. |
+| [NEAT-AI-Snapshot](https://github.com/stSoftwareAU/NEAT-AI-Snapshot) | Creature/genome snapshot format and fixtures produced by NEAT-AI and consumed by downstream tools. |
+| [NEAT-AI-scorer](https://github.com/stSoftwareAU/NEAT-AI-scorer) | Production forward-only scoring application built on `neat-core` via a path dependency. |
+| [NEAT-AI-Explore](https://github.com/stSoftwareAU/NEAT-AI-Explore) | Visualiser for creatures that reads NEAT-AI-Snapshot data. |
+| [NEAT-AI-Examples](https://github.com/stSoftwareAU/NEAT-AI-Examples) | Worked examples and tutorials that depend on NEAT-AI. |
+
+### Dependency graph
+
+```mermaid
+graph TD
+    Core[NEAT-AI-core<br/>Rust shared lib]
+    Main[NEAT-AI<br/>Deno/TypeScript engine]
+    Discovery[NEAT-AI-Discovery<br/>Rust, via Deno FFI]
+    Snapshot[NEAT-AI-Snapshot<br/>creature data]
+    Scorer[NEAT-AI-scorer<br/>Rust scorer app]
+    Explore[NEAT-AI-Explore<br/>visualiser]
+    Examples[NEAT-AI-Examples<br/>tutorials]
+
+    Main -->|Deno FFI| Discovery
+    Main -->|produces| Snapshot
+    Scorer -->|path dependency| Core
+    Explore -->|reads| Snapshot
+    Examples -->|depends on| Main
+```
+
 ## 📚 Additional Documentation
 
 | Document | Description |

--- a/docs/pr-summary-1147.md
+++ b/docs/pr-summary-1147.md
@@ -1,0 +1,14 @@
+## Summary
+Added a `## 🔗 Related Repositories` section to the NEAT-AI-Discovery README using the canonical markdown block defined in [stSoftwareAU/NEAT-AI-core#18](https://github.com/stSoftwareAU/NEAT-AI-core/issues/18). The section lists all seven public NEAT-AI-* repositories with one-line descriptions and includes the canonical Mermaid dependency diagram, with a small framing note indicating this repository is NEAT-AI-Discovery. Placed before the `## 📚 Additional Documentation` section so it sits alongside other project-level navigation content. Closes #1147.
+
+## Evidence
+This is a documentation-only change; no UI or performance impact.
+
+- README renders the new section with the seven-repo table and the Mermaid dependency graph.
+- Canonical repo list, descriptions, and diagram are preserved verbatim from the source issue.
+- Repo quality gate (`./quality.sh`) exercises Rust build/lint/test — README-only change does not affect it.
+
+## Test Plan
+- [x] README opens to the new `🔗 Related Repositories` section with all seven repos and working GitHub links.
+- [x] Mermaid block is valid and matches the canonical diagram (same nodes and edges as the source issue).
+- [x] `./quality.sh` run locally.


### PR DESCRIPTION
## Summary
Added a `## 🔗 Related Repositories` section to the NEAT-AI-Discovery README using the canonical markdown block defined in [stSoftwareAU/NEAT-AI-core#18](https://github.com/stSoftwareAU/NEAT-AI-core/issues/18). The section lists all seven public NEAT-AI-* repositories with one-line descriptions and includes the canonical Mermaid dependency diagram, with a small framing note indicating this repository is NEAT-AI-Discovery. Placed before the `## 📚 Additional Documentation` section so it sits alongside other project-level navigation content. Closes #1147.

## Evidence
This is a documentation-only change; no UI or performance impact.

- README renders the new section with the seven-repo table and the Mermaid dependency graph.
- Canonical repo list, descriptions, and diagram are preserved verbatim from the source issue.
- Repo quality gate (`./quality.sh`) exercises Rust build/lint/test — README-only change does not affect it.

## Test Plan
- [x] README opens to the new `🔗 Related Repositories` section with all seven repos and working GitHub links.
- [x] Mermaid block is valid and matches the canonical diagram (same nodes and edges as the source issue).
- [x] `./quality.sh` run locally.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1147 -->