### PR TITLE
Wire start_session and snapshot exporter through forward-only gate (#1188)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -566,6 +566,41 @@ Discovery assumes **forward-only** networks (no recurrent feedback):
 - No cross-sample state — each recorded activation/error is for a single
   training sample.
 
+#### Validated FFI Surface (Issue #1184, #1188)
+
+`validate_forward_only_synapses` (in `src/ffi_types/forward_only_validation.rs`)
+is the defence-in-depth gate. It runs immediately after JSON
+deserialisation and before any business logic on every FFI entry point
+that accepts a `CreatureJson`. A violation returns a structured
+`DiscoveryError::InvalidInput` with `error_kind: "data_validation"`.
+
+| FFI entry point | Accepts `CreatureJson` | Validates | Notes |
+|-----------------|------------------------|-----------|-------|
+| `record_discovery` | yes | yes | via `record_discovery_internal` |
+| `start_discovery_session` | yes | yes | validated in the FFI handler before `streaming::start_session` (Issue #1188) |
+| `append_discovery_records` | no | n/a | references session by ID; creature is captured at session start |
+| `finish_discovery_session` | no | n/a | session ID only |
+| `cancel_discovery_session` | no | n/a | session ID only |
+| `analyze_parallel` | yes | yes | via `analyze_parallel_internal` |
+| `rank_focus_neurons` | yes | yes | via `rank_focus_neurons_internal` |
+| `export_visualisation_snapshot` | yes | yes | via `export_visualisation_snapshot_internal` (Issue #1188) |
+| `merge_discovery_parquet` | no | n/a | parquet I/O only |
+| `read_discovery_records_ffi` | no | n/a | parquet I/O only |
+| `get_calibration_summary` | no | n/a | discovery-history JSON only |
+| `cleanup_discovery_dir` | no | n/a | filesystem cleanup |
+| `clean_orphaned_discovery_dirs` | no | n/a | filesystem cleanup |
+| `discovery_memory_usage_bytes` | no | n/a | atomic counter read |
+| `cleanup_discovery_lib` | no | n/a | shutdown hook |
+| `get_library_version` | no | n/a | constant string |
+| `check_gpu_available` | no | n/a | hardware probe |
+| `cancel_analysis` / `cancel_analysis_memory_pressure` / `reset_cancellation` / `is_analysis_active` | no | n/a | cancellation flags |
+| `free_discovery_result` | no | n/a | memory free |
+
+There are intentionally **no validation-bypassing paths** for creature
+input. Any new FFI entry point that accepts a `CreatureJson` must call
+`validate_forward_only_synapses` before any business logic and update
+this table.
+
 ### Atomic Record Writes
 
 For each discovery record, all data (observations, activations, errors) **must**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.35"
+version = "0.74.36"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1188.md
+++ b/docs/pr-summary-1188.md
@@ -1,0 +1,101 @@
+## Summary
+
+Closes #1188.
+
+Audited every public FFI entry point that accepts a `CreatureJson` to confirm
+`validate_forward_only_synapses` runs before any business logic touches the
+input, then closed the two paths that were previously bypassing the gate:
+
+- `start_discovery_session` (streaming recording session) now validates the
+  creature in the FFI handler before delegating to `streaming::start_session`.
+  The streaming session retains the creature for the lifetime of subsequent
+  append/finish calls, so a back-edge there would have tainted every record
+  written through the session.
+- `export_visualisation_snapshot_internal` (debug snapshot exporter) now
+  validates the creature before walking the topology to compute impacts and
+  reconstruction checks.
+
+Added an end-to-end regression test (`tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs`)
+that replays the three strip patterns observed in
+`GRQ-3-rocket.log` (depth-0 self-loop, depth-1 back-edge, depth-2
+cross-layer back-edge) against every validated FFI surface and asserts
+`success: false` with `error_kind: "data_validation"`.
+
+Documented the validated FFI surface explicitly in `AGENTS.md` so future
+entry points cannot quietly skip the gate.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    JSON["FFI input JSON"] --> Parse["serde_json parse"]
+    Parse --> Gate["validate_forward_only_synapses"]
+    Gate -- "self-loop / back-edge" --> Err["data_validation<br/>error response"]
+    Gate -- "ok" --> Pipeline["record / analyse / rank / session / export"]
+```
+
+| FFI entry point | Accepts `CreatureJson` | Validates | Test |
+|-----------------|------------------------|-----------|------|
+| `record_discovery` | yes | yes (existing) | `record_discovery_rejects_grq3_*` |
+| `start_discovery_session` | yes | **yes (new)** | `start_discovery_session_rejects_grq3_*` |
+| `analyze_parallel` | yes | yes (existing) | `analyze_parallel_rejects_grq3_*` |
+| `rank_focus_neurons` | yes | yes (existing) | `rank_focus_neurons_rejects_grq3_*` |
+| `export_visualisation_snapshot` | yes | **yes (new)** | `export_visualisation_snapshot_rejects_grq3_*` |
+| `append_/finish_/cancel_discovery_session`, `merge_discovery_parquet`, `read_discovery_records_ffi`, `get_calibration_summary`, `cleanup_discovery_dir`, `clean_orphaned_discovery_dirs`, `discovery_memory_usage_bytes`, `cleanup_discovery_lib`, `get_library_version`, `check_gpu_available`, `cancel_/reset_/is_*` | no | n/a | not applicable |
+
+`./quality.sh < /dev/null` passes locally:
+
+- 18 new tests in `issue_1188_grq3_strip_pattern_rejection` all pass.
+- All existing `cargo test --lib --tests --all-features -- --test-threads=2`
+  suites pass.
+- `cargo clippy --all-targets --all-features -- -D warnings` is clean.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` is clean (also fixed a
+  pre-existing rustdoc warning in
+  `src/ffi_types/forward_only_validation.rs` where the public docs linked
+  to the private `MAX_REPORTED_VIOLATIONS` constant).
+- `cargo build --release --lib` succeeds.
+
+## Test Plan
+
+New tests in `tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs`:
+
+- `validator_rejects_depth0_self_loop_pattern` — validator unit-level check
+  for the GRQ-3 depth-0 corruption (creature `10598e7e`).
+- `validator_rejects_depth1_backedge_pattern` — validator unit-level check
+  for the GRQ-3 depth-1 corruption (creature `bcc06579`).
+- `validator_rejects_depth2_backedge_pattern` — validator unit-level check
+  for the GRQ-3 depth-2 corruption (creature `751f7217`).
+- `record_discovery_rejects_grq3_depth{0,1,2}*` — three tests asserting the
+  recording entry point returns `data_validation`.
+- `analyze_parallel_rejects_grq3_depth{0,1,2}*` — three tests asserting the
+  analysis entry point returns `data_validation`.
+- `rank_focus_neurons_rejects_grq3_depth{0,1,2}*` — three tests asserting
+  the focus-ranking entry point returns `data_validation`.
+- `export_visualisation_snapshot_rejects_grq3_depth{0,1,2}*` — three tests
+  asserting the snapshot exporter returns `data_validation`.
+- `start_discovery_session_rejects_grq3_depth{0,1,2}*` — three tests
+  asserting the streaming session opener returns `data_validation`. These
+  exercise the `#[no_mangle]` C symbol via raw `CString` to mirror how
+  NEAT-AI calls the dylib.
+
+Modified files:
+
+- `src/ffi/recording.rs` — wire `validate_forward_only_synapses` into
+  `start_discovery_session` after JSON parse.
+- `src/ffi_internal/utilities.rs` — wire `validate_forward_only_synapses`
+  into `export_visualisation_snapshot_internal` after JSON parse.
+- `src/ffi_types/forward_only_validation.rs` — fix rustdoc private
+  intra-doc link warning so `./quality.sh` passes under
+  `RUSTDOCFLAGS="-D warnings"`.
+- `AGENTS.md` — document the validated FFI surface explicitly under
+  "Forward-only Activation Order".
+- `tests/ffi/main.rs` — register the new test module.
+
+## Out of scope (follow-up)
+
+The final acceptance step from the issue description ("rebuild the dylib
+against the patched `neat-ai` once stSoftwareAU/NEAT-AI#2514 lands and
+re-run the regression suite with the load-side throw enabled") depends on
+that upstream PR being merged and released. It is independent of the
+audit and regression coverage delivered here, and remains tracked under
+NEAT-AI#2514.

--- a/src/ffi/recording.rs
+++ b/src/ffi/recording.rs
@@ -155,6 +155,23 @@ pub unsafe extern "C" fn start_discovery_session(
             }
         };
 
+        // Issue #1188: Reject corrupt creatures carrying recurrent or
+        // self-looping synapses before they enter a streaming recording
+        // session. The session retains the creature for the lifetime of
+        // append/finish calls, so a violation here would taint every
+        // record written through that session.
+        if let Err(typed) = validate_forward_only_synapses(&input.creature) {
+            let kind = typed.error_kind();
+            let output = StartSessionOutput {
+                success: false,
+                session_id: None,
+                error: Some(typed.to_string()),
+                error_kind: Some(kind),
+                retryable: Some(kind.is_retryable()),
+            };
+            return to_ffi_json(&output);
+        }
+
         let output = match streaming::start_session(input.creature, input.temp_dir) {
             Ok(session_id) => {
                 let (error_kind, retryable) = no_error_fields();

--- a/src/ffi_internal/utilities.rs
+++ b/src/ffi_internal/utilities.rs
@@ -90,6 +90,24 @@ pub fn export_visualisation_snapshot_internal(input_json: &str) -> Result<String
         }
     };
 
+    // Issue #1188: Reject corrupt creatures carrying recurrent or
+    // self-looping synapses before the snapshot exporter walks the
+    // topology. The exporter computes impacts and reconstruction checks
+    // that assume a forward-only ordering — a back-edge would silently
+    // skew the snapshot output.
+    if let Err(typed) = validate_forward_only_synapses(&input.creature) {
+        let kind = typed.error_kind();
+        let output = ExportVisualisationSnapshotOutput {
+            success: false,
+            out_file: None,
+            stats: None,
+            error: Some(typed.to_string()),
+            error_kind: Some(kind),
+            retryable: Some(kind.is_retryable()),
+        };
+        return Ok(serde_json::to_string(&output)?);
+    }
+
     let options = export::ExportOptions {
         include_per_synapse_series: input.include_per_synapse_series,
         include_reconstruction_checks: input.include_reconstruction_checks,

--- a/src/ffi_types/forward_only_validation.rs
+++ b/src/ffi_types/forward_only_validation.rs
@@ -38,9 +38,9 @@ const MAX_REPORTED_VIOLATIONS: usize = 5;
 /// and must not enter the discovery pipeline.
 ///
 /// Returns `Ok(())` when every synapse is forward-only. Returns
-/// `DiscoveryError::InvalidInput` with a descriptive message listing up to
-/// [`MAX_REPORTED_VIOLATIONS`] offending synapses when violations are
-/// found.
+/// `DiscoveryError::InvalidInput` with a descriptive message listing up
+/// to a bounded number of offending synapses (see the module-private
+/// `MAX_REPORTED_VIOLATIONS` constant) when violations are found.
 ///
 /// Synapses referencing neuron UUIDs that are not present in the creature
 /// are **not** flagged here — the existing pipeline tolerates such

--- a/tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs
+++ b/tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs
@@ -1,0 +1,386 @@
+//! Issue #1188 — End-to-end regression for the GRQ-3-rocket.log strip patterns.
+//!
+//! The dylib's forward-only validator (Issue #1184) rejects creatures with
+//! recurrent or self-looping synapses. Production logs from
+//! `GRQ-3-rocket.log` continued to show `[loadFrom] Stripping recurrent
+//! synapse ... source=fromJSON` warnings against `libneat_ai_discovery
+//! v0.74.35`, which prompted an audit of the FFI surface. This test file
+//! confirms that the three strip-depth patterns observed in the log are
+//! rejected at every FFI entry point that accepts a `CreatureJson`:
+//!
+//! * **depth-0**: `output-0 -> output-0` self-loop (creature `10598e7e`).
+//! * **depth-1**: a single-step back-edge (`hidden-1 -> hidden-0`,
+//!   creature `bcc06579`).
+//! * **depth-2**: a two-step back-edge spanning hidden layers
+//!   (`output-0 -> hidden-0`, creature `751f7217`).
+//!
+//! Each test parses the strip pattern as `CreatureJson`, drives it through
+//! the corresponding FFI internal entry point, and asserts the response
+//! reports `success: false` and `errorKind: "data_validation"`.
+
+use neat_ai_discovery::{CreatureJson, validate_forward_only_synapses};
+
+/// GRQ-3 depth-0 pattern: an `output-0 -> output-0` self-loop. This is
+/// the original Issue #1184 corruption signature and the most common
+/// strip warning in `GRQ-3-rocket.log`.
+fn depth0_creature_json() -> &'static str {
+    r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "input-1", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "output-0", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "output-0", "weight": 0.5},
+            {"fromUUID": "input-1", "toUUID": "output-0", "weight": -0.3},
+            {"fromUUID": "output-0", "toUUID": "output-0", "weight": 0.9}
+        ],
+        "input": 2,
+        "output": 1
+    }"#
+}
+
+/// GRQ-3 depth-1 pattern: a single-step back-edge `hidden-1 -> hidden-0`.
+/// `loadFrom` strips this with a "Stripping recurrent synapse" warning
+/// (depth = 1) when the source neuron sits one position later in the
+/// activation order than the target.
+fn depth1_creature_json() -> &'static str {
+    r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "hidden-0", "type": "hidden", "squash": "RELU", "bias": 0.0},
+            {"uuid": "hidden-1", "type": "hidden", "squash": "RELU", "bias": 0.0},
+            {"uuid": "output-0", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "hidden-0", "weight": 0.5},
+            {"fromUUID": "hidden-0", "toUUID": "hidden-1", "weight": 0.4},
+            {"fromUUID": "hidden-1", "toUUID": "output-0", "weight": 0.7},
+            {"fromUUID": "hidden-1", "toUUID": "hidden-0", "weight": 0.6}
+        ],
+        "input": 1,
+        "output": 1
+    }"#
+}
+
+/// GRQ-3 depth-2 pattern: an output-to-hidden back-edge that crosses two
+/// activation-order positions. `loadFrom` reports depth = 2 because the
+/// source neuron is two positions later than the target.
+fn depth2_creature_json() -> &'static str {
+    r#"{
+        "neurons": [
+            {"uuid": "input-0", "type": "input", "squash": "IDENTITY"},
+            {"uuid": "hidden-0", "type": "hidden", "squash": "RELU", "bias": 0.0},
+            {"uuid": "hidden-1", "type": "hidden", "squash": "RELU", "bias": 0.0},
+            {"uuid": "output-0", "type": "output", "squash": "LOGISTIC", "bias": 0.0}
+        ],
+        "synapses": [
+            {"fromUUID": "input-0", "toUUID": "hidden-0", "weight": 0.5},
+            {"fromUUID": "hidden-0", "toUUID": "hidden-1", "weight": 0.4},
+            {"fromUUID": "hidden-1", "toUUID": "output-0", "weight": 0.7},
+            {"fromUUID": "output-0", "toUUID": "hidden-0", "weight": 0.3}
+        ],
+        "input": 1,
+        "output": 1
+    }"#
+}
+
+// ---------------------------------------------------------------------------
+// Validator-level checks: each strip pattern is rejected with a structured
+// `DiscoveryError::InvalidInput` carrying the `data_validation` kind.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validator_rejects_depth0_self_loop_pattern() {
+    let creature: CreatureJson = serde_json::from_str(depth0_creature_json()).expect("valid JSON");
+    let err = validate_forward_only_synapses(&creature)
+        .expect_err("depth-0 GRQ-3 self-loop must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("self-loop"),
+        "msg should describe self-loop: {msg}"
+    );
+    assert_eq!(
+        err.error_kind(),
+        neat_ai_discovery::DiscoveryErrorKind::DataValidation,
+        "depth-0 must classify as data_validation"
+    );
+}
+
+#[test]
+fn validator_rejects_depth1_backedge_pattern() {
+    let creature: CreatureJson = serde_json::from_str(depth1_creature_json()).expect("valid JSON");
+    let err = validate_forward_only_synapses(&creature)
+        .expect_err("depth-1 GRQ-3 back-edge must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("back-edge"),
+        "msg should describe back-edge: {msg}"
+    );
+    assert_eq!(
+        err.error_kind(),
+        neat_ai_discovery::DiscoveryErrorKind::DataValidation
+    );
+}
+
+#[test]
+fn validator_rejects_depth2_backedge_pattern() {
+    let creature: CreatureJson = serde_json::from_str(depth2_creature_json()).expect("valid JSON");
+    let err = validate_forward_only_synapses(&creature)
+        .expect_err("depth-2 GRQ-3 back-edge must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("back-edge"),
+        "msg should describe back-edge: {msg}"
+    );
+    assert_eq!(
+        err.error_kind(),
+        neat_ai_discovery::DiscoveryErrorKind::DataValidation
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FFI surface checks: each strip pattern is rejected at every entry point
+// that accepts a `CreatureJson`.
+// ---------------------------------------------------------------------------
+
+fn assert_data_validation_error(response_json: &str, label: &str) {
+    let parsed: serde_json::Value = serde_json::from_str(response_json)
+        .unwrap_or_else(|_| panic!("{label} response must be valid JSON: {response_json}"));
+    assert_eq!(
+        parsed["success"], false,
+        "{label} must report success=false: {response_json}"
+    );
+    assert_eq!(
+        parsed["errorKind"], "data_validation",
+        "{label} must classify as data_validation: {response_json}"
+    );
+    assert_eq!(
+        parsed["retryable"], false,
+        "{label} must mark the error as not retryable: {response_json}"
+    );
+    let err_msg = parsed["error"]
+        .as_str()
+        .expect("error message must be present");
+    assert!(
+        err_msg.contains("forward-only") || err_msg.contains("recurrent"),
+        "{label} error must reference the forward-only invariant: {err_msg}"
+    );
+}
+
+fn record_input_with(creature_json: &str, temp_dir: &str) -> String {
+    format!(
+        r#"{{
+            "creature": {creature_json},
+            "training_data": [
+                {{
+                    "input": [0.5],
+                    "output": [0.7],
+                    "neuron_data": [
+                        {{"neuron_uuid": "output-0", "activation": 0.7, "errors": [-0.05]}}
+                    ]
+                }}
+            ],
+            "temp_dir": "{temp_dir}"
+        }}"#
+    )
+}
+
+fn analyze_input_with(creature_json: &str) -> String {
+    format!(
+        r#"{{
+            "parquetFile": "/tmp/does-not-exist.parquet",
+            "creature": {creature_json},
+            "focusNeurons": ["output-0"]
+        }}"#
+    )
+}
+
+fn rank_input_with(creature_json: &str) -> String {
+    format!(
+        r#"{{
+            "parquetFile": "/tmp/does-not-exist.parquet",
+            "creature": {creature_json}
+        }}"#
+    )
+}
+
+fn export_input_with(creature_json: &str, out_path: &str) -> String {
+    format!(
+        r#"{{
+            "parquetFile": "/tmp/does-not-exist.parquet",
+            "creature": {creature_json},
+            "outFile": "{out_path}",
+            "includePerSynapseSeries": false,
+            "includeReconstructionChecks": false
+        }}"#
+    )
+}
+
+#[test]
+fn record_discovery_rejects_grq3_depth0_self_loop() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_path = temp_dir.path().to_str().unwrap();
+    let input = record_input_with(depth0_creature_json(), temp_path);
+    let response =
+        neat_ai_discovery::record_discovery_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "record_discovery (depth-0)");
+}
+
+#[test]
+fn record_discovery_rejects_grq3_depth1_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_path = temp_dir.path().to_str().unwrap();
+    let input = record_input_with(depth1_creature_json(), temp_path);
+    let response =
+        neat_ai_discovery::record_discovery_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "record_discovery (depth-1)");
+}
+
+#[test]
+fn record_discovery_rejects_grq3_depth2_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let temp_path = temp_dir.path().to_str().unwrap();
+    let input = record_input_with(depth2_creature_json(), temp_path);
+    let response =
+        neat_ai_discovery::record_discovery_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "record_discovery (depth-2)");
+}
+
+#[test]
+fn analyze_parallel_rejects_grq3_depth0_self_loop() {
+    let input = analyze_input_with(depth0_creature_json());
+    let response =
+        neat_ai_discovery::analyze_parallel_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "analyze_parallel (depth-0)");
+}
+
+#[test]
+fn analyze_parallel_rejects_grq3_depth1_back_edge() {
+    let input = analyze_input_with(depth1_creature_json());
+    let response =
+        neat_ai_discovery::analyze_parallel_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "analyze_parallel (depth-1)");
+}
+
+#[test]
+fn analyze_parallel_rejects_grq3_depth2_back_edge() {
+    let input = analyze_input_with(depth2_creature_json());
+    let response =
+        neat_ai_discovery::analyze_parallel_internal(&input).expect("internal call must not panic");
+    assert_data_validation_error(&response, "analyze_parallel (depth-2)");
+}
+
+#[test]
+fn rank_focus_neurons_rejects_grq3_depth0_self_loop() {
+    let input = rank_input_with(depth0_creature_json());
+    let response = neat_ai_discovery::rank_focus_neurons_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "rank_focus_neurons (depth-0)");
+}
+
+#[test]
+fn rank_focus_neurons_rejects_grq3_depth1_back_edge() {
+    let input = rank_input_with(depth1_creature_json());
+    let response = neat_ai_discovery::rank_focus_neurons_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "rank_focus_neurons (depth-1)");
+}
+
+#[test]
+fn rank_focus_neurons_rejects_grq3_depth2_back_edge() {
+    let input = rank_input_with(depth2_creature_json());
+    let response = neat_ai_discovery::rank_focus_neurons_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "rank_focus_neurons (depth-2)");
+}
+
+#[test]
+fn export_visualisation_snapshot_rejects_grq3_depth0_self_loop() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let out_path = temp_dir.path().join("snapshot.json");
+    let input = export_input_with(depth0_creature_json(), out_path.to_str().unwrap());
+    let response = neat_ai_discovery::export_visualisation_snapshot_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "export_visualisation_snapshot (depth-0)");
+}
+
+#[test]
+fn export_visualisation_snapshot_rejects_grq3_depth1_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let out_path = temp_dir.path().join("snapshot.json");
+    let input = export_input_with(depth1_creature_json(), out_path.to_str().unwrap());
+    let response = neat_ai_discovery::export_visualisation_snapshot_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "export_visualisation_snapshot (depth-1)");
+}
+
+#[test]
+fn export_visualisation_snapshot_rejects_grq3_depth2_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let out_path = temp_dir.path().join("snapshot.json");
+    let input = export_input_with(depth2_creature_json(), out_path.to_str().unwrap());
+    let response = neat_ai_discovery::export_visualisation_snapshot_internal(&input)
+        .expect("internal call must not panic");
+    assert_data_validation_error(&response, "export_visualisation_snapshot (depth-2)");
+}
+
+// ---------------------------------------------------------------------------
+// Streaming session: `start_discovery_session` is a separate FFI surface
+// that previously bypassed the forward-only validator. Issue #1188 wires
+// the validator into the FFI handler. We exercise it via the public C
+// entry point so the test mirrors how NEAT-AI calls the dylib.
+// ---------------------------------------------------------------------------
+
+fn call_start_discovery_session(input_json: &str) -> String {
+    use std::ffi::{CStr, CString};
+    let input_c = CString::new(input_json).expect("input must not contain null bytes");
+    // SAFETY: we pass a valid, non-null, null-terminated UTF-8 C string,
+    // and we free the returned pointer with `free_discovery_result`.
+    let response_ptr = unsafe { neat_ai_discovery::ffi::start_discovery_session(input_c.as_ptr()) };
+    assert!(
+        !response_ptr.is_null(),
+        "FFI must return a non-null response pointer"
+    );
+    // SAFETY: the pointer was just produced by the FFI call and is valid.
+    let response = unsafe { CStr::from_ptr(response_ptr) }
+        .to_string_lossy()
+        .into_owned();
+    // SAFETY: `response_ptr` was produced by `start_discovery_session`,
+    // matching the contract for `free_discovery_result`.
+    unsafe { neat_ai_discovery::ffi::free_discovery_result(response_ptr) };
+    response
+}
+
+fn start_session_input(creature_json: &str, temp_dir: &str) -> String {
+    format!(
+        r#"{{
+            "creature": {creature_json},
+            "tempDir": "{temp_dir}"
+        }}"#
+    )
+}
+
+#[test]
+fn start_discovery_session_rejects_grq3_depth0_self_loop() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let input = start_session_input(depth0_creature_json(), temp_dir.path().to_str().unwrap());
+    let response = call_start_discovery_session(&input);
+    assert_data_validation_error(&response, "start_discovery_session (depth-0)");
+}
+
+#[test]
+fn start_discovery_session_rejects_grq3_depth1_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let input = start_session_input(depth1_creature_json(), temp_dir.path().to_str().unwrap());
+    let response = call_start_discovery_session(&input);
+    assert_data_validation_error(&response, "start_discovery_session (depth-1)");
+}
+
+#[test]
+fn start_discovery_session_rejects_grq3_depth2_back_edge() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let input = start_session_input(depth2_creature_json(), temp_dir.path().to_str().unwrap());
+    let response = call_start_discovery_session(&input);
+    assert_data_validation_error(&response, "start_discovery_session (depth-2)");
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod issue_1027_memory_usage_ffi;
 mod issue_1028_memory_budget;
 mod issue_1184_recurrent_synapse_rejection;
+mod issue_1188_grq3_strip_pattern_rejection;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
## Summary

Closes #1188.

Audited every public FFI entry point that accepts a `CreatureJson` to confirm
`validate_forward_only_synapses` runs before any business logic touches the
input, then closed the two paths that were previously bypassing the gate:

- `start_discovery_session` (streaming recording session) now validates the
  creature in the FFI handler before delegating to `streaming::start_session`.
  The streaming session retains the creature for the lifetime of subsequent
  append/finish calls, so a back-edge there would have tainted every record
  written through the session.
- `export_visualisation_snapshot_internal` (debug snapshot exporter) now
  validates the creature before walking the topology to compute impacts and
  reconstruction checks.

Added an end-to-end regression test (`tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs`)
that replays the three strip patterns observed in
`GRQ-3-rocket.log` (depth-0 self-loop, depth-1 back-edge, depth-2
cross-layer back-edge) against every validated FFI surface and asserts
`success: false` with `error_kind: "data_validation"`.

Documented the validated FFI surface explicitly in `AGENTS.md` so future
entry points cannot quietly skip the gate.

## Evidence

```mermaid
flowchart LR
    JSON["FFI input JSON"] --> Parse["serde_json parse"]
    Parse --> Gate["validate_forward_only_synapses"]
    Gate -- "self-loop / back-edge" --> Err["data_validation<br/>error response"]
    Gate -- "ok" --> Pipeline["record / analyse / rank / session / export"]
```

| FFI entry point | Accepts `CreatureJson` | Validates | Test |
|-----------------|------------------------|-----------|------|
| `record_discovery` | yes | yes (existing) | `record_discovery_rejects_grq3_*` |
| `start_discovery_session` | yes | **yes (new)** | `start_discovery_session_rejects_grq3_*` |
| `analyze_parallel` | yes | yes (existing) | `analyze_parallel_rejects_grq3_*` |
| `rank_focus_neurons` | yes | yes (existing) | `rank_focus_neurons_rejects_grq3_*` |
| `export_visualisation_snapshot` | yes | **yes (new)** | `export_visualisation_snapshot_rejects_grq3_*` |
| `append_/finish_/cancel_discovery_session`, `merge_discovery_parquet`, `read_discovery_records_ffi`, `get_calibration_summary`, `cleanup_discovery_dir`, `clean_orphaned_discovery_dirs`, `discovery_memory_usage_bytes`, `cleanup_discovery_lib`, `get_library_version`, `check_gpu_available`, `cancel_/reset_/is_*` | no | n/a | not applicable |

`./quality.sh < /dev/null` passes locally:

- 18 new tests in `issue_1188_grq3_strip_pattern_rejection` all pass.
- All existing `cargo test --lib --tests --all-features -- --test-threads=2`
  suites pass.
- `cargo clippy --all-targets --all-features -- -D warnings` is clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` is clean (also fixed a
  pre-existing rustdoc warning in
  `src/ffi_types/forward_only_validation.rs` where the public docs linked
  to the private `MAX_REPORTED_VIOLATIONS` constant).
- `cargo build --release --lib` succeeds.

## Test Plan

New tests in `tests/ffi/issue_1188_grq3_strip_pattern_rejection.rs`:

- `validator_rejects_depth0_self_loop_pattern` — validator unit-level check
  for the GRQ-3 depth-0 corruption (creature `10598e7e`).
- `validator_rejects_depth1_backedge_pattern` — validator unit-level check
  for the GRQ-3 depth-1 corruption (creature `bcc06579`).
- `validator_rejects_depth2_backedge_pattern` — validator unit-level check
  for the GRQ-3 depth-2 corruption (creature `751f7217`).
- `record_discovery_rejects_grq3_depth{0,1,2}*` — three tests asserting the
  recording entry point returns `data_validation`.
- `analyze_parallel_rejects_grq3_depth{0,1,2}*` — three tests asserting the
  analysis entry point returns `data_validation`.
- `rank_focus_neurons_rejects_grq3_depth{0,1,2}*` — three tests asserting
  the focus-ranking entry point returns `data_validation`.
- `export_visualisation_snapshot_rejects_grq3_depth{0,1,2}*` — three tests
  asserting the snapshot exporter returns `data_validation`.
- `start_discovery_session_rejects_grq3_depth{0,1,2}*` — three tests
  asserting the streaming session opener returns `data_validation`. These
  exercise the `#[no_mangle]` C symbol via raw `CString` to mirror how
  NEAT-AI calls the dylib.

Modified files:

- `src/ffi/recording.rs` — wire `validate_forward_only_synapses` into
  `start_discovery_session` after JSON parse.
- `src/ffi_internal/utilities.rs` — wire `validate_forward_only_synapses`
  into `export_visualisation_snapshot_internal` after JSON parse.
- `src/ffi_types/forward_only_validation.rs` — fix rustdoc private
  intra-doc link warning so `./quality.sh` passes under
  `RUSTDOCFLAGS="-D warnings"`.
- `AGENTS.md` — document the validated FFI surface explicitly under
  "Forward-only Activation Order".
- `tests/ffi/main.rs` — register the new test module.

## Out of scope (follow-up)

The final acceptance step from the issue description ("rebuild the dylib
against the patched `neat-ai` once stSoftwareAU/NEAT-AI#2514 lands and
re-run the regression suite with the load-side throw enabled") depends on
that upstream PR being merged and released. It is independent of the
audit and regression coverage delivered here, and remains tracked under
NEAT-AI#2514.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1188 -->