### PR TITLE
Adaptive target-cooldown relaxation during drought (Issue #1204)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.44"
+version = "0.74.45"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/benches/cache_locality.rs
+++ b/benches/cache_locality.rs
@@ -128,6 +128,7 @@ fn benchmark_cache_locality(c: &mut Criterion) {
                         random_seed: Some(42),
                         temperature: 1.0,
                         failure_cache: None,
+                        discovery_outcome_log: None,
                     };
 
                     let result = analyze_synapses_with_cache_and_gpu_queue(

--- a/benches/sample_locality.rs
+++ b/benches/sample_locality.rs
@@ -147,6 +147,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     random_seed: Some(42),
                     temperature: 1.0,
                     failure_cache: None,
+                    discovery_outcome_log: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);
@@ -177,6 +178,7 @@ fn benchmark_sample_locality(c: &mut Criterion) {
                     random_seed: Some(42),
                     temperature: 1.0,
                     failure_cache: None,
+                    discovery_outcome_log: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/benches/zero_copy_buffer.rs
+++ b/benches/zero_copy_buffer.rs
@@ -78,6 +78,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                 random_seed: Some(42),
                 temperature: 1.0,
                 failure_cache: None,
+                discovery_outcome_log: None,
             };
             let result = analyze_synapses(&input).expect("Analysis should succeed");
             black_box(result);
@@ -100,6 +101,7 @@ fn benchmark_zero_copy_vs_copying(c: &mut Criterion) {
                     random_seed: Some(42),
                     temperature: 1.0,
                     failure_cache: None,
+                    discovery_outcome_log: None,
                 };
                 let result = analyze_synapses(&input).expect("Analysis should succeed");
                 black_box(result);

--- a/docs/pr-summary-1204.md
+++ b/docs/pr-summary-1204.md
@@ -1,0 +1,101 @@
+## Summary
+
+Relax `TargetFailureTracker` cooldown thresholds when the rolling outcome log
+signals a drought so previously-failing targets re-enter the focus list
+sooner. Mirrors the candidate-cache staleness window relaxation (Issue #1203)
+so the two adaptive controls compose during a drought instead of locking the
+pipeline out of its own search space. Closes #1204.
+
+### What changed
+
+- New methods on `TargetFailureTracker`
+  (`src/analysis/target_failure_tracker.rs`):
+  - `effective_cooldown_epochs(mode, drought_failures) -> u64` — returns the
+    configured window in Normal mode, half the window in Conservative mode,
+    and a quarter of the window with a floor of 2 under extended drought
+    (`drought_failures >= conservative_mode_max_epochs`).
+  - `effective_consecutive_failures(mode, drought_failures) -> u32` — raises
+    the trigger threshold by `+1` per regime step under drought (`+1` in
+    Conservative, `+2` in extended drought), so fewer targets enter cooldown
+    in the first place.
+  - `is_in_cooldown_adaptive` and the free-function
+    `filter_cooldown_targets_adaptive` plumb mode/drought through the
+    existing predicate. Static-threshold call sites (tests, callers without
+    mode info) keep working via the original `is_in_cooldown` /
+    `filter_cooldown_targets` entry points.
+  - Logs a single `tracing::info!` on regime transitions naming the old and
+    new effective cooldown.
+- New constants and env-var overrides in
+  `src/analysis/constants/detection_thresholds.rs`:
+  - `COOLDOWN_CONSERVATIVE_DIVISOR = 2`, env override
+    `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR`.
+  - `COOLDOWN_EXTENDED_DROUGHT_DIVISOR = 4`, env override
+    `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR`.
+  - `COOLDOWN_EPOCHS_FLOOR = 2` (post-divisor floor) and
+    `[COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING] = [1, 64]` clamping
+    for the divisor env vars.
+- `AnalyzeNeuronsInput` and `AnalyzeSynapsesInput` (in
+  `src/ffi_types/requests.rs`) gain an optional
+  `discovery_outcome_log: Option<DiscoveryOutcomeLog>` (camelCase, serde
+  `default`). Threaded down from `AnalyzeAllInput` in
+  `src/analysis/orchestration.rs` so the per-phase cooldown filter can
+  consult mode/drought.
+- Per-phase cooldown helpers (`apply_target_cooldown` in
+  `src/analysis/neuron/preparation.rs` and
+  `src/analysis/synapse/orchestration.rs`) now derive mode and
+  trailing-failure drought from the threaded outcome log and call the
+  adaptive filter. When the log is absent or empty, the static-threshold
+  filter is used.
+- Env-var documentation table in `src/config/mod.rs` extended with the two
+  new variables.
+
+### Adaptive regime table
+
+| Mode + drought                                    | Effective cooldown            | Effective trigger          |
+|---------------------------------------------------|-------------------------------|----------------------------|
+| `Normal` (or drought below the conservative cap)  | `cooldown_epochs`             | `cooldown_consecutive_failures` |
+| `Conservative`, drought `< conservative_mode_max` | `cooldown_epochs / 2`         | `+1`                       |
+| drought `>= conservative_mode_max` (extended)     | `max(cooldown_epochs / 4, 2)` | `+2`                       |
+
+```mermaid
+flowchart LR
+    OL[DiscoveryOutcomeLog] --> Mode{Mode + drought}
+    Mode -->|Normal| Full[cooldown_epochs]
+    Mode -->|Conservative| Half[cooldown_epochs / 2]
+    Mode -->|Extended drought| Quarter[max cooldown_epochs / 4, floor 2]
+    Full --> Cooldown[is_in_cooldown_adaptive]
+    Half --> Cooldown
+    Quarter --> Cooldown
+```
+
+## Evidence
+
+- `cargo test --test analysis issue_1204` — 15/15 tests pass covering the
+  three regimes, env-var overrides, the integration acceptance criterion
+  (target with 3 failures at epoch 0 in cooldown at epoch 15 under Normal,
+  released at epoch 15 under Conservative), and the borderline trigger case.
+- `cargo test --lib target_failure_tracker` — 10/10 tests pass; new
+  `effective_*` unit tests sit alongside the existing 8 cooldown tests.
+- `./quality.sh` runs green (fmt, clippy, check, full test suite, doc build,
+  release build).
+
+This is a backend/CLI change with no web interface to screenshot.
+
+## Test Plan
+
+- [x] Unit tests for `effective_cooldown_epochs` covering Normal,
+      Conservative, extended drought, and the floor-of-2 clamp in
+      `tests/analysis/issue_1204_adaptive_target_cooldown.rs`.
+- [x] Unit tests for `effective_consecutive_failures` covering Normal,
+      Conservative (+1), extended drought (+2), and `u32::MAX` saturation.
+- [x] Env-var override tests for both
+      `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR` and
+      `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR`, including
+      unparsable values, zero, and the clamping behaviour.
+- [x] Integration test confirming a target with three consecutive failures
+      at epoch 0 is in cooldown at epoch 15 under Normal but released in
+      Conservative mode at the same epoch.
+- [x] Unit tests under `src/analysis/target_failure_tracker.rs::tests`
+      ensuring the adaptive thresholds match the static values in Normal
+      mode and relax in Conservative mode.
+- [x] `./quality.sh` passes cleanly.

--- a/src/analysis/constants/detection_thresholds.rs
+++ b/src/analysis/constants/detection_thresholds.rs
@@ -174,6 +174,88 @@ pub const TARGET_COOLDOWN_CONSECUTIVE_FAILURES: u32 = 3;
 pub const TARGET_COOLDOWN_EPOCHS: u64 = 10;
 
 // =============================================================================
+// Adaptive Target-Cooldown Relaxation (Issue #1204)
+// =============================================================================
+
+/// Divisor applied to the target cooldown epoch window while the discovery
+/// pipeline is in [`crate::analysis::discovery_mode::DiscoveryMode::Conservative`]
+/// mode (Issue #1204).
+///
+/// Halving the cooldown window during a drought lets previously-failing
+/// targets re-enter the focus list twice as fast, instead of staying parked
+/// for the full default while the pipeline struggles to find any
+/// improvement. Mirrors the candidate-cache staleness relaxation
+/// (Issue #1203).
+///
+/// Overridable via `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR`.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above 8 reduce the effective cooldown below the
+/// floor of 2 for any realistic base window.
+pub const COOLDOWN_CONSERVATIVE_DIVISOR: u64 = 2;
+
+/// Divisor applied to the target cooldown epoch window during an extended
+/// drought — i.e. once `drought_failures` has met or exceeded
+/// `conservative_mode_max_epochs` (Issue #1204).
+///
+/// Quartering the cooldown window is a last-ditch escape hatch before the
+/// operator-controlled reset path. The effective cooldown never drops
+/// below the [`COOLDOWN_EPOCHS_FLOOR`].
+///
+/// Overridable via `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR`.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above 32 collapse the window to the floor for any
+/// realistic base window.
+pub const COOLDOWN_EXTENDED_DROUGHT_DIVISOR: u64 = 4;
+
+/// Floor applied to the effective target cooldown window after a divisor is
+/// applied (Issue #1204).
+///
+/// Prevents the cooldown from collapsing so far that a target re-enters the
+/// focus list before any structural change can have landed.
+pub const COOLDOWN_EPOCHS_FLOOR: u64 = 2;
+
+/// Lower clamp for env-var overrides of the adaptive cooldown divisors.
+pub const COOLDOWN_DIVISOR_FLOOR: u64 = 1;
+
+/// Upper clamp for env-var overrides of the adaptive cooldown divisors.
+/// Values above this would collapse the window to the floor for any
+/// sensible base window.
+pub const COOLDOWN_DIVISOR_CEILING: u64 = 64;
+
+/// Returns the effective conservative-mode cooldown divisor (Issue #1204).
+///
+/// Reads `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR` at call time so
+/// tests and operators can override the default without recompiling. Values
+/// outside `[COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING]` are clamped.
+/// Unparsable or missing values fall back to [`COOLDOWN_CONSERVATIVE_DIVISOR`].
+#[must_use]
+pub fn cooldown_conservative_divisor() -> u64 {
+    std::env::var("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(COOLDOWN_CONSERVATIVE_DIVISOR)
+        .clamp(COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING)
+}
+
+/// Returns the effective extended-drought cooldown divisor (Issue #1204).
+///
+/// Reads `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR` at call time
+/// so tests and operators can override the default without recompiling.
+/// Values outside `[COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING]` are
+/// clamped. Unparsable or missing values fall back to
+/// [`COOLDOWN_EXTENDED_DROUGHT_DIVISOR`].
+#[must_use]
+pub fn cooldown_extended_drought_divisor() -> u64 {
+    std::env::var("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(COOLDOWN_EXTENDED_DROUGHT_DIVISOR)
+        .clamp(COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING)
+}
+
+// =============================================================================
 // Within-Batch Target Failure Short-Circuit (Issue #1164)
 // =============================================================================
 

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -72,6 +72,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let err =
@@ -147,6 +148,7 @@ fn analyze_synapses_rejects_duplicate_focus_targets() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let err = analyze_synapses(&input)
@@ -258,6 +260,7 @@ fn analyze_synapses_reports_eligible_sources_correctly_for_non_input_neurons() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -399,6 +402,7 @@ fn analyze_synapses_reports_fully_connected_neuron_explicitly() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -451,6 +455,7 @@ fn analyze_synapses_requires_focus_targets() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let err =
@@ -505,6 +510,7 @@ fn analyze_synapses_reports_diagnostics_when_no_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result =
@@ -617,6 +623,7 @@ fn analyze_synapses_stops_harmful_processing_after_deadline() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = pool
@@ -771,6 +778,7 @@ fn analyze_neurons_reports_diagnostics_when_no_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result =
@@ -883,6 +891,7 @@ fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = pool
@@ -1018,6 +1027,7 @@ fn analyze_synapses_uses_vertical_timeout_with_randomized_order() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = pool
@@ -1116,6 +1126,7 @@ fn analyze_synapses_accepts_positive_improvements_below_threshold() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1215,6 +1226,7 @@ fn analyze_synapses_rejects_non_positive_improvements() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -1290,6 +1302,7 @@ fn analyze_synapses_accepts_positive_improvements_above_threshold() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -155,7 +155,11 @@ pub(crate) fn prepare_neuron_analysis<'a>(
     );
 
     // Issue #1130: drop targets currently in cooldown after focus filtering.
-    let cooldown_skipped = apply_target_cooldown(&mut focus_order);
+    // Issue #1204: thread the discovery outcome log so cooldown relaxes during
+    // a drought when mode/drought signals are available; static thresholds are
+    // used when the log is absent.
+    let cooldown_skipped =
+        apply_target_cooldown(&mut focus_order, input.discovery_outcome_log.as_ref());
 
     // If no output neurons remain after filtering, return early with empty results
     let early_return = if focus_order.is_empty() {
@@ -199,8 +203,17 @@ pub(crate) fn prepare_neuron_analysis<'a>(
 /// (Issue #1130). Returns the number of targets removed so callers can include
 /// it in diagnostics alongside the `cooldown_skipped` reason-name convention
 /// from Issue #1129.
-fn apply_target_cooldown(focus_order: &mut Vec<String>) -> u32 {
-    use crate::analysis::target_failure_tracker::{filter_cooldown_targets, global_tracker};
+///
+/// Issue #1204: when `discovery_outcome_log` is supplied, the adaptive form is
+/// used so the cooldown window shrinks during a drought. When it is `None` or
+/// empty, the static-threshold form is used.
+fn apply_target_cooldown(
+    focus_order: &mut Vec<String>,
+    discovery_outcome_log: Option<&crate::analysis::discovery_mode::DiscoveryOutcomeLog>,
+) -> u32 {
+    use crate::analysis::target_failure_tracker::{
+        filter_cooldown_targets, filter_cooldown_targets_adaptive, global_tracker,
+    };
 
     let tracker_lock = match global_tracker().lock() {
         Ok(guard) => guard,
@@ -211,7 +224,24 @@ fn apply_target_cooldown(focus_order: &mut Vec<String>) -> u32 {
         return 0;
     }
     let current_epoch = tracker_lock.current_epoch();
-    filter_cooldown_targets(focus_order, &tracker_lock, current_epoch)
+    match discovery_outcome_log {
+        Some(log) if !log.is_empty() => {
+            let mode = crate::analysis::discovery_mode::decide_mode(
+                log,
+                crate::config::low_success_rate_threshold(),
+                crate::config::conservative_mode_max_epochs(),
+            );
+            let drought_failures = log.consecutive_trailing_failures();
+            filter_cooldown_targets_adaptive(
+                focus_order,
+                &tracker_lock,
+                current_epoch,
+                mode,
+                drought_failures,
+            )
+        }
+        _ => filter_cooldown_targets(focus_order, &tracker_lock, current_epoch),
+    }
 }
 
 /// Load source neuron records for a given target, filtering by eligibility

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -495,6 +495,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             random_seed: input.random_seed,
             temperature: input.temperature,
             failure_cache: input.failure_cache.clone(),
+            discovery_outcome_log: input.discovery_outcome_log.clone(),
         })
     } else {
         None
@@ -510,6 +511,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             random_seed: input.random_seed,
             temperature: input.temperature,
             failure_cache: input.failure_cache.clone(),
+            discovery_outcome_log: input.discovery_outcome_log.clone(),
         })
     } else {
         None

--- a/src/analysis/synapse/orchestration.rs
+++ b/src/analysis/synapse/orchestration.rs
@@ -60,7 +60,10 @@ pub(crate) fn analyze_synapses_with_cache_impl(
 
     // Issue #1130: drop targets currently in cooldown after focus filtering,
     // before we incur any per-target analysis cost.
-    let _cooldown_skipped = apply_target_cooldown(&mut focus_order);
+    // Issue #1204: thread the discovery outcome log so cooldown relaxes during
+    // a drought when mode/drought signals are available.
+    let _cooldown_skipped =
+        apply_target_cooldown(&mut focus_order, input.discovery_outcome_log.as_ref());
 
     log_analysis_start(
         "synapse",
@@ -205,8 +208,13 @@ pub(crate) fn analyze_synapses_with_cache_impl(
 /// (Issue #1130). Returns the number of targets removed so callers can include
 /// it in diagnostics alongside the `cooldown_skipped` reason-name convention
 /// from Issue #1129.
-fn apply_target_cooldown(focus_order: &mut Vec<String>) -> u32 {
-    use crate::analysis::target_failure_tracker::{filter_cooldown_targets, global_tracker};
+fn apply_target_cooldown(
+    focus_order: &mut Vec<String>,
+    discovery_outcome_log: Option<&crate::analysis::discovery_mode::DiscoveryOutcomeLog>,
+) -> u32 {
+    use crate::analysis::target_failure_tracker::{
+        filter_cooldown_targets, filter_cooldown_targets_adaptive, global_tracker,
+    };
 
     let tracker_lock = match global_tracker().lock() {
         Ok(guard) => guard,
@@ -216,5 +224,22 @@ fn apply_target_cooldown(focus_order: &mut Vec<String>) -> u32 {
         return 0;
     }
     let current_epoch = tracker_lock.current_epoch();
-    filter_cooldown_targets(focus_order, &tracker_lock, current_epoch)
+    match discovery_outcome_log {
+        Some(log) if !log.is_empty() => {
+            let mode = crate::analysis::discovery_mode::decide_mode(
+                log,
+                crate::config::low_success_rate_threshold(),
+                crate::config::conservative_mode_max_epochs(),
+            );
+            let drought_failures = log.consecutive_trailing_failures();
+            filter_cooldown_targets_adaptive(
+                focus_order,
+                &tracker_lock,
+                current_epoch,
+                mode,
+                drought_failures,
+            )
+        }
+        _ => filter_cooldown_targets(focus_order, &tracker_lock, current_epoch),
+    }
 }

--- a/src/analysis/synapse/preparation.rs
+++ b/src/analysis/synapse/preparation.rs
@@ -239,6 +239,7 @@ mod tests {
             temperature: 1.0,
             analysis_deadline_ms: None,
             failure_cache: None,
+            discovery_outcome_log: None,
         }
     }
 
@@ -314,6 +315,7 @@ mod tests {
             temperature: 1.0,
             analysis_deadline_ms: None,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
         let lookups = build_creature_lookups(&input);
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -59,6 +59,8 @@
 //! | `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` | u32 | `3` | Consecutive target-neuron failures before cooldown (Issue #1130) |
 //! | `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_EPOCHS` | u64 | `10` | Cooldown duration in epochs for skipped targets (Issue #1130) |
 //! | `NEAT_AI_DISCOVERY_BATCH_TARGET_FAILURE_LIMIT` | u32 | `1` | Within-batch failure limit before same-target candidates are short-circuited (Issue #1164) |
+//! | `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR` | u64 | `2` | Divisor applied to the target cooldown window during conservative mode (Issue #1204) |
+//! | `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR` | u64 | `4` | Divisor applied to the target cooldown window during extended drought (Issue #1204) |
 //!
 //! ## Internal/Debug Variables
 //!

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -133,6 +133,14 @@ pub struct AnalyzeSynapsesInput {
     /// Per-creature failure cache (Issue #1131). See `AnalyzeParallelInput`.
     #[serde(default)]
     pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
+    /// Per-creature rolling discovery outcome log (Issue #1132, #1204).
+    ///
+    /// Threaded down from `AnalyzeAllInput` so the target-cooldown adaptive
+    /// relaxation (Issue #1204) can shrink the cooldown window during a
+    /// drought instead of locking the pipeline out of its own search space.
+    /// When absent or empty, cooldown uses the static configured thresholds.
+    #[serde(default)]
+    pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
 }
 
 /// Internal input structure for neuron analysis (used by `analyze_all`)
@@ -162,6 +170,14 @@ pub struct AnalyzeNeuronsInput {
     /// Per-creature failure cache (Issue #1131). See `AnalyzeParallelInput`.
     #[serde(default)]
     pub failure_cache: Option<Vec<analysis::scoring::calibration_correction::FailureCacheEntry>>,
+    /// Per-creature rolling discovery outcome log (Issue #1132, #1204).
+    ///
+    /// Threaded down from `AnalyzeAllInput` so the target-cooldown adaptive
+    /// relaxation (Issue #1204) can shrink the cooldown window during a
+    /// drought instead of locking the pipeline out of its own search space.
+    /// When absent or empty, cooldown uses the static configured thresholds.
+    #[serde(default)]
+    pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
 }
 
 /// Internal input structure for combined analysis (used by `analyze_parallel`)

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -126,6 +126,7 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/leaky_relu_filtered.rs
+++ b/tests/activation/leaky_relu_filtered.rs
@@ -73,6 +73,7 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/relu_adjacent_filtered.rs
+++ b/tests/activation/relu_adjacent_filtered.rs
@@ -77,6 +77,7 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/step_hidden_neuron_prediction.rs
+++ b/tests/activation/step_hidden_neuron_prediction.rs
@@ -172,6 +172,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -264,6 +265,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -370,6 +372,7 @@ fn test_step_output_neuron_no_identity_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -111,6 +111,7 @@ fn synapse_analysis_respects_deadline() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let start = Instant::now();
@@ -201,6 +202,7 @@ fn neuron_analysis_respects_deadline() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let start = Instant::now();
@@ -286,6 +288,7 @@ fn focus_neurons_are_randomised_across_runs() {
             random_seed: None,
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let result = analyze_neurons(&input).expect("Analysis should complete successfully");

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -155,6 +155,7 @@ fn test_optimised_params_vary_by_sample() {
             random_seed: None,
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -234,6 +235,7 @@ fn test_conservative_params_more_stable_across_samples() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let subset_result = analyze_neurons(&subset_input).unwrap();
@@ -368,6 +370,7 @@ fn test_relu_fixed_params_consistent_across_samples() {
             random_seed: None,
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -467,6 +470,7 @@ fn test_synapse_candidates_no_bias_optimisation() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).unwrap();
@@ -529,6 +533,7 @@ fn test_synapse_weight_distribution() {
             random_seed: None,
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let result = analyze_synapses(&input).unwrap();

--- a/tests/analysis/issue_1101_no_target_records_diagnostic.rs
+++ b/tests/analysis/issue_1101_no_target_records_diagnostic.rs
@@ -79,6 +79,7 @@ fn zero_target_records_reports_no_target_records_reason() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/analysis/issue_1204_adaptive_target_cooldown.rs
+++ b/tests/analysis/issue_1204_adaptive_target_cooldown.rs
@@ -1,0 +1,309 @@
+//! Tests for Issue #1204: adaptive target-cooldown relaxation during drought.
+//!
+//! Relax `TargetFailureTracker` cooldown thresholds when the rolling outcome
+//! log signals a drought so previously-failing targets re-enter the focus
+//! list sooner. Complements the candidate-cache staleness window relaxation
+//! (Issue #1203).
+//!
+//! ## Key Behaviours Verified
+//!
+//! - Normal mode keeps the full cooldown window and configured trigger.
+//! - Conservative mode halves the effective cooldown and raises the trigger
+//!   by 1.
+//! - Extended drought (`drought_failures >= conservative_mode_max_epochs`)
+//!   quarters the cooldown with a floor of 2 and raises the trigger by 2.
+//! - Env-var overrides for both divisors are parsed and respected.
+//! - Integration: a target with 3 consecutive failures at epoch 0 is in
+//!   cooldown at epoch 15 under Normal mode (30-epoch cooldown) but cleared
+//!   at epoch 15 in Conservative mode.
+
+#![allow(clippy::cast_sign_loss)]
+
+use neat_ai_discovery::analysis::constants::{
+    COOLDOWN_CONSERVATIVE_DIVISOR, COOLDOWN_EPOCHS_FLOOR, COOLDOWN_EXTENDED_DROUGHT_DIVISOR,
+    cooldown_conservative_divisor, cooldown_extended_drought_divisor,
+};
+use neat_ai_discovery::analysis::discovery_mode::{
+    DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS, DiscoveryMode,
+};
+use neat_ai_discovery::analysis::target_failure_tracker::{
+    TargetFailureTracker, filter_cooldown_targets_adaptive,
+};
+use serial_test::serial;
+
+/// Guard that restores or removes an env var on drop so a test does not leak
+/// configuration into siblings that share the process.
+struct EnvGuard {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prior }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+// =============================================================================
+// effective_cooldown_epochs — three regimes
+// =============================================================================
+
+#[test]
+#[serial]
+fn normal_mode_keeps_full_cooldown_window() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    let effective = tracker.effective_cooldown_epochs(DiscoveryMode::Normal, 0);
+    assert_eq!(effective, 30);
+}
+
+#[test]
+#[serial]
+fn conservative_mode_halves_cooldown_window() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    let effective = tracker.effective_cooldown_epochs(DiscoveryMode::Conservative, 5);
+    assert_eq!(effective, 30 / COOLDOWN_CONSERVATIVE_DIVISOR);
+}
+
+#[test]
+#[serial]
+fn extended_drought_quarters_cooldown_window() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 40);
+    let effective = tracker
+        .effective_cooldown_epochs(DiscoveryMode::Normal, DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS);
+    assert_eq!(effective, 40 / COOLDOWN_EXTENDED_DROUGHT_DIVISOR);
+}
+
+#[test]
+#[serial]
+fn extended_drought_honours_floor_of_two() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    // Tiny base cooldown (4) divided by extended-drought divisor (4) → 1,
+    // which is below the floor of 2 → clamped to 2.
+    let tracker = TargetFailureTracker::with_thresholds(3, 4);
+    let effective = tracker.effective_cooldown_epochs(
+        DiscoveryMode::Normal,
+        DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS + 10,
+    );
+    assert_eq!(effective, COOLDOWN_EPOCHS_FLOOR);
+    assert_eq!(COOLDOWN_EPOCHS_FLOOR, 2);
+}
+
+// =============================================================================
+// effective_consecutive_failures — three regimes
+// =============================================================================
+
+#[test]
+#[serial]
+fn normal_mode_keeps_configured_failure_trigger() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    let effective = tracker.effective_consecutive_failures(DiscoveryMode::Normal, 0);
+    assert_eq!(effective, 3);
+}
+
+#[test]
+#[serial]
+fn conservative_mode_raises_failure_trigger_by_one() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    let effective = tracker.effective_consecutive_failures(DiscoveryMode::Conservative, 5);
+    assert_eq!(effective, 4);
+}
+
+#[test]
+#[serial]
+fn extended_drought_raises_failure_trigger_by_two() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    let effective = tracker.effective_consecutive_failures(
+        DiscoveryMode::Normal,
+        DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS,
+    );
+    assert_eq!(effective, 5);
+}
+
+#[test]
+#[serial]
+fn effective_failures_saturate_at_u32_max() {
+    let tracker = TargetFailureTracker::with_thresholds(u32::MAX, 30);
+    // Saturating-add: u32::MAX + 2 stays at u32::MAX.
+    let effective = tracker.effective_consecutive_failures(
+        DiscoveryMode::Normal,
+        DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS + 1,
+    );
+    assert_eq!(effective, u32::MAX);
+}
+
+// =============================================================================
+// Env-var overrides
+// =============================================================================
+
+#[test]
+#[serial]
+fn env_var_overrides_cooldown_conservative_divisor() {
+    let _g_extended = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+    let _g = EnvGuard::set("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR", "5");
+    assert_eq!(cooldown_conservative_divisor(), 5);
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 100);
+    let effective = tracker.effective_cooldown_epochs(DiscoveryMode::Conservative, 0);
+    assert_eq!(effective, 100 / 5);
+}
+
+#[test]
+#[serial]
+fn env_var_overrides_cooldown_extended_drought_divisor() {
+    let _g_cons = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g = EnvGuard::set("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR", "10");
+    assert_eq!(cooldown_extended_drought_divisor(), 10);
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 100);
+    let effective = tracker
+        .effective_cooldown_epochs(DiscoveryMode::Normal, DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS);
+    assert_eq!(effective, 100 / 10);
+}
+
+#[test]
+#[serial]
+fn unparsable_cooldown_env_vars_fall_back_to_defaults() {
+    let _g1 = EnvGuard::set(
+        "NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR",
+        "not-a-number",
+    );
+    let _g2 = EnvGuard::set(
+        "NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR",
+        "also-bogus",
+    );
+    assert_eq!(
+        cooldown_conservative_divisor(),
+        COOLDOWN_CONSERVATIVE_DIVISOR
+    );
+    assert_eq!(
+        cooldown_extended_drought_divisor(),
+        COOLDOWN_EXTENDED_DROUGHT_DIVISOR,
+    );
+}
+
+#[test]
+#[serial]
+fn zero_cooldown_divisor_env_var_clamped_to_floor() {
+    let _g = EnvGuard::set("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR", "0");
+    assert!(cooldown_conservative_divisor() >= 1);
+
+    let tracker = TargetFailureTracker::with_thresholds(3, 30);
+    // Should not panic and should produce a sensible window >= floor.
+    let effective = tracker.effective_cooldown_epochs(DiscoveryMode::Conservative, 0);
+    assert!(effective >= COOLDOWN_EPOCHS_FLOOR);
+}
+
+// =============================================================================
+// Integration: a previously-cooldown target is released earlier in Conservative mode
+// =============================================================================
+
+#[test]
+#[serial]
+fn target_in_cooldown_under_normal_is_released_in_conservative_at_same_epoch() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    // Acceptance criterion: a target with 3 consecutive failures at epoch 0
+    // is in cooldown at epoch 15 under Normal mode (30-epoch cooldown) but
+    // cleared at epoch 15 in Conservative mode (effective cooldown = 15).
+    let mut tracker = TargetFailureTracker::with_thresholds(3, 30);
+    tracker.record_failure("target-T", 0);
+    tracker.record_failure("target-T", 0);
+    tracker.record_failure("target-T", 0);
+
+    // Normal mode at epoch 15: still in cooldown (15 < 0 + 30).
+    assert!(tracker.is_in_cooldown_adaptive("target-T", 15, DiscoveryMode::Normal, 0,));
+
+    // Conservative mode at epoch 15: released (15 < 0 + 15 is false).
+    assert!(!tracker.is_in_cooldown_adaptive("target-T", 15, DiscoveryMode::Conservative, 5,));
+}
+
+#[test]
+#[serial]
+fn filter_cooldown_targets_adaptive_drops_only_under_normal() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    // Build a tracker with three failures at epoch 0 on target-T.
+    let mut tracker = TargetFailureTracker::with_thresholds(3, 30);
+    for _ in 0..3 {
+        tracker.record_failure("target-T", 0);
+    }
+
+    // Normal mode at epoch 15: target is dropped.
+    let mut focus = vec!["target-T".to_string(), "target-healthy".to_string()];
+    let skipped =
+        filter_cooldown_targets_adaptive(&mut focus, &tracker, 15, DiscoveryMode::Normal, 0);
+    assert_eq!(skipped, 1);
+    assert_eq!(focus, vec!["target-healthy".to_string()]);
+
+    // Conservative mode at epoch 15: target is kept (effective cooldown = 15).
+    let mut focus = vec!["target-T".to_string(), "target-healthy".to_string()];
+    let skipped =
+        filter_cooldown_targets_adaptive(&mut focus, &tracker, 15, DiscoveryMode::Conservative, 5);
+    assert_eq!(skipped, 0);
+    assert_eq!(
+        focus,
+        vec!["target-T".to_string(), "target-healthy".to_string()]
+    );
+}
+
+#[test]
+#[serial]
+fn raised_trigger_under_drought_keeps_borderline_targets_out_of_cooldown() {
+    let _g1 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR");
+    let _g2 = EnvGuard::unset("NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR");
+
+    // Configured trigger = 3 failures. Effective trigger in Conservative mode
+    // is 4, so a target with exactly 3 failures is *not* in cooldown under
+    // Conservative mode but *is* under Normal mode.
+    let mut tracker = TargetFailureTracker::with_thresholds(3, 30);
+    tracker.record_failure("target-T", 0);
+    tracker.record_failure("target-T", 0);
+    tracker.record_failure("target-T", 0);
+
+    assert!(tracker.is_in_cooldown_adaptive("target-T", 5, DiscoveryMode::Normal, 0));
+    assert!(!tracker.is_in_cooldown_adaptive("target-T", 5, DiscoveryMode::Conservative, 5));
+}

--- a/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
+++ b/tests/analysis/issue_199_dynamic_constant_source_threshold.rs
@@ -100,6 +100,7 @@ fn issue_199_low_variance_sources_use_default_threshold() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -210,6 +211,7 @@ fn issue_199_high_variance_sources_scale_threshold() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -317,6 +319,7 @@ fn issue_199_env_var_override_takes_precedence() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)
@@ -399,6 +402,7 @@ fn issue_199_env_var_zero_disables_folding() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/analysis/issue_221_sample_locality.rs
+++ b/tests/analysis/issue_221_sample_locality.rs
@@ -385,6 +385,7 @@ fn sample_locality_batching_produces_results() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs
@@ -461,6 +462,7 @@ fn sample_locality_preserves_correctness() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -515,6 +517,7 @@ fn source_batching_90_percent_overlap_produces_results() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Note: The benchmark has been moved to benches/sample_locality.rs

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -105,6 +105,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -160,6 +161,7 @@ fn input_neuron_reported_as_filtered_in_neuron_diagnostics() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -232,6 +234,7 @@ fn synapse_diagnostics_include_rejection_reasons_for_unpromising_targets() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("synapse analysis should succeed");
@@ -417,6 +420,7 @@ fn multiple_focus_targets_each_get_separate_diagnostic_entry() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -480,6 +484,7 @@ fn fully_connected_neuron_reports_no_eligible_sources() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/analysis/split_error_all_activations.rs
+++ b/tests/analysis/split_error_all_activations.rs
@@ -151,6 +151,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -284,6 +285,7 @@ fn test_skewed_errors_return_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/split_error_fallback_candidates.rs
+++ b/tests/analysis/split_error_fallback_candidates.rs
@@ -168,6 +168,7 @@ fn regression_split_error_must_return_fallback_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -350,6 +351,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/target_map_optimization.rs
+++ b/tests/analysis/target_map_optimization.rs
@@ -97,6 +97,7 @@ fn synapse_analysis_with_target_map_optimization_succeeds() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -182,6 +183,7 @@ fn multiple_focus_neurons_share_target_map_optimization() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result =
@@ -283,6 +285,7 @@ fn target_map_filters_non_finite_values() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Analysis should complete without errors from non-finite values
@@ -355,6 +358,7 @@ fn empty_target_records_skips_source_processing() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Should complete quickly without processing sources

--- a/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
@@ -125,6 +125,7 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/focus/issue_182_focus_unused_observations.rs
+++ b/tests/focus/issue_182_focus_unused_observations.rs
@@ -218,6 +218,7 @@ fn issue_182_focus_unused_observations_prioritises_inputs_without_synapses() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");
@@ -295,6 +296,7 @@ fn issue_182_without_env_var_no_prioritisation() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("analysis should succeed");

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -133,6 +133,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -264,6 +265,7 @@ fn test_all_new_activations_produce_candidates() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -87,6 +87,7 @@ fn synapse_analysis_works_with_gpu_work_queue() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -155,6 +156,7 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Run analysis - this uses the GPU work queue internally
@@ -266,6 +268,7 @@ fn multiple_focus_neurons_work_with_shared_queue() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Run analysis with multiple focus neurons
@@ -351,6 +354,7 @@ fn harmful_synapse_detection_works_with_queue() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Run analysis

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -91,6 +91,7 @@ fn neuron_analysis_with_deadline_completes() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis with deadline should succeed");
@@ -131,6 +132,7 @@ fn synapse_analysis_with_deadline_completes() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis with deadline should succeed");
@@ -174,6 +176,7 @@ fn analysis_with_expired_deadline_returns_promptly() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let start = std::time::Instant::now();

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -125,6 +125,7 @@ fn timing_enabled_via_env_var() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -187,6 +188,7 @@ fn per_shader_timing_collected() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -328,6 +330,7 @@ fn neuron_analysis_timing_collected() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_196_cache_locality_benchmark.rs
+++ b/tests/infrastructure/issue_196_cache_locality_benchmark.rs
@@ -136,6 +136,7 @@ fn cache_locality_optimization_preserves_correctness() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -156,6 +157,7 @@ fn cache_locality_optimization_preserves_correctness() {
         random_seed: Some(123),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result2 = analyze_synapses(&input2).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_228_zero_copy_buffer.rs
+++ b/tests/infrastructure/issue_228_zero_copy_buffer.rs
@@ -207,6 +207,7 @@ fn zero_copy_produces_correct_results() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
     let result_zero_copy =
         analyze_synapses(&input).expect("Analysis with zero-copy should succeed");
@@ -227,6 +228,7 @@ fn zero_copy_produces_correct_results() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
     let result_copy = analyze_synapses(&input).expect("Analysis with copy should succeed");
     unsafe {
@@ -328,6 +330,7 @@ fn metadata_includes_zero_copy_status() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -415,6 +418,7 @@ fn zero_copy_no_data_corruption() {
             random_seed: Some(seed),
             temperature: 1.0,
             failure_cache: None,
+            discovery_outcome_log: None,
         };
 
         let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/infrastructure/issue_718_bug_comment_error_handling.rs
+++ b/tests/infrastructure/issue_718_bug_comment_error_handling.rs
@@ -73,6 +73,7 @@ fn target_with_only_constant_upstream_returns_empty_results() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input);

--- a/tests/infrastructure/observability.rs
+++ b/tests/infrastructure/observability.rs
@@ -376,6 +376,7 @@ fn integration_timing_output() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result =
@@ -445,6 +446,7 @@ fn integration_gpu_metrics() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result =

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -510,6 +510,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -607,6 +608,7 @@ fn test_bias_values_are_activation_specific() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -878,6 +880,7 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -988,6 +991,7 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1088,6 +1092,7 @@ fn test_bias_improves_neuron_performance() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1219,6 +1224,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1383,6 +1389,7 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/neuron/issue_134_direction_flip.rs
+++ b/tests/neuron/issue_134_direction_flip.rs
@@ -82,6 +82,7 @@ fn issue_134_bent_identity_target_simulation_rejects_linear_false_positive() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");
@@ -162,6 +163,7 @@ fn issue_134_identity_target_accepts_linear_candidate_sanity_check() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Synapse analysis should succeed");

--- a/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
+++ b/tests/neuron/issue_178_constant_source_folds_to_setbias.rs
@@ -80,6 +80,7 @@ fn issue_178_constant_source_becomes_setbias_candidate() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_180_setweight_operation.rs
+++ b/tests/neuron/issue_180_setweight_operation.rs
@@ -108,6 +108,7 @@ fn issue_180_setweight_replaces_remove_add_pattern() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/neuron/issue_834_lock_free_error_collection.rs
+++ b/tests/neuron/issue_834_lock_free_error_collection.rs
@@ -161,6 +161,7 @@ fn test_lock_free_error_collection_many_targets() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -244,6 +244,7 @@ fn test_add_neuron_between_hidden_neurons() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -355,6 +356,7 @@ fn test_hidden_neuron_candidate_properties() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/regression/regression_v0_1_123.rs
+++ b/tests/regression/regression_v0_1_123.rs
@@ -139,6 +139,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -272,6 +273,7 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -540,6 +542,7 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -728,6 +731,7 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_192_error_distribution_analysis.rs
+++ b/tests/scoring/issue_192_error_distribution_analysis.rs
@@ -460,6 +460,7 @@ fn test_synapse_analysis_includes_error_distribution() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -572,6 +573,7 @@ fn test_candidate_includes_outlier_info_when_enabled() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -674,6 +676,7 @@ fn test_bimodal_error_pattern_detection() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/scoring/issue_486_neuron_error_distribution.rs
+++ b/tests/scoring/issue_486_neuron_error_distribution.rs
@@ -99,6 +99,7 @@ fn test_neuron_analysis_populates_error_distribution() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -199,6 +200,7 @@ fn test_neuron_analysis_no_errors_returns_none() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -305,6 +307,7 @@ fn test_neuron_analysis_error_distribution_multiple_targets() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
+++ b/tests/scoring/issue_506_score_prediction_pessimism_discount.rs
@@ -212,6 +212,7 @@ fn test_issue_506_synapse_candidates_have_pessimism_discount() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
+++ b/tests/synapse/issue_413_add_synapse_prediction_accuracy.rs
@@ -134,6 +134,7 @@ fn test_issue_413_add_synapse_hard_tanh_prediction_not_inverted() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();
@@ -215,6 +216,7 @@ fn test_issue_413_add_synapse_prediction_direction_correct() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_416_harmful_synapse_threshold.rs
+++ b/tests/synapse/issue_416_harmful_synapse_threshold.rs
@@ -143,6 +143,7 @@ fn test_harmful_synapse_candidates_must_have_positive_expected_gain() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -241,6 +242,7 @@ fn test_helpful_synapse_is_not_marked_as_harmful() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -370,6 +372,7 @@ fn test_mixed_helpful_and_harmful_synapses() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/synapse/issue_522_synapse_post_processing.rs
+++ b/tests/synapse/issue_522_synapse_post_processing.rs
@@ -128,6 +128,7 @@ fn output_targets_have_full_impact_hidden_targets_are_discounted() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -257,6 +258,7 @@ fn candidates_sorted_by_expected_score_gain_descending() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -370,6 +372,7 @@ fn max_candidates_limits_total_output() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -462,6 +465,7 @@ fn pipeline_applies_pessimism_discount_to_candidates() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();
@@ -566,6 +570,7 @@ fn metadata_contains_candidate_counts_and_timing() {
         random_seed: Some(42),
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::synapse::analyze_synapses(&input).unwrap();

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -230,6 +230,7 @@ fn test_remove_harmful_synapse_discovery() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");
@@ -358,6 +359,7 @@ fn test_harmful_synapse_identifies_correct_neurons() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_synapses(&input).expect("Analysis should succeed");

--- a/tests/synapse/sample_matching.rs
+++ b/tests/synapse/sample_matching.rs
@@ -78,6 +78,7 @@ fn analysis_handles_non_finite_values_gracefully() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Should complete without error
@@ -146,6 +147,7 @@ fn analysis_pairs_samples_by_obs_index() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Should complete successfully with 5 matching sample pairs
@@ -212,6 +214,7 @@ fn analysis_skips_neurons_without_errors() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     // Should complete and find candidates using input-0 as source

--- a/tests/synapse/source_variance_discounting.rs
+++ b/tests/synapse/source_variance_discounting.rs
@@ -132,6 +132,7 @@ fn test_constant_source_gives_zero_improvement() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -234,6 +235,7 @@ fn test_low_variance_source_discounts_prediction() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -336,6 +338,7 @@ fn test_high_variance_source_not_discounted() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -445,6 +448,7 @@ fn test_constant_vs_varying_source_comparison() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/synapse/synapse_candidate_indices.rs
+++ b/tests/synapse/synapse_candidate_indices.rs
@@ -113,6 +113,7 @@ fn synapse_candidates_populate_from_and_to_indices() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input)

--- a/tests/synapse/synapse_impact_discounting.rs
+++ b/tests/synapse/synapse_impact_discounting.rs
@@ -181,6 +181,7 @@ fn test_synapse_candidate_hidden_neuron_is_impact_discounted() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -297,6 +298,7 @@ fn test_synapse_candidate_output_neuron_no_discount() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);
@@ -388,6 +390,7 @@ fn test_harmful_synapse_candidate_is_impact_discounted() {
         random_seed: None,
         temperature: 1.0,
         failure_cache: None,
+        discovery_outcome_log: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_synapses(&input);

--- a/tests/unit/analysis_implementation.rs
+++ b/tests/unit/analysis_implementation.rs
@@ -830,6 +830,7 @@ Pages speculative:                        12345.
             random_seed: Some(123),
             temperature: 1.0,
             failure_cache: None,
+        discovery_outcome_log: None,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;
@@ -924,6 +925,7 @@ Pages speculative:                        12345.
             random_seed: Some(123),
             temperature: 1.0,
             failure_cache: None,
+        discovery_outcome_log: None,
         };
 
         let result = analyze_neurons_with_cache(&input, cache)?;


### PR DESCRIPTION
## Summary

Relax `TargetFailureTracker` cooldown thresholds when the rolling outcome log
signals a drought so previously-failing targets re-enter the focus list
sooner. Mirrors the candidate-cache staleness window relaxation (Issue #1203)
so the two adaptive controls compose during a drought instead of locking the
pipeline out of its own search space. Closes #1204.

### What changed

- New methods on `TargetFailureTracker`
  (`src/analysis/target_failure_tracker.rs`):
  - `effective_cooldown_epochs(mode, drought_failures) -> u64` — returns the
    configured window in Normal mode, half the window in Conservative mode,
    and a quarter of the window with a floor of 2 under extended drought
    (`drought_failures >= conservative_mode_max_epochs`).
  - `effective_consecutive_failures(mode, drought_failures) -> u32` — raises
    the trigger threshold by `+1` per regime step under drought (`+1` in
    Conservative, `+2` in extended drought), so fewer targets enter cooldown
    in the first place.
  - `is_in_cooldown_adaptive` and the free-function
    `filter_cooldown_targets_adaptive` plumb mode/drought through the
    existing predicate. Static-threshold call sites (tests, callers without
    mode info) keep working via the original `is_in_cooldown` /
    `filter_cooldown_targets` entry points.
  - Logs a single `tracing::info!` on regime transitions naming the old and
    new effective cooldown.
- New constants and env-var overrides in
  `src/analysis/constants/detection_thresholds.rs`:
  - `COOLDOWN_CONSERVATIVE_DIVISOR = 2`, env override
    `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR`.
  - `COOLDOWN_EXTENDED_DROUGHT_DIVISOR = 4`, env override
    `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR`.
  - `COOLDOWN_EPOCHS_FLOOR = 2` (post-divisor floor) and
    `[COOLDOWN_DIVISOR_FLOOR, COOLDOWN_DIVISOR_CEILING] = [1, 64]` clamping
    for the divisor env vars.
- `AnalyzeNeuronsInput` and `AnalyzeSynapsesInput` (in
  `src/ffi_types/requests.rs`) gain an optional
  `discovery_outcome_log: Option<DiscoveryOutcomeLog>` (camelCase, serde
  `default`). Threaded down from `AnalyzeAllInput` in
  `src/analysis/orchestration.rs` so the per-phase cooldown filter can
  consult mode/drought.
- Per-phase cooldown helpers (`apply_target_cooldown` in
  `src/analysis/neuron/preparation.rs` and
  `src/analysis/synapse/orchestration.rs`) now derive mode and
  trailing-failure drought from the threaded outcome log and call the
  adaptive filter. When the log is absent or empty, the static-threshold
  filter is used.
- Env-var documentation table in `src/config/mod.rs` extended with the two
  new variables.

### Adaptive regime table

| Mode + drought                                    | Effective cooldown            | Effective trigger          |
|---------------------------------------------------|-------------------------------|----------------------------|
| `Normal` (or drought below the conservative cap)  | `cooldown_epochs`             | `cooldown_consecutive_failures` |
| `Conservative`, drought `< conservative_mode_max` | `cooldown_epochs / 2`         | `+1`                       |
| drought `>= conservative_mode_max` (extended)     | `max(cooldown_epochs / 4, 2)` | `+2`                       |

```mermaid
flowchart LR
    OL[DiscoveryOutcomeLog] --> Mode{Mode + drought}
    Mode -->|Normal| Full[cooldown_epochs]
    Mode -->|Conservative| Half[cooldown_epochs / 2]
    Mode -->|Extended drought| Quarter[max cooldown_epochs / 4, floor 2]
    Full --> Cooldown[is_in_cooldown_adaptive]
    Half --> Cooldown
    Quarter --> Cooldown
```

## Evidence

- `cargo test --test analysis issue_1204` — 15/15 tests pass covering the
  three regimes, env-var overrides, the integration acceptance criterion
  (target with 3 failures at epoch 0 in cooldown at epoch 15 under Normal,
  released at epoch 15 under Conservative), and the borderline trigger case.
- `cargo test --lib target_failure_tracker` — 10/10 tests pass; new
  `effective_*` unit tests sit alongside the existing 8 cooldown tests.
- `./quality.sh` runs green (fmt, clippy, check, full test suite, doc build,
  release build).

This is a backend/CLI change with no web interface to screenshot.

## Test Plan

- [x] Unit tests for `effective_cooldown_epochs` covering Normal,
      Conservative, extended drought, and the floor-of-2 clamp in
      `tests/analysis/issue_1204_adaptive_target_cooldown.rs`.
- [x] Unit tests for `effective_consecutive_failures` covering Normal,
      Conservative (+1), extended drought (+2), and `u32::MAX` saturation.
- [x] Env-var override tests for both
      `NEAT_AI_DISCOVERY_COOLDOWN_CONSERVATIVE_DIVISOR` and
      `NEAT_AI_DISCOVERY_COOLDOWN_EXTENDED_DROUGHT_DIVISOR`, including
      unparsable values, zero, and the clamping behaviour.
- [x] Integration test confirming a target with three consecutive failures
      at epoch 0 is in cooldown at epoch 15 under Normal but released in
      Conservative mode at the same epoch.
- [x] Unit tests under `src/analysis/target_failure_tracker.rs::tests`
      ensuring the adaptive thresholds match the static values in Normal
      mode and relax in Conservative mode.
- [x] `./quality.sh` passes cleanly.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1204 -->