### PR TITLE
Per-variant calibration for variant_generation expected_multiplier (Issue #1163)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.28"
+version = "0.74.29"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/ffi_marshalling.rs
+++ b/benches/ffi_marshalling.rs
@@ -91,6 +91,7 @@ fn create_synapse_candidates(count: usize) -> Vec<CandidateSynapseJson> {
             prediction_confidence: 0.85,
             expected_score_gain_confidence_interval: [0.01, 0.09],
             comment: Some(format!("candidate-{i}")),
+            variant_key: None,
         })
         .collect()
 }
@@ -118,6 +119,7 @@ fn create_neuron_candidates(count: usize) -> Vec<CandidateNeuronJson> {
             prediction_confidence: 0.75,
             expected_score_gain_confidence_interval: [0.01, 0.07],
             target_saturation_factor: None,
+            variant_key: None,
         })
         .collect()
 }

--- a/benches/upsert_candidate.rs
+++ b/benches/upsert_candidate.rs
@@ -33,6 +33,7 @@ fn make_candidate(source_idx: usize, target_idx: usize, squash: &str) -> Candida
         prediction_confidence: 0.5,
         expected_score_gain_confidence_interval: [0.01, 0.09],
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 

--- a/docs/pr-summary-1163.md
+++ b/docs/pr-summary-1163.md
@@ -1,0 +1,40 @@
+## Summary
+
+Per-variant calibration for `variant_generation` `expected_multiplier`. Failure-cache entries now carry an optional `variantKey`; the calibrator groups by `(change_type, variant_key)` and `make_neuron_variant` / `make_synapse_variant` apply `min(static_multiplier, calibrated_correction)` so a variant whose recent history shows persistent over-estimation is automatically demoted, while the static multiplier remains a ceiling. Closes #1163.
+
+## What Changed
+
+- `FailureCacheEntry` gains `variant_key: Option<String>` (top-level `variantKey` or nested `variantInfo.key`; missing field tolerated for backward compatibility).
+- `CalibrationCorrection` gains `variant_corrections: HashMap<(String, String), f32>` and a `variant_correction_for(change_type, variant_key) -> f32` lookup. Specific corrections are only retained once `MIN_SPECIFIC_VARIANT_KEY_SAMPLES` (= 3) usable entries exist for the bucket; otherwise the lookup returns `NEUTRAL_CORRECTION` so the static multiplier wins.
+- `NeuronVariantConfig` and `SynapseVariantConfig` gain `variant_key: &'static str`. Each static config (`CONSERVATIVE`, `GENTLE_NUDGE`, `MICRO_NUDGE`, `FEATHER_TOUCH`, `WHISPER`) is now identified by a stable machine-readable key — the canonical identifier the calibrator groups by; the comment string is human-readable only.
+- `CandidateNeuronJson` and `CandidateSynapseJson` gain `variant_key: Option<String>` (skipped from the wire schema when absent — additive, no `wireSchemaVersion` bump).
+- `make_neuron_variant_with_correction` / `make_synapse_variant_with_correction`: new entry points that consult the calibration. The original two-arg `make_*_variant` functions delegate to them with `None` for backward compatibility but still populate `variant_key`.
+- `pair_extreme_candidates_with_conservative_variants_calibrated` / `pair_synapse_candidates_with_weight_variants_calibrated`: calibrated pair functions used by `neuron::post_processing` and `synapse::post_processing`.
+
+## Evidence
+
+CLI / library change — no UI to screenshot. The new behaviour is exercised by 8 lib tests in `analysis::utils::variant_generation::calibrated_variant_tests` and 6 lib tests in `analysis::scoring::calibration_correction::tests` covering the three acceptance regimes plus parsing and isolation between variant buckets. `./quality.sh` passes cleanly.
+
+```mermaid
+flowchart LR
+    FC[Failure cache<br/>variantKey] --> CC[CalibrationCorrection<br/>variant_corrections]
+    CC -->|variant_correction_for| MV[make_neuron_variant_with_correction]
+    SC[NeuronVariantConfig<br/>expected_multiplier ceiling<br/>variant_key]
+    SC --> MV
+    MV -->|min ceiling, calibrated| EM[Effective multiplier]
+    EM --> CN[CandidateNeuronJson<br/>variant_key set]
+```
+
+## Test Plan
+
+New tests (all passing):
+
+- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_uses_static_multiplier_when_history_insufficient` — fewer than 3 entries → static `expected_multiplier` used.
+- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_uses_calibrated_multiplier_when_history_indicates_failure` — long failure history drives the multiplier toward the floor.
+- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_static_multiplier_acts_as_ceiling_for_long_success_history` — long success history clamps to neutral so static value remains a ceiling.
+- Mirror tests for synapse variants (`synapse_variant_uses_*`).
+- `synapse_variant_populates_key_without_calibration` / `neuron_variant_populates_key_without_calibration` — `variant_key` is set even when no calibration is supplied.
+- `analysis::scoring::calibration_correction::tests::variant_key_parsed_from_top_level_field` / `..._nested_variant_info` / `..._optional_for_legacy_entries` — JSON wire-format parsing.
+- `analysis::scoring::calibration_correction::tests::insufficient_variant_history_falls_back_to_neutral` / `long_variant_failure_history_drives_calibrated_value` / `long_variant_success_history_clamps_at_neutral` / `variant_key_buckets_are_independent` — calibration regimes.
+
+Existing tests still pass (`./quality.sh`).

--- a/src/analysis/candidate_compression/gain_estimation.rs
+++ b/src/analysis/candidate_compression/gain_estimation.rs
@@ -111,6 +111,7 @@ mod tests {
             prediction_confidence: 0.8,
             expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
             comment: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/candidate_compression/grouping.rs
+++ b/src/analysis/candidate_compression/grouping.rs
@@ -78,6 +78,7 @@ mod tests {
             prediction_confidence: 0.8,
             expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
             comment: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/candidate_compression/identity.rs
+++ b/src/analysis/candidate_compression/identity.rs
@@ -165,6 +165,7 @@ mod tests {
             prediction_confidence: 0.8,
             expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
             comment: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/candidate_compression/nonlinear.rs
+++ b/src/analysis/candidate_compression/nonlinear.rs
@@ -191,6 +191,7 @@ mod tests {
             prediction_confidence: 0.8,
             expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
             comment: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/implementation_tests/clone_reduction_tests.rs
+++ b/src/analysis/implementation_tests/clone_reduction_tests.rs
@@ -37,6 +37,7 @@ fn make_candidate(
         prediction_confidence: 0.5,
         expected_score_gain_confidence_interval: [0.01, 0.09],
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 

--- a/src/analysis/implementation_tests/relu_evaluation_tests.rs
+++ b/src/analysis/implementation_tests/relu_evaluation_tests.rs
@@ -203,6 +203,7 @@ fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Negative-orientation ReLU candidate
@@ -226,6 +227,7 @@ fn test_upsert_keeps_complementary_relu_candidates_by_incoming_weight() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Insert both candidates
@@ -285,6 +287,7 @@ fn test_upsert_keeps_split_error_complementary_pairs() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Candidate for negative-error samples (negative outgoing weight)
@@ -308,6 +311,7 @@ fn test_upsert_keeps_split_error_complementary_pairs() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Insert both candidates

--- a/src/analysis/mod_tests.rs
+++ b/src/analysis/mod_tests.rs
@@ -109,6 +109,7 @@ fn postprocess_truncates_across_all_synapse_buckets_not_just_coordinated() {
             prediction_confidence: 0.0,
             expected_score_gain_confidence_interval: [0.0, 0.0],
             comment: None,
+            variant_key: None,
         }],
         harmful_synapses: Vec::new(),
         synapse_weight_updates: Vec::new(),
@@ -170,6 +171,7 @@ fn postprocess_updates_candidates_returned_after_merging_neuron_replacements() {
             prediction_confidence: 0.0,
             expected_score_gain_confidence_interval: [0.0, 0.0],
             comment: None,
+            variant_key: None,
         }],
         harmful_synapses: Vec::new(),
         synapse_weight_updates: Vec::new(),
@@ -230,6 +232,7 @@ fn postprocess_updates_neuron_candidates_returned_after_filtering_replacements()
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let cand_b = CandidateNeuronJson {
@@ -252,6 +255,7 @@ fn postprocess_updates_neuron_candidates_returned_after_filtering_replacements()
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let mut neuron = shared::AnalyzeNeuronsResult {

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -99,10 +99,14 @@ pub(crate) fn build_neuron_results(
     });
 
     // Production experiment: pair "extreme" candidates with a conservative variant.
-    helpful_results = crate::analysis::utils::pair_extreme_candidates_with_conservative_variants(
-        helpful_results,
-        None,
-    );
+    // Issue #1163: pass the per-variant calibration so each variant's
+    // expected-improvement multiplier is `min(static, calibrated)`.
+    helpful_results =
+        crate::analysis::utils::pair_extreme_candidates_with_conservative_variants_calibrated(
+            helpful_results,
+            None,
+            Some(&calibration_correction),
+        );
 
     // Production guard rail (Dec 2025): only return candidates within sensible parameter ranges.
     helpful_results = crate::analysis::utils::filter_candidates_to_sensible_ranges(helpful_results);
@@ -417,6 +421,7 @@ mod tests {
             prediction_confidence: 0.5,
             expected_score_gain_confidence_interval: [gain, gain],
             target_saturation_factor: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/samples/statistics.rs
+++ b/src/analysis/samples/statistics.rs
@@ -380,6 +380,7 @@ impl ReluStats {
             expected_score_gain_confidence_interval: confidence_metrics
                 .expected_score_gain_confidence_interval,
             target_saturation_factor: None,
+            variant_key: None,
         })
     }
 }

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -92,6 +92,17 @@ pub const CALIBRATION_CORRECTION_EWMA_ALPHA: f32 = 0.3;
 /// to the per-`change_type` correction.
 pub const MIN_SPECIFIC_TARGET_SQUASH_SAMPLES: usize = 3;
 
+/// Minimum number of usable failure-cache entries required for a
+/// `(change_type, variant_key)` group before its specific correction is
+/// applied to variant generators (Issue #1163).
+///
+/// Three entries is the same threshold as
+/// [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`]: enough to establish a per-variant
+/// trend without letting a single noisy outlier dominate the static
+/// `expected_multiplier`. Smaller groups fall through to the static value
+/// (the issue specifies the static multiplier as a ceiling).
+pub const MIN_SPECIFIC_VARIANT_KEY_SAMPLES: usize = 3;
+
 // =============================================================================
 // Change-type identifiers
 // =============================================================================
@@ -142,6 +153,16 @@ pub struct FailureCacheEntry {
     /// compatibility (Issue #1162).
     #[serde(default)]
     pub target_squash: Option<String>,
+
+    /// Variant key identifying which `variant_generation` strategy produced
+    /// the candidate (Issue #1163).
+    ///
+    /// When supplied this lets the calibration learn that, say, the
+    /// `gentle-nudge` neuron variant against a particular history of
+    /// failures should have its static `expected_multiplier` discounted.
+    /// `None` for legacy entries and for original (non-variant) candidates.
+    #[serde(default)]
+    pub variant_key: Option<String>,
 }
 
 /// Wire-format helper for [`FailureCacheEntry`] (Issue #1162).
@@ -159,6 +180,10 @@ struct FailureCacheEntryRaw {
     target_neuron_info: Option<TargetNeuronInfoRaw>,
     #[serde(default)]
     target_squash: Option<String>,
+    #[serde(default)]
+    variant_key: Option<String>,
+    #[serde(default)]
+    variant_info: Option<VariantInfoRaw>,
 }
 
 #[derive(Deserialize)]
@@ -168,6 +193,18 @@ struct TargetNeuronInfoRaw {
     squash: Option<String>,
 }
 
+/// Wire-format helper for nested `variantInfo.key` payloads (Issue #1163).
+///
+/// The upstream NEAT-AI emitter may nest the variant identifier under a
+/// `variantInfo` object. This struct lets us accept either layout while the
+/// in-memory [`FailureCacheEntry`] keeps a flat `variant_key`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VariantInfoRaw {
+    #[serde(default)]
+    key: Option<String>,
+}
+
 impl From<FailureCacheEntryRaw> for FailureCacheEntry {
     fn from(raw: FailureCacheEntryRaw) -> Self {
         // Prefer an explicit top-level `targetSquash`, fall back to the
@@ -175,11 +212,17 @@ impl From<FailureCacheEntryRaw> for FailureCacheEntry {
         let target_squash = raw
             .target_squash
             .or_else(|| raw.target_neuron_info.and_then(|info| info.squash));
+        // Issue #1163: prefer top-level `variantKey`, fall back to
+        // `variantInfo.key`. Both are optional for backward compatibility.
+        let variant_key = raw
+            .variant_key
+            .or_else(|| raw.variant_info.and_then(|info| info.key));
         Self {
             change_type: raw.change_type,
             expected_error_reduction: raw.expected_error_reduction,
             actual_error_reduction: raw.actual_error_reduction,
             target_squash,
+            variant_key,
         }
     }
 }
@@ -210,6 +253,10 @@ impl From<FailureCacheEntryRaw> for FailureCacheEntry {
 pub struct CalibrationCorrection {
     corrections: HashMap<String, f32>,
     specific_corrections: HashMap<(String, String), f32>,
+    /// Per-variant corrections keyed by `(change_type, variant_key)`
+    /// (Issue #1163). Only populated for groups with at least
+    /// [`MIN_SPECIFIC_VARIANT_KEY_SAMPLES`] usable entries.
+    variant_corrections: HashMap<(String, String), f32>,
 }
 
 impl CalibrationCorrection {
@@ -245,6 +292,8 @@ impl CalibrationCorrection {
         // group so the EWMA reflects oldest -> newest.
         let mut grouped: HashMap<&str, Vec<f32>> = HashMap::new();
         let mut grouped_specific: HashMap<(&str, &str), Vec<f32>> = HashMap::new();
+        // Issue #1163: per-variant grouping keyed by (change_type, variant_key).
+        let mut grouped_variant: HashMap<(&str, &str), Vec<f32>> = HashMap::new();
         for entry in cache {
             // Skip entries with undefined ratios.
             if entry.expected_error_reduction == 0.0 {
@@ -262,6 +311,12 @@ impl CalibrationCorrection {
             if let Some(squash) = entry.target_squash.as_deref() {
                 grouped_specific
                     .entry((entry.change_type.as_str(), squash))
+                    .or_default()
+                    .push(ratio);
+            }
+            if let Some(variant) = entry.variant_key.as_deref() {
+                grouped_variant
+                    .entry((entry.change_type.as_str(), variant))
                     .or_default()
                     .push(ratio);
             }
@@ -287,9 +342,23 @@ impl CalibrationCorrection {
             specific_corrections.insert((change_type.to_string(), squash.to_string()), clamped);
         }
 
+        let mut variant_corrections: HashMap<(String, String), f32> = HashMap::new();
+        for ((change_type, variant), ratios) in grouped_variant {
+            // Issue #1163: only retain per-variant corrections backed by enough
+            // samples; smaller groups fall through to the static multiplier
+            // ceiling at lookup time.
+            if ratios.len() < MIN_SPECIFIC_VARIANT_KEY_SAMPLES {
+                continue;
+            }
+            let ewma = ewma(&ratios, CALIBRATION_CORRECTION_EWMA_ALPHA);
+            let clamped = ewma.clamp(MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION);
+            variant_corrections.insert((change_type.to_string(), variant.to_string()), clamped);
+        }
+
         Self {
             corrections,
             specific_corrections,
+            variant_corrections,
         }
     }
 
@@ -352,6 +421,36 @@ impl CalibrationCorrection {
         &self.specific_corrections
     }
 
+    /// Returns a reference to the per-(`change_type`, `variant_key`) map
+    /// (Issue #1163). Exposed for diagnostic tests; the FFI metadata only
+    /// includes the per-`change_type` map for backward compatibility.
+    #[must_use]
+    pub fn variant_as_map(&self) -> &HashMap<(String, String), f32> {
+        &self.variant_corrections
+    }
+
+    /// Look up the per-variant correction factor (Issue #1163).
+    ///
+    /// Resolution:
+    ///
+    /// 1. If `variant_key` is supplied **and** at least
+    ///    [`MIN_SPECIFIC_VARIANT_KEY_SAMPLES`] usable failure-cache entries
+    ///    exist for `(change_type, variant_key)`, return that calibrated
+    ///    correction.
+    /// 2. Otherwise return [`NEUTRAL_CORRECTION`] (= 1.0). This neutral value
+    ///    means the static `expected_multiplier` is used unchanged at the
+    ///    call site (the issue specifies the static value as a ceiling).
+    ///
+    /// Callers wanting the per-variant correction combined with the static
+    /// multiplier should compute `min(static, variant_correction_for(...))`.
+    #[must_use]
+    pub fn variant_correction_for(&self, change_type: &str, variant_key: &str) -> f32 {
+        self.variant_corrections
+            .get(&(change_type.to_string(), variant_key.to_string()))
+            .copied()
+            .unwrap_or(NEUTRAL_CORRECTION)
+    }
+
     /// True when no change-type has a correction recorded.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -393,6 +492,7 @@ mod tests {
             expected_error_reduction: predicted,
             actual_error_reduction: actual,
             target_squash: None,
+            variant_key: None,
         }
     }
 
@@ -407,6 +507,22 @@ mod tests {
             expected_error_reduction: predicted,
             actual_error_reduction: actual,
             target_squash: Some(squash.to_string()),
+            variant_key: None,
+        }
+    }
+
+    fn entry_with_variant(
+        change_type: &str,
+        predicted: f32,
+        actual: f32,
+        variant: &str,
+    ) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: change_type.to_string(),
+            expected_error_reduction: predicted,
+            actual_error_reduction: actual,
+            target_squash: None,
+            variant_key: Some(variant.to_string()),
         }
     }
 
@@ -709,6 +825,154 @@ mod tests {
         assert!(
             (value - NEUTRAL_CORRECTION).abs() < 1e-9,
             "expected NEUTRAL_CORRECTION, got {value}"
+        );
+    }
+
+    // =========================================================================
+    // Issue #1163 — per-(change_type, variant_key) calibration tracking
+    // =========================================================================
+
+    #[test]
+    fn variant_key_parsed_from_top_level_field() {
+        // Top-level `variantKey` should be honoured.
+        let json = r#"{
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001,
+            "variantKey": "gentle-nudge"
+        }"#;
+        let parsed: FailureCacheEntry = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.variant_key.as_deref(), Some("gentle-nudge"));
+    }
+
+    #[test]
+    fn variant_key_parsed_from_nested_variant_info() {
+        // Nested `variantInfo.key` is also accepted (Issue #1163).
+        let json = r#"{
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001,
+            "variantInfo": { "key": "micro-nudge" }
+        }"#;
+        let parsed: FailureCacheEntry = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.variant_key.as_deref(), Some("micro-nudge"));
+    }
+
+    #[test]
+    fn variant_key_optional_for_legacy_entries() {
+        // Entries without any variant identifier must still parse.
+        let json = r#"{
+            "changeType": "add-neurons",
+            "expectedErrorReduction": 0.001,
+            "actualErrorReduction": 0.000001
+        }"#;
+        let parsed: FailureCacheEntry = serde_json::from_str(json).expect("parse");
+        assert!(parsed.variant_key.is_none());
+    }
+
+    #[test]
+    fn variant_correction_neutral_when_no_history() {
+        // No variant history -> neutral so the static multiplier wins.
+        let correction = CalibrationCorrection::neutral();
+        let value = correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "gentle-nudge");
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION, got {value}"
+        );
+    }
+
+    #[test]
+    fn insufficient_variant_history_falls_back_to_neutral() {
+        // Fewer than MIN_SPECIFIC_VARIANT_KEY_SAMPLES variant entries — no
+        // calibrated value should be retained.
+        const _: () = assert!(MIN_SPECIFIC_VARIANT_KEY_SAMPLES >= 2);
+        let mut cache = Vec::new();
+        for _ in 0..(MIN_SPECIFIC_VARIANT_KEY_SAMPLES - 1) {
+            cache.push(entry_with_variant(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                "gentle-nudge",
+            ));
+        }
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        assert!(
+            correction.variant_as_map().is_empty(),
+            "variant corrections must not be retained below the sample threshold"
+        );
+        let lookup = correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "gentle-nudge");
+        assert!(
+            (lookup - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION fallback, got {lookup}"
+        );
+    }
+
+    #[test]
+    fn long_variant_failure_history_drives_calibrated_value() {
+        // 10 SELU-against-Gentle-Nudge failures with 1000× over-estimation should
+        // produce a calibrated value at the floor (0.001).
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| entry_with_variant(CHANGE_TYPE_ADD_NEURONS, 0.001, 0.000_001, "gentle-nudge"))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "gentle-nudge");
+        assert!(
+            (value - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+            "expected MIN_CALIBRATION_CORRECTION, got {value}"
+        );
+    }
+
+    #[test]
+    fn long_variant_success_history_clamps_at_neutral() {
+        // A run where every variant outcome over-shot the prediction must be
+        // clamped to NEUTRAL_CORRECTION (= 1.0). The calibrated value never
+        // inflates predictions above the static `expected_multiplier` ceiling.
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| entry_with_variant(CHANGE_TYPE_ADD_NEURONS, 0.001, 0.01, "gentle-nudge"))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "gentle-nudge");
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION ceiling, got {value}"
+        );
+    }
+
+    #[test]
+    fn variant_key_buckets_are_independent() {
+        // Two variants for the same change_type must keep separate corrections.
+        let mut cache = Vec::new();
+        for _ in 0..MIN_SPECIFIC_VARIANT_KEY_SAMPLES {
+            cache.push(entry_with_variant(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                "gentle-nudge",
+            ));
+        }
+        for _ in 0..MIN_SPECIFIC_VARIANT_KEY_SAMPLES {
+            cache.push(entry_with_variant(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.5,
+                "conservative",
+            ));
+        }
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let gentle = correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "gentle-nudge");
+        let conservative =
+            correction.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, "conservative");
+        assert!(
+            (gentle - 0.001).abs() < 1e-4,
+            "gentle-nudge should be near floor, got {gentle}"
+        );
+        assert!(
+            (conservative - 0.5).abs() < 1e-4,
+            "conservative should be near 0.5, got {conservative}"
+        );
+        assert!(
+            conservative > gentle,
+            "conservative ({conservative}) should exceed gentle-nudge ({gentle})"
         );
     }
 

--- a/src/analysis/synapse/activation_evaluation.rs
+++ b/src/analysis/synapse/activation_evaluation.rs
@@ -496,6 +496,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                     expected_score_gain_confidence_interval: confidence_metrics
                         .expected_score_gain_confidence_interval,
                     target_saturation_factor: None,
+                    variant_key: None,
                 });
             }
 
@@ -532,6 +533,7 @@ pub(crate) fn evaluate_activation_candidate<G: GpuEvaluator>(
                     expected_score_gain_confidence_interval: confidence_metrics
                         .expected_score_gain_confidence_interval,
                     target_saturation_factor: None,
+                    variant_key: None,
                 });
             }
         }

--- a/src/analysis/synapse/activation_subset_evaluation.rs
+++ b/src/analysis/synapse/activation_subset_evaluation.rs
@@ -200,6 +200,7 @@ pub(crate) fn evaluate_activation_for_subset<G: GpuEvaluator>(
                     expected_score_gain_confidence_interval: confidence_metrics
                         .expected_score_gain_confidence_interval,
                     target_saturation_factor: None,
+                    variant_key: None,
                 });
             }
         }

--- a/src/analysis/synapse/add_synapse_gating.rs
+++ b/src/analysis/synapse/add_synapse_gating.rs
@@ -425,6 +425,7 @@ mod tests {
             prediction_confidence: 0.5,
             expected_score_gain_confidence_interval: [0.005, 0.015],
             comment: None,
+            variant_key: None,
         }
     }
 

--- a/src/analysis/synapse/gpu_evaluation.rs
+++ b/src/analysis/synapse/gpu_evaluation.rs
@@ -209,6 +209,7 @@ pub(crate) fn evaluate_all_activation_specs_batched<G: GpuEvaluator>(
                 expected_score_gain_confidence_interval: confidence_metrics
                     .expected_score_gain_confidence_interval,
                 target_saturation_factor: None,
+                variant_key: None,
             };
             best_candidates[spec_idx] = Some((candidate, net_improvement));
         }

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -480,10 +480,14 @@ pub(crate) fn apply_post_processing(
     // Issue #513: Generate weight variants for helpful synapse candidates.
     // Each candidate gets conservative (0.5×), gentle-nudge (0.25×), and micro-nudge (0.1×)
     // weight variants. This maximises the pay-off from the expensive discovery process.
-    *helpful_results = crate::analysis::utils::pair_synapse_candidates_with_weight_variants(
-        std::mem::take(helpful_results),
-        input.max_candidates,
-    );
+    // Issue #1163: pass the per-variant calibration so the effective
+    // expected-improvement multiplier is `min(static, calibrated)`.
+    *helpful_results =
+        crate::analysis::utils::pair_synapse_candidates_with_weight_variants_calibrated(
+            std::mem::take(helpful_results),
+            input.max_candidates,
+            Some(&calibration_correction),
+        );
 
     // Issue #510: Generate conservative weight variants for coordinated-structural candidates.
     // AddSynapse weights are scaled to 0.2× (conservative), 0.1× (gentle nudge), 0.05× (micro-nudge).

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -554,6 +554,7 @@ pub(crate) fn collect_and_process_helpful_results(
                     expected_score_gain_confidence_interval: confidence_metrics
                         .expected_score_gain_confidence_interval,
                     comment: None,
+                    variant_key: None,
                 });
             }
         } // End timing scope for result processing
@@ -663,6 +664,7 @@ pub(crate) fn process_harmful_batch_from_prepared(
             expected_score_gain_confidence_interval: confidence_metrics
                 .expected_score_gain_confidence_interval,
             comment: None,
+            variant_key: None,
         });
     }
 

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -77,7 +77,9 @@ pub(crate) use variant_generation::sensible_bias_abs_max_for_squash;
 pub use variant_generation::{
     filter_candidates_to_sensible_ranges, pair_coordinated_structural_with_weight_variants,
     pair_extreme_candidates_with_conservative_variants,
+    pair_extreme_candidates_with_conservative_variants_calibrated,
     pair_synapse_candidates_with_weight_variants,
+    pair_synapse_candidates_with_weight_variants_calibrated,
 };
 
 /// Check if verbose logging is enabled. Result is cached for performance.

--- a/src/analysis/utils/variant_generation.rs
+++ b/src/analysis/utils/variant_generation.rs
@@ -14,6 +14,29 @@ use crate::CandidateNeuronJson;
 use crate::CandidateSynapseJson;
 use crate::CoordinatedStructuralCandidateJson;
 use crate::CoordinatedStructuralOpJson;
+use crate::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_ADD_NEURONS, CHANGE_TYPE_ADD_SYNAPSES, CalibrationCorrection,
+};
+
+// =============================================================================
+// Stable variant keys (Issue #1163)
+// =============================================================================
+//
+// These keys are the canonical machine-readable identifiers for each variant
+// strategy. They replace the comment string as the calibration grouping key
+// so that wording changes in the user-facing comment cannot silently re-key
+// the failure-cache history.
+
+/// Variant key for the `Conservative` strategy.
+pub const VARIANT_KEY_CONSERVATIVE: &str = "conservative";
+/// Variant key for the `Gentle Nudge` strategy.
+pub const VARIANT_KEY_GENTLE_NUDGE: &str = "gentle-nudge";
+/// Variant key for the `Micro-Nudge` strategy.
+pub const VARIANT_KEY_MICRO_NUDGE: &str = "micro-nudge";
+/// Variant key for the `Feather-Touch` strategy.
+pub const VARIANT_KEY_FEATHER_TOUCH: &str = "feather-touch";
+/// Variant key for the `Whisper` strategy.
+pub const VARIANT_KEY_WHISPER: &str = "whisper";
 
 // ============================================================================
 // Neuron variant configuration and generation
@@ -23,6 +46,14 @@ use crate::CoordinatedStructuralOpJson;
 ///
 /// Each variant strategy (conservative, gentle nudge, micro-nudge) is expressed
 /// as a static `NeuronVariantConfig` instance rather than a separate function.
+///
+/// Issue #1163: `expected_multiplier` is now an **upper bound**, not a fixed
+/// value. When a calibrated correction is supplied via
+/// [`make_neuron_variant_with_correction`], the multiplier actually applied
+/// is `min(expected_multiplier, calibrated_correction)` so a long failure
+/// history can drive predictions further toward the noise floor while a long
+/// success streak cannot inflate them above the static ceiling. The variant
+/// is identified by [`Self::variant_key`], not the comment string.
 pub struct NeuronVariantConfig {
     /// Maximum absolute incoming weight (clamped symmetrically).
     pub incoming_abs_max: f32,
@@ -32,12 +63,20 @@ pub struct NeuronVariantConfig {
     pub outgoing_abs_max: f32,
     /// Scale factor applied to outgoing weight before clamping.
     pub outgoing_scale: f32,
-    /// Multiplier for expected improvement (lower = less displacement in ranking).
+    /// Upper bound on the expected-improvement multiplier (Issue #1163).
+    ///
+    /// Lower = less displacement in ranking. Acts as a ceiling: the
+    /// calibrated per-variant correction (when available) can drive the
+    /// effective multiplier lower, but never higher.
     pub expected_multiplier: f32,
     /// Minimum non-zero outgoing weight fallback when scaling produces near-zero.
     pub min_outgoing_fallback: f32,
     /// Comment text applied to the variant.
     pub comment: &'static str,
+    /// Stable variant key used for failure-cache calibration grouping
+    /// (Issue #1163). This is the canonical machine-readable identifier;
+    /// the [`Self::comment`] is human-readable only.
+    pub variant_key: &'static str,
 }
 
 /// Conservative: tight clamps on all parameters.
@@ -52,6 +91,7 @@ pub static CONSERVATIVE_CONFIG: NeuronVariantConfig = NeuronVariantConfig {
     expected_multiplier: 0.5,
     min_outgoing_fallback: 0.001,
     comment: "Conservative variant (clamped incoming/bias, outgoing scaled)",
+    variant_key: VARIANT_KEY_CONSERVATIVE,
 };
 
 /// Gentle Nudge: moderate incoming/bias range, very small outgoing.
@@ -67,6 +107,7 @@ pub static GENTLE_NUDGE_CONFIG: NeuronVariantConfig = NeuronVariantConfig {
     expected_multiplier: 0.75,
     min_outgoing_fallback: 0.002,
     comment: "Gentle Nudge variant (tight outgoing, bias tamed)",
+    variant_key: VARIANT_KEY_GENTLE_NUDGE,
 };
 
 /// Micro-Nudge: ultra-conservative, targeting ±0.002–0.005 outgoing range.
@@ -83,6 +124,7 @@ pub static MICRO_NUDGE_CONFIG: NeuronVariantConfig = NeuronVariantConfig {
     expected_multiplier: 0.5,
     min_outgoing_fallback: 0.002,
     comment: "Micro-Nudge variant (ultra-conservative outgoing, tight incoming/bias)",
+    variant_key: VARIANT_KEY_MICRO_NUDGE,
 };
 
 /// Feather-Touch: finer-grained variant for near-equilibrium networks (Issue #962).
@@ -97,6 +139,7 @@ pub static FEATHER_TOUCH_CONFIG: NeuronVariantConfig = NeuronVariantConfig {
     expected_multiplier: 0.25,
     min_outgoing_fallback: 0.0005,
     comment: "Feather-Touch variant (near-equilibrium outgoing, minimal perturbation)",
+    variant_key: VARIANT_KEY_FEATHER_TOUCH,
 };
 
 /// Whisper: the most conservative variant tier (Issue #962).
@@ -111,15 +154,36 @@ pub static WHISPER_CONFIG: NeuronVariantConfig = NeuronVariantConfig {
     expected_multiplier: 0.1,
     min_outgoing_fallback: 0.0002,
     comment: "Whisper variant (minimal outgoing, near-zero perturbation)",
+    variant_key: VARIANT_KEY_WHISPER,
 };
 
 /// Create a variant of an add-neuron candidate using the given configuration.
 ///
 /// Clamps incoming weight, bias, and outgoing weight according to the config,
 /// scales expected improvement, and sets the comment.
+///
+/// Equivalent to [`make_neuron_variant_with_correction`] called with `None` —
+/// only the static `expected_multiplier` (the upper bound) is applied.
 pub fn make_neuron_variant(
     candidate: &CandidateNeuronJson,
     config: &NeuronVariantConfig,
+) -> CandidateNeuronJson {
+    make_neuron_variant_with_correction(candidate, config, None)
+}
+
+/// Create a variant of an add-neuron candidate, optionally consulting the
+/// per-variant calibration history (Issue #1163).
+///
+/// When `calibration` is supplied and reports a per-variant correction for
+/// `(add-neurons, config.variant_key)` the effective multiplier becomes
+/// `min(config.expected_multiplier, calibrated_correction)` — the static
+/// value remains a ceiling so a long success streak cannot inflate
+/// predictions, while a long failure history drives the multiplier toward
+/// the noise floor.
+pub fn make_neuron_variant_with_correction(
+    candidate: &CandidateNeuronJson,
+    config: &NeuronVariantConfig,
+    calibration: Option<&CalibrationCorrection>,
 ) -> CandidateNeuronJson {
     let incoming_sign = if candidate.incoming_weight >= 0.0 {
         1.0
@@ -145,14 +209,37 @@ pub fn make_neuron_variant(
         outgoing_weight = outgoing_sign * config.min_outgoing_fallback;
     }
 
+    // Issue #1163: apply min(static_multiplier, calibrated_correction).
+    let effective_multiplier = effective_multiplier_for_neuron(config, calibration);
+
     let mut variant = candidate.clone();
     variant.incoming_weight = incoming_weight;
     variant.bias = bias;
     variant.outgoing_weight = outgoing_weight;
-    variant.expected_creature_error_reduction *= config.expected_multiplier;
+    variant.expected_creature_error_reduction *= effective_multiplier;
     variant.expected_creature_score_gain = variant.expected_creature_error_reduction;
     variant.comment = Some(config.comment.to_string());
+    variant.variant_key = Some(config.variant_key.to_string());
     variant
+}
+
+/// Resolve the effective expected-improvement multiplier for a neuron variant
+/// (Issue #1163).
+///
+/// Returns `min(config.expected_multiplier, calibrated_correction)` when a
+/// calibration is supplied and reports a per-variant correction, otherwise
+/// the static multiplier alone.
+fn effective_multiplier_for_neuron(
+    config: &NeuronVariantConfig,
+    calibration: Option<&CalibrationCorrection>,
+) -> f32 {
+    match calibration {
+        Some(c) => {
+            let calibrated = c.variant_correction_for(CHANGE_TYPE_ADD_NEURONS, config.variant_key);
+            config.expected_multiplier.min(calibrated)
+        }
+        None => config.expected_multiplier,
+    }
 }
 
 // ============================================================================
@@ -160,13 +247,21 @@ pub fn make_neuron_variant(
 // ============================================================================
 
 /// Configuration for generating a scaled variant of a synapse candidate.
+///
+/// Issue #1163: `expected_multiplier` is now an **upper bound**, mirroring
+/// [`NeuronVariantConfig`]. The calibrated per-variant correction (when
+/// available) can drive the effective multiplier lower but not higher. The
+/// canonical identifier is [`Self::variant_key`], not the comment string.
 pub struct SynapseVariantConfig {
     /// Scale factor applied to the synapse weight.
     pub weight_scale: f32,
-    /// Multiplier for expected improvement.
+    /// Upper bound on the expected-improvement multiplier (Issue #1163).
     pub expected_multiplier: f32,
     /// Comment text applied to the variant.
     pub comment: &'static str,
+    /// Stable variant key used for failure-cache calibration grouping
+    /// (Issue #1163).
+    pub variant_key: &'static str,
 }
 
 /// Conservative: halve the weight.
@@ -174,6 +269,7 @@ pub static SYNAPSE_CONSERVATIVE_CONFIG: SynapseVariantConfig = SynapseVariantCon
     weight_scale: 0.5,
     expected_multiplier: 0.5,
     comment: "Conservative variant (weight scaled to 0.5\u{00d7})",
+    variant_key: VARIANT_KEY_CONSERVATIVE,
 };
 
 /// Gentle Nudge: quarter the weight.
@@ -181,6 +277,7 @@ pub static SYNAPSE_GENTLE_NUDGE_CONFIG: SynapseVariantConfig = SynapseVariantCon
     weight_scale: 0.25,
     expected_multiplier: 0.75,
     comment: "Gentle Nudge variant (weight scaled to 0.25\u{00d7})",
+    variant_key: VARIANT_KEY_GENTLE_NUDGE,
 };
 
 /// Micro-Nudge: tenth of the weight.
@@ -188,6 +285,7 @@ pub static SYNAPSE_MICRO_NUDGE_CONFIG: SynapseVariantConfig = SynapseVariantConf
     weight_scale: 0.1,
     expected_multiplier: 0.25,
     comment: "Micro-Nudge variant (weight scaled to 0.1\u{00d7})",
+    variant_key: VARIANT_KEY_MICRO_NUDGE,
 };
 
 /// Feather-Touch: 5% of the weight (Issue #962).
@@ -197,6 +295,7 @@ pub static SYNAPSE_FEATHER_TOUCH_CONFIG: SynapseVariantConfig = SynapseVariantCo
     weight_scale: 0.05,
     expected_multiplier: 0.25,
     comment: "Feather-Touch variant (weight scaled to 0.05\u{00d7})",
+    variant_key: VARIANT_KEY_FEATHER_TOUCH,
 };
 
 /// Whisper: 2% of the weight (Issue #962).
@@ -206,19 +305,57 @@ pub static SYNAPSE_WHISPER_CONFIG: SynapseVariantConfig = SynapseVariantConfig {
     weight_scale: 0.02,
     expected_multiplier: 0.1,
     comment: "Whisper variant (weight scaled to 0.02\u{00d7})",
+    variant_key: VARIANT_KEY_WHISPER,
 };
 
 /// Create a variant of a synapse candidate using the given configuration.
+///
+/// Equivalent to [`make_synapse_variant_with_correction`] called with
+/// `None` — only the static `expected_multiplier` (the upper bound) is
+/// applied.
 pub fn make_synapse_variant(
     candidate: &CandidateSynapseJson,
     config: &SynapseVariantConfig,
 ) -> CandidateSynapseJson {
+    make_synapse_variant_with_correction(candidate, config, None)
+}
+
+/// Create a variant of a synapse candidate, optionally consulting the
+/// per-variant calibration history (Issue #1163).
+///
+/// When `calibration` is supplied and reports a per-variant correction for
+/// `(add-synapses, config.variant_key)` the effective multiplier becomes
+/// `min(config.expected_multiplier, calibrated_correction)` — the static
+/// value remains a ceiling.
+pub fn make_synapse_variant_with_correction(
+    candidate: &CandidateSynapseJson,
+    config: &SynapseVariantConfig,
+    calibration: Option<&CalibrationCorrection>,
+) -> CandidateSynapseJson {
+    let effective_multiplier = effective_multiplier_for_synapse(config, calibration);
+
     let mut variant = candidate.clone();
     variant.weight = candidate.weight * config.weight_scale;
-    variant.expected_creature_error_reduction *= config.expected_multiplier;
-    variant.expected_creature_score_gain *= config.expected_multiplier;
+    variant.expected_creature_error_reduction *= effective_multiplier;
+    variant.expected_creature_score_gain *= effective_multiplier;
     variant.comment = Some(config.comment.to_string());
+    variant.variant_key = Some(config.variant_key.to_string());
     variant
+}
+
+/// Resolve the effective expected-improvement multiplier for a synapse
+/// variant (Issue #1163).
+fn effective_multiplier_for_synapse(
+    config: &SynapseVariantConfig,
+    calibration: Option<&CalibrationCorrection>,
+) -> f32 {
+    match calibration {
+        Some(c) => {
+            let calibrated = c.variant_correction_for(CHANGE_TYPE_ADD_SYNAPSES, config.variant_key);
+            config.expected_multiplier.min(calibrated)
+        }
+        None => config.expected_multiplier,
+    }
 }
 
 // ============================================================================
@@ -316,6 +453,22 @@ pub fn pair_extreme_candidates_with_conservative_variants(
     sorted_candidates: Vec<CandidateNeuronJson>,
     max_candidates: Option<usize>,
 ) -> Vec<CandidateNeuronJson> {
+    pair_extreme_candidates_with_conservative_variants_calibrated(
+        sorted_candidates,
+        max_candidates,
+        None,
+    )
+}
+
+/// Like [`pair_extreme_candidates_with_conservative_variants`] but consults
+/// the per-variant failure-cache calibration when generating each variant
+/// (Issue #1163). Pass `None` for the original behaviour.
+#[doc(hidden)]
+pub fn pair_extreme_candidates_with_conservative_variants_calibrated(
+    sorted_candidates: Vec<CandidateNeuronJson>,
+    max_candidates: Option<usize>,
+    calibration: Option<&CalibrationCorrection>,
+) -> Vec<CandidateNeuronJson> {
     let limit = max_candidates.unwrap_or(usize::MAX);
     if limit == 0 {
         return Vec::new();
@@ -336,7 +489,8 @@ pub fn pair_extreme_candidates_with_conservative_variants(
         let mut added_gentle_nudge = false;
         let mut added_micro_nudge = false;
         if should_pair && output.len() < limit {
-            let conservative = make_neuron_variant(&candidate, &CONSERVATIVE_CONFIG);
+            let conservative =
+                make_neuron_variant_with_correction(&candidate, &CONSERVATIVE_CONFIG, calibration);
             if candidates_meaningfully_differ(&conservative, &candidate) {
                 output.push(conservative);
                 added_conservative = true;
@@ -344,7 +498,8 @@ pub fn pair_extreme_candidates_with_conservative_variants(
         }
 
         if should_pair && output.len() < limit {
-            let gentle = make_neuron_variant(&candidate, &GENTLE_NUDGE_CONFIG);
+            let gentle =
+                make_neuron_variant_with_correction(&candidate, &GENTLE_NUDGE_CONFIG, calibration);
             if candidates_meaningfully_differ(&gentle, &candidate)
                 && output
                     .iter()
@@ -356,7 +511,8 @@ pub fn pair_extreme_candidates_with_conservative_variants(
         }
 
         if should_pair && output.len() < limit && should_generate_micro_nudge(&candidate) {
-            let micro = make_neuron_variant(&candidate, &MICRO_NUDGE_CONFIG);
+            let micro =
+                make_neuron_variant_with_correction(&candidate, &MICRO_NUDGE_CONFIG, calibration);
             if candidates_meaningfully_differ(&micro, &candidate)
                 && output
                     .iter()
@@ -374,7 +530,8 @@ pub fn pair_extreme_candidates_with_conservative_variants(
             candidate.outgoing_weight.abs() >= ULTRA_CONSERVATIVE_BASE_WEIGHT_THRESHOLD;
 
         if should_pair && output.len() < limit && base_weight_above_threshold {
-            let feather = make_neuron_variant(&candidate, &FEATHER_TOUCH_CONFIG);
+            let feather =
+                make_neuron_variant_with_correction(&candidate, &FEATHER_TOUCH_CONFIG, calibration);
             if candidates_meaningfully_differ(&feather, &candidate)
                 && output
                     .iter()
@@ -386,7 +543,8 @@ pub fn pair_extreme_candidates_with_conservative_variants(
         }
 
         if should_pair && output.len() < limit && base_weight_above_threshold {
-            let whisper = make_neuron_variant(&candidate, &WHISPER_CONFIG);
+            let whisper =
+                make_neuron_variant_with_correction(&candidate, &WHISPER_CONFIG, calibration);
             if candidates_meaningfully_differ(&whisper, &candidate)
                 && output
                     .iter()
@@ -470,6 +628,18 @@ pub fn pair_synapse_candidates_with_weight_variants(
     sorted_candidates: Vec<CandidateSynapseJson>,
     max_candidates: Option<usize>,
 ) -> Vec<CandidateSynapseJson> {
+    pair_synapse_candidates_with_weight_variants_calibrated(sorted_candidates, max_candidates, None)
+}
+
+/// Like [`pair_synapse_candidates_with_weight_variants`] but consults the
+/// per-variant failure-cache calibration when generating each variant
+/// (Issue #1163). Pass `None` for the original behaviour.
+#[doc(hidden)]
+pub fn pair_synapse_candidates_with_weight_variants_calibrated(
+    sorted_candidates: Vec<CandidateSynapseJson>,
+    max_candidates: Option<usize>,
+    calibration: Option<&CalibrationCorrection>,
+) -> Vec<CandidateSynapseJson> {
     let limit = max_candidates.unwrap_or(usize::MAX);
     if limit == 0 {
         return Vec::new();
@@ -500,7 +670,7 @@ pub fn pair_synapse_candidates_with_weight_variants(
             if output.len() >= limit {
                 break;
             }
-            let variant = make_synapse_variant(&candidate, config);
+            let variant = make_synapse_variant_with_correction(&candidate, config, calibration);
             if variant.weight.abs() > SYNAPSE_VARIANT_MIN_WEIGHT
                 && synapse_candidates_meaningfully_differ(&variant, &candidate)
                 && output
@@ -519,7 +689,7 @@ pub fn pair_synapse_candidates_with_weight_variants(
                 if output.len() >= limit {
                     break;
                 }
-                let variant = make_synapse_variant(&candidate, config);
+                let variant = make_synapse_variant_with_correction(&candidate, config, calibration);
                 if variant.weight.abs() > SYNAPSE_VARIANT_MIN_WEIGHT
                     && synapse_candidates_meaningfully_differ(&variant, &candidate)
                     && output
@@ -744,4 +914,320 @@ pub fn pair_coordinated_structural_with_weight_variants(
     }
 
     output
+}
+
+// =============================================================================
+// Tests for per-variant calibration (Issue #1163)
+// =============================================================================
+
+#[cfg(test)]
+mod calibrated_variant_tests {
+    use super::*;
+    use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
+
+    fn neuron_candidate(gain: f32) -> CandidateNeuronJson {
+        CandidateNeuronJson {
+            source_neuron_uuid: "src".to_string(),
+            target_neuron_uuid: "tgt".to_string(),
+            source_neuron_index: None,
+            target_neuron_index: None,
+            incoming_weight: 1.0,
+            outgoing_weight: 0.1,
+            squash: "TANH".to_string(),
+            bias: 0.0,
+            comment: None,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: gain,
+            expected_creature_score_gain: gain,
+            improved_count: 10,
+            total_count: 20,
+            improvement_magnitude_ratio: None,
+            target_neuron_stats: None,
+            prediction_confidence: 0.0,
+            expected_score_gain_confidence_interval: [0.0, 0.0],
+            target_saturation_factor: None,
+            variant_key: None,
+        }
+    }
+
+    fn synapse_candidate(gain: f32) -> CandidateSynapseJson {
+        CandidateSynapseJson {
+            from_neuron_uuid: "from".to_string(),
+            to_neuron_uuid: "to".to_string(),
+            from_neuron_index: None,
+            to_neuron_index: None,
+            weight: 0.5,
+            target_neuron_impact: 1.0,
+            expected_creature_error_reduction: gain,
+            expected_creature_score_gain: gain,
+            improved_count: 10,
+            total_count: 20,
+            improvement_magnitude_ratio: None,
+            target_neuron_stats: None,
+            outlier_reduction_info: None,
+            prediction_confidence: 0.8,
+            expected_score_gain_confidence_interval: [0.0, 0.0],
+            comment: None,
+            variant_key: None,
+        }
+    }
+
+    /// Helper: build a failure-cache entry with a variant key.
+    fn fc_entry(
+        change_type: &str,
+        predicted: f32,
+        actual: f32,
+        variant: &str,
+    ) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: change_type.to_string(),
+            expected_error_reduction: predicted,
+            actual_error_reduction: actual,
+            target_squash: None,
+            variant_key: Some(variant.to_string()),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Acceptance criterion 1: insufficient history → static multiplier used.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn neuron_variant_uses_static_multiplier_when_history_insufficient() {
+        // Two failure entries — below MIN_SPECIFIC_VARIANT_KEY_SAMPLES (3).
+        let cache = vec![
+            fc_entry(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                VARIANT_KEY_GENTLE_NUDGE,
+            ),
+            fc_entry(
+                CHANGE_TYPE_ADD_NEURONS,
+                1.0,
+                0.001,
+                VARIANT_KEY_GENTLE_NUDGE,
+            ),
+        ];
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = neuron_candidate(0.2);
+        let variant = make_neuron_variant_with_correction(
+            &candidate,
+            &GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        // Static multiplier (0.75) wins because the calibrated lookup falls
+        // back to NEUTRAL_CORRECTION (1.0); min(0.75, 1.0) == 0.75.
+        let expected = 0.2 * GENTLE_NUDGE_CONFIG.expected_multiplier;
+        assert!(
+            (variant.expected_creature_error_reduction - expected).abs() < 1e-6,
+            "expected static multiplier ({expected}), got {}",
+            variant.expected_creature_error_reduction
+        );
+        assert_eq!(
+            variant.variant_key.as_deref(),
+            Some(VARIANT_KEY_GENTLE_NUDGE),
+            "variant_key should be populated even without calibration data"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Acceptance criterion 2: long failure history → calibrated value used.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn neuron_variant_uses_calibrated_multiplier_when_history_indicates_failure() {
+        // 10 failure entries with 1000× over-estimation — the calibrated value
+        // should drop to the floor (0.001), which is far below the static
+        // 0.75 ceiling.
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| {
+                fc_entry(
+                    CHANGE_TYPE_ADD_NEURONS,
+                    0.001,
+                    0.000_001,
+                    VARIANT_KEY_GENTLE_NUDGE,
+                )
+            })
+            .collect();
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = neuron_candidate(0.2);
+        let static_variant =
+            make_neuron_variant_with_correction(&candidate, &GENTLE_NUDGE_CONFIG, None);
+        let calibrated_variant = make_neuron_variant_with_correction(
+            &candidate,
+            &GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        assert!(
+            calibrated_variant.expected_creature_error_reduction
+                < static_variant.expected_creature_error_reduction,
+            "calibrated reduction ({}) must be smaller than static ({})",
+            calibrated_variant.expected_creature_error_reduction,
+            static_variant.expected_creature_error_reduction
+        );
+
+        // The calibrated multiplier should be at the floor (~0.001).
+        let expected = 0.2_f32 * 0.001;
+        assert!(
+            (calibrated_variant.expected_creature_error_reduction - expected).abs() < 1e-5,
+            "expected calibrated reduction near floor ({expected}), got {}",
+            calibrated_variant.expected_creature_error_reduction
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Acceptance criterion 3: long success history → static multiplier as ceiling.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn neuron_variant_static_multiplier_acts_as_ceiling_for_long_success_history() {
+        // 10 entries where actual exceeds predicted — the calibrated value
+        // would clamp to NEUTRAL_CORRECTION (1.0), but min(0.75, 1.0) = 0.75
+        // means the static ceiling holds.
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| {
+                fc_entry(
+                    CHANGE_TYPE_ADD_NEURONS,
+                    0.001,
+                    0.01,
+                    VARIANT_KEY_GENTLE_NUDGE,
+                )
+            })
+            .collect();
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = neuron_candidate(0.2);
+        let variant = make_neuron_variant_with_correction(
+            &candidate,
+            &GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        let expected = 0.2 * GENTLE_NUDGE_CONFIG.expected_multiplier;
+        assert!(
+            (variant.expected_creature_error_reduction - expected).abs() < 1e-6,
+            "static ceiling violated: expected {expected}, got {}",
+            variant.expected_creature_error_reduction
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Synapse variants — same three regimes, mirrored for add-synapses.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn synapse_variant_uses_static_multiplier_when_history_insufficient() {
+        let cache = vec![fc_entry(
+            CHANGE_TYPE_ADD_SYNAPSES,
+            1.0,
+            0.001,
+            VARIANT_KEY_GENTLE_NUDGE,
+        )];
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = synapse_candidate(0.4);
+        let variant = make_synapse_variant_with_correction(
+            &candidate,
+            &SYNAPSE_GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        let expected = 0.4 * SYNAPSE_GENTLE_NUDGE_CONFIG.expected_multiplier;
+        assert!(
+            (variant.expected_creature_error_reduction - expected).abs() < 1e-6,
+            "expected static synapse multiplier ({expected}), got {}",
+            variant.expected_creature_error_reduction
+        );
+        assert_eq!(
+            variant.variant_key.as_deref(),
+            Some(VARIANT_KEY_GENTLE_NUDGE)
+        );
+    }
+
+    #[test]
+    fn synapse_variant_uses_calibrated_multiplier_for_long_failure_history() {
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| {
+                fc_entry(
+                    CHANGE_TYPE_ADD_SYNAPSES,
+                    0.001,
+                    0.000_001,
+                    VARIANT_KEY_GENTLE_NUDGE,
+                )
+            })
+            .collect();
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = synapse_candidate(0.4);
+        let calibrated = make_synapse_variant_with_correction(
+            &candidate,
+            &SYNAPSE_GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        let expected = 0.4_f32 * 0.001;
+        assert!(
+            (calibrated.expected_creature_error_reduction - expected).abs() < 1e-4,
+            "expected calibrated synapse reduction near floor ({expected}), got {}",
+            calibrated.expected_creature_error_reduction
+        );
+    }
+
+    #[test]
+    fn synapse_variant_static_multiplier_caps_long_success_history() {
+        let cache: Vec<FailureCacheEntry> = (0..10)
+            .map(|_| {
+                fc_entry(
+                    CHANGE_TYPE_ADD_SYNAPSES,
+                    0.001,
+                    0.01,
+                    VARIANT_KEY_GENTLE_NUDGE,
+                )
+            })
+            .collect();
+        let calibration = CalibrationCorrection::from_failure_cache(&cache);
+
+        let candidate = synapse_candidate(0.4);
+        let variant = make_synapse_variant_with_correction(
+            &candidate,
+            &SYNAPSE_GENTLE_NUDGE_CONFIG,
+            Some(&calibration),
+        );
+
+        let expected = 0.4 * SYNAPSE_GENTLE_NUDGE_CONFIG.expected_multiplier;
+        assert!(
+            (variant.expected_creature_error_reduction - expected).abs() < 1e-6,
+            "static synapse ceiling violated: expected {expected}, got {}",
+            variant.expected_creature_error_reduction
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Backward-compat: variant_key is populated even without calibration data.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn neuron_variant_populates_key_without_calibration() {
+        let candidate = neuron_candidate(0.2);
+        let variant = make_neuron_variant(&candidate, &CONSERVATIVE_CONFIG);
+        assert_eq!(
+            variant.variant_key.as_deref(),
+            Some(VARIANT_KEY_CONSERVATIVE)
+        );
+    }
+
+    #[test]
+    fn synapse_variant_populates_key_without_calibration() {
+        let candidate = synapse_candidate(0.4);
+        let variant = make_synapse_variant(&candidate, &SYNAPSE_MICRO_NUDGE_CONFIG);
+        assert_eq!(
+            variant.variant_key.as_deref(),
+            Some(VARIANT_KEY_MICRO_NUDGE)
+        );
+    }
 }

--- a/src/ffi_types/candidates.rs
+++ b/src/ffi_types/candidates.rs
@@ -78,6 +78,16 @@ pub struct CandidateSynapseJson {
     /// comment lists which variants were included.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
+    /// Stable variant identifier (Issue #1163).
+    ///
+    /// When a synapse candidate is produced by `variant_generation`, this
+    /// field carries the canonical variant key (e.g., `gentle-nudge`,
+    /// `micro-nudge`, `conservative`) — the canonical identifier the
+    /// failure-cache calibrator groups by. The `comment` string remains
+    /// human-readable; `variant_key` is the machine-readable label.
+    /// `None` for original (non-variant) candidates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant_key: Option<String>,
 }
 
 /// Candidate to update the weight of an existing synapse (delta-based).
@@ -254,6 +264,16 @@ pub struct CandidateNeuronJson {
     /// Candidates targeting near-saturated neurons have reduced expected gains.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_saturation_factor: Option<f32>,
+    /// Stable variant identifier (Issue #1163).
+    ///
+    /// When an add-neuron candidate is produced by `variant_generation`, this
+    /// field carries the canonical variant key (e.g., `gentle-nudge`,
+    /// `micro-nudge`, `conservative`, `feather-touch`, `whisper`) — the
+    /// canonical identifier the failure-cache calibrator groups by. The
+    /// `comment` string remains human-readable; `variant_key` is the
+    /// machine-readable label. `None` for original (non-variant) candidates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant_key: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/tests/analysis/extreme_candidate_pairing.rs
+++ b/tests/analysis/extreme_candidate_pairing.rs
@@ -32,6 +32,7 @@ fn extreme_candidate_comment_does_not_claim_pairing_when_limit_prevents_variant(
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Limit leaves no room for any safety variants.
@@ -74,6 +75,7 @@ fn extreme_candidate_pairing_considers_outgoing_weight_differences() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(2));
@@ -119,6 +121,7 @@ fn extreme_candidate_includes_gentle_nudge_variant_when_limit_allows() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let paired = pair_extreme_candidates_with_conservative_variants(vec![candidate], Some(3));
@@ -189,6 +192,7 @@ fn gentle_nudge_variants_are_not_deduped_across_different_neuron_pairs() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let candidate_b = CandidateNeuronJson {
@@ -211,6 +215,7 @@ fn gentle_nudge_variants_are_not_deduped_across_different_neuron_pairs() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Limit allows both originals plus all safety variants per candidate.

--- a/tests/analysis/issue_1003_parallel_candidate_compression.rs
+++ b/tests/analysis/issue_1003_parallel_candidate_compression.rs
@@ -29,6 +29,7 @@ fn candidate(from: &str, to: &str, weight: f32, gain: f32) -> CandidateSynapseJs
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_1004_overlap_compression_discovery.rs
+++ b/tests/analysis/issue_1004_overlap_compression_discovery.rs
@@ -88,6 +88,7 @@ fn synapse_candidate(from: &str, to: &str, weight: f32, gain: f32) -> CandidateS
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_1057_add_synapse_gating.rs
+++ b/tests/analysis/issue_1057_add_synapse_gating.rs
@@ -69,6 +69,7 @@ fn make_test_candidate(from: &str, to: &str) -> CandidateSynapseJson {
         prediction_confidence: 0.5,
         expected_score_gain_confidence_interval: [0.005, 0.015],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_1131_calibration_correction.rs
+++ b/tests/analysis/issue_1131_calibration_correction.rs
@@ -117,6 +117,7 @@ fn twenty_over_estimations_clamp_to_minimum_correction() {
             expected_error_reduction: 0.001,
             actual_error_reduction: 0.000_001,
             target_squash: None,
+            variant_key: None,
         })
         .collect();
     let correction = CalibrationCorrection::from_failure_cache(&cache);
@@ -154,6 +155,7 @@ fn analyze_all_exposes_calibration_corrections_in_metadata() {
                 expected_error_reduction: 0.001,
                 actual_error_reduction: 0.000_001,
                 target_squash: None,
+                variant_key: None,
             });
         }
     }
@@ -242,6 +244,7 @@ fn calibration_corrections_are_deterministic() {
             // Vary slightly so the EWMA is a non-trivial value.
             actual_error_reduction: 0.002 + (i as f32) * 0.000_05,
             target_squash: None,
+            variant_key: None,
         })
         .collect();
 

--- a/tests/analysis/issue_1162_calibration_per_target_squash.rs
+++ b/tests/analysis/issue_1162_calibration_per_target_squash.rs
@@ -24,6 +24,7 @@ fn entry_with_squash(
         expected_error_reduction: predicted,
         actual_error_reduction: actual,
         target_squash: squash.map(str::to_string),
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_340_discovery_categories.rs
+++ b/tests/analysis/issue_340_discovery_categories.rs
@@ -45,6 +45,7 @@ fn candidate_synapse_json_serialisation_contract() {
         prediction_confidence: 0.9,
         expected_score_gain_confidence_interval: [0.005, 0.015],
         comment: None,
+        variant_key: None,
     };
 
     let json = serde_json::to_value(&candidate).expect("serialisation should succeed");
@@ -94,6 +95,7 @@ fn candidate_neuron_json_serialisation_contract() {
         prediction_confidence: 0.85,
         expected_score_gain_confidence_interval: [0.01, 0.03],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let json = serde_json::to_value(&candidate).expect("serialisation should succeed");

--- a/tests/analysis/issue_806_dry_variant_generation.rs
+++ b/tests/analysis/issue_806_dry_variant_generation.rs
@@ -40,6 +40,7 @@ fn make_test_neuron_candidate(incoming: f32, outgoing: f32, bias: f32) -> Candid
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 
@@ -62,6 +63,7 @@ fn make_test_synapse_candidate(weight: f32, expected_gain: f32) -> CandidateSyna
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         comment: None,
+        variant_key: None,
     }
 }
 
@@ -358,6 +360,7 @@ fn custom_neuron_config_produces_expected_variant() {
         expected_multiplier: 0.6,
         min_outgoing_fallback: 0.008,
         comment: "Custom variant",
+        variant_key: "custom",
     };
 
     let candidate = make_test_neuron_candidate(100.0, 0.1, 20.0);
@@ -390,6 +393,7 @@ fn custom_synapse_config_produces_expected_variant() {
         weight_scale: 0.33,
         expected_multiplier: 0.4,
         comment: "Custom synapse variant",
+        variant_key: "custom-synapse",
     };
 
     let candidate = make_test_synapse_candidate(0.09, 0.2);

--- a/tests/analysis/issue_921_candidate_compression.rs
+++ b/tests/analysis/issue_921_candidate_compression.rs
@@ -39,6 +39,7 @@ fn candidate(from: &str, to: &str, weight: f32, gain: f32) -> CandidateSynapseJs
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_922_nonlinear_candidate_compression.rs
+++ b/tests/analysis/issue_922_nonlinear_candidate_compression.rs
@@ -37,6 +37,7 @@ fn candidate(from: &str, to: &str, weight: f32, gain: f32) -> CandidateSynapseJs
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [gain * 0.5, gain * 1.5],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/analysis/issue_962_ultra_conservative_variants.rs
+++ b/tests/analysis/issue_962_ultra_conservative_variants.rs
@@ -44,6 +44,7 @@ fn make_test_neuron_candidate(incoming: f32, outgoing: f32, bias: f32) -> Candid
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 
@@ -66,6 +67,7 @@ fn make_test_synapse_candidate(weight: f32, expected_gain: f32) -> CandidateSyna
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/neuron/neuron_metadata_candidates_found_includes_pairing.rs
+++ b/tests/neuron/neuron_metadata_candidates_found_includes_pairing.rs
@@ -41,6 +41,7 @@ fn candidates_found_includes_paired_variants() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Simulate CORRECT neuron analysis behaviour:
@@ -129,6 +130,7 @@ fn non_extreme_candidates_maintain_count_invariant() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Apply pairing with no limit
@@ -183,6 +185,7 @@ fn truncation_respects_invariant_with_multiple_extreme_candidates() {
             prediction_confidence: 0.0,
             expected_score_gain_confidence_interval: [0.0, 0.0],
             target_saturation_factor: None,
+            variant_key: None,
         })
         .collect();
 

--- a/tests/recommendation/issue_507_micro_nudge_variant.rs
+++ b/tests/recommendation/issue_507_micro_nudge_variant.rs
@@ -42,6 +42,7 @@ fn make_extreme_candidate(
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 

--- a/tests/scoring/issue_888_weight_constraints.rs
+++ b/tests/scoring/issue_888_weight_constraints.rs
@@ -68,6 +68,7 @@ fn make_test_candidate(incoming: f32, outgoing: f32, bias: f32) -> CandidateNeur
         expected_score_gain_confidence_interval: [0.005, 0.015],
         comment: None,
         target_saturation_factor: None,
+        variant_key: None,
     }
 }
 

--- a/tests/synapse/issue_513_synapse_weight_variants.rs
+++ b/tests/synapse/issue_513_synapse_weight_variants.rs
@@ -33,6 +33,7 @@ fn make_synapse_candidate(
         prediction_confidence: 0.8,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         comment: None,
+        variant_key: None,
     }
 }
 

--- a/tests/synapse/sensible_range_filtering.rs
+++ b/tests/synapse/sensible_range_filtering.rs
@@ -32,6 +32,7 @@ fn extreme_candidate_is_not_returned_after_sensible_range_filtering() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     // Existing production experiment: pair with safety variants.
@@ -89,6 +90,7 @@ fn absurd_identity_bias_is_filtered_out() {
         prediction_confidence: 0.0,
         expected_score_gain_confidence_interval: [0.0, 0.0],
         target_saturation_factor: None,
+        variant_key: None,
     };
 
     let filtered = filter_candidates_to_sensible_ranges(vec![absurd]);


### PR DESCRIPTION
## Summary

Per-variant calibration for `variant_generation` `expected_multiplier`. Failure-cache entries now carry an optional `variantKey`; the calibrator groups by `(change_type, variant_key)` and `make_neuron_variant` / `make_synapse_variant` apply `min(static_multiplier, calibrated_correction)` so a variant whose recent history shows persistent over-estimation is automatically demoted, while the static multiplier remains a ceiling. Closes #1163.

## What Changed

- `FailureCacheEntry` gains `variant_key: Option<String>` (top-level `variantKey` or nested `variantInfo.key`; missing field tolerated for backward compatibility).
- `CalibrationCorrection` gains `variant_corrections: HashMap<(String, String), f32>` and a `variant_correction_for(change_type, variant_key) -> f32` lookup. Specific corrections are only retained once `MIN_SPECIFIC_VARIANT_KEY_SAMPLES` (= 3) usable entries exist for the bucket; otherwise the lookup returns `NEUTRAL_CORRECTION` so the static multiplier wins.
- `NeuronVariantConfig` and `SynapseVariantConfig` gain `variant_key: &'static str`. Each static config (`CONSERVATIVE`, `GENTLE_NUDGE`, `MICRO_NUDGE`, `FEATHER_TOUCH`, `WHISPER`) is now identified by a stable machine-readable key — the canonical identifier the calibrator groups by; the comment string is human-readable only.
- `CandidateNeuronJson` and `CandidateSynapseJson` gain `variant_key: Option<String>` (skipped from the wire schema when absent — additive, no `wireSchemaVersion` bump).
- `make_neuron_variant_with_correction` / `make_synapse_variant_with_correction`: new entry points that consult the calibration. The original two-arg `make_*_variant` functions delegate to them with `None` for backward compatibility but still populate `variant_key`.
- `pair_extreme_candidates_with_conservative_variants_calibrated` / `pair_synapse_candidates_with_weight_variants_calibrated`: calibrated pair functions used by `neuron::post_processing` and `synapse::post_processing`.

## Evidence

CLI / library change — no UI to screenshot. The new behaviour is exercised by 8 lib tests in `analysis::utils::variant_generation::calibrated_variant_tests` and 6 lib tests in `analysis::scoring::calibration_correction::tests` covering the three acceptance regimes plus parsing and isolation between variant buckets. `./quality.sh` passes cleanly.

```mermaid
flowchart LR
    FC[Failure cache<br/>variantKey] --> CC[CalibrationCorrection<br/>variant_corrections]
    CC -->|variant_correction_for| MV[make_neuron_variant_with_correction]
    SC[NeuronVariantConfig<br/>expected_multiplier ceiling<br/>variant_key]
    SC --> MV
    MV -->|min ceiling, calibrated| EM[Effective multiplier]
    EM --> CN[CandidateNeuronJson<br/>variant_key set]
```

## Test Plan

New tests (all passing):

- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_uses_static_multiplier_when_history_insufficient` — fewer than 3 entries → static `expected_multiplier` used.
- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_uses_calibrated_multiplier_when_history_indicates_failure` — long failure history drives the multiplier toward the floor.
- `analysis::utils::variant_generation::calibrated_variant_tests::neuron_variant_static_multiplier_acts_as_ceiling_for_long_success_history` — long success history clamps to neutral so static value remains a ceiling.
- Mirror tests for synapse variants (`synapse_variant_uses_*`).
- `synapse_variant_populates_key_without_calibration` / `neuron_variant_populates_key_without_calibration` — `variant_key` is set even when no calibration is supplied.
- `analysis::scoring::calibration_correction::tests::variant_key_parsed_from_top_level_field` / `..._nested_variant_info` / `..._optional_for_legacy_entries` — JSON wire-format parsing.
- `analysis::scoring::calibration_correction::tests::insufficient_variant_history_falls_back_to_neutral` / `long_variant_failure_history_drives_calibrated_value` / `long_variant_success_history_clamps_at_neutral` / `variant_key_buckets_are_independent` — calibration regimes.

Existing tests still pass (`./quality.sh`).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1163 -->