### PR TITLE
Add description, repository, readme to Cargo.toml [package] (#1241)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.56"
+version = "0.74.57"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "neat_ai_discovery"
 version = "0.74.56"
 edition = "2024"
 license = "Apache-2.0"
+description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."
+repository = "https://github.com/stSoftwareAU/NEAT-AI-Discovery"
+readme = "README.md"
 
 [lib]
 name = "neat_ai_discovery"

--- a/docs/archive/pr-summaries/pr-summary-1241.md
+++ b/docs/archive/pr-summaries/pr-summary-1241.md
@@ -1,0 +1,35 @@
+## Summary
+
+Added the missing `description`, `repository`, and `readme` fields to the
+`[package]` table in `Cargo.toml` so the `neat_ai_discovery` crate meets
+the Rust API Guidelines (C-METADATA). This unblocks `cargo publish`,
+gives `cargo metadata` consumers (SBOM tools, doc generators) the
+upstream source, and brings Discovery into line with the sibling
+`rust_scorer` crate. Closes #1241.
+
+## Evidence
+
+This is a metadata-only change with no runtime or UI surface. Verified
+by:
+
+- New regression test `tests/issue_1241_cargo_toml_metadata.rs` reads
+  `Cargo.toml` and asserts the three fields are present, that
+  `repository` points at the canonical GitHub repo, and that the
+  referenced `README.md` exists on disk.
+- `./quality.sh` passes cleanly (fmt, clippy, check, test, release
+  build).
+
+Before the fix the new test failed with:
+
+```
+Cargo.toml [package] must declare `description` (Issue #1241)
+```
+
+After applying the manifest edit the test passes.
+
+## Test Plan
+
+- Added `tests/issue_1241_cargo_toml_metadata.rs::cargo_toml_declares_required_package_metadata`
+  which fails against the unfixed manifest and passes after the fix.
+- Ran `cargo test --test issue_1241_cargo_toml_metadata` — 1 passed.
+- Ran `./quality.sh` — all quality checks passed.

--- a/tests/issue_1241_cargo_toml_metadata.rs
+++ b/tests/issue_1241_cargo_toml_metadata.rs
@@ -1,0 +1,103 @@
+//! Issue #1241: `Cargo.toml [package]` must declare `description`,
+//! `repository`, and `readme` so the crate is discoverable, the source
+//! of truth is unambiguous, and `cargo publish`/`cargo metadata`
+//! consumers (tooling, SBOM, doc generators) have the expected metadata
+//! per the Rust API Guidelines (C-METADATA).
+//!
+//! This test reads `Cargo.toml` directly (without parsing TOML) so the
+//! library does not need to pull in a new dependency just for the test.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn cargo_toml_declares_required_package_metadata() {
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let contents = fs::read_to_string(&manifest_path).expect("read Cargo.toml");
+
+    let package_section = extract_section(&contents, "[package]")
+        .expect("Cargo.toml must contain a [package] section");
+
+    let description = field_value(package_section, "description")
+        .expect("Cargo.toml [package] must declare `description` (Issue #1241)");
+    assert!(
+        description.len() >= 20,
+        "Cargo.toml [package].description should be a meaningful sentence, got: {description:?}"
+    );
+
+    let repository = field_value(package_section, "repository")
+        .expect("Cargo.toml [package] must declare `repository` (Issue #1241)");
+    assert!(
+        repository.starts_with("https://github.com/stSoftwareAU/NEAT-AI-Discovery"),
+        "Cargo.toml [package].repository must point at the canonical GitHub repo, got: \
+         {repository:?}"
+    );
+
+    let readme = field_value(package_section, "readme")
+        .expect("Cargo.toml [package] must declare `readme` (Issue #1241)");
+    assert_eq!(
+        readme, "README.md",
+        "Cargo.toml [package].readme should be README.md"
+    );
+
+    // The referenced README must exist.
+    let readme_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(&readme);
+    assert!(
+        readme_path.is_file(),
+        "Cargo.toml [package].readme = {readme:?} but {readme_path:?} does not exist"
+    );
+}
+
+/// Return the body of the named section (everything up to the next
+/// `[section]` header).
+fn extract_section<'a>(contents: &'a str, header: &str) -> Option<&'a str> {
+    let start = contents.find(header)?;
+    let after_header = &contents[start + header.len()..];
+    // Find the next section header at the start of a line.
+    let mut end = after_header.len();
+    for (idx, line) in after_header.lines().enumerate() {
+        if idx == 0 {
+            continue;
+        }
+        if line.trim_start().starts_with('[') {
+            // Recompute byte offset of this line within after_header.
+            let mut offset = 0usize;
+            for (i, l) in after_header.lines().enumerate() {
+                if i == idx {
+                    break;
+                }
+                offset += l.len() + 1; // +1 for the newline
+            }
+            end = offset;
+            break;
+        }
+    }
+    Some(&after_header[..end])
+}
+
+/// Find a `key = "value"` declaration inside a TOML section body.
+fn field_value(section: &str, key: &str) -> Option<String> {
+    for line in section.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = rest.trim();
+        // Strip trailing comment.
+        let value = value.split('#').next().unwrap_or("").trim();
+        // Strip surrounding quotes.
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))?;
+        return Some(value.to_string());
+    }
+    None
+}


### PR DESCRIPTION
## Summary

Added the missing `description`, `repository`, and `readme` fields to the
`[package]` table in `Cargo.toml` so the `neat_ai_discovery` crate meets
the Rust API Guidelines (C-METADATA). This unblocks `cargo publish`,
gives `cargo metadata` consumers (SBOM tools, doc generators) the
upstream source, and brings Discovery into line with the sibling
`rust_scorer` crate. Closes #1241.

## Evidence

This is a metadata-only change with no runtime or UI surface. Verified
by:

- New regression test `tests/issue_1241_cargo_toml_metadata.rs` reads
  `Cargo.toml` and asserts the three fields are present, that
  `repository` points at the canonical GitHub repo, and that the
  referenced `README.md` exists on disk.
- `./quality.sh` passes cleanly (fmt, clippy, check, test, release
  build).

Before the fix the new test failed with:

```
Cargo.toml [package] must declare `description` (Issue #1241)
```

After applying the manifest edit the test passes.

## Test Plan

- Added `tests/issue_1241_cargo_toml_metadata.rs::cargo_toml_declares_required_package_metadata`
  which fails against the unfixed manifest and passes after the fix.
- Ran `cargo test --test issue_1241_cargo_toml_metadata` — 1 passed.
- Ran `./quality.sh` — all quality checks passed.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1241 -->