### PR TITLE
Cross-target diversity spread before per-target cap (#1193)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -644,6 +644,7 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | Metropolis-Hastings probabilistic acceptance temperature |
 | `NEAT_AI_DISCOVERY_MAX_WALL_CLOCK_MINUTES` | Overall wall-clock cap for discovery time in minutes (default 20, range 1–120) |
 | `NEAT_AI_DISCOVERY_MAX_ADD_NEURON_PER_TARGET` | Max add-neuron candidates per target within a single batch (default 3, range 1–32) (Issue #1140) |
+| `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH` | Minimum distinct target neurons in an emitted add-neuron batch when the candidate pool supports it. The top of the gain-sorted list is reordered to cover this many distinct targets before the per-target cap is applied (default 3, range 1–32) (Issue #1193) |
 | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | Cap focus-ranking eager pre-load size in MB. When set and projected size (file × 3) exceeds the budget, lazy mode is used with a structured `info` log (Issue #1172). |
 | `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` | Cold-start calibration prior multiplier for non-invertible / periodic target activations (SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE). Applied while the per-(`change_type`, `target_squash`) bucket has fewer than three failure samples. Default 0.25, clamped to `[0.001, 1.0]` (Issue #1192). |
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.37"
+version = "0.74.38"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1193.md
+++ b/docs/pr-summary-1193.md
@@ -1,0 +1,87 @@
+## Summary
+
+Cross-target diversity selection in candidate batch emission. The per-target
+cap from Issue #1140 only fires after three slots have already been consumed
+by one target, so a single problematic neuron can still monopolise an
+add-neuron batch when the top of the gain-sorted list clusters on it. This
+change reorders the gain-sorted candidate pool inside `apply_per_target_cap`
+so the front of the batch covers at least `MIN_DISTINCT_TARGETS_PER_BATCH`
+distinct target neurons before the cap is applied — when the pool supports
+it. Closes #1193.
+
+## Changes
+
+- New constants in `src/analysis/constants/candidate_scoring.rs`:
+  `MIN_DISTINCT_TARGETS_PER_BATCH` (default `3`),
+  `MIN_DISTINCT_TARGETS_PER_BATCH_FLOOR`,
+  `MIN_DISTINCT_TARGETS_PER_BATCH_CEILING`, and a
+  `min_distinct_targets_per_batch()` accessor reading
+  `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH` with `[1, 32]` clamping.
+- New `apply_distinct_target_spread()` helper in
+  `src/analysis/neuron/post_processing.rs` reorders a gain-sorted candidate
+  list so the front covers at least the configured number of distinct target
+  neurons. It assumes the input is already gain-sorted and is a stable
+  partition: spread bucket carries the highest-gain entry per first-seen
+  target, the rest follows in gain order.
+- `apply_per_target_cap()` now calls the spread immediately after sorting and
+  before the per-target retain. The per-target cap of three is preserved; a
+  single very productive target can still receive its full quota when fewer
+  alternatives exist.
+- AGENTS.md updated to document the new env-var override.
+
+## Evidence
+
+CLI / library change — no UI surface to screenshot. Behaviour is verified by
+unit tests; see Test Plan below.
+
+```mermaid
+flowchart LR
+    A[Sorted candidate pool] --> B{distinct targets &gt;= MIN?}
+    B -->|yes| C[Take top-1 per target until MIN distinct]
+    B -->|no| D[Skip spread - gain order preserved]
+    C --> E[Append remaining by gain rank]
+    D --> E
+    E --> F[Apply per-target cap of 3]
+```
+
+## Test Plan
+
+Inline unit tests added in `src/analysis/neuron/post_processing.rs`:
+
+- `distinct_target_spread_reorders_when_pool_supports_min` — six
+  highest-gain candidates against `target-A` plus one each against B/C/D;
+  asserts the front three positions cover three distinct targets and the
+  tail remains in gain-descending order.
+- `distinct_target_spread_falls_through_when_pool_too_narrow` — two
+  distinct targets, MIN=3; asserts the spread is a no-op.
+- `per_target_cap_emits_distinct_targets_when_top_dominated_by_one_target`
+  — acceptance test: top six all on one target plus three other targets;
+  after `apply_per_target_cap`, asserts at least
+  `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets remain and the front
+  three slots each hit a distinct target.
+- `per_target_cap_preserves_full_quota_when_no_alternatives` — only one
+  target in the pool; cap retains the full quota of three.
+- `distinct_target_spread_env_override_controls_min` (#[serial]) — sets
+  `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH=1` and asserts the
+  spread becomes a no-op.
+
+Additional acceptance test in
+`src/analysis/implementation_tests/distinct_target_spread_tests.rs`:
+
+- `emitted_batch_covers_min_distinct_targets_when_pool_supports_it` —
+  reproduces the failure-cache pattern from Issue #1189 (top six all hit
+  `neuron-1978541840`) and asserts the emitted batch has at least
+  `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets.
+- `fall_through_preserves_per_target_cap_when_only_one_target` — only
+  `only-target` exists; cap retains the full quota of three.
+
+Existing regression coverage retained:
+
+- `per_target_cap_truncates_target_over_limit` (Issue #1140)
+- `per_target_cap_leaves_targets_under_limit_unchanged` (Issue #1140)
+- `per_target_cap_breakdown_reports_drop` (Issue #1140)
+- `per_target_cap_env_override_controls_limit` (Issue #1140)
+- `squash_diversity_*` (Issue #1141)
+
+`./quality.sh` passes locally (cargo deny, fmt, clippy, check, all unit and
+integration tests, doc build, release build).

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -65,6 +65,54 @@ pub fn max_add_neuron_candidates_per_target() -> usize {
 }
 
 // =============================================================================
+// Cross-Target Diversity Spread (Issue #1193)
+// =============================================================================
+
+/// Default minimum number of distinct target neurons that an emitted batch
+/// must include when the candidate pool supports it (Issue #1193).
+///
+/// The per-target cap (Issue #1140) only fires once three slots for one target
+/// have already been consumed. When the top of the gain-sorted list is
+/// dominated by candidates against a single problematic target, the cap saves
+/// nothing — every slot is spent on that target before any other is
+/// considered. Reordering the top of the list to cover at least
+/// `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets first keeps a single
+/// risky neuron from monopolising the budget while still letting the cap
+/// admit up to three candidates per target where alternatives are scarce.
+///
+/// Overridable via the `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH`
+/// environment variable.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above ~16 may starve high-gain targets.
+pub const MIN_DISTINCT_TARGETS_PER_BATCH: usize = 3;
+
+/// Minimum permitted distinct-target spread after env-var override clamping.
+pub const MIN_DISTINCT_TARGETS_PER_BATCH_FLOOR: usize = 1;
+
+/// Maximum permitted distinct-target spread after env-var override clamping.
+pub const MIN_DISTINCT_TARGETS_PER_BATCH_CEILING: usize = 32;
+
+/// Return the effective minimum distinct-target spread (Issue #1193).
+///
+/// Reads `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH` at call time so
+/// tests and operators can override the default. Values outside the permitted
+/// range are clamped to `[MIN_DISTINCT_TARGETS_PER_BATCH_FLOOR,
+/// MIN_DISTINCT_TARGETS_PER_BATCH_CEILING]`. Unparsable or missing values
+/// fall back to `MIN_DISTINCT_TARGETS_PER_BATCH`.
+#[must_use]
+pub fn min_distinct_targets_per_batch() -> usize {
+    std::env::var("NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(MIN_DISTINCT_TARGETS_PER_BATCH)
+        .clamp(
+            MIN_DISTINCT_TARGETS_PER_BATCH_FLOOR,
+            MIN_DISTINCT_TARGETS_PER_BATCH_CEILING,
+        )
+}
+
+// =============================================================================
 // Source-Type Scoring (Issue #465)
 // =============================================================================
 

--- a/src/analysis/implementation_tests/distinct_target_spread_tests.rs
+++ b/src/analysis/implementation_tests/distinct_target_spread_tests.rs
@@ -1,0 +1,109 @@
+//! Cross-target diversity selection tests (Issue #1193).
+//!
+//! Acceptance criteria from the issue:
+//! - Constructs a candidate pool where the top six candidates all hit one
+//!   target.
+//! - Asserts the emitted batch contains at least
+//!   `MIN_DISTINCT_TARGETS_PER_BATCH` distinct target neurons (provided that
+//!   many exist in the pool).
+
+use crate::CandidateNeuronJson;
+use crate::analysis::constants::min_distinct_targets_per_batch;
+use crate::analysis::neuron::post_processing::apply_per_target_cap;
+use std::collections::HashSet;
+
+fn candidate(target_uuid: &str, gain: f32) -> CandidateNeuronJson {
+    let squash = format!("SQUASH-{target_uuid}-{gain}");
+    CandidateNeuronJson {
+        source_neuron_uuid: format!("source-{target_uuid}-{gain}"),
+        target_neuron_uuid: target_uuid.to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.0,
+        outgoing_weight: 1.0,
+        squash,
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: gain,
+        expected_creature_score_gain: gain,
+        improved_count: 10,
+        total_count: 10,
+        improvement_magnitude_ratio: None,
+        target_neuron_stats: None,
+        prediction_confidence: 0.5,
+        expected_score_gain_confidence_interval: [gain, gain],
+        target_saturation_factor: None,
+        variant_key: None,
+    }
+}
+
+/// Acceptance test for Issue #1193.
+///
+/// The top six gain-ranked candidates all target `neuron-1978541840` — the
+/// failure-cache pattern from Issue #1189. Three additional targets each have
+/// one lower-gain candidate. After post-processing the emitted batch must
+/// contain at least `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets.
+#[test]
+fn emitted_batch_covers_min_distinct_targets_when_pool_supports_it() {
+    let mut candidates = vec![
+        // Six candidates against the dominant problematic target.
+        candidate("neuron-1978541840", 0.99),
+        candidate("neuron-1978541840", 0.95),
+        candidate("neuron-1978541840", 0.92),
+        candidate("neuron-1978541840", 0.90),
+        candidate("neuron-1978541840", 0.87),
+        candidate("neuron-1978541840", 0.85),
+        // One candidate each against three other targets.
+        candidate("neuron-other-B", 0.50),
+        candidate("neuron-other-C", 0.40),
+        candidate("neuron-other-D", 0.30),
+    ];
+
+    let _dropped = apply_per_target_cap(&mut candidates);
+
+    let distinct: HashSet<&str> = candidates
+        .iter()
+        .map(|c| c.target_neuron_uuid.as_str())
+        .collect();
+    let min_distinct = min_distinct_targets_per_batch();
+    assert!(
+        distinct.len() >= min_distinct,
+        "emitted batch must include at least {} distinct targets, got {} ({:?})",
+        min_distinct,
+        distinct.len(),
+        distinct
+    );
+    // The dominant target keeps its full per-target quota of three (three of
+    // the original six are dropped by the cap); three other targets are
+    // represented with one candidate each, for a total of six retained.
+    assert_eq!(candidates.len(), 6);
+}
+
+/// Fall-through case: when the pool only contains a single distinct target,
+/// the spread does not over-rotate — the per-target cap of three still
+/// caps the dominant target without forcing distinctness that does not exist.
+#[test]
+fn fall_through_preserves_per_target_cap_when_only_one_target() {
+    let mut candidates = vec![
+        candidate("only-target", 0.9),
+        candidate("only-target", 0.8),
+        candidate("only-target", 0.7),
+        candidate("only-target", 0.6),
+        candidate("only-target", 0.5),
+    ];
+
+    let dropped = apply_per_target_cap(&mut candidates);
+
+    assert_eq!(candidates.len(), 3, "cap retains the full quota of 3");
+    assert_eq!(dropped, 2);
+    let distinct: HashSet<&str> = candidates
+        .iter()
+        .map(|c| c.target_neuron_uuid.as_str())
+        .collect();
+    assert_eq!(
+        distinct.len(),
+        1,
+        "no spread possible — pool has one target"
+    );
+}

--- a/src/analysis/implementation_tests/mod.rs
+++ b/src/analysis/implementation_tests/mod.rs
@@ -81,6 +81,7 @@ mod bias_calculation_tests;
 mod cache_tests;
 mod clone_reduction_tests;
 mod diagnostics_tests;
+mod distinct_target_spread_tests;
 mod gpu_batch_tests;
 mod improvement_model_tests;
 mod optimal_weight_tests;

--- a/src/analysis/neuron/mod.rs
+++ b/src/analysis/neuron/mod.rs
@@ -13,7 +13,7 @@
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 mod evaluation;
-mod post_processing;
+pub(crate) mod post_processing;
 pub(crate) mod preparation;
 
 use crate::{AnalyzeNeuronsInput, CandidateNeuronJson};

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -351,11 +351,13 @@ pub(crate) fn apply_same_target_squash_diversity(
 /// batch (Issue #1140).
 ///
 /// Sorts `candidates` by `expected_creature_score_gain` descending (NaN-safe
-/// via `total_cmp`), then retains only the top-K candidates per
-/// `target_neuron_uuid`, where K is
-/// [`max_add_neuron_candidates_per_target`]. The retained candidates remain
-/// in gain-descending order. Returns the number of candidates dropped by the
-/// cap so callers can record it in the rejection breakdown.
+/// via `total_cmp`), applies the cross-target diversity spread (Issue #1193),
+/// then retains only the top-K candidates per `target_neuron_uuid`, where K
+/// is [`max_add_neuron_candidates_per_target`]. The retained candidates start
+/// with up to [`min_distinct_targets_per_batch`] distinct targets (in
+/// gain-descending order) followed by the remaining candidates in gain-
+/// descending order. Returns the number of candidates dropped by the cap so
+/// callers can record it in the rejection breakdown.
 pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) -> usize {
     let cap = crate::analysis::constants::max_add_neuron_candidates_per_target();
     if candidates.is_empty() || cap == 0 {
@@ -369,6 +371,12 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
         b.expected_creature_score_gain
             .total_cmp(&a.expected_creature_score_gain)
     });
+
+    // Issue #1193: reorder so the top of the list covers at least
+    // `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets when the pool supports
+    // it. This stops a single problematic target from filling all three cap
+    // slots before any other target is considered.
+    apply_distinct_target_spread(candidates);
 
     let original_len = candidates.len();
     let mut per_target: HashMap<String, usize> = HashMap::new();
@@ -386,15 +394,74 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
     original_len - candidates.len()
 }
 
+/// Cross-target diversity spread (Issue #1193).
+///
+/// Assumes `candidates` is already sorted by `expected_creature_score_gain`
+/// descending. When the pool contains at least
+/// [`min_distinct_targets_per_batch`] distinct target neurons, reorders so
+/// the top of the list contains the highest-gain candidate from each of the
+/// first `min_distinct_targets_per_batch` distinct targets, followed by the
+/// remaining candidates in their original gain-descending order. When the
+/// pool has fewer distinct targets than the spread requires, falls through
+/// without reordering.
+///
+/// The reorder is a stable partition: candidates kept "in front" appear in
+/// the gain-rank order at which their target was first encountered, and
+/// candidates pushed to the rear remain in gain-rank order relative to each
+/// other.
+pub(crate) fn apply_distinct_target_spread(candidates: &mut Vec<CandidateNeuronJson>) {
+    let min_distinct = crate::analysis::constants::min_distinct_targets_per_batch();
+    if candidates.len() <= 1 || min_distinct <= 1 {
+        return;
+    }
+
+    // Count distinct targets in the pool. If the pool cannot support the
+    // requested spread, fall through and let the existing gain-rank ordering
+    // stand — Issue #1193 acceptance criteria 2.
+    let distinct_count: usize = {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for c in candidates.iter() {
+            seen.insert(c.target_neuron_uuid.as_str());
+        }
+        seen.len()
+    };
+    if distinct_count < min_distinct {
+        return;
+    }
+
+    // Walk the gain-sorted list once. The first occurrence of each new target
+    // (until `min_distinct` distinct targets have been collected) goes to the
+    // spread bucket; everything else falls to the rest bucket in gain order.
+    let mut seen_targets: HashSet<String> = HashSet::new();
+    let mut spread: Vec<CandidateNeuronJson> = Vec::with_capacity(min_distinct);
+    let mut rest: Vec<CandidateNeuronJson> = Vec::with_capacity(candidates.len());
+    for candidate in candidates.drain(..) {
+        if spread.len() < min_distinct
+            && !seen_targets.contains(candidate.target_neuron_uuid.as_str())
+        {
+            seen_targets.insert(candidate.target_neuron_uuid.clone());
+            spread.push(candidate);
+        } else {
+            rest.push(candidate);
+        }
+    }
+
+    candidates.extend(spread);
+    candidates.extend(rest);
+}
+
 // =============================================================================
 // Tests (Issue #1140)
 // =============================================================================
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_per_target_cap, apply_same_target_squash_diversity};
+    use super::{
+        apply_distinct_target_spread, apply_per_target_cap, apply_same_target_squash_diversity,
+    };
     use crate::CandidateNeuronJson;
     use serial_test::serial;
+    use std::collections::HashSet;
 
     fn test_candidate_with_squash(
         target_uuid: &str,
@@ -607,6 +674,201 @@ mod tests {
             "rejection breakdown should report two squash-duplicate drops"
         );
         assert_eq!(breakdown.total(), 2);
+    }
+
+    // =========================================================================
+    // Issue #1193 — cross-target diversity spread
+    // =========================================================================
+
+    #[test]
+    fn distinct_target_spread_reorders_when_pool_supports_min() {
+        // Top six candidates all hit target-A; three other targets have one
+        // candidate each lower down the list. With MIN_DISTINCT=3, the front
+        // of the reordered list must contain three distinct targets.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+
+        // Pre-sort to mirror the precondition documented on the function.
+        candidates.sort_by(|a, b| {
+            b.expected_creature_score_gain
+                .total_cmp(&a.expected_creature_score_gain)
+        });
+
+        apply_distinct_target_spread(&mut candidates);
+
+        // Front three positions cover three distinct targets: A, B, C
+        // (highest-gain occurrence of each in gain order).
+        let front_targets: Vec<&str> = candidates[0..3]
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert_eq!(front_targets, vec!["target-A", "target-B", "target-C"]);
+
+        // Front candidates are the highest-gain entry per distinct target.
+        assert!((candidates[0].expected_creature_score_gain - 0.99).abs() < f32::EPSILON);
+        assert!((candidates[1].expected_creature_score_gain - 0.50).abs() < f32::EPSILON);
+        assert!((candidates[2].expected_creature_score_gain - 0.40).abs() < f32::EPSILON);
+
+        // Tail preserves gain order for the remaining candidates.
+        let tail_gains: Vec<f32> = candidates[3..]
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        let mut sorted_tail = tail_gains.clone();
+        sorted_tail.sort_by(|a, b| b.total_cmp(a));
+        assert_eq!(
+            tail_gains, sorted_tail,
+            "tail must remain in gain-descending order"
+        );
+        // No candidates are dropped.
+        assert_eq!(candidates.len(), 9);
+    }
+
+    #[test]
+    fn distinct_target_spread_falls_through_when_pool_too_narrow() {
+        // Only two distinct targets — below MIN_DISTINCT (3) — so the spread
+        // must leave the gain-sorted ordering untouched.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.8),
+            test_candidate("target-A", 0.7),
+            test_candidate("target-B", 0.6),
+        ];
+        candidates.sort_by(|a, b| {
+            b.expected_creature_score_gain
+                .total_cmp(&a.expected_creature_score_gain)
+        });
+        let before: Vec<(String, f32)> = candidates
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+
+        apply_distinct_target_spread(&mut candidates);
+
+        let after: Vec<(String, f32)> = candidates
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+        assert_eq!(
+            before, after,
+            "fall-through path must not reorder when distinct < MIN"
+        );
+    }
+
+    #[test]
+    fn per_target_cap_emits_distinct_targets_when_top_dominated_by_one_target() {
+        // Acceptance: top six candidates all hit target-A; three other targets
+        // exist. After cap, the emitted batch must contain at least
+        // `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+
+        let _dropped = apply_per_target_cap(&mut candidates);
+
+        let distinct: HashSet<&str> = candidates
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        let min_distinct = crate::analysis::constants::min_distinct_targets_per_batch();
+        assert!(
+            distinct.len() >= min_distinct,
+            "emitted batch must include at least {} distinct targets, got {}",
+            min_distinct,
+            distinct.len()
+        );
+
+        // The front three positions of the cap output must each hit a distinct
+        // target — that is the visible signature of the spread.
+        let front_targets: HashSet<&str> = candidates[0..3]
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert_eq!(
+            front_targets.len(),
+            3,
+            "first three slots of the emitted batch should each hit a distinct target"
+        );
+    }
+
+    #[test]
+    fn per_target_cap_preserves_full_quota_when_no_alternatives() {
+        // Only one distinct target exists. The per-target cap of three must
+        // still admit that target's full quota — the spread must not reduce
+        // the cap below `max_add_neuron_candidates_per_target`.
+        let mut candidates = vec![
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.8),
+            test_candidate("target-A", 0.7),
+            test_candidate("target-A", 0.6),
+            test_candidate("target-A", 0.5),
+        ];
+
+        let dropped = apply_per_target_cap(&mut candidates);
+
+        assert_eq!(candidates.len(), 3, "cap should retain the full quota of 3");
+        assert_eq!(dropped, 2);
+        let retained_gains: Vec<f32> = candidates
+            .iter()
+            .map(|c| c.expected_creature_score_gain)
+            .collect();
+        assert_eq!(retained_gains, vec![0.9, 0.8, 0.7]);
+    }
+
+    #[test]
+    #[serial]
+    fn distinct_target_spread_env_override_controls_min() {
+        // SAFETY: env access is serialised via `#[serial]`.
+        unsafe {
+            std::env::set_var("NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH", "1");
+        }
+
+        let mut candidates = vec![
+            test_candidate("target-A", 0.9),
+            test_candidate("target-A", 0.8),
+            test_candidate("target-B", 0.5),
+        ];
+        candidates.sort_by(|a, b| {
+            b.expected_creature_score_gain
+                .total_cmp(&a.expected_creature_score_gain)
+        });
+        let before: Vec<(String, f32)> = candidates
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+
+        apply_distinct_target_spread(&mut candidates);
+
+        let after: Vec<(String, f32)> = candidates
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+
+        // SAFETY: env access is serialised via `#[serial]`.
+        unsafe {
+            std::env::remove_var("NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH");
+        }
+
+        // With min_distinct = 1 the spread becomes a no-op (early return) and
+        // the gain-sorted order is preserved verbatim.
+        assert_eq!(before, after);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cross-target diversity selection in candidate batch emission. The per-target
cap from Issue #1140 only fires after three slots have already been consumed
by one target, so a single problematic neuron can still monopolise an
add-neuron batch when the top of the gain-sorted list clusters on it. This
change reorders the gain-sorted candidate pool inside `apply_per_target_cap`
so the front of the batch covers at least `MIN_DISTINCT_TARGETS_PER_BATCH`
distinct target neurons before the cap is applied — when the pool supports
it. Closes #1193.

## Changes

- New constants in `src/analysis/constants/candidate_scoring.rs`:
  `MIN_DISTINCT_TARGETS_PER_BATCH` (default `3`),
  `MIN_DISTINCT_TARGETS_PER_BATCH_FLOOR`,
  `MIN_DISTINCT_TARGETS_PER_BATCH_CEILING`, and a
  `min_distinct_targets_per_batch()` accessor reading
  `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH` with `[1, 32]` clamping.
- New `apply_distinct_target_spread()` helper in
  `src/analysis/neuron/post_processing.rs` reorders a gain-sorted candidate
  list so the front covers at least the configured number of distinct target
  neurons. It assumes the input is already gain-sorted and is a stable
  partition: spread bucket carries the highest-gain entry per first-seen
  target, the rest follows in gain order.
- `apply_per_target_cap()` now calls the spread immediately after sorting and
  before the per-target retain. The per-target cap of three is preserved; a
  single very productive target can still receive its full quota when fewer
  alternatives exist.
- AGENTS.md updated to document the new env-var override.

## Evidence

CLI / library change — no UI surface to screenshot. Behaviour is verified by
unit tests; see Test Plan below.

```mermaid
flowchart LR
    A[Sorted candidate pool] --> B{distinct targets &gt;= MIN?}
    B -->|yes| C[Take top-1 per target until MIN distinct]
    B -->|no| D[Skip spread - gain order preserved]
    C --> E[Append remaining by gain rank]
    D --> E
    E --> F[Apply per-target cap of 3]
```

## Test Plan

Inline unit tests added in `src/analysis/neuron/post_processing.rs`:

- `distinct_target_spread_reorders_when_pool_supports_min` — six
  highest-gain candidates against `target-A` plus one each against B/C/D;
  asserts the front three positions cover three distinct targets and the
  tail remains in gain-descending order.
- `distinct_target_spread_falls_through_when_pool_too_narrow` — two
  distinct targets, MIN=3; asserts the spread is a no-op.
- `per_target_cap_emits_distinct_targets_when_top_dominated_by_one_target`
  — acceptance test: top six all on one target plus three other targets;
  after `apply_per_target_cap`, asserts at least
  `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets remain and the front
  three slots each hit a distinct target.
- `per_target_cap_preserves_full_quota_when_no_alternatives` — only one
  target in the pool; cap retains the full quota of three.
- `distinct_target_spread_env_override_controls_min` (#[serial]) — sets
  `NEAT_AI_DISCOVERY_MIN_DISTINCT_TARGETS_PER_BATCH=1` and asserts the
  spread becomes a no-op.

Additional acceptance test in
`src/analysis/implementation_tests/distinct_target_spread_tests.rs`:

- `emitted_batch_covers_min_distinct_targets_when_pool_supports_it` —
  reproduces the failure-cache pattern from Issue #1189 (top six all hit
  `neuron-1978541840`) and asserts the emitted batch has at least
  `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets.
- `fall_through_preserves_per_target_cap_when_only_one_target` — only
  `only-target` exists; cap retains the full quota of three.

Existing regression coverage retained:

- `per_target_cap_truncates_target_over_limit` (Issue #1140)
- `per_target_cap_leaves_targets_under_limit_unchanged` (Issue #1140)
- `per_target_cap_breakdown_reports_drop` (Issue #1140)
- `per_target_cap_env_override_controls_limit` (Issue #1140)
- `squash_diversity_*` (Issue #1141)

`./quality.sh` passes locally (cargo deny, fmt, clippy, check, all unit and
integration tests, doc build, release build).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1193 -->