### PR TITLE
Document drought diagnostic playbook in docs/DROUGHT_PLAYBOOK.md (Issue #1206)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.45"
+version = "0.74.46"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ graph TD
 | [docs/CACHE_TUNING.md](docs/CACHE_TUNING.md) | Cache tier tuning, diagnostics, and example configurations |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Benchmark regression tracking and comparison workflow |
 | [docs/CANDIDATE_PIPELINE_MCMC_AUDIT.md](docs/CANDIDATE_PIPELINE_MCMC_AUDIT.md) | MCMC applicability audit for candidate selection pipeline |
+| [docs/DROUGHT_PLAYBOOK.md](docs/DROUGHT_PLAYBOOK.md) | Operator playbook for diagnosing "no successful candidates" droughts (suppression layers, regimes, env vars) |
 | [CodeWiki](https://codewiki.google/github.com/stsoftwareau/neat-ai-discovery) | AI-powered documentation and code exploration |
 
 ## 📄 Licence

--- a/docs/DROUGHT_PLAYBOOK.md
+++ b/docs/DROUGHT_PLAYBOOK.md
@@ -1,0 +1,232 @@
+# Discovery Drought Playbook
+
+When NEAT-AI-Discovery reports "no successful candidates for a while", four
+suppression layers interact: the candidate outcome cache, the per-target
+cooldown tracker, conservative-mode module bias, and post-processing rejection
+filters. This playbook explains how to diagnose and respond without reading
+source.
+
+It is the operator companion to:
+
+- Issue #1132 — creature-level discovery mode (Normal / Conservative).
+- Issue #1130 — target cooldown tracker.
+- Issue #465 — candidate outcome cache and source-type stats.
+- Issue #1202 — drought diagnostic (`droughtDiagnostic`).
+- Issue #1203 — adaptive staleness window.
+- Issue #1205 — operator escape hatch (forced reset).
+
+## Symptoms
+
+A discovery drought presents as one or more of:
+
+- **Empty `analyze_parallel` responses** — no candidates returned for several
+  consecutive passes (typically ≥ 5).
+- **`tracing::warn!` event** from `src/analysis/drought_diagnostic.rs`:
+
+  ```text
+  WARN Issue #1202: discovery drought — no successful candidates for N
+  consecutive passes
+      consecutive_failures=N rolling_success_rate=0.0
+      discovery_mode="conservative" candidate_cache_size=…
+      candidate_cache_suppressed_count=…  target_cooldown_active_count=…
+      target_cooldown_skipped=…  dominant_rejection_reason="…"
+      dominant_rejection_count=…  total_candidates_considered=…
+      total_candidates_rejected=…  drought_threshold=5
+  ```
+
+- **`droughtDiagnostic` populated on FFI metadata**. Both
+  `synapseMetadata.droughtDiagnostic` and `neuronMetadata.droughtDiagnostic`
+  carry the same JSON shape:
+
+  ```json
+  {
+    "consecutiveFailures": 7,
+    "rollingSuccessRate": 0.0,
+    "discoveryMode": "conservative",
+    "candidateCacheSize": 412,
+    "candidateCacheSuppressedCount": 138,
+    "targetCooldownActiveCount": 24,
+    "targetCooldownSkipped": 3,
+    "dominantRejectionReason": "no_eligible_sources",
+    "dominantRejectionCount": 91,
+    "totalCandidatesConsidered": 91,
+    "totalCandidatesRejected": 91
+  }
+  ```
+
+- **`discovery_mode` flips to `"conservative"`** in FFI metadata (Issue #1132)
+  once the rolling success rate over the last 10 passes drops below the
+  threshold.
+
+## Suppression Layers
+
+Four mechanisms can independently suppress candidate emission. They run in
+sequence; each one passes its survivors to the next.
+
+```mermaid
+flowchart LR
+    Detect[Detection modules<br/>generate raw candidates]
+    Cache[CandidateOutcomeCache<br/>is_suppressed?]
+    Cooldown[TargetFailureTracker<br/>is_in_cooldown?]
+    Bias[Conservative-mode<br/>module bias + gain floor]
+    Post[Post-processing filters<br/>RejectionBreakdown]
+    Out[FFI response]
+
+    Detect --> Cache
+    Cache -- "passes" --> Cooldown
+    Cooldown -- "passes" --> Bias
+    Bias -- "passes" --> Post
+    Post -- "survives" --> Out
+
+    Cache -. "drops failed candidates<br/>within staleness window" .-> X1[(suppressed)]
+    Cooldown -. "drops targets with<br/>≥3 consecutive failures" .-> X2[(skipped)]
+    Bias -. "demotes high-risk modules<br/>raises coordinated gain floor 10×" .-> X3[(under-weighted)]
+    Post -. "no_eligible_sources<br/>below_threshold<br/>budget_exceeded<br/>…" .-> X4[(rejected)]
+```
+
+| Layer | Source file | Records into the diagnostic as |
+|-------|-------------|-------------------------------|
+| Candidate cache | `src/analysis/candidate_cache.rs` | `candidateCacheSize`, `candidateCacheSuppressedCount` |
+| Target cooldown | `src/analysis/target_failure_tracker.rs` | `targetCooldownActiveCount`, `targetCooldownSkipped` |
+| Conservative bias | `src/analysis/discovery_mode.rs` | `discoveryMode`, indirectly via lowered acceptance |
+| Post-processing | `src/analysis/diagnostics/rejection.rs` | `dominantRejectionReason`, `dominantRejectionCount`, `totalCandidates*` |
+
+Notes:
+
+- **Candidate cache** suppresses a candidate when the same
+  `(source, target, operation)` triple failed within the **effective**
+  staleness window (Issue #1203 — see below).
+- **Target cooldown** drops a target after
+  `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` consecutive failures and keeps
+  it out for `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_EPOCHS` epochs.
+- **Conservative mode** is creature-level: the same module set is biased, the
+  coordinated-structural gain floor is tightened by
+  `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER`× (default 10×), and high-risk
+  modules (`add-neurons`, `coordinated-structural`, …) are penalised.
+- **Post-processing rejection** is the source of `dominantRejectionReason`. The
+  reason name tells you which lever to investigate first.
+
+## Diagnostic Walkthrough
+
+When you see the warn log or a populated `droughtDiagnostic`, read it
+top-to-bottom and follow the lever each field points at.
+
+| Field | Meaning | Lever to investigate |
+|-------|---------|----------------------|
+| `consecutiveFailures` | Trailing empty-pass streak. Threshold for emission: `NEAT_AI_DISCOVERY_DROUGHT_LOG_THRESHOLD` (default 5). | If unexpectedly large, also check `DROUGHT_RESET_AFTER_EPOCHS`. |
+| `rollingSuccessRate` | Successes in last 10 passes / 10. Below `LOW_SUCCESS_RATE_THRESHOLD` (default 0.2) drives Conservative mode. | If at or near 0.0, every suppression layer is operating at full strength — look for the dominant rejection reason. |
+| `discoveryMode` | `"normal"` or `"conservative"`. | If `conservative` and the rate is still falling, conservative mode is not helping — tune `CONSERVATIVE_GAIN_MULTIPLIER` or wait for the `CONSERVATIVE_MODE_MAX_EPOCHS` cooldown exit. |
+| `candidateCacheSize` | Total cache entries (successes + failures). | A very large cache (>10k) with high suppression suggests the staleness window is too long for this run. |
+| `candidateCacheSuppressedCount` | Failed entries inside the **effective** staleness window — actively suppressing candidates. | If this dominates the diagnostic, the staleness window is the culprit. Conservative mode already halves it (Issue #1203); extended drought quarters it. If still too large, the operator reset (`DROUGHT_RESET_AFTER_EPOCHS`, Issue #1205) is the next lever. |
+| `targetCooldownActiveCount` | Targets in cooldown right now. | Compare to total focus targets. If most targets are in cooldown, lower `TARGET_COOLDOWN_FAILURES` is unsafe — raise `LOW_SUCCESS_RATE_THRESHOLD` instead so Conservative mode triggers earlier. |
+| `targetCooldownSkipped` | Targets dropped by the cooldown filter on **this** pass. | If 0 with a large `targetCooldownActiveCount`, the focus set never included those targets — pre-screening is filtering before cooldown. |
+| `dominantRejectionReason` | Most-frequent post-processing reject reason. | Each reason maps to a different mechanism: see the table below. |
+| `dominantRejectionCount` | Hits for that reason on the current pass. | Compare to `totalCandidatesRejected` to gauge how dominant it is. |
+| `totalCandidatesConsidered` | Returned + rejected. | If 0, no candidates reached post-processing — the cache and cooldown ate them. Reach for `DROUGHT_RESET_AFTER_EPOCHS`. |
+| `totalCandidatesRejected` | Rejected across all reasons. | High counts with `totalCandidatesConsidered == totalCandidatesRejected` mean every candidate failed a filter — read `dominantRejectionReason` first. |
+
+Common `dominantRejectionReason` values and the lever each implies:
+
+| Reason | Implication |
+|--------|-------------|
+| `no_eligible_sources` | Source pre-screening (sample variance, range checks) eliminated every source. Often a sign that the creature has converged structurally. |
+| `below_threshold` | Candidates were generated but their expected gain failed the coordinated-structural floor. Conservative mode raises this floor 10×; consider lowering `CONSERVATIVE_GAIN_MULTIPLIER` or waiting for cooldown exit. |
+| `budget_exceeded` | Module budget allocation is leaving no headroom. Inspect `module_weights` snapshot. |
+| `cooldown_skipped` | Targets eliminated by `TargetFailureTracker`. Cross-check `targetCooldownActiveCount`. |
+| `duplicate` / `redundant_path` | Deduplication is eating the candidate pool — the creature is in a flat region of the search space. |
+
+## Adaptive Responses
+
+The library applies two automatic relaxation mechanisms before any operator
+action is required.
+
+### Three regimes
+
+```mermaid
+stateDiagram-v2
+    [*] --> Normal
+    Normal --> Conservative: rolling rate below LOW_SUCCESS_RATE_THRESHOLD (default 0.2)
+    Conservative --> ExtendedDrought: streak meets CONSERVATIVE_MODE_MAX_EPOCHS (default 20)
+    Conservative --> Normal: rolling rate climbs back above threshold
+    ExtendedDrought --> Normal: any successful pass
+    Normal --> [*]
+```
+
+| Regime | Trigger | Cache effective window | Module bias | Coordinated gain floor |
+|--------|---------|------------------------|-------------|------------------------|
+| **Normal** | Default | `staleness_window` (default 100 epochs) | unchanged | 1× |
+| **Conservative** | Rolling success rate &lt; `LOW_SUCCESS_RATE_THRESHOLD` and streak ≤ `CONSERVATIVE_MODE_MAX_EPOCHS` | `staleness_window / STALENESS_CONSERVATIVE_DIVISOR` (default 100 / 2 = 50), floor 5 | low-risk modules boosted 1.5×, high-risk penalised 1/1.5× | `CONSERVATIVE_GAIN_MULTIPLIER`× (default 10×) |
+| **Extended Drought** | Streak ≥ `CONSERVATIVE_MODE_MAX_EPOCHS` | `staleness_window / STALENESS_EXTENDED_DROUGHT_DIVISOR` (default 100 / 4 = 25), floor 5 | reverts to Normal — the bias did not help | reverts to 1× |
+
+Notes:
+
+- The Cache effective window is recomputed on every `is_suppressed` call. A
+  transition emits a single `tracing::info!` event so the operator sees the
+  window change without re-running under debug logging.
+- After Extended Drought reverts to Normal, the **operator escape hatch**
+  (Issue #1205, env var `NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS`) can
+  clear failed cache entries and active cooldowns in one shot. A successful
+  pass re-arms the lever.
+- Adaptive target-cooldown relaxation is tracked under **Issue #1204** and is
+  not yet shipped. Until it lands the target cooldown thresholds remain
+  static (`TARGET_COOLDOWN_FAILURES`, `TARGET_COOLDOWN_EPOCHS`); the operator
+  reset path covers the worst case.
+
+## Operator Levers
+
+Every relevant environment variable, its default, valid range, and when an
+operator should change it. All variables are read at runtime so they can be
+flipped between runs without recompilation.
+
+| Env var | Type | Default | Range | When to change |
+|---------|------|---------|-------|----------------|
+| `NEAT_AI_DISCOVERY_DROUGHT_LOG_THRESHOLD` | u32 | 5 | ≥ 1 | Lower to surface droughts earlier in noisy environments; raise to suppress the warn log when short droughts are expected. |
+| `NEAT_AI_DISCOVERY_STALENESS_CONSERVATIVE_DIVISOR` | u64 | 2 | 1–64 (clamped) | Larger value (e.g. 4) shrinks the Conservative-mode cache window further, re-enabling failed candidates sooner. Use only when conservative bias plus halved window is not freeing candidates. |
+| `NEAT_AI_DISCOVERY_STALENESS_EXTENDED_DROUGHT_DIVISOR` | u64 | 4 | 1–64 (clamped) | Larger value (e.g. 8) shrinks the Extended-Drought cache window further. Effective window has a hard floor of 5 epochs regardless of divisor. |
+| `NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS` | u32 | unset (off) | ≥ 1 | Enable the operator escape hatch. Set to e.g. 30 to force a one-shot cache + cooldown reset after a 30-pass drought. Most operators leave this off and intervene manually. |
+| `NEAT_AI_DISCOVERY_LOW_SUCCESS_RATE_THRESHOLD` | f32 | 0.2 | (0.0, 1.0] | Raise to enter Conservative mode earlier (e.g. 0.3 if 30 % success is too low for this workload). Values outside the range are ignored. |
+| `NEAT_AI_DISCOVERY_CONSERVATIVE_MODE_MAX_EPOCHS` | u32 | 20 | ≥ 1 | Lower to revert to Normal sooner when bias is not helping; raise to give Conservative mode more time before it gives up. |
+| `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` | f32 | 10.0 | ≥ 1.0 (values < 1 clamped) | Lower (e.g. 3.0) when 10× is starving the pipeline of coordinated-structural candidates. The floor never relaxes below the base constant. |
+| `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` | u32 | 3 | ≥ 1 | Raise to make the cooldown less aggressive when many targets are in cooldown simultaneously. |
+| `NEAT_AI_DISCOVERY_TARGET_COOLDOWN_EPOCHS` | u64 | 10 | ≥ 1 | Lower to free targets faster after a failure streak. |
+| `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | f32 | unset (uses calibration default) | 0.01–5.0 | Raise to accept lower-gain candidates during a drought, lower to be stricter. Values outside the range are ignored with a warn log. |
+
+## Worked Example — 30-epoch Drought
+
+A creature reaches epoch 50 in Normal mode with a healthy 0.6 rolling success
+rate, then starts producing empty passes. This example uses the defaults.
+
+| Epoch | Streak | Rolling rate | Regime | What happens | Diagnostic / log to look at |
+|-------|--------|--------------|--------|--------------|----------------------------|
+| 51 | 1 | 0.5 | Normal | Empty pass. No diagnostic. | — |
+| 52–54 | 2–4 | 0.4 → 0.2 | Normal | Three more empty passes. Streak < `DROUGHT_LOG_THRESHOLD`. | — |
+| 55 | 5 | 0.1 | Normal | Streak hits the log threshold. `tracing::warn!` fires once, `droughtDiagnostic` populated. Rolling rate (0.1) is below `LOW_SUCCESS_RATE_THRESHOLD` (0.2) → mode flips. | `dominantRejectionReason` — likely `below_threshold` or `no_eligible_sources`. |
+| 56 | 6 | 0.0 | **Conservative** | `discoveryMode="conservative"` in FFI metadata. Cache effective window halves to 50 (Issue #1203 `info!` log). High-risk modules penalised, coordinated gain floor × 10. | `info!` log: `effective_staleness_window=50 prior=100`. |
+| 57–69 | 7–19 | 0.0 | Conservative | Conservative mode persists. `candidateCacheSuppressedCount` declines as the halved window re-enables candidates that failed > 50 epochs ago. | Watch `candidateCacheSuppressedCount` ramp down. |
+| 70 | 20 | 0.0 | Conservative→**Extended Drought** | Streak crosses `CONSERVATIVE_MODE_MAX_EPOCHS`. Conservative bias drops; cache window quarters to 25 (floor still 5). | `info!` log: `effective_staleness_window=25 prior=50`. Mode in metadata flips back to `"normal"`; the drought diagnostic still fires every pass. |
+| 71–79 | 21–29 | 0.0 | Extended Drought | Window is at 25 epochs. Any candidate that failed before epoch 46 is re-eligible. If `DROUGHT_RESET_AFTER_EPOCHS` is set (e.g. 25), the operator reset fires here. | Look for the one-shot `info!`: `Drought reset cleared N failed cache entries, M target cooldowns`. |
+| 80 | 30 | 0.0 | Extended Drought | A new candidate finally succeeds. Streak collapses to 0; tombstone clears; cache window jumps back to 100 on next call. | `info!` log: `effective_staleness_window=100 prior=25`. Mode resumes Normal on the next pass. |
+
+What an operator should look at, in order:
+
+1. The first `droughtDiagnostic` payload at epoch 55 — confirm
+   `dominantRejectionReason`.
+2. Whether the rolling rate is climbing across epochs 56–69 — if yes,
+   conservative bias is helping; if no, it is not and the pipeline will
+   self-exit at epoch 70.
+3. If the streak reaches 20 with no improvement, decide whether to enable
+   `DROUGHT_RESET_AFTER_EPOCHS` for the next run.
+4. If the streak passes 30 with no improvement, that is a structural
+   problem (the creature has saturated the search space) — escalate to a
+   human reviewer with the most recent `droughtDiagnostic` attached.
+
+## See Also
+
+- `src/analysis/discovery_mode.rs` — mode decision and bias logic.
+- `src/analysis/candidate_cache.rs` — adaptive staleness window.
+- `src/analysis/target_failure_tracker.rs` — per-target cooldown.
+- `src/analysis/drought_diagnostic.rs` — `DroughtDiagnostic` schema and
+  emission rule.
+- [docs/CACHE_TUNING.md](CACHE_TUNING.md) — cache tier configuration.
+- [docs/ANALYSIS_DEEP_DIVE.md](ANALYSIS_DEEP_DIVE.md) — overall analysis flow.
+- [docs/FFI_API.md](FFI_API.md) — full FFI metadata reference.

--- a/docs/pr-summary-1206.md
+++ b/docs/pr-summary-1206.md
@@ -1,0 +1,72 @@
+## Summary
+
+Added `docs/DROUGHT_PLAYBOOK.md` — an operator playbook consolidating the
+suppression layers, regimes, and env vars that drive the "no successful
+candidates for a while" symptom into a single diagnostic lookup. Linked the
+playbook from the README and from the rustdoc on the three modules that
+implement the behaviour. Closes #1206.
+
+The playbook covers:
+
+- Symptoms (log examples + `droughtDiagnostic` shape).
+- Suppression-layer interaction (Mermaid flowchart of
+  cache → cooldown → conservative-mode bias → post-processing rejection).
+- Diagnostic walkthrough for every field of the `droughtDiagnostic` payload
+  from Issue #1202, with the lever each field points at.
+- Adaptive responses — the Normal / Conservative / Extended Drought regimes
+  from Issue #1132 and the adaptive staleness window from Issue #1203, with
+  a Mermaid state diagram of the regime transitions.
+- Operator levers — table of every relevant env var with default, range, and
+  when to change it.
+- Worked 30-epoch drought example walking through each regime transition
+  and what the operator should look at.
+
+Issue #1204 (adaptive target-cooldown relaxation) is still open; the playbook
+notes this and documents the existing static cooldown env vars
+(`NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` / `_EPOCHS`) plus the
+operator escape hatch (`NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS` from
+#1205) as the path covering the worst case until #1204 lands. All other
+env var names and defaults match the actual constants in `src/config/` and
+`src/analysis/constants/`.
+
+## Evidence
+
+This is a documentation change with no UI or runtime behaviour modification.
+
+- `./quality.sh` passes locally: shellcheck, `cargo deny check`, `cargo build`,
+  `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo check`, `cargo test --lib --tests --all-features`,
+  `RUSTDOCFLAGS=-D warnings cargo doc --no-deps`, and release build.
+- `markdownlint-cli2 docs/DROUGHT_PLAYBOOK.md` reports 0 errors.
+- Both Mermaid blocks (a `flowchart LR` for the suppression layers and a
+  `stateDiagram-v2` for the three regimes) use canonical syntax and render in
+  GitHub's native Mermaid preview.
+
+Architectural overview of where the playbook sits in the docs tree:
+
+```mermaid
+flowchart LR
+    User[Operator sees<br/>empty candidates] --> Log[drought warn log<br/>+ droughtDiagnostic]
+    Log --> Playbook[docs/DROUGHT_PLAYBOOK.md]
+    Playbook --> Cache[candidate_cache.rs]
+    Playbook --> Cooldown[target_failure_tracker.rs]
+    Playbook --> Mode[discovery_mode.rs]
+    Playbook --> Diag[drought_diagnostic.rs]
+    Cache -.rustdoc link.-> Playbook
+    Cooldown -.rustdoc link.-> Playbook
+    Mode -.rustdoc link.-> Playbook
+```
+
+## Test Plan
+
+No code paths were changed — existing tests cover the underlying behaviour
+(cooldown threshold transitions, conservative-mode bias, adaptive staleness
+window, drought diagnostic emission). The pre-existing suites that gate the
+documented behaviour are:
+
+- `src/analysis/discovery_mode.rs` — mode transition tests.
+- `src/analysis/candidate_cache.rs` — adaptive window and suppression tests.
+- `src/analysis/target_failure_tracker.rs` — cooldown threshold tests.
+- `src/analysis/drought_diagnostic.rs` — diagnostic emission tests.
+
+All pass under `./quality.sh`.

--- a/src/analysis/candidate_cache.rs
+++ b/src/analysis/candidate_cache.rs
@@ -18,6 +18,14 @@
 //! - Only the **most recent** outcome is stored per candidate key (not a history).
 //! - The staleness window is configurable and defaults to [`DEFAULT_STALENESS_WINDOW`].
 //! - Source-type stats use Bayesian scoring (same approach as `DiscoveryHistory`).
+//!
+//! # Operator playbook
+//!
+//! See [`docs/DROUGHT_PLAYBOOK.md`](https://github.com/stSoftwareAU/NEAT-AI-Discovery/blob/main/docs/DROUGHT_PLAYBOOK.md)
+//! for the end-to-end drought diagnostic walkthrough — how this cache, the
+//! target cooldown tracker, conservative-mode bias, and post-processing
+//! rejection filters interact, and which env var to reach for when
+//! `candidateCacheSuppressedCount` dominates the diagnostic.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/analysis/discovery_mode.rs
+++ b/src/analysis/discovery_mode.rs
@@ -41,6 +41,14 @@
 //!   [`DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`] = 20)
 //! - `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` (f32, default
 //!   [`DEFAULT_CONSERVATIVE_GAIN_MULTIPLIER`] = 10.0)
+//!
+//! ## Operator playbook
+//!
+//! See [`docs/DROUGHT_PLAYBOOK.md`](https://github.com/stSoftwareAU/NEAT-AI-Discovery/blob/main/docs/DROUGHT_PLAYBOOK.md)
+//! for the end-to-end diagnostic walkthrough — symptoms, the suppression-layer
+//! interaction with the candidate cache and target cooldown, the
+//! Normal/Conservative/Extended Drought regimes, and a worked 30-epoch
+//! example.
 
 #![allow(clippy::cast_precision_loss)] // success-rate maths over small counts
 #![allow(clippy::cast_possible_truncation)] // clamped before `as` casts

--- a/src/analysis/target_failure_tracker.rs
+++ b/src/analysis/target_failure_tracker.rs
@@ -30,6 +30,15 @@
 //! `record_discovery_result` hook (and analogues inside Rust) should forward
 //! per-target pass/fail signals to the global tracker so preparation layers
 //! consult a consistent view.
+//!
+//! # Operator playbook
+//!
+//! See [`docs/DROUGHT_PLAYBOOK.md`](https://github.com/stSoftwareAU/NEAT-AI-Discovery/blob/main/docs/DROUGHT_PLAYBOOK.md)
+//! for the end-to-end drought diagnostic walkthrough — how this tracker, the
+//! candidate outcome cache, conservative-mode bias, and post-processing
+//! rejection filters interact, plus the operator escape hatch
+//! (`NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS`) that drops all active
+//! cooldown entries in one shot.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};


### PR DESCRIPTION
## Summary

Added `docs/DROUGHT_PLAYBOOK.md` — an operator playbook consolidating the
suppression layers, regimes, and env vars that drive the "no successful
candidates for a while" symptom into a single diagnostic lookup. Linked the
playbook from the README and from the rustdoc on the three modules that
implement the behaviour. Closes #1206.

The playbook covers:

- Symptoms (log examples + `droughtDiagnostic` shape).
- Suppression-layer interaction (Mermaid flowchart of
  cache → cooldown → conservative-mode bias → post-processing rejection).
- Diagnostic walkthrough for every field of the `droughtDiagnostic` payload
  from Issue #1202, with the lever each field points at.
- Adaptive responses — the Normal / Conservative / Extended Drought regimes
  from Issue #1132 and the adaptive staleness window from Issue #1203, with
  a Mermaid state diagram of the regime transitions.
- Operator levers — table of every relevant env var with default, range, and
  when to change it.
- Worked 30-epoch drought example walking through each regime transition
  and what the operator should look at.

Issue #1204 (adaptive target-cooldown relaxation) is still open; the playbook
notes this and documents the existing static cooldown env vars
(`NEAT_AI_DISCOVERY_TARGET_COOLDOWN_FAILURES` / `_EPOCHS`) plus the
operator escape hatch (`NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS` from
#1205) as the path covering the worst case until #1204 lands. All other
env var names and defaults match the actual constants in `src/config/` and
`src/analysis/constants/`.

## Evidence

This is a documentation change with no UI or runtime behaviour modification.

- `./quality.sh` passes locally: shellcheck, `cargo deny check`, `cargo build`,
  `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo check`, `cargo test --lib --tests --all-features`,
  `RUSTDOCFLAGS=-D warnings cargo doc --no-deps`, and release build.
- `markdownlint-cli2 docs/DROUGHT_PLAYBOOK.md` reports 0 errors.
- Both Mermaid blocks (a `flowchart LR` for the suppression layers and a
  `stateDiagram-v2` for the three regimes) use canonical syntax and render in
  GitHub's native Mermaid preview.

Architectural overview of where the playbook sits in the docs tree:

```mermaid
flowchart LR
    User[Operator sees<br/>empty candidates] --> Log[drought warn log<br/>+ droughtDiagnostic]
    Log --> Playbook[docs/DROUGHT_PLAYBOOK.md]
    Playbook --> Cache[candidate_cache.rs]
    Playbook --> Cooldown[target_failure_tracker.rs]
    Playbook --> Mode[discovery_mode.rs]
    Playbook --> Diag[drought_diagnostic.rs]
    Cache -.rustdoc link.-> Playbook
    Cooldown -.rustdoc link.-> Playbook
    Mode -.rustdoc link.-> Playbook
```

## Test Plan

No code paths were changed — existing tests cover the underlying behaviour
(cooldown threshold transitions, conservative-mode bias, adaptive staleness
window, drought diagnostic emission). The pre-existing suites that gate the
documented behaviour are:

- `src/analysis/discovery_mode.rs` — mode transition tests.
- `src/analysis/candidate_cache.rs` — adaptive window and suppression tests.
- `src/analysis/target_failure_tracker.rs` — cooldown threshold tests.
- `src/analysis/drought_diagnostic.rs` — diagnostic emission tests.

All pass under `./quality.sh`.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1206 -->