### PR TITLE
feat: within-batch target-failure short-circuit (#1164)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.27"
+version = "0.74.28"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1164.md
+++ b/docs/pr-summary-1164.md
@@ -1,0 +1,84 @@
+## Summary
+
+Within-batch target-failure short-circuit during candidate evaluation.
+Closes #1164.
+
+A new `WithinBatchFailureTracker` is created per orchestration call and shared
+across the per-target rayon workers. When a candidate targeting neuron T fails
+post-evaluation (the local model concludes no improvement), the tracker
+records the failure for T. Subsequent same-target candidates in the same
+batch consult the tracker and short-circuit when T's failure count reaches
+the configured threshold. Complements the cross-batch cooldown (#1130) by
+closing the within-batch gap that allowed several failing candidates per
+target to be emitted from one batch.
+
+The threshold is env-var overridable via
+`NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT` (default `1`). Diagnostic
+counters are surfaced via a single `tracing::info!` line per phase
+(synapse / neuron) so the operator can see budget being saved.
+
+```mermaid
+flowchart TD
+    A[Candidate evaluation] --> B{Target in failed-this-batch set?}
+    B -- yes --> C[Skip, increment skip metric]
+    B -- no --> D[Evaluate]
+    D --> E{Improved?}
+    E -- no --> F[Add target to set, record failure]
+    E -- yes --> G[Keep candidate, do not add to set]
+```
+
+### Scope decisions
+
+- **Helpful (additive) candidates only.** The synapse helpful path and the
+  neuron evaluation path consult and update the tracker. The synapse
+  **harmful** (synapse-removal) path was deliberately left independent — a
+  failed addition for T does not predict that a removal targeting T will
+  also fail; they explore different structural moves and tying them together
+  broke `issue_927_remove_harmful_synapse` coverage.
+- **Cross-batch cooldown unaffected.** The global
+  `TargetFailureTracker` (Issue #1130) keeps its existing semantics; the
+  new within-batch tracker is per-call and discarded at the end of each
+  orchestration call.
+
+## Evidence
+
+Backend / CLI change — no UI to screenshot. Verified via:
+
+- New unit tests (`src/analysis/within_batch_failures.rs::tests`) covering
+  default threshold, first-failure short-circuit, success path, threshold
+  > 1 path, skip-count accumulation, unrelated-target isolation, and the
+  zero-threshold clamp.
+- New integration tests in
+  `tests/issue_1164_within_batch_failures.rs` covering the GRQ-sampler
+  scenario from the issue (3 same-target add-neuron candidates → 1
+  evaluated, 2 short-circuited).
+- Existing per-target cooldown coverage (`issue_1130_target_cooldown`) still
+  passes; cross-batch behaviour is unchanged.
+- Full library + integration suite passes (890 lib tests, 579 analysis
+  integration tests, all other suites green) — see PR CI.
+
+### Behaviour change recorded in tests
+
+`tests/analysis/issue_221_sample_locality.rs` — three locality-batching
+tests submit 100 sources for a single target and expected at least one
+candidate. With the default within-batch limit of 1, an early-failing
+source short-circuits the rest. These tests are not exercising the
+short-circuit, so they now wrap their `analyze_synapses` call in a
+`WithinBatchLimitGuard` (sets the env var to a high number,
+`#[serial]`-protected, restored on drop). No assertions removed.
+
+## Test Plan
+
+- `cargo test --lib within_batch_failures` — new unit tests pass.
+- `cargo test --test issue_1164_within_batch_failures` — 7 acceptance
+  tests pass.
+- `cargo test --test issue_1130_target_cooldown` — cross-batch cooldown
+  unaffected.
+- `cargo test --test analysis -- --test-threads=2` — all 579 analysis
+  integration tests pass (locality tests now use the env-var guard).
+- `cargo test --test synapse issue_927_remove_harmful_synapse` —
+  remove-harmful-synapse coverage preserved by keeping the harmful path
+  independent of the tracker.
+- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
+- `cargo fmt --all -- --check` — clean.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.

--- a/src/analysis/constants/detection_thresholds.rs
+++ b/src/analysis/constants/detection_thresholds.rs
@@ -172,3 +172,24 @@ pub const TARGET_COOLDOWN_CONSECUTIVE_FAILURES: u32 = 3;
 /// landscape has meaningfully changed. Values above 100 risk stranding a
 /// target for too long.
 pub const TARGET_COOLDOWN_EPOCHS: u64 = 10;
+
+// =============================================================================
+// Within-Batch Target Failure Short-Circuit (Issue #1164)
+// =============================================================================
+
+/// Number of within-batch failures on a target before subsequent same-target
+/// candidates in the same batch are short-circuited.
+///
+/// Issue #1164: complements the cross-batch cooldown (Issue #1130) by closing
+/// the within-batch gap. In GRQ-sampler commit `8c177b7`, three add-neuron
+/// candidates all targeting `neuron-1063112866` were evaluated in the same
+/// batch — exactly the workload the target-failure tracker (Issue #1130) was
+/// created to avoid, but the per-target cooldown only persists across batches
+/// via the failure cache.
+///
+/// ## Valid Range
+/// Must be >= 1. The default of `1` causes the very next same-target candidate
+/// to be skipped after the first failure, maximising the budget saved.
+/// Larger values let more candidates be tried before the short-circuit
+/// engages. Override via `NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT`.
+pub const WITHIN_BATCH_TARGET_FAILURE_LIMIT: u32 = 1;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -55,6 +55,7 @@ pub mod synapse;
 pub mod system;
 pub mod target_failure_tracker;
 pub mod utils;
+pub mod within_batch_failures;
 
 // Thematic subdirectories (Issue #528)
 pub mod detection;

--- a/src/analysis/neuron/evaluation.rs
+++ b/src/analysis/neuron/evaluation.rs
@@ -48,6 +48,9 @@ pub(crate) struct NeuronEvalContext<'a> {
     pub threshold: f32,
     /// Target saturation info from the pre-check (Issue #1111).
     pub target_saturation: super::preparation::TargetSaturationInfo,
+    /// Issue #1164: Within-batch target-failure short-circuit tracker.
+    pub within_batch_failures:
+        &'a Arc<crate::analysis::within_batch_failures::WithinBatchFailureTracker>,
 }
 
 /// Evaluate neuron candidates for all sources with samples against a single
@@ -70,6 +73,13 @@ pub(crate) fn evaluate_neuron_candidates(
         }
 
         if result.samples.is_empty() {
+            continue;
+        }
+
+        // Issue #1164: short-circuit subsequent same-target candidates if
+        // an earlier candidate for this target failed within this batch.
+        if ctx.within_batch_failures.should_skip(target_uuid) {
+            ctx.within_batch_failures.record_skip();
             continue;
         }
 
@@ -145,6 +155,9 @@ fn evaluate_relu_split(
     if let Some(mut candidate) = split_result.positive_error_candidate {
         // Issue #733: Filter neuron candidates where insufficient samples improve.
         if !passes_neuron_improved_ratio(&candidate) {
+            // Issue #1164: a rejected candidate counts as a within-batch failure
+            // for the target so subsequent same-target candidates can be skipped.
+            ctx.within_batch_failures.record_failure(target_uuid);
             if verbose_enabled() {
                 tracing::trace!(
                     direction = "push UP",
@@ -185,6 +198,8 @@ fn evaluate_relu_split(
     if let Some(mut candidate) = split_result.negative_error_candidate {
         // Issue #733: Filter neuron candidates where insufficient samples improve.
         if !passes_neuron_improved_ratio(&candidate) {
+            // Issue #1164: rejected candidate → within-batch failure for target.
+            ctx.within_batch_failures.record_failure(target_uuid);
             if verbose_enabled() {
                 tracing::trace!(
                     direction = "push DOWN",
@@ -263,6 +278,8 @@ fn evaluate_activation_specs(
     for mut candidate in batched_candidates {
         // Issue #733: Filter neuron candidates where insufficient samples improve.
         if !passes_neuron_improved_ratio(&candidate) {
+            // Issue #1164: rejected candidate → within-batch failure for target.
+            ctx.within_batch_failures.record_failure(target_uuid);
             continue;
         }
 

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -178,6 +178,12 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
     let total_focus_count = focus_order.len();
     let completed_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
+    // Issue #1164: within-batch target-failure short-circuit. Lives for the
+    // duration of this orchestration call only. Shared across rayon workers
+    // so different parallel target evaluations contribute to a single view.
+    let within_batch_failures =
+        Arc::new(crate::analysis::within_batch_failures::WithinBatchFailureTracker::new());
+
     let focus_order_arc = Arc::new(focus_order);
     let ordered_neurons_arc = Arc::new(ordered_neurons);
     let order_map_arc = Arc::new(prep.order_map);
@@ -356,6 +362,7 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
                     helpful_map: &helpful_map,
                     threshold,
                     target_saturation,
+                    within_batch_failures: &within_batch_failures,
                 };
                 evaluation::evaluate_neuron_candidates(
                     &work_results,
@@ -381,6 +388,18 @@ pub fn analyze_neurons_with_cache_and_gpu_queue(
             a.extend(b);
             Ok(a)
         })?;
+
+    // Issue #1164: surface the within-batch short-circuit savings.
+    let within_batch_skips = within_batch_failures.skip_count();
+    if within_batch_skips > 0 {
+        tracing::info!(
+            phase = "neuron",
+            within_batch_skipped = within_batch_skips,
+            failed_targets = within_batch_failures.failed_target_count(),
+            failure_limit = within_batch_failures.failure_limit(),
+            "Short-circuited same-target candidates after within-batch failure (Issue #1164)"
+        );
+    }
 
     // Post-processing: impact discounting, sorting, filtering, result assembly
     let result_params = post_processing::NeuronResultParams {

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -96,6 +96,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     // Issue #1021: MCMC diagnostics tracker for acceptance rate and diversity metrics
     let mcmc_tracker =
         Arc::new(crate::analysis::diagnostics::mcmc_diagnostics::McmcDiagnosticsTracker::new());
+    // Issue #1164: within-batch target-failure short-circuit. Lives for the
+    // duration of this orchestration call only.
+    let within_batch_failures =
+        Arc::new(crate::analysis::within_batch_failures::WithinBatchFailureTracker::new());
     let ctx = Arc::new(target_analysis::TargetAnalysisContext {
         ordered_neurons: Arc::new(lookups.ordered_neurons),
         order_map: Arc::new(lookups.order_map),
@@ -116,6 +120,7 @@ pub(crate) fn analyze_synapses_with_cache_impl(
         acceptance_tracker,
         temperature: input.temperature,
         mcmc_tracker: mcmc_tracker.clone(),
+        within_batch_failures: within_batch_failures.clone(),
     });
 
     // Phase 6: Process each focus neuron in parallel — thread-local collection (Issue #744)
@@ -152,6 +157,18 @@ pub(crate) fn analyze_synapses_with_cache_impl(
             Ok(Some(target_results))
         })
         .collect::<Result<Vec<_>>>()?;
+
+    // Issue #1164: surface the within-batch short-circuit savings.
+    let within_batch_skips = within_batch_failures.skip_count();
+    if within_batch_skips > 0 {
+        tracing::info!(
+            phase = "synapse",
+            within_batch_skipped = within_batch_skips,
+            failed_targets = within_batch_failures.failed_target_count(),
+            failure_limit = within_batch_failures.failure_limit(),
+            "Short-circuited same-target candidates after within-batch failure (Issue #1164)"
+        );
+    }
 
     // Phase 7: Single-threaded merge (fast, no contention)
     let collectors = MergedResults::from_per_target(

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -77,6 +77,15 @@ pub(crate) fn collect_and_process_helpful_results(
     {
         let _timing = TimingScope::result_processing(&ctx.timing_collector);
         for (work, stats) in helpful_work_batch.iter().zip(helpful_stats_batch.iter()) {
+            // Issue #1164: short-circuit subsequent same-target candidates if
+            // an earlier candidate for this target failed within this batch.
+            if ctx
+                .within_batch_failures
+                .should_skip(work.target_uuid.as_str())
+            {
+                ctx.within_batch_failures.record_skip();
+                continue;
+            }
             let positive_is_better = stats.positive_count >= stats.negative_count;
             let gpu_improved_count = if positive_is_better {
                 stats.positive_count
@@ -91,6 +100,10 @@ pub(crate) fn collect_and_process_helpful_results(
                     stats.positive_count,
                     stats.negative_count,
                 ));
+                // Issue #1164: a candidate that did not improve any sample is
+                // a within-batch failure for this target.
+                ctx.within_batch_failures
+                    .record_failure(work.target_uuid.as_str());
                 continue;
             }
 
@@ -330,6 +343,11 @@ pub(crate) fn collect_and_process_helpful_results(
                 .record_evaluated(&work.source_uuid, &work.target_uuid, mcmc_type);
 
             if neuron_error_improvement <= 0.0 {
+                // Issue #1164: post-evaluation concluded no improvement —
+                // record the within-batch failure so subsequent same-target
+                // candidates can be short-circuited.
+                ctx.within_batch_failures
+                    .record_failure(work.target_uuid.as_str());
                 continue;
             }
 
@@ -604,6 +622,13 @@ pub(crate) fn process_harmful_batch_from_prepared(
         .map(|s| s.to_json());
 
     for (work, stats) in harmful_work.iter().zip(batch_stats.iter()) {
+        // Issue #1164: harmful (synapse-removal) candidates intentionally do
+        // not consult or update the within-batch failure tracker. The tracker
+        // gates additive (helpful synapse / neuron) candidates that target
+        // the same neuron; a failed addition for T is not evidence that a
+        // synapse removal targeting T will also fail — they explore different
+        // structural moves. Keeping the harmful path independent preserves
+        // existing remove-harmful-synapse coverage.
         let total_count = work.samples.len() as u32;
         if total_count == 0 {
             continue;

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -68,6 +68,11 @@ pub(crate) struct TargetAnalysisContext<'a> {
     pub temperature: f32,
     /// Issue #1021: MCMC diagnostics tracker for acceptance rate and diversity metrics.
     pub mcmc_tracker: Arc<crate::analysis::diagnostics::mcmc_diagnostics::McmcDiagnosticsTracker>,
+    /// Issue #1164: Within-batch target-failure short-circuit tracker. Shared
+    /// across rayon workers so a target that fails post-evaluation can be
+    /// skipped for the remainder of the batch.
+    pub within_batch_failures:
+        Arc<crate::analysis::within_batch_failures::WithinBatchFailureTracker>,
 }
 
 /// Results from analysing a single target neuron.

--- a/src/analysis/within_batch_failures.rs
+++ b/src/analysis/within_batch_failures.rs
@@ -1,0 +1,225 @@
+//! Within-batch target-failure short-circuit (Issue #1164).
+//!
+//! When a candidate targeting neuron T fails post-evaluation in the current
+//! discovery batch, the within-batch tracker records the failure and lets the
+//! next candidate evaluation short-circuit if the target's failure count has
+//! reached the configured threshold. Complements the cross-batch cooldown
+//! (Issue #1130) by closing the within-batch gap: a single batch could
+//! otherwise emit several failing candidates for the same target before the
+//! cross-batch cooldown engaged.
+//!
+//! # Design
+//!
+//! - Keyed by `target_neuron_uuid`.
+//! - Tracks the within-batch failure count per target and the total number of
+//!   skip events for diagnostics.
+//! - A target is short-circuited once its within-batch failure count reaches
+//!   [`WithinBatchFailureTracker::failure_limit`]. Default is `1` so the very
+//!   next same-target candidate is skipped after the first failure.
+//! - The threshold is env-var overridable via
+//!   `NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT`.
+//!
+//! # Lifetime
+//!
+//! Each orchestration call creates a fresh tracker; it does not persist
+//! across batches. Cross-batch cooldown is the responsibility of the global
+//! [`crate::analysis::target_failure_tracker::TargetFailureTracker`].
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::analysis::constants::WITHIN_BATCH_TARGET_FAILURE_LIMIT;
+use crate::config::within_batch_target_failure_limit_env;
+
+/// Per-batch tracker keyed by target UUID.
+///
+/// Designed to be shared across rayon worker threads via `Arc`. Internal
+/// state is guarded by a `Mutex`; the critical sections are short
+/// (`HashMap` insert/lookup) so contention is negligible compared to the GPU
+/// evaluation work the tracker is gating.
+#[derive(Debug)]
+pub struct WithinBatchFailureTracker {
+    state: Mutex<State>,
+    failure_limit: u32,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    failures: HashMap<String, u32>,
+    skip_count: u32,
+}
+
+impl WithinBatchFailureTracker {
+    /// Create a tracker using the env-var override or the compiled default.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_threshold(
+            within_batch_target_failure_limit_env().unwrap_or(WITHIN_BATCH_TARGET_FAILURE_LIMIT),
+        )
+    }
+
+    /// Create a tracker with an explicit threshold (for tests).
+    #[must_use]
+    pub fn with_threshold(failure_limit: u32) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            failure_limit: failure_limit.max(1),
+        }
+    }
+
+    /// Returns the configured failure threshold.
+    #[must_use]
+    pub fn failure_limit(&self) -> u32 {
+        self.failure_limit
+    }
+
+    /// Record a within-batch failure for `target_uuid`.
+    pub fn record_failure(&self, target_uuid: &str) {
+        let mut guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = guard.failures.entry(target_uuid.to_string()).or_insert(0);
+        *entry = entry.saturating_add(1);
+    }
+
+    /// Returns `true` when `target_uuid` should be skipped because its
+    /// within-batch failure count has reached the threshold.
+    #[must_use]
+    pub fn should_skip(&self, target_uuid: &str) -> bool {
+        let guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.failures.get(target_uuid).copied().unwrap_or(0) >= self.failure_limit
+    }
+
+    /// Increment the diagnostic skip counter; called when a candidate is
+    /// short-circuited by [`Self::should_skip`].
+    pub fn record_skip(&self) {
+        let mut guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.skip_count = guard.skip_count.saturating_add(1);
+    }
+
+    /// Returns the cumulative number of candidates skipped during this batch.
+    #[must_use]
+    pub fn skip_count(&self) -> u32 {
+        let guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.skip_count
+    }
+
+    /// Returns the within-batch failure count recorded for `target_uuid`.
+    #[must_use]
+    pub fn failure_count(&self, target_uuid: &str) -> u32 {
+        let guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.failures.get(target_uuid).copied().unwrap_or(0)
+    }
+
+    /// Returns the number of distinct targets that have at least one
+    /// within-batch failure.
+    #[must_use]
+    pub fn failed_target_count(&self) -> usize {
+        let guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.failures.len()
+    }
+}
+
+impl Default for WithinBatchFailureTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tracker_defaults_match_constant() {
+        let tracker = WithinBatchFailureTracker::with_threshold(1);
+        assert_eq!(tracker.failure_limit(), 1);
+        assert_eq!(tracker.skip_count(), 0);
+        assert_eq!(tracker.failed_target_count(), 0);
+        assert!(!tracker.should_skip("any"));
+    }
+
+    /// First failure for a target → subsequent same-target candidates are
+    /// short-circuited (default threshold 1).
+    #[test]
+    fn first_failure_short_circuits_subsequent_same_target_candidates() {
+        let tracker = WithinBatchFailureTracker::with_threshold(1);
+        assert!(!tracker.should_skip("T"));
+
+        tracker.record_failure("T");
+        assert!(tracker.should_skip("T"));
+        assert_eq!(tracker.failure_count("T"), 1);
+        assert_eq!(tracker.failed_target_count(), 1);
+    }
+
+    /// A success for a target does NOT add it to the failure set, so other
+    /// candidates targeting T proceed normally.
+    #[test]
+    fn success_does_not_add_target_to_set() {
+        let tracker = WithinBatchFailureTracker::with_threshold(1);
+
+        // No failure recorded for "T" — should not be skipped.
+        assert!(!tracker.should_skip("T"));
+        assert_eq!(tracker.failed_target_count(), 0);
+    }
+
+    /// Threshold > 1 — only short-circuit after N within-batch failures.
+    #[test]
+    fn threshold_gt_one_requires_n_failures_before_skip() {
+        let tracker = WithinBatchFailureTracker::with_threshold(3);
+
+        tracker.record_failure("T");
+        assert!(!tracker.should_skip("T"));
+        tracker.record_failure("T");
+        assert!(!tracker.should_skip("T"));
+
+        tracker.record_failure("T");
+        assert!(
+            tracker.should_skip("T"),
+            "skip should engage at the threshold"
+        );
+    }
+
+    #[test]
+    fn record_skip_increments_skip_count() {
+        let tracker = WithinBatchFailureTracker::with_threshold(1);
+        tracker.record_skip();
+        tracker.record_skip();
+        assert_eq!(tracker.skip_count(), 2);
+    }
+
+    #[test]
+    fn unrelated_target_not_affected_by_failures() {
+        let tracker = WithinBatchFailureTracker::with_threshold(1);
+        tracker.record_failure("A");
+        assert!(tracker.should_skip("A"));
+        assert!(!tracker.should_skip("B"));
+    }
+
+    #[test]
+    fn explicit_threshold_zero_is_clamped_to_one() {
+        // A threshold of zero would be nonsensical (skip even before any
+        // failure). The constructor clamps to 1.
+        let tracker = WithinBatchFailureTracker::with_threshold(0);
+        assert_eq!(tracker.failure_limit(), 1);
+        assert!(!tracker.should_skip("T"));
+        tracker.record_failure("T");
+        assert!(tracker.should_skip("T"));
+    }
+}

--- a/src/config/detection.rs
+++ b/src/config/detection.rs
@@ -58,3 +58,16 @@ pub fn target_cooldown_epochs_env() -> Option<u64> {
         .and_then(|s| s.trim().parse().ok())
         .filter(|v| *v >= 1)
 }
+
+/// Read the env-var override for the within-batch target-failure short-circuit
+/// limit (Issue #1164).
+///
+/// Returns `Some(n)` when `NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT` is set
+/// to a valid `u32 >= 1`, otherwise `None` so callers fall back to the
+/// compiled default `WITHIN_BATCH_TARGET_FAILURE_LIMIT`.
+pub fn within_batch_target_failure_limit_env() -> Option<u32> {
+    std::env::var("NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .filter(|v| *v >= 1)
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,7 @@
 //! | `NEAT_AI_DISCOVERY_NOISE_SIGNAL_THRESHOLD` | f32 | module default | Noise-to-signal ratio threshold |
 //! | `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` | u32 | `3` | Consecutive target-neuron failures before cooldown (Issue #1130) |
 //! | `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_EPOCHS` | u64 | `10` | Cooldown duration in epochs for skipped targets (Issue #1130) |
+//! | `NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT` | u32 | `1` | Within-batch failure limit before same-target candidates are short-circuited (Issue #1164) |
 //!
 //! ## Internal/Debug Variables
 //!

--- a/tests/analysis/issue_221_sample_locality.rs
+++ b/tests/analysis/issue_221_sample_locality.rs
@@ -22,8 +22,43 @@
 use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_synapses};
 use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson};
+use serial_test::serial;
 use std::collections::HashSet;
 use tempfile::tempdir;
+
+/// Issue #1164: locality tests submit 100 sources for a single target. With
+/// the default within-batch failure limit of 1, the very first failing source
+/// short-circuits all subsequent same-target candidates and the test sees no
+/// candidates. Locality tests are unrelated to the within-batch short-circuit,
+/// so they raise the limit while running. Restored on drop to avoid leaking
+/// the env var into other tests.
+struct WithinBatchLimitGuard {
+    previous: Option<String>,
+}
+
+impl WithinBatchLimitGuard {
+    fn high() -> Self {
+        let previous = std::env::var("NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT").ok();
+        // SAFETY: tests using this guard are gated by `#[serial]` so no other
+        // thread mutates the same variable concurrently.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT", "10000");
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for WithinBatchLimitGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `high` — guarded by `#[serial]`.
+        unsafe {
+            match &self.previous {
+                Some(v) => std::env::set_var("NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT", v),
+                None => std::env::remove_var("NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT"),
+            }
+        }
+    }
+}
 
 /// Skip test if no GPU available
 macro_rules! skip_without_gpu {
@@ -320,8 +355,12 @@ fn group_sources_by_locality_test(
 /// Benchmark test to verify that sample locality batching improves performance.
 /// Test that sample locality batching produces correct results with correlated inputs.
 #[test]
+#[serial]
 fn sample_locality_batching_produces_results() {
     skip_without_gpu!();
+    // Issue #1164: locality test submits 100 sources for one target — keep the
+    // within-batch short-circuit out of the way so all sources are evaluated.
+    let _within_batch_guard = WithinBatchLimitGuard::high();
 
     let temp_dir = tempdir().expect("Failed to create temp directory");
     let parquet_path = temp_dir.path().join("records.parquet");
@@ -362,8 +401,12 @@ fn sample_locality_batching_produces_results() {
 /// Test that sample locality optimisation preserves correctness.
 /// Results should be identical whether or not batching is applied.
 #[test]
+#[serial]
 fn sample_locality_preserves_correctness() {
     skip_without_gpu!();
+    // Issue #1164: keep the within-batch short-circuit out of the way so the
+    // correctness comparison sees the full set of source candidates.
+    let _within_batch_guard = WithinBatchLimitGuard::high();
 
     let temp_dir = tempdir().expect("Failed to create temp directory");
     let parquet_path = temp_dir.path().join("records.parquet");
@@ -440,8 +483,13 @@ fn sample_locality_preserves_correctness() {
 /// Test the specific scenario from the issue: 100 sources with 90% sample overlap.
 /// Verifies that analysis produces correct results with high overlap.
 #[test]
+#[serial]
 fn source_batching_90_percent_overlap_produces_results() {
     skip_without_gpu!();
+    // Issue #1164: keep the within-batch short-circuit out of the way so all
+    // 100 same-target sources are evaluated; this test exercises locality
+    // batching, not the within-batch failure short-circuit.
+    let _within_batch_guard = WithinBatchLimitGuard::high();
 
     let temp_dir = tempdir().expect("Failed to create temp directory");
     let parquet_path = temp_dir.path().join("records.parquet");

--- a/tests/issue_1164_within_batch_failures.rs
+++ b/tests/issue_1164_within_batch_failures.rs
@@ -1,0 +1,142 @@
+//! Integration tests for the within-batch target-failure short-circuit
+//! (Issue #1164).
+//!
+//! These tests cover the orchestration-layer tracker, not the GPU evaluation
+//! pipeline (which requires a GPU adapter and a Parquet record fixture).
+//! They verify the three acceptance behaviours called out in #1164:
+//!   1. First failure for target T → subsequent same-target candidates are
+//!      skipped within the same batch.
+//!   2. A success for target T does NOT add T to the failure set.
+//!   3. Threshold > 1 → only short-circuit after N within-batch failures.
+
+use neat_ai_discovery::analysis::constants::WITHIN_BATCH_TARGET_FAILURE_LIMIT;
+use neat_ai_discovery::analysis::within_batch_failures::WithinBatchFailureTracker;
+
+/// Issue #1164 acceptance: first failure for a target → subsequent same-target
+/// candidates are short-circuited.
+#[test]
+fn first_failure_skips_subsequent_same_target_candidates() {
+    let tracker = WithinBatchFailureTracker::with_threshold(1);
+
+    // Simulate the first candidate for T failing post-evaluation.
+    tracker.record_failure("neuron-1063112866");
+
+    // The next same-target candidate sees the short-circuit.
+    assert!(tracker.should_skip("neuron-1063112866"));
+    tracker.record_skip();
+
+    // A third candidate for the same target also short-circuits.
+    assert!(tracker.should_skip("neuron-1063112866"));
+    tracker.record_skip();
+
+    assert_eq!(tracker.skip_count(), 2);
+    assert_eq!(tracker.failure_count("neuron-1063112866"), 1);
+}
+
+/// Issue #1164 acceptance: a success for target T does not add T to the
+/// failure set; subsequent same-target candidates proceed.
+#[test]
+fn success_does_not_short_circuit_subsequent_candidates() {
+    let tracker = WithinBatchFailureTracker::with_threshold(1);
+
+    // No failure recorded for T — a successful candidate does not call
+    // record_failure, so the tracker stays empty for T.
+    assert!(!tracker.should_skip("T"));
+    assert_eq!(tracker.skip_count(), 0);
+    assert_eq!(tracker.failed_target_count(), 0);
+}
+
+/// Issue #1164 acceptance: threshold > 1 → only short-circuit after N
+/// within-batch failures.
+#[test]
+fn threshold_greater_than_one_only_skips_after_n_failures() {
+    let tracker = WithinBatchFailureTracker::with_threshold(3);
+
+    tracker.record_failure("T");
+    assert!(!tracker.should_skip("T"));
+    tracker.record_failure("T");
+    assert!(!tracker.should_skip("T"));
+
+    tracker.record_failure("T");
+    assert!(tracker.should_skip("T"));
+}
+
+/// Issue #1164: separate targets are tracked independently.
+#[test]
+fn unrelated_target_not_affected_by_failures_on_other_target() {
+    let tracker = WithinBatchFailureTracker::with_threshold(1);
+
+    tracker.record_failure("neuron-1063112866");
+
+    assert!(tracker.should_skip("neuron-1063112866"));
+    assert!(
+        !tracker.should_skip("neuron-healthy"),
+        "an unrelated target must not be short-circuited"
+    );
+}
+
+/// Issue #1164: compiled default short-circuits as soon as the first failure
+/// is recorded for a target.
+#[test]
+fn compiled_default_short_circuits_after_first_failure() {
+    assert_eq!(
+        WITHIN_BATCH_TARGET_FAILURE_LIMIT, 1,
+        "documented default is 1 failure"
+    );
+
+    let tracker = WithinBatchFailureTracker::new();
+    assert_eq!(tracker.failure_limit(), 1);
+
+    tracker.record_failure("T");
+    assert!(tracker.should_skip("T"));
+}
+
+/// Issue #1164: simulate the GRQ-sampler `8c177b7` workload — three
+/// same-target add-neuron candidates land in one batch. After the first
+/// failure, the remaining two are short-circuited.
+#[test]
+fn grq_sampler_batch_short_circuits_remaining_same_target_candidates() {
+    let tracker = WithinBatchFailureTracker::with_threshold(1);
+    let hot_target = "neuron-1063112866";
+
+    // Three add-neuron candidates targeting the same neuron arrive in one
+    // batch. The first one is evaluated and fails; the next two should be
+    // short-circuited.
+    let mut evaluations = 0u32;
+    for candidate_idx in 0..3 {
+        if tracker.should_skip(hot_target) {
+            tracker.record_skip();
+            continue;
+        }
+        // Simulate evaluation: the first candidate runs and fails.
+        evaluations += 1;
+        let _ = candidate_idx;
+        tracker.record_failure(hot_target);
+    }
+
+    assert_eq!(
+        evaluations, 1,
+        "only the first candidate should reach evaluation; the other two are short-circuited"
+    );
+    assert_eq!(
+        tracker.skip_count(),
+        2,
+        "two candidates should be short-circuited after the first failure"
+    );
+}
+
+/// Issue #1164: the diagnostic skip counter accumulates across many recorded
+/// skips (used by the orchestration log line so the operator sees the budget
+/// being saved).
+#[test]
+fn skip_count_accumulates_across_record_skip_calls() {
+    let tracker = WithinBatchFailureTracker::with_threshold(1);
+    tracker.record_failure("A");
+    tracker.record_failure("B");
+
+    for _ in 0..5 {
+        tracker.record_skip();
+    }
+    assert_eq!(tracker.skip_count(), 5);
+    assert_eq!(tracker.failed_target_count(), 2);
+}


### PR DESCRIPTION
## Summary

Within-batch target-failure short-circuit during candidate evaluation.
Closes #1164.

A new `WithinBatchFailureTracker` is created per orchestration call and shared
across the per-target rayon workers. When a candidate targeting neuron T fails
post-evaluation (the local model concludes no improvement), the tracker
records the failure for T. Subsequent same-target candidates in the same
batch consult the tracker and short-circuit when T's failure count reaches
the configured threshold. Complements the cross-batch cooldown (#1130) by
closing the within-batch gap that allowed several failing candidates per
target to be emitted from one batch.

The threshold is env-var overridable via
`NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT` (default `1`). Diagnostic
counters are surfaced via a single `tracing::info!` line per phase
(synapse / neuron) so the operator can see budget being saved.

```mermaid
flowchart TD
    A[Candidate evaluation] --> B{Target in failed-this-batch set?}
    B -- yes --> C[Skip, increment skip metric]
    B -- no --> D[Evaluate]
    D --> E{Improved?}
    E -- no --> F[Add target to set, record failure]
    E -- yes --> G[Keep candidate, do not add to set]
```

### Scope decisions

- **Helpful (additive) candidates only.** The synapse helpful path and the
  neuron evaluation path consult and update the tracker. The synapse
  **harmful** (synapse-removal) path was deliberately left independent — a
  failed addition for T does not predict that a removal targeting T will
  also fail; they explore different structural moves and tying them together
  broke `issue_927_remove_harmful_synapse` coverage.
- **Cross-batch cooldown unaffected.** The global
  `TargetFailureTracker` (Issue #1130) keeps its existing semantics; the
  new within-batch tracker is per-call and discarded at the end of each
  orchestration call.

## Evidence

Backend / CLI change — no UI to screenshot. Verified via:

- New unit tests (`src/analysis/within_batch_failures.rs::tests`) covering
  default threshold, first-failure short-circuit, success path, threshold
  > 1 path, skip-count accumulation, unrelated-target isolation, and the
  zero-threshold clamp.
- New integration tests in
  `tests/issue_1164_within_batch_failures.rs` covering the GRQ-sampler
  scenario from the issue (3 same-target add-neuron candidates → 1
  evaluated, 2 short-circuited).
- Existing per-target cooldown coverage (`issue_1130_target_cooldown`) still
  passes; cross-batch behaviour is unchanged.
- Full library + integration suite passes (890 lib tests, 579 analysis
  integration tests, all other suites green) — see PR CI.

### Behaviour change recorded in tests

`tests/analysis/issue_221_sample_locality.rs` — three locality-batching
tests submit 100 sources for a single target and expected at least one
candidate. With the default within-batch limit of 1, an early-failing
source short-circuits the rest. These tests are not exercising the
short-circuit, so they now wrap their `analyze_synapses` call in a
`WithinBatchLimitGuard` (sets the env var to a high number,
`#[serial]`-protected, restored on drop). No assertions removed.

## Test Plan

- `cargo test --lib within_batch_failures` — new unit tests pass.
- `cargo test --test issue_1164_within_batch_failures` — 7 acceptance
  tests pass.
- `cargo test --test issue_1130_target_cooldown` — cross-batch cooldown
  unaffected.
- `cargo test --test analysis -- --test-threads=2` — all 579 analysis
  integration tests pass (locality tests now use the env-var guard).
- `cargo test --test synapse issue_927_remove_harmful_synapse` —
  remove-harmful-synapse coverage preserved by keeping the harmful path
  independent of the tracker.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1164 -->