### PR TITLE
Add calibration mismatch logging and MCMC counters (#1165)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.29"
+version = "0.74.30"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1165.md
+++ b/docs/pr-summary-1165.md
@@ -1,0 +1,71 @@
+## Summary
+
+Adds structured prediction-vs-actual calibration mismatch logging so the
+team can tune the constants in `analysis::constants::candidate_scoring`
+from data instead of one-off failure JSON files (Issue #1160's "Gentle
+Nudge against SELU" was over-predicting by ~3000×). Closes #1165.
+
+When a failure-cache entry's `actual / expected` ratio falls outside
+`[1/threshold, threshold]` (default 10×, overridable via
+`NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD`), the synapse pipeline:
+
+1. Emits a `tracing::warn!` with the structured tuple
+   `(change_type, target_squash, variant_key, expected, actual, ratio)`
+   on the existing `neat_ai_discovery::observability` target.
+2. Increments `mcmc_diagnostics.calibration_miss_count` (always tracked
+   so the rate is visible in non-verbose runs).
+3. In verbose mode (`NEAT_AI_DISCOVERY_VERBOSE=1`), appends a
+   `CalibrationMissEntry` to a 1000-entry capped vector that is
+   surfaced in the analysis JSON output as
+   `mcmcDiagnostics.calibrationMisses`.
+
+The hook lives at the synapse orchestration layer (where the MCMC
+tracker is already created) so each failure-cache entry is processed
+exactly once per analysis run.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    FC[Failure cache<br/>JSON entries] --> ORCH[synapse orchestration]
+    ORCH -->|threshold| TR[McmcDiagnosticsTracker<br/>record_calibration_misses_from_cache]
+    TR -->|"|ratio| > threshold<br/>or |ratio| < 1/threshold"| LOG[tracing::warn!]
+    TR -->|count++| SUM[McmcDiagnosticsSummary]
+    TR -->|verbose only, capped 1000| VEC[CalibrationMissEntry vec]
+    SUM --> JSON[mcmcDiagnostics.calibrationMissCount]
+    VEC --> JSON2[mcmcDiagnostics.calibrationMisses]
+```
+
+CLI/library change — no UI screenshots. Verified by:
+
+- `cargo test --lib mcmc_diagnostics` — 7 new unit tests pass (in
+  tolerance, above threshold, below reciprocal, zero/non-finite skipped,
+  non-verbose count-only, vec cap at 1000, threshold clamp).
+- `cargo test --test analysis issue_1165` — env-var integration test
+  passes.
+- `./quality.sh` — full gate (`fmt`, `clippy -D warnings`, `cargo
+  check`, `cargo test`, doc build, release build) passes.
+
+## Test Plan
+
+- [x] `src/analysis/diagnostics/mcmc_diagnostics.rs::tests::calibration_miss_in_tolerance_records_nothing`
+- [x] `…calibration_miss_above_threshold_is_recorded`
+- [x] `…calibration_miss_below_reciprocal_threshold_is_recorded`
+- [x] `…calibration_miss_skips_zero_or_non_finite_entries`
+- [x] `…calibration_miss_non_verbose_mode_skips_vec_but_counts`
+- [x] `…calibration_miss_vec_capped_at_max_size`
+- [x] `…calibration_miss_threshold_clamps_invalid_inputs`
+- [x] `tests/analysis/issue_1165_calibration_miss_logging.rs::calibration_miss_threshold_env_var_overrides_default`
+
+## Acceptance Criteria
+
+- [x] Calibration mismatch logging gated by an env-var threshold and
+      emitted via existing `tracing` infrastructure
+- [x] Verbose MCMC diagnostics include a bounded
+      `Vec<CalibrationMissEntry>` and surface a count
+      (`calibrationMissCount` always; `calibrationMisses` verbose only)
+- [x] Unit tests cover threshold behaviour, verbose vs non-verbose,
+      capping
+- [x] No PII / large payloads logged; only the structured tuple
+- [x] Documentation in `src/observability/mod.rs` and
+      `src/config/mod.rs` describes the new field/env var

--- a/src/analysis/diagnostics/mcmc_diagnostics.rs
+++ b/src/analysis/diagnostics/mcmc_diagnostics.rs
@@ -12,9 +12,46 @@
 
 #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)] // Intentional numeric casts for ratio computation
 
+use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
 use crate::analysis::utils::verbose_enabled;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Maximum number of `CalibrationMissEntry` records retained in verbose mode
+/// (Issue #1165). The counter is unbounded; only the per-entry vector is
+/// capped to bound memory.
+pub const CALIBRATION_MISS_VEC_CAP: usize = 1000;
+
+/// Default threshold for the `actual / expected` ratio above which (or whose
+/// reciprocal exceeds) a calibration mismatch is logged (Issue #1165).
+///
+/// A miss is reported when `|ratio| > threshold` or `|ratio| < 1 / threshold`.
+/// Overridable via `NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD`.
+pub const DEFAULT_CALIBRATION_MISS_THRESHOLD: f32 = 10.0;
+
+/// A single prediction-vs-actual calibration mismatch (Issue #1165).
+///
+/// Captured when the recorded `actual_error_reduction` differs from the
+/// `expected_error_reduction` by more than the configured threshold (default
+/// 10×). The structured tuple lets future tuning of calibration constants
+/// in `analysis::constants::candidate_scoring` work from data instead of a
+/// handful of failure JSON files.
+#[derive(Debug, Clone)]
+pub struct CalibrationMissEntry {
+    /// Candidate classification — same key used for `CalibrationCorrection`.
+    pub change_type: String,
+    /// Target neuron's activation function, when supplied by the upstream
+    /// emitter.
+    pub target_squash: Option<String>,
+    /// Variant key identifying the variant generator (Issue #1163).
+    pub variant_key: Option<String>,
+    /// What was predicted at proposal time.
+    pub expected: f32,
+    /// What actually happened after applying the candidate.
+    pub actual: f32,
+    /// `actual / expected` (finite, non-zero divisor).
+    pub ratio: f32,
+}
 
 // =============================================================================
 // Per-candidate-type acceptance counters (lock-free atomics)
@@ -100,6 +137,14 @@ pub(crate) struct McmcDiagnosticsTracker {
     accepted_sources: std::sync::Mutex<HashSet<String>>,
     /// Unique target neuron UUIDs among accepted candidates.
     accepted_targets: std::sync::Mutex<HashSet<String>>,
+
+    /// Total count of calibration mismatches detected this run (Issue #1165).
+    /// Always tracked, regardless of verbose mode, so the rate is visible at
+    /// a glance via [`McmcDiagnosticsSummary::calibration_miss_count`].
+    calibration_miss_count: AtomicU32,
+    /// Per-entry calibration mismatch records (Issue #1165). Only populated in
+    /// verbose mode and capped at [`CALIBRATION_MISS_VEC_CAP`] to bound memory.
+    calibration_misses: std::sync::Mutex<Vec<CalibrationMissEntry>>,
 }
 
 impl McmcDiagnosticsTracker {
@@ -116,6 +161,8 @@ impl McmcDiagnosticsTracker {
             evaluated_targets: std::sync::Mutex::new(HashSet::new()),
             accepted_sources: std::sync::Mutex::new(HashSet::new()),
             accepted_targets: std::sync::Mutex::new(HashSet::new()),
+            calibration_miss_count: AtomicU32::new(0),
+            calibration_misses: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -132,6 +179,8 @@ impl McmcDiagnosticsTracker {
             evaluated_targets: std::sync::Mutex::new(HashSet::new()),
             accepted_sources: std::sync::Mutex::new(HashSet::new()),
             accepted_targets: std::sync::Mutex::new(HashSet::new()),
+            calibration_miss_count: AtomicU32::new(0),
+            calibration_misses: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -177,6 +226,76 @@ impl McmcDiagnosticsTracker {
         }
     }
 
+    /// Inspect a failure cache for prediction-vs-actual calibration mismatches
+    /// and record any that are out of tolerance (Issue #1165).
+    ///
+    /// A miss is reported when the per-entry ratio
+    /// `actual / expected` satisfies `|ratio| > threshold` or
+    /// `|ratio| < 1 / threshold`. For each miss, this method:
+    ///
+    /// 1. Emits a `tracing::warn!` with the structured tuple
+    ///    `(change_type, target_squash, variant_key, expected, actual, ratio)`.
+    /// 2. Increments the calibration-miss counter.
+    /// 3. In verbose mode, appends a [`CalibrationMissEntry`] to the bounded
+    ///    in-memory vector (capped at [`CALIBRATION_MISS_VEC_CAP`]).
+    ///
+    /// Entries with `expected_error_reduction == 0` or non-finite ratios are
+    /// skipped (no defined ratio). Threshold values `<= 1.0` are clamped to
+    /// `1.0` so the upper and lower bounds remain meaningful.
+    pub(crate) fn record_calibration_misses_from_cache(
+        &self,
+        cache: &[FailureCacheEntry],
+        threshold: f32,
+    ) {
+        let threshold = if threshold.is_finite() && threshold > 1.0 {
+            threshold
+        } else {
+            1.0
+        };
+        let lower = 1.0 / threshold;
+        for entry in cache {
+            if entry.expected_error_reduction == 0.0 {
+                continue;
+            }
+            let ratio = entry.actual_error_reduction / entry.expected_error_reduction;
+            if !ratio.is_finite() {
+                continue;
+            }
+            let abs_ratio = ratio.abs();
+            if abs_ratio <= threshold && abs_ratio >= lower {
+                continue;
+            }
+
+            tracing::warn!(
+                target: "neat_ai_discovery::observability",
+                change_type = %entry.change_type,
+                target_squash = entry.target_squash.as_deref().unwrap_or("<none>"),
+                variant_key = entry.variant_key.as_deref().unwrap_or("<none>"),
+                expected = entry.expected_error_reduction,
+                actual = entry.actual_error_reduction,
+                ratio,
+                threshold,
+                "prediction-vs-actual calibration mismatch (Issue #1165)"
+            );
+
+            self.calibration_miss_count.fetch_add(1, Ordering::Relaxed);
+
+            if self.collect_details
+                && let Ok(mut vec) = self.calibration_misses.lock()
+                && vec.len() < CALIBRATION_MISS_VEC_CAP
+            {
+                vec.push(CalibrationMissEntry {
+                    change_type: entry.change_type.clone(),
+                    target_squash: entry.target_squash.clone(),
+                    variant_key: entry.variant_key.clone(),
+                    expected: entry.expected_error_reduction,
+                    actual: entry.actual_error_reduction,
+                    ratio,
+                });
+            }
+        }
+    }
+
     fn counters_for(&self, candidate_type: CandidateType) -> &AcceptanceCounters {
         match candidate_type {
             CandidateType::Synapse => &self.synapse_counters,
@@ -206,6 +325,21 @@ impl McmcDiagnosticsTracker {
             None
         };
 
+        let calibration_miss_count = self.calibration_miss_count.load(Ordering::Relaxed);
+        let calibration_misses = if self.collect_details {
+            let vec = self
+                .calibration_misses
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if vec.is_empty() {
+                None
+            } else {
+                Some(vec.clone())
+            }
+        } else {
+            None
+        };
+
         McmcDiagnosticsSummary {
             synapse_acceptance: synapse,
             neuron_acceptance: neuron,
@@ -214,6 +348,8 @@ impl McmcDiagnosticsTracker {
             total_accepted,
             proposal_quality,
             diversity,
+            calibration_miss_count,
+            calibration_misses,
         }
     }
 
@@ -310,6 +446,13 @@ pub struct McmcDiagnosticsSummary {
     pub proposal_quality: Option<ProposalQuality>,
     /// Source/target diversity among evaluated vs accepted candidates (verbose only).
     pub diversity: Option<DiversityMetric>,
+    /// Total number of prediction-vs-actual calibration mismatches detected
+    /// during this run (Issue #1165). Always populated; surfaced in JSON so
+    /// operators can see the rate at a glance.
+    pub calibration_miss_count: u32,
+    /// Per-entry calibration mismatches (Issue #1165). Only populated in
+    /// verbose mode (capped at [`CALIBRATION_MISS_VEC_CAP`]).
+    pub calibration_misses: Option<Vec<CalibrationMissEntry>>,
 }
 
 impl McmcDiagnosticsSummary {
@@ -478,6 +621,148 @@ mod tests {
         assert_eq!(summary.total_accepted, 0);
         assert_eq!(summary.overall_acceptance_rate(), 0.0);
         assert!(summary.proposal_quality.is_none());
+    }
+
+    // =========================================================================
+    // Issue #1165 — calibration mismatch logging
+    // =========================================================================
+
+    fn miss_entry(
+        change_type: &str,
+        expected: f32,
+        actual: f32,
+        target_squash: Option<&str>,
+        variant_key: Option<&str>,
+    ) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: change_type.to_string(),
+            expected_error_reduction: expected,
+            actual_error_reduction: actual,
+            target_squash: target_squash.map(str::to_string),
+            variant_key: variant_key.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn calibration_miss_in_tolerance_records_nothing() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        // Ratio = 0.5, well within +/-10×.
+        let cache = vec![miss_entry("add-neurons", 1.0, 0.5, Some("SELU"), None)];
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 0);
+        assert!(summary.calibration_misses.is_none());
+    }
+
+    #[test]
+    fn calibration_miss_above_threshold_is_recorded() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        // Ratio = 100, way above the 10× threshold.
+        let cache = vec![miss_entry("add-synapses", 0.001, 0.1, None, None)];
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 1);
+        let misses = summary
+            .calibration_misses
+            .expect("verbose mode should populate the vec");
+        assert_eq!(misses.len(), 1);
+        assert_eq!(misses[0].change_type, "add-synapses");
+        assert!((misses[0].ratio - 100.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn calibration_miss_below_reciprocal_threshold_is_recorded() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        // Ratio = 1/3000, far below 1/10 = 0.1 — the canonical "Gentle Nudge"
+        // case from Issue #1160.
+        let cache = vec![miss_entry(
+            "add-neurons",
+            0.003,
+            0.000_001,
+            Some("SELU"),
+            Some("gentle-nudge"),
+        )];
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 1);
+        let misses = summary
+            .calibration_misses
+            .expect("verbose mode should populate the vec");
+        assert_eq!(misses[0].target_squash.as_deref(), Some("SELU"));
+        assert_eq!(misses[0].variant_key.as_deref(), Some("gentle-nudge"));
+    }
+
+    #[test]
+    fn calibration_miss_skips_zero_or_non_finite_entries() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        let cache = vec![
+            // expected = 0 → undefined ratio, skip.
+            miss_entry("add-neurons", 0.0, 0.5, None, None),
+            // expected = MIN_POSITIVE, actual = MAX → non-finite, skip.
+            miss_entry("add-neurons", f32::MIN_POSITIVE, f32::MAX, None, None),
+        ];
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 0);
+    }
+
+    #[test]
+    fn calibration_miss_non_verbose_mode_skips_vec_but_counts() {
+        // Default tracker — collect_details follows verbose_enabled() which is
+        // false in the test environment. Regardless, the count must be tracked.
+        let tracker = McmcDiagnosticsTracker {
+            synapse_counters: AcceptanceCounters::new(),
+            neuron_counters: AcceptanceCounters::new(),
+            coordinated_counters: AcceptanceCounters::new(),
+            collect_details: false,
+            improvement_values: std::sync::Mutex::new(Vec::new()),
+            evaluated_sources: std::sync::Mutex::new(HashSet::new()),
+            evaluated_targets: std::sync::Mutex::new(HashSet::new()),
+            accepted_sources: std::sync::Mutex::new(HashSet::new()),
+            accepted_targets: std::sync::Mutex::new(HashSet::new()),
+            calibration_miss_count: AtomicU32::new(0),
+            calibration_misses: std::sync::Mutex::new(Vec::new()),
+        };
+        let cache = vec![
+            miss_entry("add-neurons", 0.001, 0.1, None, None), // ratio 100
+            miss_entry("add-neurons", 1.0, 0.000_01, None, None), // ratio 1e-5
+        ];
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 2);
+        assert!(
+            summary.calibration_misses.is_none(),
+            "non-verbose mode must not populate the per-entry vec"
+        );
+    }
+
+    #[test]
+    fn calibration_miss_vec_capped_at_max_size() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        // Generate CAP + 25 misses; vector must cap, count must reflect all.
+        let total = CALIBRATION_MISS_VEC_CAP + 25;
+        let cache: Vec<FailureCacheEntry> = (0..total)
+            .map(|_| miss_entry("add-neurons", 1.0, 100.0, None, None))
+            .collect();
+        tracker.record_calibration_misses_from_cache(&cache, 10.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count as usize, total);
+        let misses = summary
+            .calibration_misses
+            .expect("verbose mode should populate the vec");
+        assert_eq!(misses.len(), CALIBRATION_MISS_VEC_CAP);
+    }
+
+    #[test]
+    fn calibration_miss_threshold_clamps_invalid_inputs() {
+        let tracker = McmcDiagnosticsTracker::new_verbose();
+        let cache = vec![miss_entry("add-neurons", 1.0, 0.5, None, None)];
+        // Threshold <= 1.0 collapses to threshold = 1.0 so the symmetric
+        // window degenerates to exactly 1.0, marking any non-unit ratio as a
+        // miss. This guards against silently disabling the check on bad input.
+        tracker.record_calibration_misses_from_cache(&cache, -5.0);
+        let summary = tracker.build_summary();
+        assert_eq!(summary.calibration_miss_count, 1);
     }
 
     #[test]

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -178,6 +178,15 @@ pub(crate) fn analyze_synapses_with_cache_impl(
     );
 
     // Phase 8: Collect results and build final output
+    // Issue #1165: scan the failure cache for prediction-vs-actual calibration
+    // mismatches and emit structured diagnostic logs + per-entry records on
+    // the MCMC tracker before the summary is built.
+    if let Some(cache) = input.failure_cache.as_deref() {
+        mcmc_tracker.record_calibration_misses_from_cache(
+            cache,
+            crate::config::calibration_miss_threshold(),
+        );
+    }
     let mcmc_summary = mcmc_tracker.build_summary();
     finalise_synapse_results(FinaliseParams {
         collectors,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,7 @@
 //! | `NEAT_AI_DISCOVERY_TIMING` | bool | `false` | Print phase timing to stderr |
 //! | `NEAT_AI_DISCOVERY_PROFILE` | `json`/empty | disabled | Output structured profile as JSON |
 //! | `NEAT_AI_DISCOVERY_GPU_METRICS` | bool | `false` | Print GPU metrics to stderr |
+//! | `NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD` | f32 | `10.0` | Ratio above which prediction-vs-actual mismatches are logged (Issue #1165) |
 //!
 //! ## Detection Tuning Variables
 //!

--- a/src/config/observability.rs
+++ b/src/config/observability.rs
@@ -45,3 +45,23 @@ pub fn gpu_metrics() -> bool {
     static VAL: OnceLock<bool> = OnceLock::new();
     *VAL.get_or_init(|| std::env::var("NEAT_AI_DISCOVERY_GPU_METRICS").is_ok())
 }
+
+/// Threshold for prediction-vs-actual calibration mismatch logging
+/// (Issue #1165).
+///
+/// A failure-cache entry's `actual / expected` ratio triggers a structured
+/// `tracing::warn!` when `|ratio| > threshold` or `|ratio| < 1 / threshold`.
+/// Default `10.0` (matches the historical "10× off" rule of thumb in Issue
+/// #1160). Override via `NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD`.
+///
+/// Values that fail to parse, are non-finite, or `<= 1.0` fall back to the
+/// default so the log channel cannot be silenced by a malformed value.
+pub fn calibration_miss_threshold() -> f32 {
+    std::env::var("NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD")
+        .ok()
+        .and_then(|s| s.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite() && *v > 1.0)
+        .unwrap_or(
+            crate::analysis::diagnostics::mcmc_diagnostics::DEFAULT_CALIBRATION_MISS_THRESHOLD,
+        )
+}

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -204,6 +204,29 @@ pub struct McmcDiagnosticsJson {
     /// Only present when verbose mode is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diversity: Option<DiversityMetricJson>,
+    /// Total prediction-vs-actual calibration mismatches detected in the
+    /// failure cache (Issue #1165). Surfaced so operators can see the rate at
+    /// a glance.
+    pub calibration_miss_count: u32,
+    /// Per-entry calibration mismatch records (Issue #1165). Only present in
+    /// verbose mode and capped at the internal `CALIBRATION_MISS_VEC_CAP`
+    /// (currently 1000) to bound memory.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calibration_misses: Option<Vec<CalibrationMissEntryJson>>,
+}
+
+/// JSON form of a single calibration mismatch (Issue #1165).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationMissEntryJson {
+    pub change_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_squash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant_key: Option<String>,
+    pub expected: f32,
+    pub actual: f32,
+    pub ratio: f32,
 }
 
 /// Acceptance rate for a single candidate type (Issue #1021).
@@ -410,6 +433,20 @@ pub(crate) fn mcmc_to_json(
             evaluated_unique_targets: d.evaluated_unique_targets,
             accepted_unique_sources: d.accepted_unique_sources,
             accepted_unique_targets: d.accepted_unique_targets,
+        }),
+        calibration_miss_count: summary.calibration_miss_count,
+        calibration_misses: summary.calibration_misses.as_ref().map(|misses| {
+            misses
+                .iter()
+                .map(|m| CalibrationMissEntryJson {
+                    change_type: m.change_type.clone(),
+                    target_squash: m.target_squash.clone(),
+                    variant_key: m.variant_key.clone(),
+                    expected: m.expected,
+                    actual: m.actual,
+                    ratio: m.ratio,
+                })
+                .collect()
         }),
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -22,6 +22,7 @@
 //! | `NEAT_AI_DISCOVERY_TIMING` | `1` | Print phase timing to stderr |
 //! | `NEAT_AI_DISCOVERY_PROFILE` | `json` | Output structured profile as JSON |
 //! | `NEAT_AI_DISCOVERY_GPU_METRICS` | `1` | Print GPU metrics to stderr |
+//! | `NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD` | f32 (>1) | Threshold (default 10) above which prediction-vs-actual mismatches are logged via `tracing::warn!` (Issue #1165) |
 
 pub mod gpu_metrics;
 pub mod phase_timer;

--- a/tests/analysis/issue_1165_calibration_miss_logging.rs
+++ b/tests/analysis/issue_1165_calibration_miss_logging.rs
@@ -1,0 +1,54 @@
+//! Integration tests for Issue #1165: structured prediction-vs-actual
+//! calibration mismatch logging and counters.
+//!
+//! These tests cover the public surface of:
+//!
+//! * [`neat_ai_discovery::config::calibration_miss_threshold`] — the env-var
+//!   gate that controls the warn threshold.
+//! * The `calibrationMissCount` field in the analysis JSON output (asserted
+//!   indirectly via the public summary type that backs it — see the unit
+//!   tests in `src/analysis/diagnostics/mcmc_diagnostics.rs` for the
+//!   tracker-level coverage).
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use neat_ai_discovery::config::calibration_miss_threshold;
+use serial_test::serial;
+
+/// Acceptance: the threshold defaults to 10.0 when the env-var is unset, and
+/// is overridable to a finite value greater than 1.0. Invalid values fall
+/// back to the default so a malformed env-var cannot silence the channel.
+#[test]
+#[serial]
+fn calibration_miss_threshold_env_var_overrides_default() {
+    // SAFETY: This test is `#[serial]` so no other thread mutates env vars.
+    unsafe {
+        std::env::remove_var("NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD");
+    }
+    assert!((calibration_miss_threshold() - 10.0).abs() < 1e-6);
+
+    // Override with a valid value.
+    unsafe {
+        std::env::set_var("NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD", "25.5");
+    }
+    assert!((calibration_miss_threshold() - 25.5).abs() < 1e-3);
+
+    // Malformed -> default.
+    unsafe {
+        std::env::set_var(
+            "NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD",
+            "not-a-number",
+        );
+    }
+    assert!((calibration_miss_threshold() - 10.0).abs() < 1e-6);
+
+    // <=1.0 is rejected (would silence the check).
+    unsafe {
+        std::env::set_var("NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD", "0.5");
+    }
+    assert!((calibration_miss_threshold() - 10.0).abs() < 1e-6);
+
+    unsafe {
+        std::env::remove_var("NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD");
+    }
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -24,6 +24,7 @@ mod issue_1109_neuron_min_improved_ratio_raise;
 mod issue_1131_calibration_correction;
 mod issue_1132_conservative_mode;
 mod issue_1162_calibration_per_target_squash;
+mod issue_1165_calibration_miss_logging;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Adds structured prediction-vs-actual calibration mismatch logging so the
team can tune the constants in `analysis::constants::candidate_scoring`
from data instead of one-off failure JSON files (Issue #1160's "Gentle
Nudge against SELU" was over-predicting by ~3000×). Closes #1165.

When a failure-cache entry's `actual / expected` ratio falls outside
`[1/threshold, threshold]` (default 10×, overridable via
`NEAT_AI_DISCOVERY_CALIBRATION_MISS_THRESHOLD`), the synapse pipeline:

1. Emits a `tracing::warn!` with the structured tuple
   `(change_type, target_squash, variant_key, expected, actual, ratio)`
   on the existing `neat_ai_discovery::observability` target.
2. Increments `mcmc_diagnostics.calibration_miss_count` (always tracked
   so the rate is visible in non-verbose runs).
3. In verbose mode (`NEAT_AI_DISCOVERY_VERBOSE=1`), appends a
   `CalibrationMissEntry` to a 1000-entry capped vector that is
   surfaced in the analysis JSON output as
   `mcmcDiagnostics.calibrationMisses`.

The hook lives at the synapse orchestration layer (where the MCMC
tracker is already created) so each failure-cache entry is processed
exactly once per analysis run.

## Evidence

```mermaid
flowchart LR
    FC[Failure cache<br/>JSON entries] --> ORCH[synapse orchestration]
    ORCH -->|threshold| TR[McmcDiagnosticsTracker<br/>record_calibration_misses_from_cache]
    TR -->|"|ratio| > threshold<br/>or |ratio| < 1/threshold"| LOG[tracing::warn!]
    TR -->|count++| SUM[McmcDiagnosticsSummary]
    TR -->|verbose only, capped 1000| VEC[CalibrationMissEntry vec]
    SUM --> JSON[mcmcDiagnostics.calibrationMissCount]
    VEC --> JSON2[mcmcDiagnostics.calibrationMisses]
```

CLI/library change — no UI screenshots. Verified by:

- `cargo test --lib mcmc_diagnostics` — 7 new unit tests pass (in
  tolerance, above threshold, below reciprocal, zero/non-finite skipped,
  non-verbose count-only, vec cap at 1000, threshold clamp).
- `cargo test --test analysis issue_1165` — env-var integration test
  passes.
- `./quality.sh` — full gate (`fmt`, `clippy -D warnings`, `cargo
  check`, `cargo test`, doc build, release build) passes.

## Test Plan

- [x] `src/analysis/diagnostics/mcmc_diagnostics.rs::tests::calibration_miss_in_tolerance_records_nothing`
- [x] `…calibration_miss_above_threshold_is_recorded`
- [x] `…calibration_miss_below_reciprocal_threshold_is_recorded`
- [x] `…calibration_miss_skips_zero_or_non_finite_entries`
- [x] `…calibration_miss_non_verbose_mode_skips_vec_but_counts`
- [x] `…calibration_miss_vec_capped_at_max_size`
- [x] `…calibration_miss_threshold_clamps_invalid_inputs`
- [x] `tests/analysis/issue_1165_calibration_miss_logging.rs::calibration_miss_threshold_env_var_overrides_default`

## Acceptance Criteria

- [x] Calibration mismatch logging gated by an env-var threshold and
      emitted via existing `tracing` infrastructure
- [x] Verbose MCMC diagnostics include a bounded
      `Vec<CalibrationMissEntry>` and surface a count
      (`calibrationMissCount` always; `calibrationMisses` verbose only)
- [x] Unit tests cover threshold behaviour, verbose vs non-verbose,
      capping
- [x] No PII / large payloads logged; only the structured tuple
- [x] Documentation in `src/observability/mod.rs` and
      `src/config/mod.rs` describes the new field/env var



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1165 -->