### PR TITLE
test: cover all 7 built-in cost types end-to-end (Issue #1246)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.59"
+version = "0.74.60"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1246.md
+++ b/docs/archive/pr-summaries/pr-summary-1246.md
@@ -1,0 +1,77 @@
+## Summary
+
+Adds end-to-end integration tests that exercise the full
+`record_discovery` → `analyze_parallel` pipeline against fixtures shaped
+like each of the seven built-in NEAT-AI cost functions (`MSE`, `MAE`,
+`MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`, `CATEGORICAL_ERROR`). Discovery
+is **cost-agnostic by construction** — it never reads the cost name —
+but until now there was no regression coverage proving the pipeline
+survives every cost's residual distribution end-to-end. This PR delivers
+that coverage so a regression in cost-agnostic behaviour fails CI rather
+than surfacing as silent production drift. Closes #1246.
+
+## Evidence
+
+The change is backend Rust integration tests only — no UI, no
+performance work. Verification comes from the new tests passing.
+
+```text
+$ cargo test --test cost_compatibility -- --test-threads=2
+running 9 tests
+test end_to_end::cost_compatibility_categorical_error ... ok
+test end_to_end::cost_compatibility_categorical_error_quantised_zero_variance ... ok
+test end_to_end::cost_compatibility_cross_entropy ... ok
+test end_to_end::cost_compatibility_hinge ... ok
+test end_to_end::cost_compatibility_mae ... ok
+test end_to_end::cost_compatibility_mape ... ok
+test end_to_end::cost_compatibility_mse ... ok
+test end_to_end::every_built_in_cost_has_a_dedicated_test ... ok
+test end_to_end::cost_compatibility_msle ... ok
+
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;
+finished in 4.00s
+```
+
+All nine tests complete in **4 seconds** total — well inside the
+10-second-per-test budget (Issue #603).
+
+### Pipeline exercised
+
+```mermaid
+flowchart LR
+    A["BUILT_IN_COST_NAMES<br/>(MSE / MAE / MAPE / MSLE /<br/>HINGE / CROSS_ENTROPY / CATEGORICAL_ERROR)"] --> B["cost_shaped_error()<br/>per-cost residual fixture"]
+    B --> C["TrainingRecord<br/>(neuron_data.errors)"]
+    C --> D["record_discovery_internal()"]
+    D --> E["Parquet file"]
+    E --> F["analyze_parallel_internal()"]
+    F --> G["Assertions:<br/>success == true<br/>finite expectedCreatureScoreGain<br/>(every candidate, every bucket)"]
+```
+
+## Test Plan
+
+New test file `tests/cost_compatibility/end_to_end.rs` (with
+`tests/cost_compatibility/main.rs` wiring it up). Tests added:
+
+- `cost_compatibility_mse`
+- `cost_compatibility_mae`
+- `cost_compatibility_mape`
+- `cost_compatibility_msle`
+- `cost_compatibility_hinge`
+- `cost_compatibility_cross_entropy`
+- `cost_compatibility_categorical_error`
+- `cost_compatibility_categorical_error_quantised_zero_variance`
+  — covers acceptance criterion #6 (variance-based detectors must not
+  divide by zero on quantised `{0, 1}` output errors).
+- `every_built_in_cost_has_a_dedicated_test` — meta-guard that fails if a
+  new cost is added to `BUILT_IN_COST_NAMES` without a matching test.
+
+Shared helpers added to `tests/common/mod.rs`:
+
+- `BUILT_IN_COST_NAMES` — canonical list of NEAT-AI's seven costs.
+- `cost_shaped_error(cost, obs_index, output_index)` — deterministic
+  per-cost residual generator.
+- `toy_cost_creature()` — small 2-input, 3-hidden, 2-output creature
+  shared across the cost-compatibility tests.
+
+Quality gate: `./quality.sh < /dev/null` passes (fmt, clippy with
+`-D warnings`, check, full test suite, doc build, release build).

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -197,3 +197,101 @@ pub fn record(
         errors: vec![0.01],
     }
 }
+
+// ---------------------------------------------------------------------------
+// Cost-compatibility fixtures (Issue #1246)
+//
+// Helpers for building deterministic per-cost output-neuron error fixtures
+// and a small toy creature shared by the cost-compatibility integration
+// tests. Discovery is cost-agnostic by construction — these fixtures
+// reproduce each built-in cost's per-record residual shape so the
+// `record_discovery` → `analyze_parallel` pipeline can be exercised
+// end-to-end against every cost without depending on the NEAT-AI runtime.
+// ---------------------------------------------------------------------------
+
+/// The seven built-in NEAT-AI cost names that discovery must remain
+/// compatible with. Mirrors `BUILT_IN_COST_NAMES` in NEAT-AI's `Costs.ts`.
+#[allow(dead_code)]
+pub const BUILT_IN_COST_NAMES: [&str; 7] = [
+    "MSE",
+    "MAE",
+    "MAPE",
+    "MSLE",
+    "HINGE",
+    "CROSS_ENTROPY",
+    "CATEGORICAL_ERROR",
+];
+
+/// Produce a deterministic output-neuron error value shaped like a
+/// per-record residual under `cost`.
+///
+/// The shapes follow §1 of `docs/COST_FUNCTION_NOTES.md`:
+/// - `MSE`/`MAE`: continuous signed.
+/// - `MAPE`: continuous signed, smaller scale (percentage-like).
+/// - `MSLE`: continuous signed (log-space residual).
+/// - `HINGE`: non-negative, sparse (frequent zeros for margined samples).
+/// - `CROSS_ENTROPY`: continuous signed in `[-1, 1]` (soft-max gradient).
+/// - `CATEGORICAL_ERROR`: quantised misclassification flag in `{0, 1}`.
+///
+/// Deterministic in `(cost, obs_index, output_index)` so tests are
+/// reproducible without an RNG.
+#[allow(dead_code)]
+#[allow(clippy::cast_precision_loss)]
+pub fn cost_shaped_error(cost: &str, obs_index: u32, output_index: usize) -> f32 {
+    let phase = (obs_index as f32) * 0.37 + (output_index as f32) * 1.7;
+    match cost {
+        "MSE" | "MAE" => phase.sin() * 0.3,
+        "MAPE" => phase.sin() * 0.15,
+        "MSLE" => phase.sin() * 0.2,
+        "HINGE" => {
+            // Sparse: zero on roughly half of samples ("correctly margined"),
+            // positive magnitude on the rest. Sign convention follows
+            // NEAT-AI's chain rule which preserves the sign of the residual.
+            if phase.sin() > 0.0 {
+                (1.0 - phase.cos() * 0.6).clamp(0.0, 1.5)
+            } else {
+                0.0
+            }
+        }
+        "CROSS_ENTROPY" => (phase.sin() * 0.5).clamp(-0.95, 0.95),
+        "CATEGORICAL_ERROR" => {
+            if phase.sin() > 0.3 {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        _ => phase.sin() * 0.3,
+    }
+}
+
+/// Build a small 2-input, 3-hidden, 2-output toy creature used by the
+/// cost-compatibility tests. Returns the `CreatureJson` together with the
+/// list of hidden + output neuron UUIDs (in forward-only order).
+///
+/// Topology (forward-only):
+/// - `input-0`, `input-1` → `h0`, `h1`
+/// - `h0`, `h1` → `h2`
+/// - `h2` → `o0`, `o1`
+#[allow(dead_code)]
+pub fn toy_cost_creature() -> CreatureJson {
+    CreatureJson {
+        input: 2,
+        output: 2,
+        neurons: vec![
+            hidden("h0", "TANH"),
+            hidden("h1", "LOGISTIC"),
+            hidden("h2", "TANH"),
+            output("o0", "IDENTITY"),
+            output("o1", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "h0", 0.7),
+            synapse("input-1", "h1", -0.5),
+            synapse("h0", "h2", 0.6),
+            synapse("h1", "h2", 0.4),
+            synapse("h2", "o0", 0.8),
+            synapse("h2", "o1", -0.3),
+        ],
+    }
+}

--- a/tests/cost_compatibility/end_to_end.rs
+++ b/tests/cost_compatibility/end_to_end.rs
@@ -1,0 +1,382 @@
+//! Parameterised end-to-end tests for the seven built-in NEAT-AI cost
+//! functions (Issue #1246).
+//!
+//! For each cost name in [`BUILT_IN_COST_NAMES`] the test:
+//! 1. Builds a small toy creature ([`toy_cost_creature`]).
+//! 2. Hand-crafts `TrainingRecord` entries whose output-neuron
+//!    `errors` mimic that cost's per-record residual distribution.
+//! 3. Calls `record_discovery_internal` to produce a Parquet file.
+//! 4. Calls `analyze_parallel_internal` and asserts:
+//!    - The call succeeds (`success == true`, no panic, no FFI error).
+//!    - Every returned candidate carries a finite
+//!      `expectedCreatureScoreGain`.
+//!
+//! `CATEGORICAL_ERROR` additionally gets a dedicated quantised-`{0, 1}`
+//! test to exercise variance-based detectors against zero-variance
+//! output errors (Issue #1246, acceptance criterion #3).
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+use crate::common::{
+    BUILT_IN_COST_NAMES, GainFloorDisableGuard, cost_shaped_error, toy_cost_creature,
+};
+use neat_ai_discovery::analysis::GpuAnalyzer;
+use neat_ai_discovery::{analyze_parallel_internal, record_discovery_internal};
+use serde_json::{Value, json};
+use serial_test::serial;
+use tempfile::tempdir;
+
+/// Number of training observations per fixture. Kept small so each test
+/// finishes well within the 10-second unit-test budget (Issue #603) while
+/// still giving discovery enough samples to exercise its variance and
+/// distribution detectors.
+const FIXTURE_SAMPLE_COUNT: u32 = 64;
+
+/// Build the JSON input expected by `record_discovery_internal`.
+///
+/// `neuron_errors_for_output` returns the per-output-neuron error vector
+/// for a given observation index — this is where the cost-shape is
+/// injected.
+fn build_record_input(
+    temp_dir: &str,
+    creature: &Value,
+    sample_count: u32,
+    mut neuron_errors_for_output: impl FnMut(u32) -> [f32; 1],
+) -> String {
+    // Deterministic activations so discovery has signal to analyse, but
+    // not so structured that detectors lock onto a single pattern.
+    let mut training_data: Vec<Value> = Vec::with_capacity(sample_count as usize);
+    for obs in 0..sample_count {
+        let phase = obs as f32 * 0.21;
+        let i0 = phase.sin();
+        let i1 = (phase * 1.7).cos();
+        // Forward-pass approximations — values must be valid f32 and
+        // consistent across the batch. Discovery never reactivates the
+        // creature, it just stores these as opaque samples.
+        let h0_act = (0.7 * i0).tanh();
+        let h1_act = 1.0 / (1.0 + (-(-0.5 * i1)).exp());
+        let h2_act = (0.6 * h0_act + 0.4 * h1_act).tanh();
+        let o0_act = 0.8 * h2_act;
+        let o1_act = -0.3 * h2_act;
+
+        // Output errors carry the cost-shaped residual; hidden neurons
+        // record empty errors (mirrors how NEAT-AI populates the field
+        // for non-output neurons in the existing test corpus).
+        let out_errors = neuron_errors_for_output(obs);
+        let o0_err = out_errors[0];
+        // Second output gets a phase-shifted residual so we exercise
+        // multi-output handling.
+        let o1_err = cost_shaped_error("MSE", obs.wrapping_add(7), 1) * 0.5 + out_errors[0] * 0.25;
+
+        training_data.push(json!({
+            "input": [i0, i1],
+            "output": [o0_act, o1_act],
+            "neuron_data": [
+                {"neuron_uuid": "h0", "activation": h0_act, "value": h0_act, "errors": []},
+                {"neuron_uuid": "h1", "activation": h1_act, "value": h1_act, "errors": []},
+                {"neuron_uuid": "h2", "activation": h2_act, "value": h2_act, "errors": []},
+                {"neuron_uuid": "o0", "activation": o0_act, "value": o0_act, "errors": [o0_err]},
+                {"neuron_uuid": "o1", "activation": o1_act, "value": o1_act, "errors": [o1_err]},
+            ]
+        }));
+    }
+
+    json!({
+        "creature": creature,
+        "training_data": training_data,
+        "temp_dir": temp_dir,
+    })
+    .to_string()
+}
+
+/// Assert that every emitted candidate carries a finite
+/// `expectedCreatureScoreGain`. The acceptance criterion is "finite for
+/// every returned candidate" regardless of which candidate bucket it
+/// lives in, so we sweep every bucket that the FFI exposes.
+fn assert_finite_gain_for_all_candidates(cost: &str, output: &Value) {
+    const BUCKETS: [&str; 5] = [
+        "helpfulSynapses",
+        "harmfulSynapses",
+        "helpfulNeurons",
+        "synapseWeightUpdates",
+        "coordinatedStructuralCandidates",
+    ];
+
+    for bucket in BUCKETS {
+        let Some(candidates) = output.get(bucket).and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for (idx, candidate) in candidates.iter().enumerate() {
+            let gain = candidate
+                .get("expectedCreatureScoreGain")
+                .and_then(Value::as_f64)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "[{cost}] {bucket}[{idx}] missing expectedCreatureScoreGain: {candidate}"
+                    )
+                });
+            assert!(
+                gain.is_finite(),
+                "[{cost}] {bucket}[{idx}] expectedCreatureScoreGain is not finite: {gain} \
+                 (candidate: {candidate})"
+            );
+        }
+    }
+}
+
+/// Drive the full `record_discovery` → `analyze_parallel` pipeline
+/// against the toy creature using cost-shaped output errors. Returns the
+/// parsed `analyze_parallel` output for further per-cost assertions.
+fn run_pipeline_for_cost(cost: &str) -> Value {
+    let temp_dir = tempdir().expect("tempdir");
+    let temp_path = temp_dir
+        .path()
+        .to_str()
+        .expect("temp path must be UTF-8")
+        .to_string();
+
+    let creature = toy_cost_creature();
+    let creature_json = serde_json::to_value(&creature).expect("serialise creature");
+
+    let record_input =
+        build_record_input(&temp_path, &creature_json, FIXTURE_SAMPLE_COUNT, |obs| {
+            [cost_shaped_error(cost, obs, 0)]
+        });
+
+    let record_result =
+        record_discovery_internal(&record_input).expect("record_discovery returned Err");
+    let record_output: Value =
+        serde_json::from_str(&record_result).expect("record_discovery returned invalid JSON");
+    assert_eq!(
+        record_output["success"], true,
+        "[{cost}] record_discovery failed: {record_output}"
+    );
+
+    let parquet_path = std::path::PathBuf::from(
+        record_output["tempDir"]
+            .as_str()
+            .expect("tempDir field missing"),
+    )
+    .join(record_output["file"].as_str().expect("file field missing"));
+    assert!(
+        parquet_path.exists(),
+        "[{cost}] parquet file not written at {parquet_path:?}"
+    );
+
+    let analyze_input = json!({
+        "parquetFile": parquet_path.to_str().expect("path UTF-8"),
+        "creature": creature_json,
+        "focusNeurons": ["o0", "o1"],
+        "maxSynapseCandidates": 16,
+        "maxNeuronCandidates": 8,
+        "randomSeed": 1246,
+    })
+    .to_string();
+
+    let analyse_result =
+        analyze_parallel_internal(&analyze_input).expect("analyze_parallel returned Err");
+    let analyse_output: Value =
+        serde_json::from_str(&analyse_result).expect("analyze_parallel returned invalid JSON");
+    assert_eq!(
+        analyse_output["success"], true,
+        "[{cost}] analyze_parallel failed: {analyse_output}"
+    );
+
+    assert_finite_gain_for_all_candidates(cost, &analyse_output);
+
+    analyse_output
+}
+
+/// Helper for the per-cost tests: skip cleanly on machines without a GPU
+/// (discovery is GPU-only) and hold the noise-floor guard for the duration
+/// of the run because the toy fixtures sit below the production
+/// `MIN_EXPECTED_GAIN` threshold (Issue #1191).
+fn run_cost_test(cost: &str) {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping cost-compatibility test for {cost}: no GPU available");
+        return;
+    }
+    let _gain_guard = GainFloorDisableGuard::new();
+    let _output = run_pipeline_for_cost(cost);
+}
+
+// ---------------------------------------------------------------------------
+// Per-cost tests — one per built-in cost name.
+//
+// Each test is `#[serial]` because `GainFloorDisableGuard` mutates a shared
+// environment variable. The seven tests together complete in well under
+// the 10-second-per-test budget (Issue #603) on a CI runner with a GPU.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn cost_compatibility_mse() {
+    run_cost_test("MSE");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_mae() {
+    run_cost_test("MAE");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_mape() {
+    run_cost_test("MAPE");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_msle() {
+    run_cost_test("MSLE");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_hinge() {
+    run_cost_test("HINGE");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_cross_entropy() {
+    run_cost_test("CROSS_ENTROPY");
+}
+
+#[test]
+#[serial]
+fn cost_compatibility_categorical_error() {
+    run_cost_test("CATEGORICAL_ERROR");
+}
+
+/// Issue #1246 acceptance criterion #6: `CATEGORICAL_ERROR` quantised
+/// `{0, 1}` output errors must not cause variance-based detectors to
+/// divide by zero, panic, or emit non-finite gains.
+///
+/// This fixture forces *all* output errors to be the same value (`1.0`)
+/// for half the observations and `0.0` for the rest, so the per-sample
+/// variance of the output residual is the maximum possible under the
+/// `{0, 1}` quantisation. It also forces both outputs to share the
+/// quantisation so any per-output variance reducer sees zero-variance
+/// columns.
+#[test]
+#[serial]
+fn cost_compatibility_categorical_error_quantised_zero_variance() {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping quantised CATEGORICAL_ERROR cost-compatibility test: no GPU available");
+        return;
+    }
+    let _gain_guard = GainFloorDisableGuard::new();
+
+    let temp_dir = tempdir().expect("tempdir");
+    let temp_path = temp_dir
+        .path()
+        .to_str()
+        .expect("temp path must be UTF-8")
+        .to_string();
+
+    let creature = toy_cost_creature();
+    let creature_json = serde_json::to_value(&creature).expect("serialise creature");
+
+    // Build a fixture where every output neuron in every observation
+    // sees either {0, 0} or {1, 1}. This is the worst case for
+    // variance-based detectors because per-output columns collapse to
+    // two constant clusters with zero within-cluster variance.
+    let record_input = serde_json::to_string(&json!({
+        "creature": creature_json,
+        "training_data": (0..FIXTURE_SAMPLE_COUNT)
+            .map(|obs| {
+                let flag: f32 = if obs % 2 == 0 { 0.0 } else { 1.0 };
+                let phase = obs as f32 * 0.21;
+                let i0 = phase.sin();
+                let i1 = (phase * 1.7).cos();
+                let h0_act = (0.7 * i0).tanh();
+                let h1_act = 1.0 / (1.0 + (-(-0.5 * i1)).exp());
+                let h2_act = (0.6 * h0_act + 0.4 * h1_act).tanh();
+                let o0_act = 0.8 * h2_act;
+                let o1_act = -0.3 * h2_act;
+                json!({
+                    "input": [i0, i1],
+                    "output": [o0_act, o1_act],
+                    "neuron_data": [
+                        {"neuron_uuid": "h0", "activation": h0_act, "value": h0_act, "errors": []},
+                        {"neuron_uuid": "h1", "activation": h1_act, "value": h1_act, "errors": []},
+                        {"neuron_uuid": "h2", "activation": h2_act, "value": h2_act, "errors": []},
+                        {"neuron_uuid": "o0", "activation": o0_act, "value": o0_act, "errors": [flag]},
+                        {"neuron_uuid": "o1", "activation": o1_act, "value": o1_act, "errors": [flag]},
+                    ]
+                })
+            })
+            .collect::<Vec<_>>(),
+        "temp_dir": temp_path,
+    }))
+    .expect("serialise record input");
+
+    let record_result = record_discovery_internal(&record_input)
+        .expect("quantised CATEGORICAL_ERROR record_discovery returned Err");
+    let record_output: Value = serde_json::from_str(&record_result)
+        .expect("quantised CATEGORICAL_ERROR record_discovery returned invalid JSON");
+    assert_eq!(
+        record_output["success"], true,
+        "quantised CATEGORICAL_ERROR record_discovery failed: {record_output}"
+    );
+
+    let parquet_path = std::path::PathBuf::from(
+        record_output["tempDir"]
+            .as_str()
+            .expect("tempDir field missing"),
+    )
+    .join(record_output["file"].as_str().expect("file field missing"));
+    assert!(
+        parquet_path.exists(),
+        "quantised CATEGORICAL_ERROR parquet not written at {parquet_path:?}"
+    );
+
+    let analyze_input = json!({
+        "parquetFile": parquet_path.to_str().expect("path UTF-8"),
+        "creature": creature_json,
+        "focusNeurons": ["o0", "o1"],
+        "maxSynapseCandidates": 16,
+        "maxNeuronCandidates": 8,
+        "randomSeed": 1246,
+    })
+    .to_string();
+
+    let analyse_result = analyze_parallel_internal(&analyze_input)
+        .expect("quantised CATEGORICAL_ERROR analyze_parallel returned Err");
+    let analyse_output: Value = serde_json::from_str(&analyse_result)
+        .expect("quantised CATEGORICAL_ERROR analyze_parallel returned invalid JSON");
+    assert_eq!(
+        analyse_output["success"], true,
+        "quantised CATEGORICAL_ERROR analyze_parallel failed: {analyse_output}"
+    );
+
+    assert_finite_gain_for_all_candidates("CATEGORICAL_ERROR (quantised)", &analyse_output);
+}
+
+/// Belt-and-braces meta-test: the explicit per-cost tests above must
+/// cover every entry in [`BUILT_IN_COST_NAMES`]. Adding a new built-in
+/// cost to the list without a matching test is an oversight — this
+/// guard test fails fast so the new cost gets its own fixture.
+#[test]
+fn every_built_in_cost_has_a_dedicated_test() {
+    // Names of the per-cost tests defined in this file. Keep in sync
+    // with the `#[test]` functions above.
+    const COVERED: [&str; 7] = [
+        "MSE",
+        "MAE",
+        "MAPE",
+        "MSLE",
+        "HINGE",
+        "CROSS_ENTROPY",
+        "CATEGORICAL_ERROR",
+    ];
+    for cost in BUILT_IN_COST_NAMES {
+        assert!(
+            COVERED.contains(&cost),
+            "Cost '{cost}' is in BUILT_IN_COST_NAMES but has no dedicated \
+             cost-compatibility test in tests/cost_compatibility/end_to_end.rs"
+        );
+    }
+}

--- a/tests/cost_compatibility/main.rs
+++ b/tests/cost_compatibility/main.rs
@@ -1,0 +1,14 @@
+//! End-to-end cost-compatibility integration tests (Issue #1246).
+//!
+//! Discovery is **cost-agnostic by construction** — per-neuron errors arrive
+//! pre-computed in `DiscoverRecord.errors[]` via `Neuron.record()` and the
+//! library never reads the cost name. These tests exercise the full
+//! `record_discovery → analyze_parallel` pipeline against fixtures shaped
+//! like the residual distribution of every built-in NEAT-AI cost, so a
+//! regression in cost-agnostic behaviour fails CI rather than surfacing as
+//! silent production drift.
+
+#[path = "../common/mod.rs"]
+mod common;
+
+mod end_to_end;


### PR DESCRIPTION
## Summary

Adds end-to-end integration tests that exercise the full
`record_discovery` → `analyze_parallel` pipeline against fixtures shaped
like each of the seven built-in NEAT-AI cost functions (`MSE`, `MAE`,
`MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`, `CATEGORICAL_ERROR`). Discovery
is **cost-agnostic by construction** — it never reads the cost name —
but until now there was no regression coverage proving the pipeline
survives every cost's residual distribution end-to-end. This PR delivers
that coverage so a regression in cost-agnostic behaviour fails CI rather
than surfacing as silent production drift. Closes #1246.

## Evidence

The change is backend Rust integration tests only — no UI, no
performance work. Verification comes from the new tests passing.

```text
$ cargo test --test cost_compatibility -- --test-threads=2
running 9 tests
test end_to_end::cost_compatibility_categorical_error ... ok
test end_to_end::cost_compatibility_categorical_error_quantised_zero_variance ... ok
test end_to_end::cost_compatibility_cross_entropy ... ok
test end_to_end::cost_compatibility_hinge ... ok
test end_to_end::cost_compatibility_mae ... ok
test end_to_end::cost_compatibility_mape ... ok
test end_to_end::cost_compatibility_mse ... ok
test end_to_end::every_built_in_cost_has_a_dedicated_test ... ok
test end_to_end::cost_compatibility_msle ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out;
finished in 4.00s
```

All nine tests complete in **4 seconds** total — well inside the
10-second-per-test budget (Issue #603).

### Pipeline exercised

```mermaid
flowchart LR
    A["BUILT_IN_COST_NAMES<br/>(MSE / MAE / MAPE / MSLE /<br/>HINGE / CROSS_ENTROPY / CATEGORICAL_ERROR)"] --> B["cost_shaped_error()<br/>per-cost residual fixture"]
    B --> C["TrainingRecord<br/>(neuron_data.errors)"]
    C --> D["record_discovery_internal()"]
    D --> E["Parquet file"]
    E --> F["analyze_parallel_internal()"]
    F --> G["Assertions:<br/>success == true<br/>finite expectedCreatureScoreGain<br/>(every candidate, every bucket)"]
```

## Test Plan

New test file `tests/cost_compatibility/end_to_end.rs` (with
`tests/cost_compatibility/main.rs` wiring it up). Tests added:

- `cost_compatibility_mse`
- `cost_compatibility_mae`
- `cost_compatibility_mape`
- `cost_compatibility_msle`
- `cost_compatibility_hinge`
- `cost_compatibility_cross_entropy`
- `cost_compatibility_categorical_error`
- `cost_compatibility_categorical_error_quantised_zero_variance`
  — covers acceptance criterion #6 (variance-based detectors must not
  divide by zero on quantised `{0, 1}` output errors).
- `every_built_in_cost_has_a_dedicated_test` — meta-guard that fails if a
  new cost is added to `BUILT_IN_COST_NAMES` without a matching test.

Shared helpers added to `tests/common/mod.rs`:

- `BUILT_IN_COST_NAMES` — canonical list of NEAT-AI's seven costs.
- `cost_shaped_error(cost, obs_index, output_index)` — deterministic
  per-cost residual generator.
- `toy_cost_creature()` — small 2-input, 3-hidden, 2-output creature
  shared across the cost-compatibility tests.

Quality gate: `./quality.sh < /dev/null` passes (fmt, clippy with
`-D warnings`, check, full test suite, doc build, release build).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1246 -->