### PR TITLE
security-scan: ludeeus/action-shellcheck pinned to mutable @master branch (Issue #1215)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ShellCheck (koalaman/shellcheck)
-        uses: ludeeus/action-shellcheck@master
+        # Pinned to a 40-char commit SHA (Issue #1215) to mitigate
+        # supply-chain risk from mutable upstream branches. Update via
+        # Renovate/Dependabot or by manually resolving the latest release.
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: .
           severity: warning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.49"
+version = "0.74.50"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/pr-summary-1215.md
+++ b/docs/pr-summary-1215.md
@@ -1,0 +1,51 @@
+# Pin `ludeeus/action-shellcheck` to a commit SHA
+
+## Summary
+
+`.github/workflows/shellcheck.yml` referenced `ludeeus/action-shellcheck@master`,
+a mutable branch. Any commit landed upstream on `master` would execute in this
+repository's CI on the next PR with access to `GITHUB_TOKEN`. The coding
+guidelines mandate commit-SHA pinning for third-party GitHub Actions.
+
+Pinned the action to `00cae500b08a931fb5698e11e79bfbd38e612a38` (tag `2.0.0`,
+published 2023-01-29) with a trailing version comment for auditability.
+
+Closes #1215.
+
+## Evidence
+
+This is a CI/workflow change with no UI or runtime behaviour to screenshot.
+
+Before — `.github/workflows/shellcheck.yml` line 20:
+
+```yaml
+        uses: ludeeus/action-shellcheck@master
+```
+
+After:
+
+```yaml
+        # Pinned to a 40-char commit SHA (Issue #1215) to mitigate
+        # supply-chain risk from mutable upstream branches. Update via
+        # Renovate/Dependabot or by manually resolving the latest release.
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+```
+
+The SHA was resolved from the upstream `2.0.0` release tag via
+`gh api repos/ludeeus/action-shellcheck/git/refs/tags/2.0.0`.
+
+## Test Plan
+
+- Added `tests/test_shellcheck_workflow_pinning.sh` which asserts the
+  workflow file:
+  1. does **not** pin the action to `@master` or `@main`,
+  2. **does** pin to a 40-character commit SHA,
+  3. carries a trailing comment recording the human-readable version.
+- The test fails against the pre-fix workflow (verified: 0 passed, 3
+  failed) and passes after the fix (3 passed, 0 failed).
+- Bash syntax check (`bash -n`) and `shellcheck` clean across the
+  repository, including the new test script.
+
+Full Rust quality gate (`cargo build`, `clippy`, `test`, `doc`) was
+not re-run because no Rust source was touched; project CI exercises
+those gates on PR.

--- a/tests/test_shellcheck_workflow_pinning.sh
+++ b/tests/test_shellcheck_workflow_pinning.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Test that .github/workflows/shellcheck.yml pins third-party actions to
+# a 40-character commit SHA rather than a mutable branch like `@master`
+# (Issue #1215).
+#
+# Pinning to a mutable branch lets any push to upstream `master` execute
+# in this repository's CI on the next PR, with access to GITHUB_TOKEN.
+# The coding guidelines mandate SHA pins for third-party actions.
+
+set -euo pipefail
+
+WORKFLOW_FILE=".github/workflows/shellcheck.yml"
+PASS=0
+FAIL=0
+
+fail() {
+  echo "FAIL: $1"
+  FAIL=$((FAIL + 1))
+}
+
+pass() {
+  PASS=$((PASS + 1))
+}
+
+if [ ! -f "$WORKFLOW_FILE" ]; then
+  echo "FAIL: $WORKFLOW_FILE not found"
+  exit 1
+fi
+
+# --- Test: no @master / @main pin for ludeeus/action-shellcheck ---
+if grep -qE 'ludeeus/action-shellcheck@(master|main)\b' "$WORKFLOW_FILE"; then
+  fail "ludeeus/action-shellcheck is pinned to a mutable branch (@master or @main)"
+else
+  pass
+fi
+
+# --- Test: ludeeus/action-shellcheck is pinned to a 40-char SHA ---
+if grep -qE 'ludeeus/action-shellcheck@[0-9a-f]{40}\b' "$WORKFLOW_FILE"; then
+  pass
+else
+  fail "ludeeus/action-shellcheck is not pinned to a 40-character commit SHA"
+fi
+
+# --- Test: a trailing comment records the human-readable version ---
+# Per the coding guideline: "Add the resolved tag in a trailing comment so
+# the version is auditable."
+if grep -qE 'ludeeus/action-shellcheck@[0-9a-f]{40}[[:space:]]+#' "$WORKFLOW_FILE"; then
+  pass
+else
+  fail "ludeeus/action-shellcheck SHA pin lacks a trailing version comment"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo "❌ Shellcheck workflow pinning validation failed"
+  exit 1
+fi
+
+echo "✅ Shellcheck workflow pinning validation passed"


### PR DESCRIPTION
# Pin `ludeeus/action-shellcheck` to a commit SHA

## Summary

`.github/workflows/shellcheck.yml` referenced `ludeeus/action-shellcheck@master`,
a mutable branch. Any commit landed upstream on `master` would execute in this
repository's CI on the next PR with access to `GITHUB_TOKEN`. The coding
guidelines mandate commit-SHA pinning for third-party GitHub Actions.

Pinned the action to `00cae500b08a931fb5698e11e79bfbd38e612a38` (tag `2.0.0`,
published 2023-01-29) with a trailing version comment for auditability.

Closes #1215.

## Evidence

This is a CI/workflow change with no UI or runtime behaviour to screenshot.

Before — `.github/workflows/shellcheck.yml` line 20:

```yaml
        uses: ludeeus/action-shellcheck@master
```

After:

```yaml
        # Pinned to a 40-char commit SHA (Issue #1215) to mitigate
        # supply-chain risk from mutable upstream branches. Update via
        # Renovate/Dependabot or by manually resolving the latest release.
        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
```

The SHA was resolved from the upstream `2.0.0` release tag via
`gh api repos/ludeeus/action-shellcheck/git/refs/tags/2.0.0`.

## Test Plan

- Added `tests/test_shellcheck_workflow_pinning.sh` which asserts the
  workflow file:
  1. does **not** pin the action to `@master` or `@main`,
  2. **does** pin to a 40-character commit SHA,
  3. carries a trailing comment recording the human-readable version.
- The test fails against the pre-fix workflow (verified: 0 passed, 3
  failed) and passes after the fix (3 passed, 0 failed).
- Bash syntax check (`bash -n`) and `shellcheck` clean across the
  repository, including the new test script.

Full Rust quality gate (`cargo build`, `clippy`, `test`, `doc`) was
not re-run because no Rust source was touched; project CI exercises
those gates on PR.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1215 -->