### PR TITLE
Per-(change_type, target_squash) calibration tracking from failure cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.26"
+version = "0.74.27"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1162.md
+++ b/docs/pr-summary-1162.md
@@ -1,0 +1,90 @@
+## Summary
+
+Extends the calibration-correction pipeline (Issue #1131) to track failures
+per `(change_type, target_squash)` in addition to the existing per
+`change_type` layer. When the failure-cache JSON includes
+`targetNeuronInfo.squash`, the pipeline now learns activation-specific
+corrections — e.g. `add-neurons` against `SELU` targets gets a much smaller
+multiplier than the generic `add-neurons` group, matching the GRQ-sampler
+evidence where every recent failure clustered on a single SELU target.
+
+Closes #1162.
+
+## Evidence
+
+This is a backend / scoring change with no UI surface. Coverage is via
+`cargo test`:
+
+- `cargo test --lib calibration_correction` — 16 unit tests pass, including
+  the seven new tests for the per-(change_type, target_squash) layer.
+- `cargo test --test analysis issue_1162` — 6 integration tests pass.
+- `./quality.sh` — full quality gate (fmt, clippy, deny, doc, release
+  build, all unit + integration tests) passes cleanly.
+
+```mermaid
+flowchart LR
+    A[FailureCacheEntry JSON] -->|targetNeuronInfo.squash| B[FailureCacheEntry]
+    B --> C[from_failure_cache]
+    C --> D[per change_type EWMA]
+    C --> E["per (change_type, target_squash) EWMA<br/>≥ MIN_SPECIFIC_TARGET_SQUASH_SAMPLES"]
+    F[Candidate post-processing] -->|to/target uuid + creature.squash| G[correction_for change_type, target_squash]
+    G -->|specific available?| E
+    G -->|fallback| D
+    G -->|neither| H[NEUTRAL_CORRECTION = 1.0]
+```
+
+## Changes
+
+- `src/analysis/scoring/calibration_correction.rs`
+  - `FailureCacheEntry` gains `target_squash: Option<String>`. JSON parsing
+    accepts the upstream `targetNeuronInfo.squash` shape via a private
+    `FailureCacheEntryRaw` helper, with a top-level `targetSquash` fallback.
+    Legacy entries without target metadata still parse — backward
+    compatible at the FFI boundary.
+  - `CalibrationCorrection` now carries two layers: the existing
+    per-`change_type` map plus a per-(`change_type`, `target_squash`) map
+    that is only populated for groups with at least
+    `MIN_SPECIFIC_TARGET_SQUASH_SAMPLES` (= 3) usable entries.
+  - New `correction_for(change_type, target_squash) -> f32` returns the
+    specific value when available, otherwise the per-`change_type`
+    fallback, otherwise `NEUTRAL_CORRECTION` (= 1.0).
+  - `specific_as_map()` exposes the new layer for diagnostic tests; the
+    public FFI metadata still emits the per-`change_type` map only.
+- `src/analysis/neuron/post_processing.rs` and
+  `src/analysis/synapse/post_processing.rs` build a `uuid -> squash` map
+  from the input creature and call `correction_for(...)` — replacing every
+  `get_correction(change_type)` call site for `add-neurons`,
+  `add-synapses`, and `coordinated-structural`.
+
+## Test Plan
+
+New unit tests (`src/analysis/scoring/calibration_correction.rs`):
+
+- `only_change_type_data_is_used_as_fallback` — no specific data → lookups
+  match the per-`change_type` EWMA.
+- `specific_data_is_preferred_when_threshold_is_met` — SELU-specific group
+  with ≥ threshold entries returns its own EWMA, smaller than the fallback.
+- `insufficient_specific_samples_fall_back_to_change_type` — below the
+  threshold the specific bucket is dropped; lookup falls back.
+- `nan_and_zero_divisor_specific_entries_are_skipped` — non-finite ratios
+  do not count toward the sample threshold.
+- `target_squash_parsed_from_target_neuron_info` — JSON round-trip from
+  `targetNeuronInfo.squash` populates `target_squash`.
+- `target_squash_optional_for_legacy_entries` — entries without target
+  metadata still parse as `None`.
+- `correction_for_returns_neutral_when_nothing_known` — empty cache
+  lookups return 1.0.
+
+New integration tests
+(`tests/analysis/issue_1162_calibration_per_target_squash.rs`):
+
+- `change_type_only_data_falls_back_for_any_squash`
+- `specific_correction_is_distinct_from_change_type_fallback`
+- `below_threshold_specific_entries_are_ignored`
+- `nan_and_zero_divisor_specific_entries_skipped`
+- `json_target_neuron_info_round_trip`
+- `empty_cache_lookup_returns_neutral`
+
+Existing `issue_1131_calibration_correction.rs` tests still pass — the
+struct-literal call sites were updated with `target_squash: None` to keep
+the previous behaviour exactly.

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -67,11 +67,23 @@ pub(crate) fn build_neuron_results(
         params.input.failure_cache.as_deref().unwrap_or(&[]),
     );
 
+    // Issue #1162: build a uuid -> target squash map so per-candidate
+    // calibration can prefer the (change_type, target_squash) specific
+    // correction when enough failure-cache evidence is available.
+    let target_squash_map: HashMap<&str, &str> = params
+        .input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
+        .collect();
+
     // Issue #128: Apply impact-based discounting and set creature-level metrics.
     apply_impact_discounting(
         &mut helpful_results,
         params.order_map,
         params.neuron_type_map,
+        &target_squash_map,
         params.input,
         params.cache,
         &calibration_correction,
@@ -201,6 +213,7 @@ fn apply_impact_discounting(
     helpful_results: &mut [CandidateNeuronJson],
     order_map_arc: &Arc<HashMap<super::preparation::SharedUuid, usize>>,
     neuron_type_map: &HashMap<super::preparation::SharedUuid, String>,
+    target_squash_map: &HashMap<&str, &str>,
     input: &AnalyzeNeuronsInput,
     cache: &Arc<RecordCache>,
     calibration_correction: &CalibrationCorrection,
@@ -262,8 +275,16 @@ fn apply_impact_discounting(
         // Issue #1131: Multiplied by the per-creature calibration correction derived
         // from the failure cache so creatures with poor recent prediction accuracy
         // receive additional discounting.
+        //
+        // Issue #1162: prefer the per-(change_type, target_squash) specific
+        // correction when enough failure-cache evidence has accumulated for
+        // this candidate's target squash, otherwise fall back to the
+        // per-change_type correction.
+        let target_squash = target_squash_map
+            .get(candidate.target_neuron_uuid.as_str())
+            .copied();
         let neuron_calibration = crate::analysis::constants::NEURON_PREDICTION_CALIBRATION
-            * calibration_correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+            * calibration_correction.correction_for(CHANGE_TYPE_ADD_NEURONS, target_squash);
         candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
             candidate.expected_creature_score_gain,
             candidate.improved_count,

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -1,4 +1,4 @@
-//! Per-change-type prediction calibration correction (Issue #1131).
+//! Per-change-type prediction calibration correction (Issue #1131, #1162).
 //!
 //! The compiled calibration constants (`NEURON_PREDICTION_CALIBRATION`,
 //! `SYNAPSE_PREDICTION_CALIBRATION`, `COORDINATED_PREDICTION_CALIBRATION`) are
@@ -15,6 +15,22 @@
 //! overrides the constant, and it is floored at
 //! [`MIN_CALIBRATION_CORRECTION`] so a run of failures cannot collapse
 //! predictions to zero.
+//!
+//! ## Per-(change-type, target-squash) tracking (Issue #1162)
+//!
+//! In practice the prediction-vs-actual gap depends strongly on the target
+//! neuron's activation function. Failures against an unbounded squash like
+//! `SELU` can over-estimate by 1000× while bounded squashes such as
+//! `HARD_TANH` over-estimate by a much smaller factor. Grouping failure
+//! entries by `change_type` alone loses that signal.
+//!
+//! When the failure-cache entries supply `targetNeuronInfo.squash`, this
+//! module also computes a *specific* correction keyed by
+//! `(change_type, target_squash)`. The lookup
+//! [`CalibrationCorrection::correction_for`] returns the specific value
+//! when at least [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] usable entries are
+//! available, otherwise it falls back to the per-`change_type` correction,
+//! and finally to [`NEUTRAL_CORRECTION`] (= 1.0) when neither is known.
 //!
 //! # Formula
 //!
@@ -66,6 +82,16 @@ pub const NEUTRAL_CORRECTION: f32 = 1.0;
 /// same direction.
 pub const CALIBRATION_CORRECTION_EWMA_ALPHA: f32 = 0.3;
 
+/// Minimum number of usable failure-cache entries required for a
+/// `(change_type, target_squash)` group before its specific correction is
+/// preferred over the per-`change_type` fallback (Issue #1162).
+///
+/// Three entries is enough to establish that a (`change_type`, squash)
+/// bucket is consistently mis-calibrated without leaking a single noisy
+/// outlier into the per-candidate prediction. Smaller groups fall through
+/// to the per-`change_type` correction.
+pub const MIN_SPECIFIC_TARGET_SQUASH_SAMPLES: usize = 3;
+
 // =============================================================================
 // Change-type identifiers
 // =============================================================================
@@ -88,8 +114,15 @@ pub const CHANGE_TYPE_COORDINATED_STRUCTURAL: &str = "coordinated-structural";
 /// `change_type` identifies which prediction bucket this outcome belongs to.
 /// Stable keys (see the `CHANGE_TYPE_*` constants) let the same cache feed
 /// back into the correction for the same class of candidate next run.
+///
+/// `target_squash` is the activation function of the target neuron the
+/// candidate was applied to (Issue #1162). It is parsed from
+/// `targetNeuronInfo.squash` in the failure-cache JSON when present and is
+/// `None` for legacy entries that omit it. When supplied it lets the
+/// calibration learn that, say, `add-neurons` against `SELU` targets needs a
+/// much smaller correction multiplier than the generic `add-neurons` group.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", from = "FailureCacheEntryRaw")]
 pub struct FailureCacheEntry {
     /// Candidate classification (e.g., `add-neurons`, `add-synapses`,
     /// `coordinated-structural`). Used as the correction key.
@@ -101,6 +134,54 @@ pub struct FailureCacheEntry {
     /// What actually happened — the post-apply `actualErrorReduction`. May be
     /// negative for candidates that harmed the network.
     pub actual_error_reduction: f32,
+
+    /// Target neuron's activation function (squash), when reported by the
+    /// upstream emitter. Populated from `targetNeuronInfo.squash` in the
+    /// failure-cache JSON, or from a top-level `targetSquash` field.
+    /// `None` for entries that lack target metadata, preserving backward
+    /// compatibility (Issue #1162).
+    #[serde(default)]
+    pub target_squash: Option<String>,
+}
+
+/// Wire-format helper for [`FailureCacheEntry`] (Issue #1162).
+///
+/// Allows the failure JSON to either nest the squash under
+/// `targetNeuronInfo` (the upstream NEAT-AI shape) or supply a top-level
+/// `targetSquash` field, while keeping the in-memory struct flat.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FailureCacheEntryRaw {
+    change_type: String,
+    expected_error_reduction: f32,
+    actual_error_reduction: f32,
+    #[serde(default)]
+    target_neuron_info: Option<TargetNeuronInfoRaw>,
+    #[serde(default)]
+    target_squash: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TargetNeuronInfoRaw {
+    #[serde(default)]
+    squash: Option<String>,
+}
+
+impl From<FailureCacheEntryRaw> for FailureCacheEntry {
+    fn from(raw: FailureCacheEntryRaw) -> Self {
+        // Prefer an explicit top-level `targetSquash`, fall back to the
+        // nested `targetNeuronInfo.squash` shape that NEAT-AI emits.
+        let target_squash = raw
+            .target_squash
+            .or_else(|| raw.target_neuron_info.and_then(|info| info.squash));
+        Self {
+            change_type: raw.change_type,
+            expected_error_reduction: raw.expected_error_reduction,
+            actual_error_reduction: raw.actual_error_reduction,
+            target_squash,
+        }
+    }
 }
 
 // =============================================================================
@@ -113,9 +194,22 @@ pub struct FailureCacheEntry {
 /// A value of 0.001 (the floor) means "this change-type has been over-estimating
 /// so much recently that predictions should be heavily discounted beyond
 /// the compiled constant".
+///
+/// Two layers of correction are tracked (Issue #1162):
+///
+/// - `corrections` — keyed by `change_type` alone. Computed from every
+///   usable entry of that change-type. This is the **fallback** layer used
+///   when no specific correction is available for the requested target
+///   squash.
+/// - `specific_corrections` — keyed by `(change_type, target_squash)`.
+///   Only populated for groups with at least
+///   [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] usable entries, so that a single
+///   noisy outcome cannot dominate per-candidate calibration. This is the
+///   **specific** layer queried by [`Self::correction_for`].
 #[derive(Debug, Clone, Default)]
 pub struct CalibrationCorrection {
     corrections: HashMap<String, f32>,
+    specific_corrections: HashMap<(String, String), f32>,
 }
 
 impl CalibrationCorrection {
@@ -129,19 +223,28 @@ impl CalibrationCorrection {
     ///
     /// # Algorithm
     ///
-    /// 1. Group entries by `change_type`.
-    /// 2. Skip entries with `expected_error_reduction == 0` (undefined ratio).
-    /// 3. For each group, compute an EWMA of `actual / expected` in the order
-    ///    supplied. Callers pass entries oldest-first; the final EWMA value
-    ///    therefore reflects the most recent outcomes most strongly.
-    /// 4. Clamp the EWMA to `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]`.
+    /// 1. Group entries by `change_type` (fallback layer) and by
+    ///    `(change_type, target_squash)` (specific layer, Issue #1162).
+    /// 2. Skip entries with `expected_error_reduction == 0` (undefined ratio)
+    ///    and entries whose ratio is non-finite.
+    /// 3. For each group, compute an EWMA of `actual / expected` in the
+    ///    order supplied. Callers pass entries oldest-first; the final EWMA
+    ///    value therefore reflects the most recent outcomes most strongly.
+    /// 4. Clamp the EWMA to
+    ///    `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]`.
+    /// 5. Only specific groups with at least
+    ///    [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] usable entries are kept; the
+    ///    rest fall through to the per-`change_type` fallback at lookup.
     ///
     /// Empty caches, or caches with no usable entries for a change-type,
     /// produce a [`Self::neutral`] correction for that change-type on lookup.
     #[must_use]
     pub fn from_failure_cache(cache: &[FailureCacheEntry]) -> Self {
-        // Group entries by change_type, preserving supplied order within each group.
+        // Group entries by change_type (fallback) and by (change_type,
+        // target_squash) (specific), preserving supplied order within each
+        // group so the EWMA reflects oldest -> newest.
         let mut grouped: HashMap<&str, Vec<f32>> = HashMap::new();
+        let mut grouped_specific: HashMap<(&str, &str), Vec<f32>> = HashMap::new();
         for entry in cache {
             // Skip entries with undefined ratios.
             if entry.expected_error_reduction == 0.0 {
@@ -156,6 +259,12 @@ impl CalibrationCorrection {
                 .entry(entry.change_type.as_str())
                 .or_default()
                 .push(ratio);
+            if let Some(squash) = entry.target_squash.as_deref() {
+                grouped_specific
+                    .entry((entry.change_type.as_str(), squash))
+                    .or_default()
+                    .push(ratio);
+            }
         }
 
         let mut corrections: HashMap<String, f32> = HashMap::new();
@@ -165,7 +274,23 @@ impl CalibrationCorrection {
             corrections.insert(change_type.to_string(), clamped);
         }
 
-        Self { corrections }
+        let mut specific_corrections: HashMap<(String, String), f32> = HashMap::new();
+        for ((change_type, squash), ratios) in grouped_specific {
+            // Issue #1162: only retain specific corrections backed by enough
+            // samples; smaller groups fall through to the per-change_type
+            // fallback at lookup time.
+            if ratios.len() < MIN_SPECIFIC_TARGET_SQUASH_SAMPLES {
+                continue;
+            }
+            let ewma = ewma(&ratios, CALIBRATION_CORRECTION_EWMA_ALPHA);
+            let clamped = ewma.clamp(MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION);
+            specific_corrections.insert((change_type.to_string(), squash.to_string()), clamped);
+        }
+
+        Self {
+            corrections,
+            specific_corrections,
+        }
     }
 
     /// Look up the correction factor for a given change-type.
@@ -173,6 +298,9 @@ impl CalibrationCorrection {
     /// Returns [`NEUTRAL_CORRECTION`] (1.0) when the change-type is absent —
     /// this preserves the compiled calibration constant unchanged for
     /// change-types with no recent failure data.
+    ///
+    /// This is the per-`change_type` fallback. Prefer
+    /// [`Self::correction_for`] when the candidate's target squash is known.
     #[must_use]
     pub fn get_correction(&self, change_type: &str) -> f32 {
         self.corrections
@@ -181,11 +309,47 @@ impl CalibrationCorrection {
             .unwrap_or(NEUTRAL_CORRECTION)
     }
 
+    /// Look up the most specific available correction factor (Issue #1162).
+    ///
+    /// Resolution order:
+    ///
+    /// 1. If `target_squash` is supplied **and** at least
+    ///    [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] usable failure-cache entries
+    ///    exist for `(change_type, target_squash)`, return that specific
+    ///    correction.
+    /// 2. Otherwise, return the per-`change_type` correction (existing
+    ///    behaviour).
+    /// 3. Otherwise, return [`NEUTRAL_CORRECTION`] (= 1.0) so the compiled
+    ///    calibration constant is used unchanged.
+    ///
+    /// Callers should pass `None` for `target_squash` when the candidate's
+    /// target squash is unknown.
+    #[must_use]
+    pub fn correction_for(&self, change_type: &str, target_squash: Option<&str>) -> f32 {
+        if let Some(squash) = target_squash
+            && let Some(value) = self
+                .specific_corrections
+                .get(&(change_type.to_string(), squash.to_string()))
+                .copied()
+        {
+            return value;
+        }
+        self.get_correction(change_type)
+    }
+
     /// Returns a reference to the underlying correction map, for metadata
     /// export at the FFI boundary.
     #[must_use]
     pub fn as_map(&self) -> &HashMap<String, f32> {
         &self.corrections
+    }
+
+    /// Returns a reference to the per-(`change_type`, `target_squash`) map
+    /// (Issue #1162). Exposed for diagnostic tests; the FFI metadata only
+    /// includes the per-`change_type` map for backward compatibility.
+    #[must_use]
+    pub fn specific_as_map(&self) -> &HashMap<(String, String), f32> {
+        &self.specific_corrections
     }
 
     /// True when no change-type has a correction recorded.
@@ -228,6 +392,21 @@ mod tests {
             change_type: change_type.to_string(),
             expected_error_reduction: predicted,
             actual_error_reduction: actual,
+            target_squash: None,
+        }
+    }
+
+    fn entry_with_squash(
+        change_type: &str,
+        predicted: f32,
+        actual: f32,
+        squash: &str,
+    ) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: change_type.to_string(),
+            expected_error_reduction: predicted,
+            actual_error_reduction: actual,
+            target_squash: Some(squash.to_string()),
         }
     }
 
@@ -359,6 +538,177 @@ mod tests {
         assert!(
             (value - NEUTRAL_CORRECTION).abs() < 1e-9,
             "expected NEUTRAL_CORRECTION (=1.0), got {value}"
+        );
+    }
+
+    // =========================================================================
+    // Issue #1162 — per-(change_type, target_squash) calibration tracking
+    // =========================================================================
+
+    #[test]
+    fn only_change_type_data_is_used_as_fallback() {
+        // No entry carries a target_squash, so the specific layer is empty
+        // and `correction_for` falls back to the per-change_type value.
+        let cache: Vec<FailureCacheEntry> = (0..6)
+            .map(|_| entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.4))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        assert!(correction.specific_as_map().is_empty());
+
+        // Specific lookup with any squash falls back to the change_type EWMA.
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+        assert!(
+            (value - 0.4).abs() < 1e-6,
+            "expected fallback ≈ 0.4, got {value}"
+        );
+
+        // Without a target_squash the result also matches the change_type EWMA.
+        let none_value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, None);
+        assert!((none_value - 0.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn specific_data_is_preferred_when_threshold_is_met() {
+        // Three or more entries against SELU establish a specific correction
+        // distinct from the change_type fallback.
+        let mut cache = vec![
+            // Generic add-neurons history dominated by mid-range outcomes.
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+        ];
+        // SELU-specific entries that consistently massively over-estimate.
+        for _ in 0..MIN_SPECIFIC_TARGET_SQUASH_SAMPLES {
+            cache.push(entry_with_squash(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                "SELU",
+            ));
+        }
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+        // Generic fallback reflects the union of both groups (SELU entries
+        // also feed the per-change_type EWMA), but `correction_for(SELU)`
+        // must return the SELU-specific value (≈ 0.001) rather than the
+        // higher fallback.
+        let selu = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+        assert!(
+            (selu - 0.001).abs() < 1e-4,
+            "expected SELU-specific ≈ 0.001, got {selu}"
+        );
+
+        // A different squash with no specific data falls back.
+        let fallback = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("HARD_TANH"));
+        let direct_fallback = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!(
+            (fallback - direct_fallback).abs() < 1e-9,
+            "expected HARD_TANH to fall back to {direct_fallback}, got {fallback}"
+        );
+        // The fallback should be larger than the SELU-specific value.
+        assert!(
+            fallback > selu,
+            "fallback ({fallback}) should exceed SELU-specific ({selu})"
+        );
+    }
+
+    #[test]
+    fn insufficient_specific_samples_fall_back_to_change_type() {
+        // Fewer than MIN_SPECIFIC_TARGET_SQUASH_SAMPLES SELU entries — the
+        // specific bucket must NOT be retained, even though the data exists.
+        const _: () = assert!(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES >= 2);
+        let mut cache = vec![
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5),
+        ];
+        for _ in 0..(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES - 1) {
+            cache.push(entry_with_squash(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                "SELU",
+            ));
+        }
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        assert!(
+            correction.specific_as_map().is_empty(),
+            "specific corrections must not be retained below the sample threshold"
+        );
+
+        // Lookup with the SELU squash returns the per-change_type fallback.
+        let lookup = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+        let fallback = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!(
+            (lookup - fallback).abs() < 1e-9,
+            "expected fallback {fallback}, got {lookup}"
+        );
+    }
+
+    #[test]
+    fn nan_and_zero_divisor_specific_entries_are_skipped() {
+        // The two zero / non-finite entries against SELU must NOT count toward
+        // the sample threshold, so the SELU-specific bucket stays empty and
+        // lookups fall back to the per-change_type value.
+        let cache = vec![
+            // Zero predicted -> undefined ratio.
+            entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 0.0, 0.0, "SELU"),
+            // Non-finite ratio.
+            entry_with_squash(CHANGE_TYPE_ADD_NEURONS, f32::MIN_POSITIVE, f32::MAX, "SELU"),
+            // One legitimate SELU entry — still below the threshold.
+            entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.001, "SELU"),
+            // Generic change_type entries to seed the fallback.
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.4),
+            entry(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.4),
+        ];
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        assert!(
+            correction.specific_as_map().is_empty(),
+            "non-finite / zero entries must not count toward the specific threshold"
+        );
+
+        let lookup = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+        let fallback = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+        assert!(
+            (lookup - fallback).abs() < 1e-9,
+            "non-finite / zero specific entries must not affect lookup"
+        );
+    }
+
+    #[test]
+    fn target_squash_parsed_from_target_neuron_info() {
+        // Issue #1162: failure-cache JSON nests squash under
+        // `targetNeuronInfo.squash`. Round-trip a representative payload.
+        let json = r#"{
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001,
+            "targetNeuronInfo": { "squash": "SELU" }
+        }"#;
+        let parsed: FailureCacheEntry = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.change_type, CHANGE_TYPE_ADD_NEURONS);
+        assert_eq!(parsed.target_squash.as_deref(), Some("SELU"));
+    }
+
+    #[test]
+    fn target_squash_optional_for_legacy_entries() {
+        // Legacy entries that omit `targetNeuronInfo` must still parse.
+        let json = r#"{
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001
+        }"#;
+        let parsed: FailureCacheEntry = serde_json::from_str(json).expect("parse");
+        assert!(parsed.target_squash.is_none());
+    }
+
+    #[test]
+    fn correction_for_returns_neutral_when_nothing_known() {
+        let correction = CalibrationCorrection::neutral();
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION, got {value}"
         );
     }
 

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -123,10 +123,12 @@ fn compute_neuron_error_sq_map<'a>(
 /// and `expected_creature_score_gain` based on the target neuron's distance
 /// from outputs. Also applies creature-level error fraction scaling (Issue #730)
 /// and source-type and target-type boosts (Issues #467, #468).
+#[allow(clippy::too_many_arguments)]
 fn apply_impact_to_helpful(
     candidate: &mut CandidateSynapseJson,
     impact_scores: &HashMap<String, f32>,
     neuron_type_map: &HashMap<&str, &str>,
+    target_squash_map: &HashMap<&str, &str>,
     order_map: &HashMap<String, usize>,
     target_error_sq: f32,
     total_error_sq: f32,
@@ -202,8 +204,15 @@ fn apply_impact_to_helpful(
     // Issue #1131: Multiplied by the per-creature calibration correction derived
     // from the failure cache, so creatures drifting from the global baseline
     // receive additional per-creature discounting.
+    //
+    // Issue #1162: prefer the per-(change_type, target_squash) specific
+    // correction when enough failure-cache evidence is available; otherwise
+    // fall back to the per-change_type correction.
+    let target_squash = target_squash_map
+        .get(candidate.to_neuron_uuid.as_str())
+        .copied();
     let synapse_calibration = crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION
-        * calibration_correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+        * calibration_correction.correction_for(CHANGE_TYPE_ADD_SYNAPSES, target_squash);
     candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
@@ -227,6 +236,7 @@ fn apply_impact_to_harmful(
     candidate: &mut CandidateSynapseJson,
     impact_scores: &HashMap<String, f32>,
     neuron_type_map: &HashMap<&str, &str>,
+    target_squash_map: &HashMap<&str, &str>,
     order_map: &HashMap<String, usize>,
     calibration_correction: &CalibrationCorrection,
 ) {
@@ -262,8 +272,12 @@ fn apply_impact_to_harmful(
 
     // Issue #1056: Apply logistic prediction calibration to harmful candidates.
     // Issue #1131: Scaled by the per-creature failure-cache correction.
+    // Issue #1162: prefer the per-(change_type, target_squash) specific value.
+    let target_squash = target_squash_map
+        .get(candidate.to_neuron_uuid.as_str())
+        .copied();
     let synapse_calibration = crate::analysis::constants::SYNAPSE_PREDICTION_CALIBRATION
-        * calibration_correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+        * calibration_correction.correction_for(CHANGE_TYPE_ADD_SYNAPSES, target_squash);
     candidate.expected_creature_score_gain = apply_logistic_prediction_calibration(
         candidate.expected_creature_score_gain,
         candidate.improved_count,
@@ -286,6 +300,7 @@ fn apply_impact_to_coordinated(
     candidate: &mut crate::CoordinatedStructuralCandidateJson,
     impact_scores: &HashMap<String, f32>,
     neuron_type_map: &HashMap<&str, &str>,
+    target_squash_map: &HashMap<&str, &str>,
     calibration_correction: &CalibrationCorrection,
 ) {
     let target_uuid = candidate
@@ -334,8 +349,11 @@ fn apply_impact_to_coordinated(
     // Issue #1056: Apply coordinated prediction calibration.
     // Coordinated candidates lack per-sample improved counts, so use flat calibration.
     // Issue #1131: Scaled by the per-creature failure-cache correction.
+    // Issue #1162: prefer the per-(change_type, target_squash) specific value
+    // when the target neuron's squash is known.
+    let target_squash = target_squash_map.get(target_uuid).copied();
     let coordinated_calibration = crate::analysis::constants::COORDINATED_PREDICTION_CALIBRATION
-        * calibration_correction.get_correction(CHANGE_TYPE_COORDINATED_STRUCTURAL);
+        * calibration_correction.correction_for(CHANGE_TYPE_COORDINATED_STRUCTURAL, target_squash);
     candidate.expected_creature_score_gain = apply_prediction_calibration(
         candidate.expected_creature_score_gain,
         coordinated_calibration,
@@ -364,6 +382,16 @@ pub(crate) fn apply_post_processing(
         .map(|n| (n.uuid.as_str(), n.neuron_type.as_str()))
         .collect();
 
+    // Issue #1162: uuid -> target squash map. Used so per-candidate
+    // calibration can prefer the (change_type, target_squash) specific
+    // correction when the failure-cache supplies enough evidence.
+    let target_squash_map: HashMap<&str, &str> = input
+        .creature
+        .neurons
+        .iter()
+        .map(|n| (n.uuid.as_str(), n.squash.as_str()))
+        .collect();
+
     // Issue #730: Compute per-neuron and total error for creature-level calibration.
     let error_sq_map = compute_neuron_error_sq_map(input, cache);
     let total_error_sq: f32 = error_sq_map.values().sum();
@@ -385,6 +413,7 @@ pub(crate) fn apply_post_processing(
             candidate,
             &impact_scores,
             &neuron_type_map,
+            &target_squash_map,
             order_map,
             target_error_sq,
             total_error_sq,
@@ -398,6 +427,7 @@ pub(crate) fn apply_post_processing(
             candidate,
             &impact_scores,
             &neuron_type_map,
+            &target_squash_map,
             order_map,
             &calibration_correction,
         );
@@ -409,6 +439,7 @@ pub(crate) fn apply_post_processing(
             candidate,
             &impact_scores,
             &neuron_type_map,
+            &target_squash_map,
             &calibration_correction,
         );
     }

--- a/tests/analysis/issue_1131_calibration_correction.rs
+++ b/tests/analysis/issue_1131_calibration_correction.rs
@@ -116,6 +116,7 @@ fn twenty_over_estimations_clamp_to_minimum_correction() {
             change_type: CHANGE_TYPE_ADD_NEURONS.to_string(),
             expected_error_reduction: 0.001,
             actual_error_reduction: 0.000_001,
+            target_squash: None,
         })
         .collect();
     let correction = CalibrationCorrection::from_failure_cache(&cache);
@@ -152,6 +153,7 @@ fn analyze_all_exposes_calibration_corrections_in_metadata() {
                 change_type: change_type.to_string(),
                 expected_error_reduction: 0.001,
                 actual_error_reduction: 0.000_001,
+                target_squash: None,
             });
         }
     }
@@ -239,6 +241,7 @@ fn calibration_corrections_are_deterministic() {
             expected_error_reduction: 0.01,
             // Vary slightly so the EWMA is a non-trivial value.
             actual_error_reduction: 0.002 + (i as f32) * 0.000_05,
+            target_squash: None,
         })
         .collect();
 

--- a/tests/analysis/issue_1162_calibration_per_target_squash.rs
+++ b/tests/analysis/issue_1162_calibration_per_target_squash.rs
@@ -1,0 +1,179 @@
+//! Integration tests for Issue #1162: per-(`change_type`, `target_squash`)
+//! calibration tracking from the failure cache.
+//!
+//! These tests cover the public surface of
+//! [`CalibrationCorrection::correction_for`] (the lookup wired into the
+//! synapse and neuron post-processing passes) and the JSON parsing of the
+//! optional `targetNeuronInfo.squash` field.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_ADD_NEURONS, CHANGE_TYPE_ADD_SYNAPSES, CalibrationCorrection, FailureCacheEntry,
+    MIN_SPECIFIC_TARGET_SQUASH_SAMPLES,
+};
+
+fn entry_with_squash(
+    change_type: &str,
+    predicted: f32,
+    actual: f32,
+    squash: Option<&str>,
+) -> FailureCacheEntry {
+    FailureCacheEntry {
+        change_type: change_type.to_string(),
+        expected_error_reduction: predicted,
+        actual_error_reduction: actual,
+        target_squash: squash.map(str::to_string),
+    }
+}
+
+/// Acceptance: when only `change_type` data is supplied (no target squash),
+/// `correction_for` falls back to the per-`change_type` value for any squash.
+#[test]
+fn change_type_only_data_falls_back_for_any_squash() {
+    let cache: Vec<FailureCacheEntry> = (0..6)
+        .map(|_| entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.25, None))
+        .collect();
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+    assert!(correction.specific_as_map().is_empty());
+
+    // Per-change_type EWMA dominates because no specific data is recorded.
+    let baseline = correction.get_correction(CHANGE_TYPE_ADD_NEURONS);
+    let with_squash = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+    let without_squash = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, None);
+    assert!((with_squash - baseline).abs() < 1e-9);
+    assert!((without_squash - baseline).abs() < 1e-9);
+}
+
+/// Acceptance: with enough specific data, `correction_for(SELU)` returns a
+/// stronger discount than the per-`change_type` fallback for an unrelated
+/// squash. This is the headline behaviour from Issue #1162's GRQ-sampler
+/// motivating example.
+#[test]
+fn specific_correction_is_distinct_from_change_type_fallback() {
+    let mut cache = vec![
+        // Change_type history: bounded squashes that recently came in close
+        // to expectation (ratio ≈ 0.8).
+        entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.8, Some("HARD_TANH")),
+        entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.8, Some("HARD_TANH")),
+        entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.8, Some("HARD_TANH")),
+    ];
+    // SELU-specific entries that consistently massively over-estimated.
+    for _ in 0..MIN_SPECIFIC_TARGET_SQUASH_SAMPLES {
+        cache.push(entry_with_squash(
+            CHANGE_TYPE_ADD_NEURONS,
+            1.0,
+            0.001,
+            Some("SELU"),
+        ));
+    }
+
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+    let selu = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+    let hard_tanh = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("HARD_TANH"));
+
+    // SELU-specific must be much smaller than the HARD_TANH-specific value.
+    assert!(
+        selu < hard_tanh,
+        "expected SELU-specific ({selu}) < HARD_TANH-specific ({hard_tanh})"
+    );
+    // SELU should be near the floor (0.001).
+    assert!(
+        selu <= 0.01,
+        "expected SELU correction near the floor, got {selu}"
+    );
+}
+
+/// Acceptance: a (`change_type`, squash) bucket below the sample threshold
+/// is ignored — `correction_for` returns the per-`change_type` fallback.
+#[test]
+fn below_threshold_specific_entries_are_ignored() {
+    let mut cache = vec![
+        entry_with_squash(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.5, None),
+        entry_with_squash(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.5, None),
+        entry_with_squash(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.5, None),
+    ];
+    // Only (MIN - 1) entries against TANH — must NOT be retained.
+    for _ in 0..(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES - 1) {
+        cache.push(entry_with_squash(
+            CHANGE_TYPE_ADD_SYNAPSES,
+            1.0,
+            0.001,
+            Some("TANH"),
+        ));
+    }
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+    assert!(correction.specific_as_map().is_empty());
+
+    let tanh_lookup = correction.correction_for(CHANGE_TYPE_ADD_SYNAPSES, Some("TANH"));
+    let baseline = correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+    assert!(
+        (tanh_lookup - baseline).abs() < 1e-9,
+        "below-threshold lookup must equal the change_type fallback"
+    );
+}
+
+/// Acceptance: zero-divisor and NaN ratios on specific entries do not count
+/// toward the sample threshold and do not pollute the EWMA.
+#[test]
+fn nan_and_zero_divisor_specific_entries_skipped() {
+    let mut cache = vec![
+        entry_with_squash(CHANGE_TYPE_ADD_SYNAPSES, 0.0, 0.0, Some("RELU")),
+        entry_with_squash(
+            CHANGE_TYPE_ADD_SYNAPSES,
+            f32::MIN_POSITIVE,
+            f32::MAX,
+            Some("RELU"),
+        ),
+    ];
+    // Add legitimate fallback data.
+    for _ in 0..3 {
+        cache.push(entry_with_squash(CHANGE_TYPE_ADD_SYNAPSES, 1.0, 0.4, None));
+    }
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+    assert!(
+        correction.specific_as_map().is_empty(),
+        "non-finite / zero specific entries must not establish a specific bucket"
+    );
+
+    let lookup = correction.correction_for(CHANGE_TYPE_ADD_SYNAPSES, Some("RELU"));
+    let baseline = correction.get_correction(CHANGE_TYPE_ADD_SYNAPSES);
+    assert!((lookup - baseline).abs() < 1e-9);
+}
+
+/// Acceptance: a failure-cache JSON entry with `targetNeuronInfo.squash`
+/// round-trips through serde into `target_squash`, and entries without it
+/// remain backward compatible.
+#[test]
+fn json_target_neuron_info_round_trip() {
+    let cache_json = r#"[
+        {
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001,
+            "targetNeuronInfo": { "squash": "SELU" }
+        },
+        {
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001
+        }
+    ]"#;
+    let parsed: Vec<FailureCacheEntry> = serde_json::from_str(cache_json).expect("parse");
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0].target_squash.as_deref(), Some("SELU"));
+    assert!(parsed[1].target_squash.is_none());
+}
+
+/// Acceptance: a fully-empty cache produces a correction that returns
+/// neutral (1.0) for every lookup, including those carrying a target squash.
+#[test]
+fn empty_cache_lookup_returns_neutral() {
+    let correction = CalibrationCorrection::from_failure_cache(&[]);
+    let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SELU"));
+    assert!((value - 1.0).abs() < 1e-9);
+    let value_no_squash = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, None);
+    assert!((value_no_squash - 1.0).abs() < 1e-9);
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -23,6 +23,7 @@ mod issue_1101_no_target_records_diagnostic;
 mod issue_1109_neuron_min_improved_ratio_raise;
 mod issue_1131_calibration_correction;
 mod issue_1132_conservative_mode;
+mod issue_1162_calibration_per_target_squash;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Extends the calibration-correction pipeline (Issue #1131) to track failures
per `(change_type, target_squash)` in addition to the existing per
`change_type` layer. When the failure-cache JSON includes
`targetNeuronInfo.squash`, the pipeline now learns activation-specific
corrections — e.g. `add-neurons` against `SELU` targets gets a much smaller
multiplier than the generic `add-neurons` group, matching the GRQ-sampler
evidence where every recent failure clustered on a single SELU target.

Closes #1162.

## Evidence

This is a backend / scoring change with no UI surface. Coverage is via
`cargo test`:

- `cargo test --lib calibration_correction` — 16 unit tests pass, including
  the seven new tests for the per-(change_type, target_squash) layer.
- `cargo test --test analysis issue_1162` — 6 integration tests pass.
- `./quality.sh` — full quality gate (fmt, clippy, deny, doc, release
  build, all unit + integration tests) passes cleanly.

```mermaid
flowchart LR
    A[FailureCacheEntry JSON] -->|targetNeuronInfo.squash| B[FailureCacheEntry]
    B --> C[from_failure_cache]
    C --> D[per change_type EWMA]
    C --> E["per (change_type, target_squash) EWMA<br/>≥ MIN_SPECIFIC_TARGET_SQUASH_SAMPLES"]
    F[Candidate post-processing] -->|to/target uuid + creature.squash| G[correction_for change_type, target_squash]
    G -->|specific available?| E
    G -->|fallback| D
    G -->|neither| H[NEUTRAL_CORRECTION = 1.0]
```

## Changes

- `src/analysis/scoring/calibration_correction.rs`
  - `FailureCacheEntry` gains `target_squash: Option<String>`. JSON parsing
    accepts the upstream `targetNeuronInfo.squash` shape via a private
    `FailureCacheEntryRaw` helper, with a top-level `targetSquash` fallback.
    Legacy entries without target metadata still parse — backward
    compatible at the FFI boundary.
  - `CalibrationCorrection` now carries two layers: the existing
    per-`change_type` map plus a per-(`change_type`, `target_squash`) map
    that is only populated for groups with at least
    `MIN_SPECIFIC_TARGET_SQUASH_SAMPLES` (= 3) usable entries.
  - New `correction_for(change_type, target_squash) -> f32` returns the
    specific value when available, otherwise the per-`change_type`
    fallback, otherwise `NEUTRAL_CORRECTION` (= 1.0).
  - `specific_as_map()` exposes the new layer for diagnostic tests; the
    public FFI metadata still emits the per-`change_type` map only.
- `src/analysis/neuron/post_processing.rs` and
  `src/analysis/synapse/post_processing.rs` build a `uuid -> squash` map
  from the input creature and call `correction_for(...)` — replacing every
  `get_correction(change_type)` call site for `add-neurons`,
  `add-synapses`, and `coordinated-structural`.

## Test Plan

New unit tests (`src/analysis/scoring/calibration_correction.rs`):

- `only_change_type_data_is_used_as_fallback` — no specific data → lookups
  match the per-`change_type` EWMA.
- `specific_data_is_preferred_when_threshold_is_met` — SELU-specific group
  with ≥ threshold entries returns its own EWMA, smaller than the fallback.
- `insufficient_specific_samples_fall_back_to_change_type` — below the
  threshold the specific bucket is dropped; lookup falls back.
- `nan_and_zero_divisor_specific_entries_are_skipped` — non-finite ratios
  do not count toward the sample threshold.
- `target_squash_parsed_from_target_neuron_info` — JSON round-trip from
  `targetNeuronInfo.squash` populates `target_squash`.
- `target_squash_optional_for_legacy_entries` — entries without target
  metadata still parse as `None`.
- `correction_for_returns_neutral_when_nothing_known` — empty cache
  lookups return 1.0.

New integration tests
(`tests/analysis/issue_1162_calibration_per_target_squash.rs`):

- `change_type_only_data_falls_back_for_any_squash`
- `specific_correction_is_distinct_from_change_type_fallback`
- `below_threshold_specific_entries_are_ignored`
- `nan_and_zero_divisor_specific_entries_skipped`
- `json_target_neuron_info_round_trip`
- `empty_cache_lookup_returns_neutral`

Existing `issue_1131_calibration_correction.rs` tests still pass — the
struct-literal call sites were updated with `target_squash: None` to keep
the previous behaviour exactly.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1162 -->