### PR TITLE
Build broken on Develop: filter_cooldown_targets_adaptive missing from target_failure_tracker (regression from PR #1209) (Issue #1212)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.46"
+version = "0.74.47"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1212.md
+++ b/docs/pr-summary-1212.md
@@ -1,0 +1,61 @@
+## Summary
+
+Restored the `Develop` build by adding the adaptive target-cooldown API that
+PR #1209 referenced but never committed. The call sites in
+`src/analysis/neuron/preparation.rs` and `src/analysis/synapse/orchestration.rs`
+imported `filter_cooldown_targets_adaptive` from `target_failure_tracker`, but
+the function — together with `is_in_cooldown_adaptive`,
+`effective_cooldown_epochs`, and `effective_consecutive_failures` — was missing
+from the module, leaving `cargo check` failing with E0432 fleet-wide.
+
+This change adds the four missing public symbols with the exact signatures the
+existing call sites and the Issue #1204 test suite already expect, and wires
+the previously-orphaned integration tests
+(`tests/analysis/issue_1204_adaptive_target_cooldown.rs`) into the
+`tests/analysis/main.rs` module tree so they actually run. No call sites or
+other behaviour changed.
+
+Closes #1212.
+
+## Evidence
+
+CLI/library change — no UI surface. Verified by:
+
+- `cargo check --lib --tests --all-features` now succeeds (previously failed
+  with the two E0432 errors from the issue).
+- `./quality.sh < /dev/null` passes end-to-end (fmt, clippy `-D warnings`,
+  check, full test suite, doc build, release build).
+- All 15 Issue #1204 integration tests in
+  `tests/analysis/issue_1204_adaptive_target_cooldown.rs` now compile, run,
+  and pass — including the acceptance criterion that a target with 3 failures
+  at epoch 0 is in cooldown at epoch 15 under `Normal` mode but cleared under
+  `Conservative` mode.
+- The pre-existing 13 unit tests in `target_failure_tracker.rs` still pass.
+
+### Adaptive cooldown decision flow
+
+```mermaid
+flowchart TD
+    A[focus_order, mode, drought_failures] --> B{drought_failures >=<br/>CONSERVATIVE_MODE_MAX_EPOCHS?}
+    B -- yes --> C[Extended drought:<br/>÷ extended divisor (default 4)<br/>trigger + 2]
+    B -- no --> D{mode == Conservative?}
+    D -- yes --> E[Conservative:<br/>÷ conservative divisor (default 2)<br/>trigger + 1]
+    D -- no --> F[Normal:<br/>÷ 1, trigger unchanged]
+    C --> G[Clamp effective window to<br/>>= COOLDOWN_EPOCHS_FLOOR (2)]
+    E --> G
+    F --> G
+    G --> H[is_in_cooldown_adaptive uses<br/>effective trigger + window]
+    H --> I[filter_cooldown_targets_adaptive<br/>drops only effective-cooldown targets]
+```
+
+## Test Plan
+
+- `cargo test --test analysis --all-features issue_1204 -- --test-threads=2`
+  — 15/15 tests pass, covering: three regimes for `effective_cooldown_epochs`,
+  three regimes for `effective_consecutive_failures`, env-var overrides for
+  both divisors (including unparsable and `0` clamped to floor),
+  saturating-add on `u32::MAX`, and integration via
+  `filter_cooldown_targets_adaptive` / `is_in_cooldown_adaptive`.
+- `cargo test --lib --all-features target_failure_tracker -- --test-threads=2`
+  — 13/13 existing tracker unit tests still pass.
+- `./quality.sh < /dev/null` — full quality gate passes.

--- a/src/analysis/target_failure_tracker.rs
+++ b/src/analysis/target_failure_tracker.rs
@@ -43,7 +43,11 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
-use crate::analysis::constants::{TARGET_COOLDOWN_CONSECUTIVE_FAILURES, TARGET_COOLDOWN_EPOCHS};
+use crate::analysis::constants::{
+    COOLDOWN_EPOCHS_FLOOR, TARGET_COOLDOWN_CONSECUTIVE_FAILURES, TARGET_COOLDOWN_EPOCHS,
+    cooldown_conservative_divisor, cooldown_extended_drought_divisor,
+};
+use crate::analysis::discovery_mode::{DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS, DiscoveryMode};
 use crate::config::{target_cooldown_consecutive_failures_env, target_cooldown_epochs_env};
 
 /// Per-target failure state.
@@ -201,6 +205,80 @@ impl TargetFailureTracker {
         current_epoch < failure_epoch.saturating_add(self.cooldown_epochs)
     }
 
+    /// Returns the effective cooldown window in epochs for the given discovery
+    /// mode and drought state (Issue #1204).
+    ///
+    /// The base [`Self::cooldown_epochs`] is divided by the conservative
+    /// divisor when the pipeline is in [`DiscoveryMode::Conservative`], and by
+    /// the extended-drought divisor once `drought_failures` has met or
+    /// exceeded [`DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`]. Extended drought
+    /// applies regardless of `mode`. The effective window is never smaller
+    /// than [`COOLDOWN_EPOCHS_FLOOR`].
+    #[must_use]
+    pub fn effective_cooldown_epochs(&self, mode: DiscoveryMode, drought_failures: u32) -> u64 {
+        let divisor = if drought_failures >= DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS {
+            cooldown_extended_drought_divisor()
+        } else if mode == DiscoveryMode::Conservative {
+            cooldown_conservative_divisor()
+        } else {
+            1
+        }
+        .max(1);
+        (self.cooldown_epochs / divisor).max(COOLDOWN_EPOCHS_FLOOR)
+    }
+
+    /// Returns the effective consecutive-failure trigger for the given
+    /// discovery mode and drought state (Issue #1204).
+    ///
+    /// The configured trigger is raised by `+1` in
+    /// [`DiscoveryMode::Conservative`] mode and by `+2` once `drought_failures`
+    /// has met or exceeded [`DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS`] (extended
+    /// drought). Saturating add — never overflows.
+    #[must_use]
+    pub fn effective_consecutive_failures(
+        &self,
+        mode: DiscoveryMode,
+        drought_failures: u32,
+    ) -> u32 {
+        let bump: u32 = if drought_failures >= DEFAULT_CONSERVATIVE_MODE_MAX_EPOCHS {
+            2
+        } else if mode == DiscoveryMode::Conservative {
+            1
+        } else {
+            0
+        };
+        self.cooldown_consecutive_failures.saturating_add(bump)
+    }
+
+    /// Adaptive cooldown check using the relaxed thresholds for the given
+    /// mode and drought state (Issue #1204).
+    ///
+    /// Identical contract to [`Self::is_in_cooldown`] but the consecutive
+    /// failure trigger and the cooldown window are sourced from
+    /// [`Self::effective_consecutive_failures`] and
+    /// [`Self::effective_cooldown_epochs`] respectively.
+    #[must_use]
+    pub fn is_in_cooldown_adaptive(
+        &self,
+        target_uuid: &str,
+        current_epoch: u64,
+        mode: DiscoveryMode,
+        drought_failures: u32,
+    ) -> bool {
+        let Some(state) = self.states.get(target_uuid) else {
+            return false;
+        };
+        let effective_trigger = self.effective_consecutive_failures(mode, drought_failures);
+        if state.consecutive_failures < effective_trigger {
+            return false;
+        }
+        let Some(failure_epoch) = state.last_failure_epoch else {
+            return false;
+        };
+        let effective_cooldown = self.effective_cooldown_epochs(mode, drought_failures);
+        current_epoch < failure_epoch.saturating_add(effective_cooldown)
+    }
+
     /// Returns the number of targets currently in cooldown at `current_epoch`
     /// (Issue #1202).
     ///
@@ -290,6 +368,41 @@ pub fn filter_cooldown_targets(
             cooldown_epochs = tracker.cooldown_epochs(),
             cooldown_consecutive_failures = tracker.cooldown_consecutive_failures(),
             "Dropped focus targets currently in cooldown"
+        );
+    }
+    skipped
+}
+
+/// Remove focus targets currently in cooldown using adaptive thresholds
+/// (Issue #1204).
+///
+/// Same contract as [`filter_cooldown_targets`] but consults
+/// [`TargetFailureTracker::is_in_cooldown_adaptive`], so the effective trigger
+/// and cooldown window shrink in [`DiscoveryMode::Conservative`] or during an
+/// extended drought.
+pub fn filter_cooldown_targets_adaptive(
+    focus_order: &mut Vec<String>,
+    tracker: &TargetFailureTracker,
+    current_epoch: u64,
+    mode: DiscoveryMode,
+    drought_failures: u32,
+) -> u32 {
+    let before = focus_order.len();
+    focus_order.retain(|target| {
+        !tracker.is_in_cooldown_adaptive(target, current_epoch, mode, drought_failures)
+    });
+    let after = focus_order.len();
+    let skipped = u32::try_from(before.saturating_sub(after)).unwrap_or(u32::MAX);
+    if skipped > 0 {
+        tracing::info!(
+            cooldown_skipped = skipped,
+            remaining_targets = after,
+            cooldown_epochs = tracker.effective_cooldown_epochs(mode, drought_failures),
+            cooldown_consecutive_failures =
+                tracker.effective_consecutive_failures(mode, drought_failures),
+            mode = mode.as_str(),
+            drought_failures,
+            "Dropped focus targets currently in cooldown (adaptive)"
         );
     }
     skipped

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -26,6 +26,7 @@ mod issue_1132_conservative_mode;
 mod issue_1162_calibration_per_target_squash;
 mod issue_1165_calibration_miss_logging;
 mod issue_1202_drought_diagnostic;
+mod issue_1204_adaptive_target_cooldown;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Restored the `Develop` build by adding the adaptive target-cooldown API that
PR #1209 referenced but never committed. The call sites in
`src/analysis/neuron/preparation.rs` and `src/analysis/synapse/orchestration.rs`
imported `filter_cooldown_targets_adaptive` from `target_failure_tracker`, but
the function — together with `is_in_cooldown_adaptive`,
`effective_cooldown_epochs`, and `effective_consecutive_failures` — was missing
from the module, leaving `cargo check` failing with E0432 fleet-wide.

This change adds the four missing public symbols with the exact signatures the
existing call sites and the Issue #1204 test suite already expect, and wires
the previously-orphaned integration tests
(`tests/analysis/issue_1204_adaptive_target_cooldown.rs`) into the
`tests/analysis/main.rs` module tree so they actually run. No call sites or
other behaviour changed.

Closes #1212.

## Evidence

CLI/library change — no UI surface. Verified by:

- `cargo check --lib --tests --all-features` now succeeds (previously failed
  with the two E0432 errors from the issue).
- `./quality.sh < /dev/null` passes end-to-end (fmt, clippy `-D warnings`,
  check, full test suite, doc build, release build).
- All 15 Issue #1204 integration tests in
  `tests/analysis/issue_1204_adaptive_target_cooldown.rs` now compile, run,
  and pass — including the acceptance criterion that a target with 3 failures
  at epoch 0 is in cooldown at epoch 15 under `Normal` mode but cleared under
  `Conservative` mode.
- The pre-existing 13 unit tests in `target_failure_tracker.rs` still pass.

### Adaptive cooldown decision flow

```mermaid
flowchart TD
    A[focus_order, mode, drought_failures] --> B{drought_failures >=<br/>CONSERVATIVE_MODE_MAX_EPOCHS?}
    B -- yes --> C[Extended drought:<br/>÷ extended divisor (default 4)<br/>trigger + 2]
    B -- no --> D{mode == Conservative?}
    D -- yes --> E[Conservative:<br/>÷ conservative divisor (default 2)<br/>trigger + 1]
    D -- no --> F[Normal:<br/>÷ 1, trigger unchanged]
    C --> G[Clamp effective window to<br/>>= COOLDOWN_EPOCHS_FLOOR (2)]
    E --> G
    F --> G
    G --> H[is_in_cooldown_adaptive uses<br/>effective trigger + window]
    H --> I[filter_cooldown_targets_adaptive<br/>drops only effective-cooldown targets]
```

## Test Plan

- `cargo test --test analysis --all-features issue_1204 -- --test-threads=2`
  — 15/15 tests pass, covering: three regimes for `effective_cooldown_epochs`,
  three regimes for `effective_consecutive_failures`, env-var overrides for
  both divisors (including unparsable and `0` clamped to floor),
  saturating-add on `u32::MAX`, and integration via
  `filter_cooldown_targets_adaptive` / `is_in_cooldown_adaptive`.
- `cargo test --lib --all-features target_failure_tracker -- --test-threads=2`
  — 13/13 existing tracker unit tests still pass.
- `./quality.sh < /dev/null` — full quality gate passes.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1212 -->