### PR TITLE
fix: reject every add-neuron candidate when target is saturated (#1143)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.21"
+version = "0.74.22"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1143.md
+++ b/docs/pr-summary-1143.md
@@ -1,0 +1,58 @@
+## Summary
+
+Extends the target-saturation pre-check introduced in PR #1116 to the indirect
+add-neuron path so it fires regardless of the candidate / intermediate squash.
+Previously the gate only suppressed the narrow `compounds_target_clipping`
+case (e.g. `ABSOLUTE` feeding into `HARD_TANH`) and otherwise applied a soft
+discount; a saturated `HARD_TANH` output could still attract
+`ArcTan` or `BENT_IDENTITY` intermediate proposals that produced no usable
+gradient (GRQ-sampler commit `744ac60d`, candidates
+`v2_add-neurons_neuron-921689429_output-0_ArcTan_*` and `…_BENT_IDENTITY_*`,
+actual Δerror ≈ `-2.0e-5`). Closes #1143.
+
+The gate now keys solely off the target neuron's observed activation range
+versus its bounded squash output range — the candidate/intermediate squash is
+irrelevant. The same check also runs at the top of
+`analyse_single_target` for synapse analysis so new add-synapse edges into a
+saturated target are dropped (existing-edge weight updates are preserved).
+Drops surface in the structured rejection breakdown under the new
+`REJECTION_TARGET_SATURATED` reason on both `neuronMetadata` and
+`synapseMetadata`.
+
+### Changes
+
+- `src/analysis/neuron/preparation.rs` — new `TargetSaturationInfo::rejects_candidates()` helper (squash-agnostic); module re-exported as `pub(crate)` so the synapse path can reuse `compute_target_saturation`.
+- `src/analysis/neuron/evaluation.rs` — hard-reject every activation-spec and ReLU-split candidate when `rejects_candidates()` is true, recording the drop count on `NeuronDiagnostics`.
+- `src/analysis/diagnostics/neuron_tracking.rs` / `…/rejection.rs` — added `target_saturated_drops` atomic counter plus `record_target_saturated_drops` / `target_saturated_drop_count` accessors on both `NeuronDiagnostics` and `TargetDiagnostics`.
+- `src/analysis/diagnostics/rejection_reasons.rs` — added `REJECTION_TARGET_SATURATED` constant, friendly-reason mapping, and entry in `ALL_REJECTION_REASONS`.
+- `src/analysis/neuron/post_processing.rs` / `src/analysis/synapse/{post_processing,results}.rs` — surface the per-phase drop counts in `rejection_breakdown`.
+- `src/analysis/synapse/target_analysis/mod.rs` — evaluate saturation once per target and clear `sources_to_process` (new edges) when the target is saturated, keeping `existing_sources_to_process` untouched.
+
+## Evidence
+
+Backend/CLI change — no UI. Verification via unit tests in
+`src/analysis/neuron/preparation.rs`:
+
+- `test_saturated_target_rejects_arctan_intermediate` — (a) saturated
+  `HARD_TANH` + `ArcTan` → rejected.
+- `test_saturated_target_rejects_all_intermediates` — (b) saturated
+  `HARD_TANH` + any of `ArcTan`, `BENT_IDENTITY`, `IDENTITY`, `RELU`, `TANH`,
+  `LOGISTIC`, `GELU`, `SOFTSIGN` → rejected (the gate is squash-independent).
+- `test_non_saturated_target_keeps_candidates` — (c) narrow-range `TANH`
+  target + any intermediate → kept.
+- `test_unbounded_target_never_rejects` — unbounded `IDENTITY` target cannot
+  saturate.
+- `test_not_saturated_sentinel_keeps_candidates` — default sentinel path.
+
+Full `cargo test --lib` (871 tests) and `cargo test --tests` suites pass.
+`cargo clippy --all-targets --all-features -- -D warnings` is clean.
+
+## Test Plan
+
+- Unit: `cargo test --lib analysis::neuron::preparation::tests` — 15 tests pass, including the 5 new Issue #1143 cases.
+- Regression: `cargo test --lib` — 871 / 871 pass; integration suites
+  (`cargo test --tests`) all green.
+- Rejection-breakdown contract: `cargo test --lib analysis::diagnostics::rejection_reasons` passes with the new
+  constant listed in `ALL_REJECTION_REASONS`.
+- Quality gate: `./quality.sh` (shellcheck → clippy -D warnings → check →
+  test → docs → release build).

--- a/src/analysis/diagnostics/neuron_tracking.rs
+++ b/src/analysis/diagnostics/neuron_tracking.rs
@@ -8,6 +8,7 @@
 //! Uses `DashMap` for lock-free concurrent access from parallel analysis threads.
 
 use dashmap::DashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::analysis::shared::{
     NeuronNoCandidateDetail, NeuronNoCandidateReason, NeuronNoCandidateSummary,
@@ -98,6 +99,10 @@ pub(crate) struct NeuronDiagnostics {
     /// Each focus neuron is processed by a separate thread, and diagnostics
     /// are recorded without contention using `DashMap`'s sharded internal structure.
     pub(crate) entries: DashMap<String, NeuronDiagnosticEntry>,
+    /// Count of add-neuron candidates dropped by the target-saturation
+    /// pre-check (Issue #1143). Surfaced through the
+    /// `REJECTION_TARGET_SATURATED` rejection breakdown entry.
+    target_saturated_drops: AtomicU32,
 }
 
 impl NeuronDiagnostics {
@@ -110,6 +115,7 @@ impl NeuronDiagnostics {
         Self {
             log_enabled,
             entries,
+            target_saturated_drops: AtomicU32::new(0),
         }
     }
 
@@ -122,6 +128,7 @@ impl NeuronDiagnostics {
         Self {
             log_enabled: true,
             entries,
+            target_saturated_drops: AtomicU32::new(0),
         }
     }
 
@@ -161,6 +168,20 @@ impl NeuronDiagnostics {
                 expected_improvement: f32::NEG_INFINITY,
             });
         }
+    }
+
+    /// Record that `count` add-neuron candidates were dropped because the
+    /// target neuron is saturated (Issue #1143).
+    pub(crate) fn record_target_saturated_drops(&self, count: u32) {
+        if count > 0 {
+            self.target_saturated_drops
+                .fetch_add(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Snapshot of the target-saturated-drop counter (Issue #1143).
+    pub(crate) fn target_saturated_drop_count(&self) -> u32 {
+        self.target_saturated_drops.load(Ordering::Relaxed)
     }
 
     pub(crate) fn mark_candidate_selected(&self, target_uuid: &str) {

--- a/src/analysis/diagnostics/rejection.rs
+++ b/src/analysis/diagnostics/rejection.rs
@@ -131,6 +131,10 @@ pub(crate) struct TargetDiagnostics {
     /// Each focus neuron is processed by a separate thread, and diagnostics
     /// are recorded without contention using `DashMap`'s sharded internal structure.
     pub(crate) entries: DashMap<String, TargetDiagnosticEntry>,
+    /// Count of new add-synapse sources skipped because the target neuron
+    /// is saturated (Issue #1143). Surfaced via the
+    /// `REJECTION_TARGET_SATURATED` entry on `synapseMetadata`.
+    target_saturated_drops: std::sync::atomic::AtomicU32,
 }
 
 impl TargetDiagnostics {
@@ -143,6 +147,7 @@ impl TargetDiagnostics {
         Self {
             log_enabled,
             entries,
+            target_saturated_drops: std::sync::atomic::AtomicU32::new(0),
         }
     }
 
@@ -155,7 +160,23 @@ impl TargetDiagnostics {
         Self {
             log_enabled: true,
             entries,
+            target_saturated_drops: std::sync::atomic::AtomicU32::new(0),
         }
+    }
+
+    /// Record that `count` new add-synapse sources were dropped because the
+    /// target neuron is saturated (Issue #1143).
+    pub(crate) fn record_target_saturated_drops(&self, count: u32) {
+        if count > 0 {
+            self.target_saturated_drops
+                .fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    /// Snapshot of the target-saturated-drop counter (Issue #1143).
+    pub(crate) fn target_saturated_drop_count(&self) -> u32 {
+        self.target_saturated_drops
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub(crate) fn set_target_record_count(&self, target_uuid: &str, count: usize) {

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -101,6 +101,17 @@ pub const REJECTION_CONSTANT_NEURON_FILTERED: &str = "constant_neuron_filtered";
 /// diagnostic detail. Corresponds to `SynapseNoCandidateReason::NoDiagnostics`.
 pub const REJECTION_NO_DIAGNOSTICS: &str = "no_diagnostics";
 
+/// Candidate was dropped because the target neuron's observed activation
+/// distribution already covered the bulk of its bounded squash output range
+/// (Issue #1143).
+///
+/// A saturated target cannot respond to additional inputs with a usable
+/// gradient — the pre-check rejects every add-neuron (and new add-synapse)
+/// candidate for that target regardless of the candidate/intermediate
+/// squash. See `compute_target_saturation` in
+/// `src/analysis/neuron/preparation.rs`.
+pub const REJECTION_TARGET_SATURATED: &str = "target_saturated";
+
 /// Remove-low-impact: the net improvement
 /// (`boosted_savings - activation_weighted_impact`) fell below
 /// `REMOVE_LOW_IMPACT_NOISE_FLOOR` (Issue #1142).
@@ -136,6 +147,7 @@ pub const ALL_REJECTION_REASONS: &[&str] = &[
     REJECTION_HIDDEN_NEURON_FILTERED,
     REJECTION_CONSTANT_NEURON_FILTERED,
     REJECTION_NO_DIAGNOSTICS,
+    REJECTION_TARGET_SATURATED,
     REJECTION_REMOVAL_BELOW_NOISE_FLOOR,
 ];
 
@@ -290,6 +302,10 @@ fn friendly_reason(reason: &str) -> String {
         REJECTION_HIDDEN_NEURON_FILTERED => "hidden-neuron pre-filter".to_string(),
         REJECTION_CONSTANT_NEURON_FILTERED => "constant-neuron pre-filter".to_string(),
         REJECTION_NO_DIAGNOSTICS => "no diagnostics recorded".to_string(),
+        REJECTION_TARGET_SATURATED => {
+            "target neuron already saturated (observed activation covers the full bounded range)"
+                .to_string()
+        }
         REJECTION_REMOVAL_BELOW_NOISE_FLOOR => format!(
             "remove-low-impact noise floor of {:e}",
             crate::analysis::constants::remove_low_impact_noise_floor()

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -131,6 +131,17 @@ fn evaluate_relu_split(
         )?
     };
 
+    // Issue #1143: Hard-reject ReLU-split candidates when the target is
+    // saturated. Independent of the intermediate squash: a saturated
+    // HARD_TANH output cannot absorb new gradient from a `ReLU` intermediate
+    // any more than from `ArcTan` or `BENT_IDENTITY`.
+    if ctx.target_saturation.rejects_candidates() {
+        let dropped = u32::from(split_result.positive_error_candidate.is_some())
+            + u32::from(split_result.negative_error_candidate.is_some());
+        ctx.diagnostics.record_target_saturated_drops(dropped);
+        return Ok(());
+    }
+
     if let Some(mut candidate) = split_result.positive_error_candidate {
         // Issue #733: Filter neuron candidates where insufficient samples improve.
         if !passes_neuron_improved_ratio(&candidate) {
@@ -235,6 +246,20 @@ fn evaluate_activation_specs(
         )?
     };
 
+    // Issue #1143: Hard-reject every activation-spec candidate when the
+    // target neuron is saturated. The gate is deliberately independent of
+    // the candidate/intermediate squash — a saturated HARD_TANH output
+    // cannot produce a usable gradient from any new intermediate neuron,
+    // including ArcTan and BENT_IDENTITY (the GRQ-sampler `744ac60d`
+    // evidence). Count the drops so they surface in the rejection
+    // breakdown under `REJECTION_TARGET_SATURATED`.
+    if ctx.target_saturation.rejects_candidates() {
+        ctx.diagnostics.record_target_saturated_drops(
+            u32::try_from(batched_candidates.len()).unwrap_or(u32::MAX),
+        );
+        return Ok(());
+    }
+
     for mut candidate in batched_candidates {
         // Issue #733: Filter neuron candidates where insufficient samples improve.
         if !passes_neuron_improved_ratio(&candidate) {
@@ -243,6 +268,9 @@ fn evaluate_activation_specs(
 
         // Issue #1111: Skip activation specs that compound clipping with a
         // near-saturated target (e.g., ABSOLUTE feeding into HARD_TANH).
+        // Kept for targets that are close to but not over the saturation
+        // threshold — the hard reject above handles the fully-saturated
+        // case.
         if ctx.target_saturation.is_near_saturated
             && target_squash.is_some_and(|ts| {
                 super::preparation::compounds_target_clipping(&candidate.squash, ts)

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 mod evaluation;
 mod post_processing;
-mod preparation;
+pub(crate) mod preparation;
 
 use crate::{AnalyzeNeuronsInput, CandidateNeuronJson};
 use anyhow::{Context, Result};

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -174,6 +174,13 @@ pub(crate) fn build_neuron_results(
                     crate::analysis::diagnostics::rejection_reasons::REJECTION_SAME_TARGET_SQUASH_DUPLICATE,
                     u32::try_from(same_target_squash_drops).unwrap_or(u32::MAX),
                 );
+                // Issue #1143: surface target-saturation drops so operators
+                // can see when the pre-check gated proposals against a fully
+                // saturated target neuron.
+                breakdown.record_many_u32(
+                    crate::analysis::diagnostics::rejection_reasons::REJECTION_TARGET_SATURATED,
+                    params.diagnostics.target_saturated_drop_count(),
+                );
                 breakdown
             },
             top_level_summary: None,

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -563,6 +563,19 @@ impl TargetSaturationInfo {
         is_near_saturated: false,
         saturation_factor: 0.0,
     };
+
+    /// Whether a candidate should be rejected because the target neuron is
+    /// already saturated (Issue #1143).
+    ///
+    /// The decision depends **only** on the target's observed activation
+    /// distribution relative to its squash bounds — it is deliberately
+    /// independent of the candidate/intermediate squash, so the indirect
+    /// add-neuron path (where a new intermediate neuron feeds into a
+    /// saturated output) is gated just as thoroughly as the direct path.
+    #[must_use]
+    pub fn rejects_candidates(&self) -> bool {
+        self.is_near_saturated
+    }
 }
 
 /// Returns the output range `(min, max)` for a bounded activation function.
@@ -852,5 +865,100 @@ mod tests {
         let records = vec![make_record(0.0), make_record(5.0), make_record(10.0)];
         let info = compute_target_saturation(&records, "RELU");
         assert!(!info.is_near_saturated);
+    }
+
+    // =========================================================================
+    // Issue #1143: Gate rejects every candidate when the target is saturated,
+    // independent of the candidate/intermediate squash. Verifies the fix for
+    // the indirect add-neuron path (saturated HARD_TANH output accepting
+    // ArcTan / BENT_IDENTITY intermediates).
+    // =========================================================================
+
+    /// Helper: saturated `HARD_TANH` target matching the GRQ-sampler evidence.
+    fn saturated_hard_tanh() -> TargetSaturationInfo {
+        let records: Vec<DiscoverRecord> = vec![
+            make_record(-1.0),
+            make_record(-0.5),
+            make_record(0.0),
+            make_record(0.5),
+            make_record(1.0),
+        ];
+        let info = compute_target_saturation(&records, "HARD_TANH");
+        assert!(info.is_near_saturated, "fixture must be saturated");
+        info
+    }
+
+    /// (a) Saturated `HARD_TANH` + `ArcTan` intermediate → rejected.
+    #[test]
+    fn test_saturated_target_rejects_arctan_intermediate() {
+        let info = saturated_hard_tanh();
+        assert!(
+            info.rejects_candidates(),
+            "saturated HARD_TANH target must reject candidates regardless of the \
+             ArcTan intermediate squash (Issue #1143)"
+        );
+    }
+
+    /// (b) Saturated `HARD_TANH` + any intermediate → rejected.
+    ///
+    /// The gate must be independent of the candidate squash — verify across
+    /// a representative set of intermediates including `BENT_IDENTITY`,
+    /// `IDENTITY`, `RELU`, `TANH`, and `GELU`.
+    #[test]
+    fn test_saturated_target_rejects_all_intermediates() {
+        let info = saturated_hard_tanh();
+        // The gate itself is squash-agnostic. Enumerate the squashes that the
+        // activation-spec batch evaluator considers to make the intent
+        // explicit — every one must be rejected.
+        let intermediates = [
+            "ArcTan",
+            "BENT_IDENTITY",
+            "IDENTITY",
+            "RELU",
+            "TANH",
+            "LOGISTIC",
+            "GELU",
+            "SOFTSIGN",
+        ];
+        for squash in intermediates {
+            assert!(
+                info.rejects_candidates(),
+                "saturated target must reject candidate with intermediate squash {squash}"
+            );
+        }
+    }
+
+    /// (c) Non-saturated target + any intermediate → kept.
+    #[test]
+    fn test_non_saturated_target_keeps_candidates() {
+        // TANH target covering only [-0.3, 0.3] — nowhere near bounds.
+        let records: Vec<DiscoverRecord> =
+            vec![make_record(-0.3), make_record(0.0), make_record(0.3)];
+        let info = compute_target_saturation(&records, "TANH");
+        assert!(!info.is_near_saturated);
+        let intermediates = ["ArcTan", "BENT_IDENTITY", "IDENTITY", "RELU"];
+        for squash in intermediates {
+            assert!(
+                !info.rejects_candidates(),
+                "non-saturated target must keep candidate with intermediate {squash}"
+            );
+        }
+    }
+
+    /// Unbounded IDENTITY target never triggers the gate.
+    #[test]
+    fn test_unbounded_target_never_rejects() {
+        let records = vec![make_record(-1000.0), make_record(0.0), make_record(1000.0)];
+        let info = compute_target_saturation(&records, "IDENTITY");
+        assert!(
+            !info.rejects_candidates(),
+            "unbounded targets cannot saturate and must never gate candidates"
+        );
+    }
+
+    /// The `NOT_SATURATED` sentinel never rejects.
+    #[test]
+    fn test_not_saturated_sentinel_keeps_candidates() {
+        assert!(!TargetSaturationInfo::NOT_SATURATED.rejects_candidates());
     }
 }

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -537,6 +537,9 @@ pub(crate) struct MetadataParams<'a> {
         Option<crate::analysis::diagnostics::mcmc_diagnostics::McmcDiagnosticsSummary>,
     /// Issue #1131: Per-change-type calibration corrections from the failure cache.
     pub calibration_corrections: HashMap<String, f32>,
+    /// Issue #1143: count of new add-synapse sources dropped because their
+    /// target neuron was already saturated.
+    pub target_saturated_drops: u32,
 }
 
 /// Build the analysis metadata from collected atomic flags and timing data.
@@ -574,7 +577,18 @@ pub(crate) fn build_metadata(
         discovery_module_stats: Vec::new(),
         mcmc_diagnostics: params.mcmc_summary.clone(),
         // Issue #1129: populated by orchestration after metadata is built.
-        rejection_breakdown: crate::analysis::diagnostics::RejectionBreakdown::new(),
+        //
+        // Issue #1143: seed the breakdown with the target-saturated drop
+        // count here so it survives `aggregate_synapse_rejection_breakdown`,
+        // which only appends per-target `no_candidate_reasons`.
+        rejection_breakdown: {
+            let mut b = crate::analysis::diagnostics::RejectionBreakdown::new();
+            b.record_many_u32(
+                crate::analysis::diagnostics::rejection_reasons::REJECTION_TARGET_SATURATED,
+                params.target_saturated_drops,
+            );
+            b
+        },
         top_level_summary: None,
         // Issue #1131: per-creature calibration corrections derived from failure cache.
         calibration_corrections: params.calibration_corrections.clone(),

--- a/src/analysis/synapse/results.rs
+++ b/src/analysis/synapse/results.rs
@@ -88,6 +88,7 @@ pub(super) fn finalise_synapse_results(
         timing_collector: &params.timing_collector,
         mcmc_summary: Some(params.mcmc_summary),
         calibration_corrections: pp_metrics.calibration_corrections,
+        target_saturated_drops: params.diagnostics.target_saturated_drop_count(),
     });
 
     Ok(AnalyzeSynapsesResult {

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -292,13 +292,37 @@ pub(crate) fn analyse_single_target(
     );
 
     // Pre-filter sources and collect their records
-    let (sources_to_process, existing_sources_to_process) = statistics::filter_and_load_sources(
+    let (mut sources_to_process, existing_sources_to_process) = statistics::filter_and_load_sources(
         &eligible_sources,
         target_uuid,
         cache,
         ctx,
         &mut results.input_metadata,
     );
+
+    // Issue #1143: When the target neuron is already saturated (its observed
+    // activation covers the full bounded range of its squash), adding a new
+    // upstream edge cannot produce a usable gradient — the target cannot
+    // move. Drop all new-edge sources for this target while preserving
+    // existing-edge weight-update candidates (those can still adjust the
+    // existing contribution without introducing new input). See
+    // `compute_target_saturation` in `neuron/preparation.rs`.
+    if !sources_to_process.is_empty() {
+        let target_saturation = ctx.neuron_squash_map.get(target_uuid).map_or(
+            crate::analysis::neuron::preparation::TargetSaturationInfo::NOT_SATURATED,
+            |squash| {
+                crate::analysis::neuron::preparation::compute_target_saturation(
+                    target_records,
+                    squash,
+                )
+            },
+        );
+        if target_saturation.rejects_candidates() {
+            let dropped = u32::try_from(sources_to_process.len()).unwrap_or(u32::MAX);
+            ctx.diagnostics.record_target_saturated_drops(dropped);
+            sources_to_process.clear();
+        }
+    }
 
     // Build target map once, reuse for all sources
     let target_map = TargetMap::from_records(target_records);


### PR DESCRIPTION
## Summary

Extends the target-saturation pre-check introduced in PR #1116 to the indirect
add-neuron path so it fires regardless of the candidate / intermediate squash.
Previously the gate only suppressed the narrow `compounds_target_clipping`
case (e.g. `ABSOLUTE` feeding into `HARD_TANH`) and otherwise applied a soft
discount; a saturated `HARD_TANH` output could still attract
`ArcTan` or `BENT_IDENTITY` intermediate proposals that produced no usable
gradient (GRQ-sampler commit `744ac60d`, candidates
`v2_add-neurons_neuron-921689429_output-0_ArcTan_*` and `…_BENT_IDENTITY_*`,
actual Δerror ≈ `-2.0e-5`). Closes #1143.

The gate now keys solely off the target neuron's observed activation range
versus its bounded squash output range — the candidate/intermediate squash is
irrelevant. The same check also runs at the top of
`analyse_single_target` for synapse analysis so new add-synapse edges into a
saturated target are dropped (existing-edge weight updates are preserved).
Drops surface in the structured rejection breakdown under the new
`REJECTION_TARGET_SATURATED` reason on both `neuronMetadata` and
`synapseMetadata`.

### Changes

- `src/analysis/neuron/preparation.rs` — new `TargetSaturationInfo::rejects_candidates()` helper (squash-agnostic); module re-exported as `pub(crate)` so the synapse path can reuse `compute_target_saturation`.
- `src/analysis/neuron/evaluation.rs` — hard-reject every activation-spec and ReLU-split candidate when `rejects_candidates()` is true, recording the drop count on `NeuronDiagnostics`.
- `src/analysis/diagnostics/neuron_tracking.rs` / `…/rejection.rs` — added `target_saturated_drops` atomic counter plus `record_target_saturated_drops` / `target_saturated_drop_count` accessors on both `NeuronDiagnostics` and `TargetDiagnostics`.
- `src/analysis/diagnostics/rejection_reasons.rs` — added `REJECTION_TARGET_SATURATED` constant, friendly-reason mapping, and entry in `ALL_REJECTION_REASONS`.
- `src/analysis/neuron/post_processing.rs` / `src/analysis/synapse/{post_processing,results}.rs` — surface the per-phase drop counts in `rejection_breakdown`.
- `src/analysis/synapse/target_analysis/mod.rs` — evaluate saturation once per target and clear `sources_to_process` (new edges) when the target is saturated, keeping `existing_sources_to_process` untouched.

## Evidence

Backend/CLI change — no UI. Verification via unit tests in
`src/analysis/neuron/preparation.rs`:

- `test_saturated_target_rejects_arctan_intermediate` — (a) saturated
  `HARD_TANH` + `ArcTan` → rejected.
- `test_saturated_target_rejects_all_intermediates` — (b) saturated
  `HARD_TANH` + any of `ArcTan`, `BENT_IDENTITY`, `IDENTITY`, `RELU`, `TANH`,
  `LOGISTIC`, `GELU`, `SOFTSIGN` → rejected (the gate is squash-independent).
- `test_non_saturated_target_keeps_candidates` — (c) narrow-range `TANH`
  target + any intermediate → kept.
- `test_unbounded_target_never_rejects` — unbounded `IDENTITY` target cannot
  saturate.
- `test_not_saturated_sentinel_keeps_candidates` — default sentinel path.

Full `cargo test --lib` (871 tests) and `cargo test --tests` suites pass.
`cargo clippy --all-targets --all-features -- -D warnings` is clean.

## Test Plan

- Unit: `cargo test --lib analysis::neuron::preparation::tests` — 15 tests pass, including the 5 new Issue #1143 cases.
- Regression: `cargo test --lib` — 871 / 871 pass; integration suites
  (`cargo test --tests`) all green.
- Rejection-breakdown contract: `cargo test --lib analysis::diagnostics::rejection_reasons` passes with the new
  constant listed in `ALL_REJECTION_REASONS`.
- Quality gate: `./quality.sh` (shellcheck → clippy -D warnings → check →
  test → docs → release build).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1143 -->