### PR TITLE
Cold-start calibration prior for periodic / non-invertible target activations (Issue #1192)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,7 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_MAX_WALL_CLOCK_MINUTES` | Overall wall-clock cap for discovery time in minutes (default 20, range 1–120) |
 | `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` | Max add-neuron candidates per target within a single batch (default 3, range 1–32) (Issue #1140) |
 | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | Cap focus-ranking eager pre-load size in MB. When set and projected size (file × 3) exceeds the budget, lazy mode is used with a structured `info` log (Issue #1172). |
+| `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` | Cold-start calibration prior multiplier for non-invertible / periodic target activations (SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE). Applied while the per-(`change_type`, `target_squash`) bucket has fewer than three failure samples. Default 0.25, clamped to `[0.001, 1.0]` (Issue #1192). |
 
 See [README.md — Troubleshooting](README.md#troubleshooting) and
 [README.md — GPU Performance Tuning](README.md#gpu-performance-tuning) for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.36"
+version = "0.74.37"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1192.md
+++ b/docs/pr-summary-1192.md
@@ -1,0 +1,66 @@
+## Summary
+
+Added a conservative cold-start calibration prior for candidates targeting
+non-invertible / periodic activations (SINE, COSINE, GAUSSIAN, SQUARE,
+ABSOLUTE). Before this change, the per-(`change_type`, `target_squash`)
+calibration introduced in Issue #1162 fell back to the global default of `1.0`
+until at least three failure-cache entries existed for the bucket — meaning
+the *first* three failures against a periodic target could not be demoted in
+advance. The prior now discounts those candidates immediately at cold start,
+and the learnt EWMA takes over once the warmup threshold is reached.
+
+Closes #1192.
+
+## Evidence
+
+CLI / library change with no UI surface, so the verification artefact is the
+new unit-test suite (`src/analysis/scoring/calibration_correction.rs`) and the
+clean run of `./quality.sh` (advisories, lint, full test suite, doc build,
+release build).
+
+```mermaid
+flowchart TD
+    A[correction_for change_type, target_squash] --> B{specific EWMA<br/>has &ge; 3 samples?}
+    B -- yes --> C[Return learnt EWMA<br/>existing path]
+    B -- no --> D{squash in<br/>RISKY_TARGET_SQUASHES?}
+    D -- yes --> E[Return risky_squash_prior<br/>default 0.25, clamped]
+    D -- no --> F[Per-change_type fallback<br/>or NEUTRAL_CORRECTION]
+```
+
+Behaviour for the cold-start path (default prior `0.25`):
+
+| Target squash | Specific samples | Returned correction |
+|---------------|------------------|---------------------|
+| SINE          | 0                | `0.25` (prior)       |
+| SINE          | 2                | `0.25` (prior)       |
+| SINE          | 3+               | learnt EWMA          |
+| ReLU          | 0                | `1.0` (neutral)      |
+
+## Test Plan
+
+New unit tests in
+`src/analysis/scoring/calibration_correction.rs::tests` (all `#[serial]` where
+they touch the env var):
+
+- `risky_target_squashes_cover_documented_non_invertibles` — asserts the new
+  set lists exactly SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE and excludes the
+  monotone activations.
+- `sine_target_with_zero_samples_receives_conservative_prior` — confirms the
+  first acceptance criterion (cold-start prior fires).
+- `sine_target_with_enough_samples_uses_learnt_ewma` — confirms the second
+  acceptance criterion (≥3 samples → EWMA wins).
+- `sine_target_below_threshold_still_uses_prior` — covers the 1–2-sample gap
+  where the EWMA is not yet retained.
+- `relu_target_with_zero_samples_uses_global_default` — confirms the third
+  acceptance criterion (non-risky targets unchanged).
+- `every_risky_squash_receives_prior_at_cold_start` — exhaustive coverage of
+  all five risky squashes.
+- `missing_target_squash_skips_risky_prior` — guards against false positives
+  when the target squash is unknown.
+- `env_var_overrides_and_clamps_risky_prior` — exercises the
+  `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` override path including clamping at
+  both bounds and the unparsable fallback.
+
+All 32 tests in the calibration module pass, and the full `./quality.sh`
+gate (advisories, fmt, clippy `-D warnings`, full test suite, rustdoc with
+`-D warnings`, release build) is clean.

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -345,6 +345,76 @@ pub const ACTIVATION_BOOST_MIN: f64 = 0.5;
 pub const ACTIVATION_BOOST_MAX: f64 = 2.0;
 
 // =============================================================================
+// Risky Target-Squash Cold-Start Prior (Issue #1192)
+// =============================================================================
+
+/// Non-invertible / periodic target activations that warrant a conservative
+/// cold-start calibration prior (Issue #1192).
+///
+/// `src/activations.rs` documents these as non-invertible: a small change in
+/// the incoming weighted sum can flip the output direction entirely. That
+/// makes any add-neuron / add-synapse candidate aimed at a target with one of
+/// these squashes substantially riskier than a candidate aimed at a monotone
+/// target (`ReLU` family, Sigmoid, Tanh).
+///
+/// The per-(`change_type`, `target_squash`) calibration introduced in
+/// Issue #1162 only kicks in once at least three failure-cache entries exist
+/// for a key. Before that threshold is reached, the lookup falls back to the
+/// per-`change_type` value (or the global neutral 1.0 default), which is too
+/// optimistic for these activations. `RISKY_TARGET_SQUASHES` lets the cold-
+/// start path use a conservative prior instead — see [`risky_squash_prior`].
+pub const RISKY_TARGET_SQUASHES: &[&str] = &["SINE", "COSINE", "GAUSSIAN", "SQUARE", "ABSOLUTE"];
+
+/// Default conservative cold-start calibration prior for risky target squashes
+/// (Issue #1192).
+///
+/// Applied only while the per-(`change_type`, `target_squash`) bucket has
+/// fewer than three usable failure samples. Once the bucket reaches the
+/// warmup threshold, the learnt EWMA value takes over.
+///
+/// ## Valid Range
+/// Must be in `[MIN_RISKY_SQUASH_PRIOR, MAX_RISKY_SQUASH_PRIOR]`.
+pub const RISKY_SQUASH_PRIOR_DEFAULT: f32 = 0.25;
+
+/// Lower clamp for the risky-squash cold-start prior (Issue #1192).
+///
+/// Matches the existing `MIN_CALIBRATION_CORRECTION` floor used for learnt
+/// corrections so the cold-start prior cannot collapse predictions to zero.
+pub const MIN_RISKY_SQUASH_PRIOR: f32 = 0.001;
+
+/// Upper clamp for the risky-squash cold-start prior (Issue #1192).
+///
+/// Matches `NEUTRAL_CORRECTION` — the prior must never inflate the base
+/// calibration constant beyond the compiled value.
+pub const MAX_RISKY_SQUASH_PRIOR: f32 = 1.0;
+
+/// Returns true when the supplied target squash name is in
+/// [`RISKY_TARGET_SQUASHES`] (Issue #1192).
+///
+/// Comparison is case-sensitive; callers should pass the canonical
+/// upper-case squash name as it appears in the failure-cache JSON.
+#[must_use]
+pub fn is_risky_target_squash(squash: &str) -> bool {
+    RISKY_TARGET_SQUASHES.contains(&squash)
+}
+
+/// Returns the effective risky-squash cold-start prior (Issue #1192).
+///
+/// Reads `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` at call time so tests and
+/// operators can override the default without recompiling. Values outside
+/// `[MIN_RISKY_SQUASH_PRIOR, MAX_RISKY_SQUASH_PRIOR]` are clamped. Unparsable,
+/// non-finite, or missing values fall back to [`RISKY_SQUASH_PRIOR_DEFAULT`].
+#[must_use]
+pub fn risky_squash_prior() -> f32 {
+    std::env::var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR")
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite())
+        .unwrap_or(RISKY_SQUASH_PRIOR_DEFAULT)
+        .clamp(MIN_RISKY_SQUASH_PRIOR, MAX_RISKY_SQUASH_PRIOR)
+}
+
+// =============================================================================
 // Saturation-Aware Prediction Discount (Issue #1112)
 // =============================================================================
 

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -32,6 +32,27 @@
 //! available, otherwise it falls back to the per-`change_type` correction,
 //! and finally to [`NEUTRAL_CORRECTION`] (= 1.0) when neither is known.
 //!
+//! ## Cold-start prior for non-invertible target squashes (Issue #1192)
+//!
+//! Non-invertible / periodic activations — SINE, COSINE, GAUSSIAN, SQUARE,
+//! ABSOLUTE — are intrinsically riskier as add-neuron / add-synapse targets:
+//! a small change in the incoming weighted sum can flip the output sign
+//! entirely. Without the cold-start prior, candidates aimed at one of these
+//! targets would receive [`NEUTRAL_CORRECTION`] (= 1.0) until at least
+//! [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] failures have been observed for the
+//! exact `(change_type, squash)` bucket — meaning the *first* three failures
+//! against, say, a SINE target cannot be demoted in advance.
+//!
+//! [`CalibrationCorrection::correction_for`] therefore returns the
+//! conservative prior from
+//! [`risky_squash_prior`]
+//! when the target squash is in
+//! [`RISKY_TARGET_SQUASHES`](crate::analysis::constants::RISKY_TARGET_SQUASHES)
+//! and the learnt EWMA is not yet available for that bucket. Once the
+//! per-key sample count reaches the warmup threshold, the learnt EWMA takes
+//! over as it does for every other squash. Non-risky squashes (`ReLU` family,
+//! Sigmoid, Tanh, …) keep the existing 1.0 cold-start default.
+//!
 //! # Formula
 //!
 //! Given failure cache entries with `expected_error_reduction` and
@@ -54,6 +75,8 @@
 
 use serde::Deserialize;
 use std::collections::HashMap;
+
+use crate::analysis::constants::{is_risky_target_squash, risky_squash_prior};
 
 // =============================================================================
 // Constants
@@ -378,31 +401,52 @@ impl CalibrationCorrection {
             .unwrap_or(NEUTRAL_CORRECTION)
     }
 
-    /// Look up the most specific available correction factor (Issue #1162).
+    /// Look up the most specific available correction factor (Issue #1162, #1192).
     ///
     /// Resolution order:
     ///
     /// 1. If `target_squash` is supplied **and** at least
     ///    [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] usable failure-cache entries
     ///    exist for `(change_type, target_squash)`, return that specific
-    ///    correction.
-    /// 2. Otherwise, return the per-`change_type` correction (existing
+    ///    learnt correction (the EWMA from Issue #1162).
+    /// 2. Otherwise, if `target_squash` is supplied and is in the
+    ///    `RISKY_TARGET_SQUASHES` set (non-invertible / periodic activations
+    ///    such as SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE), return the
+    ///    conservative cold-start prior from
+    ///    [`risky_squash_prior`]
+    ///    (Issue #1192). This applies whenever the per-key sample count is
+    ///    below the warmup threshold — including when no specific data has
+    ///    been recorded at all — so an add-neuron / add-synapse candidate
+    ///    aimed at a periodic target receives a conservative discount before
+    ///    the learnt EWMA exists.
+    /// 3. Otherwise, return the per-`change_type` correction (existing
     ///    behaviour).
-    /// 3. Otherwise, return [`NEUTRAL_CORRECTION`] (= 1.0) so the compiled
+    /// 4. Otherwise, return [`NEUTRAL_CORRECTION`] (= 1.0) so the compiled
     ///    calibration constant is used unchanged.
     ///
     /// Callers should pass `None` for `target_squash` when the candidate's
-    /// target squash is unknown.
+    /// target squash is unknown — in that case the cold-start risky-target
+    /// prior cannot be applied and resolution skips straight to step 3.
     #[must_use]
     pub fn correction_for(&self, change_type: &str, target_squash: Option<&str>) -> f32 {
-        if let Some(squash) = target_squash
-            && let Some(value) = self
+        if let Some(squash) = target_squash {
+            // 1. Learnt EWMA wins once we have enough samples for this
+            //    (change_type, target_squash) bucket.
+            if let Some(value) = self
                 .specific_corrections
                 .get(&(change_type.to_string(), squash.to_string()))
                 .copied()
-        {
-            return value;
+            {
+                return value;
+            }
+            // 2. Cold-start prior for non-invertible / periodic targets
+            //    (Issue #1192). Applied only when the learnt EWMA is not
+            //    yet available for the bucket.
+            if is_risky_target_squash(squash) {
+                return risky_squash_prior();
+            }
         }
+        // 3. Per-change_type fallback (or neutral via `get_correction`).
         self.get_correction(change_type)
     }
 
@@ -990,5 +1034,206 @@ mod tests {
                 .abs()
                 < 1e-12
         );
+    }
+
+    // =========================================================================
+    // Issue #1192 — cold-start prior for non-invertible target squashes
+    // =========================================================================
+
+    use crate::analysis::constants::{
+        MAX_RISKY_SQUASH_PRIOR, MIN_RISKY_SQUASH_PRIOR, RISKY_SQUASH_PRIOR_DEFAULT,
+        RISKY_TARGET_SQUASHES,
+    };
+    use serial_test::serial;
+
+    /// Risky-target squashes match the non-invertible activations documented
+    /// in `src/activations.rs` (the issue scopes the new prior to SINE,
+    /// COSINE, GAUSSIAN, SQUARE, ABSOLUTE).
+    #[test]
+    fn risky_target_squashes_cover_documented_non_invertibles() {
+        let expected = ["SINE", "COSINE", "GAUSSIAN", "SQUARE", "ABSOLUTE"];
+        for name in expected {
+            assert!(
+                RISKY_TARGET_SQUASHES.contains(&name),
+                "{name} should be in RISKY_TARGET_SQUASHES"
+            );
+        }
+        // Sanity check: monotone activations must NOT be in the risky set.
+        for name in ["RELU", "SIGMOID", "TANH", "GELU", "ELU", "IDENTITY"] {
+            assert!(
+                !RISKY_TARGET_SQUASHES.contains(&name),
+                "{name} must not be flagged as risky"
+            );
+        }
+    }
+
+    /// SINE target with zero failure samples receives the conservative cold-
+    /// start prior, not the global default of 1.0.
+    #[test]
+    #[serial]
+    fn sine_target_with_zero_samples_receives_conservative_prior() {
+        // SAFETY: env vars guarded by serial_test. Single-threaded under #[serial].
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        let correction = CalibrationCorrection::neutral();
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (value - RISKY_SQUASH_PRIOR_DEFAULT).abs() < 1e-6,
+            "expected risky prior {RISKY_SQUASH_PRIOR_DEFAULT}, got {value}"
+        );
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() > 1e-3,
+            "risky prior must be visibly below neutral 1.0"
+        );
+    }
+
+    /// SINE target with three or more failure samples uses the learnt EWMA,
+    /// not the cold-start prior — the prior only governs cold-start.
+    #[test]
+    #[serial]
+    fn sine_target_with_enough_samples_uses_learnt_ewma() {
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        // Three SINE failures with ratio 0.5 — well above both the prior (0.25)
+        // and the floor (0.001). The EWMA must win over the prior so the
+        // observed-better-than-prior outcome is reflected.
+        let cache: Vec<FailureCacheEntry> = (0..MIN_SPECIFIC_TARGET_SQUASH_SAMPLES)
+            .map(|_| entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.5, "SINE"))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (value - 0.5).abs() < 1e-4,
+            "expected learnt EWMA ≈ 0.5, got {value}"
+        );
+        assert!(
+            (value - RISKY_SQUASH_PRIOR_DEFAULT).abs() > 0.1,
+            "learnt EWMA must dominate the cold-start prior once warmed up"
+        );
+    }
+
+    /// SINE target with fewer than three samples still receives the prior —
+    /// the warmup threshold gates EWMA, not the prior.
+    #[test]
+    #[serial]
+    fn sine_target_below_threshold_still_uses_prior() {
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        const _: () = assert!(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES >= 2);
+        let cache: Vec<FailureCacheEntry> = (0..(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES - 1))
+            .map(|_| entry_with_squash(CHANGE_TYPE_ADD_NEURONS, 1.0, 0.001, "SINE"))
+            .collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (value - RISKY_SQUASH_PRIOR_DEFAULT).abs() < 1e-6,
+            "below-threshold SINE entries must fall through to the prior, got {value}"
+        );
+    }
+
+    /// `ReLU` (monotone, non-risky) target with zero samples still receives
+    /// the global default of 1.0 — the cold-start prior is only for the
+    /// risky squash set.
+    #[test]
+    #[serial]
+    fn relu_target_with_zero_samples_uses_global_default() {
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        let correction = CalibrationCorrection::neutral();
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("RELU"));
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "expected NEUTRAL_CORRECTION (=1.0), got {value}"
+        );
+    }
+
+    /// All five risky squashes receive the conservative prior at cold start.
+    #[test]
+    #[serial]
+    fn every_risky_squash_receives_prior_at_cold_start() {
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        let correction = CalibrationCorrection::neutral();
+        for &squash in RISKY_TARGET_SQUASHES {
+            let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some(squash));
+            assert!(
+                (value - RISKY_SQUASH_PRIOR_DEFAULT).abs() < 1e-6,
+                "{squash} should receive the cold-start prior, got {value}"
+            );
+        }
+    }
+
+    /// The per-`change_type` fallback (no `target_squash` supplied) is unaffected
+    /// by the cold-start prior — the prior only fires when a risky target
+    /// squash is provided.
+    #[test]
+    #[serial]
+    fn missing_target_squash_skips_risky_prior() {
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
+        let correction = CalibrationCorrection::neutral();
+        let value = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, None);
+        assert!(
+            (value - NEUTRAL_CORRECTION).abs() < 1e-9,
+            "missing target_squash must keep the per-change_type fallback"
+        );
+    }
+
+    /// `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` overrides the default and is
+    /// clamped to `[MIN_RISKY_SQUASH_PRIOR, MAX_RISKY_SQUASH_PRIOR]`.
+    #[test]
+    #[serial]
+    fn env_var_overrides_and_clamps_risky_prior() {
+        let correction = CalibrationCorrection::neutral();
+
+        // Sensible mid-range override.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR", "0.10");
+        }
+        let mid = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (mid - 0.10).abs() < 1e-6,
+            "expected env override 0.10, got {mid}"
+        );
+
+        // Below the lower clamp -> clamped to MIN_RISKY_SQUASH_PRIOR (0.001).
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR", "0.0");
+        }
+        let low = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (low - MIN_RISKY_SQUASH_PRIOR).abs() < 1e-6,
+            "expected lower clamp {MIN_RISKY_SQUASH_PRIOR}, got {low}"
+        );
+
+        // Above the upper clamp -> clamped to MAX_RISKY_SQUASH_PRIOR (1.0).
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR", "5.0");
+        }
+        let high = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (high - MAX_RISKY_SQUASH_PRIOR).abs() < 1e-6,
+            "expected upper clamp {MAX_RISKY_SQUASH_PRIOR}, got {high}"
+        );
+
+        // Unparsable -> default.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR", "not-a-number");
+        }
+        let bad = correction.correction_for(CHANGE_TYPE_ADD_NEURONS, Some("SINE"));
+        assert!(
+            (bad - RISKY_SQUASH_PRIOR_DEFAULT).abs() < 1e-6,
+            "unparsable env var must fall back to the default"
+        );
+
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Added a conservative cold-start calibration prior for candidates targeting
non-invertible / periodic activations (SINE, COSINE, GAUSSIAN, SQUARE,
ABSOLUTE). Before this change, the per-(`change_type`, `target_squash`)
calibration introduced in Issue #1162 fell back to the global default of `1.0`
until at least three failure-cache entries existed for the bucket — meaning
the *first* three failures against a periodic target could not be demoted in
advance. The prior now discounts those candidates immediately at cold start,
and the learnt EWMA takes over once the warmup threshold is reached.

Closes #1192.

## Evidence

CLI / library change with no UI surface, so the verification artefact is the
new unit-test suite (`src/analysis/scoring/calibration_correction.rs`) and the
clean run of `./quality.sh` (advisories, lint, full test suite, doc build,
release build).

```mermaid
flowchart TD
    A[correction_for change_type, target_squash] --> B{specific EWMA<br/>has &ge; 3 samples?}
    B -- yes --> C[Return learnt EWMA<br/>existing path]
    B -- no --> D{squash in<br/>RISKY_TARGET_SQUASHES?}
    D -- yes --> E[Return risky_squash_prior<br/>default 0.25, clamped]
    D -- no --> F[Per-change_type fallback<br/>or NEUTRAL_CORRECTION]
```

Behaviour for the cold-start path (default prior `0.25`):

| Target squash | Specific samples | Returned correction |
|---------------|------------------|---------------------|
| SINE          | 0                | `0.25` (prior)       |
| SINE          | 2                | `0.25` (prior)       |
| SINE          | 3+               | learnt EWMA          |
| ReLU          | 0                | `1.0` (neutral)      |

## Test Plan

New unit tests in
`src/analysis/scoring/calibration_correction.rs::tests` (all `#[serial]` where
they touch the env var):

- `risky_target_squashes_cover_documented_non_invertibles` — asserts the new
  set lists exactly SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE and excludes the
  monotone activations.
- `sine_target_with_zero_samples_receives_conservative_prior` — confirms the
  first acceptance criterion (cold-start prior fires).
- `sine_target_with_enough_samples_uses_learnt_ewma` — confirms the second
  acceptance criterion (≥3 samples → EWMA wins).
- `sine_target_below_threshold_still_uses_prior` — covers the 1–2-sample gap
  where the EWMA is not yet retained.
- `relu_target_with_zero_samples_uses_global_default` — confirms the third
  acceptance criterion (non-risky targets unchanged).
- `every_risky_squash_receives_prior_at_cold_start` — exhaustive coverage of
  all five risky squashes.
- `missing_target_squash_skips_risky_prior` — guards against false positives
  when the target squash is unknown.
- `env_var_overrides_and_clamps_risky_prior` — exercises the
  `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` override path including clamping at
  both bounds and the unparsable fallback.

All 32 tests in the calibration module pass, and the full `./quality.sh`
gate (advisories, fmt, clippy `-D warnings`, full test suite, rustdoc with
`-D warnings`, release build) is clean.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1192 -->