### PR TITLE
docs: rephrase MSE-specific claims in discovery docs (#1251)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.61"
+version = "0.74.62"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1251.md
+++ b/docs/archive/pr-summaries/pr-summary-1251.md
@@ -1,0 +1,46 @@
+## Summary
+
+Reworded `docs/discoveries/add-neuron.md:56` (and three sibling claims surfaced
+by the audit) to stop overclaiming that "expected improvement" equals the
+network's MSE reduction. The figure is sum-of-squared-error (SSE) reduction —
+exact only when NEAT-AI's cost function is `MSE`, and a ranking signal for the
+other six built-in costs (`MAE`, `MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`,
+`CATEGORICAL_ERROR`). Closes #1251.
+
+## Evidence
+
+Docs-only change — no code paths affected. Source references cross-checked
+against [`docs/COST_FUNCTION_NOTES.md`](../../COST_FUNCTION_NOTES.md) §4 and
+§6.
+
+Files updated:
+
+- `docs/discoveries/add-neuron.md:56` — reworded the flowchart node and added
+  a `NOTE` callout that links to `COST_FUNCTION_NOTES.md` for the per-cost
+  contract.
+- `docs/discoveries/add-synapse.md:183` — example expected-improvement line
+  reworded ("12% reduction in O1's sum-of-squared error (exact for `MSE`; a
+  ranking signal for other costs)").
+- `docs/discoveries/redundant-path.md:47` — improvement-estimation flowchart
+  node now says SSE original vs renormalised with the MSE caveat.
+- `docs/discoveries/redundant-path.md:121` — example wording reworded from
+  "MSE comparison" to "sum-of-squared-error comparison" with the same caveat.
+- `docs/discoveries/output-bias-drift.md:108-110` — Wikipedia reference
+  softened from "the loss metric that output bias drift directly inflates" to
+  acknowledge that the inflation is exact for `MSE` and a ranking signal for
+  the other costs.
+
+Audit completed across `docs/discoveries/*.md` for `MSE` / `mean squared
+error` / `sum-of-squared` / `loss reduction` / `least squares` claims. The
+remaining `least squares` references describe the regression method itself,
+not a loss claim, and remain accurate.
+
+## Test Plan
+
+- [x] Docs-only change; `quality.sh`'s spell-check / markdown lint will run
+      on CI.
+- [x] Verified all four discovery markdown files render with their existing
+      Mermaid blocks intact (no syntax changes inside fenced ` ```mermaid `
+      blocks beyond extending an existing flowchart-node label).
+- [x] Cross-referenced the new wording against `docs/COST_FUNCTION_NOTES.md`
+      §4 (per-cost behaviour) and §6 (concrete bugs surfaced).

--- a/docs/discoveries/add-neuron.md
+++ b/docs/discoveries/add-neuron.md
@@ -53,7 +53,7 @@ flowchart TD
     E --> F["a. Compute:<br/>activated = squash(w_in × S + bias)"]:::process
     F --> G["b. Optimal w_out via least squares:<br/>w_out = Σ(error × activated) / Σ(activated²)"]:::process
     G --> H["c. Optimal bias via<br/>grid search (GPU-accelerated)"]:::process
-    H --> I["d. Expected improvement =<br/>reduction in MSE"]:::process
+    H --> I["d. Expected improvement =<br/>SSE reduction<br/>(exact for MSE; ranking signal<br/>for other costs)"]:::process
     I --> D
     D --> J["Select activation function<br/>with best improvement"]:::process
     J --> K["Apply source variance discount<br/>+ impact discount"]:::process
@@ -64,6 +64,9 @@ flowchart TD
 
 > [!TIP]
 > 🎯 The algorithm tries every combination of source neuron and activation function to find the hidden neuron that would **most reduce** the target's error.
+
+> [!NOTE]
+> 📐 The "expected improvement" we score is **sum-of-squared-error (SSE) reduction**. This equals the network's loss reduction only when NEAT-AI's cost function is `MSE`; under other costs (`MAE`, `MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`, `CATEGORICAL_ERROR`) it is a useful ranking signal but is not equal to the actual loss reduction. See [`docs/COST_FUNCTION_NOTES.md`](../COST_FUNCTION_NOTES.md) §4 and §6.
 
 ### 🖥️ GPU-Accelerated Evaluation
 

--- a/docs/discoveries/add-synapse.md
+++ b/docs/discoveries/add-synapse.md
@@ -180,7 +180,7 @@ graph LR
 > **Analysis:**
 > - Matched 500 samples of I5 activation with O1 error
 > - Optimal weight: w = +0.07
-> - Expected improvement: 12% reduction in O1's MSE
+> - Expected improvement: 12% reduction in O1's sum-of-squared error (exact for `MSE`; a ranking signal for other costs)
 >
 > **Fix:** `addSynapse I5 → O1 (weight +0.07)`
 >

--- a/docs/discoveries/output-bias-drift.md
+++ b/docs/discoveries/output-bias-drift.md
@@ -106,8 +106,11 @@ consistency (majority fraction).
   [Wikipedia](https://en.wikipedia.org/wiki/Artificial_neuron#Types_of_transfer_functions):
   How the bias parameter shifts the activation function's operating point.
 - **Mean squared error** —
-  [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error): The loss
-  metric that output bias drift directly inflates.
+  [Wikipedia](https://en.wikipedia.org/wiki/Mean_squared_error): A common
+  loss metric. Output bias drift inflates the network's loss under any cost
+  function; the inflation is exact for `MSE` and a ranking signal for the
+  other built-in costs (see
+  [`docs/COST_FUNCTION_NOTES.md`](../COST_FUNCTION_NOTES.md) §4).
 - **NEAT (NeuroEvolution of Augmenting Topologies)** —
   [Wikipedia](https://en.wikipedia.org/wiki/Neuroevolution_of_augmenting_topologies):
   The evolutionary algorithm framework this library extends.

--- a/docs/discoveries/redundant-path.md
+++ b/docs/discoveries/redundant-path.md
@@ -44,7 +44,7 @@ flowchart TD
     D -->|Yes| E["🔀 Redundant pair found!"]
     E --> F["⚖️ Weaker synapse (by |weight|)<br/>= prune candidate"]
     F --> G["📐 New survivor weight<br/>= keep_weight + prune_weight"]
-    G --> H["📊 Estimate improvement:<br/>MSE original vs renormalised<br/>+ structural bonus"]
+    G --> H["📊 Estimate improvement:<br/>SSE original vs renormalised<br/>(exact for MSE; ranking signal<br/>for other costs)<br/>+ structural bonus"]
     style A fill:#e3f2fd,stroke:#1565c0,color:#000
     style B fill:#e3f2fd,stroke:#1565c0,color:#000
     style C fill:#e3f2fd,stroke:#1565c0,color:#000
@@ -118,8 +118,10 @@ graph LR
 > 1. `removeSynapse` I7 → H5
 > 2. `setWeight` I2 → H5 to 0.45 + 0.22 = **0.67**
 >
-> MSE comparison shows the single-path produces nearly identical
-> output with one fewer synapse. ✅
+> Sum-of-squared-error comparison shows the single-path produces nearly identical
+> output with one fewer synapse. ✅ (SSE reduction is exact for `MSE`; for
+> other costs it serves as a ranking signal — see
+> [`docs/COST_FUNCTION_NOTES.md`](../COST_FUNCTION_NOTES.md) §4.)
 
 ---
 


### PR DESCRIPTION
## Summary

Reworded `docs/discoveries/add-neuron.md:56` (and three sibling claims surfaced
by the audit) to stop overclaiming that "expected improvement" equals the
network's MSE reduction. The figure is sum-of-squared-error (SSE) reduction —
exact only when NEAT-AI's cost function is `MSE`, and a ranking signal for the
other six built-in costs (`MAE`, `MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`,
`CATEGORICAL_ERROR`). Closes #1251.

## Evidence

Docs-only change — no code paths affected. Source references cross-checked
against [`docs/COST_FUNCTION_NOTES.md`](../../COST_FUNCTION_NOTES.md) §4 and
§6.

Files updated:

- `docs/discoveries/add-neuron.md:56` — reworded the flowchart node and added
  a `NOTE` callout that links to `COST_FUNCTION_NOTES.md` for the per-cost
  contract.
- `docs/discoveries/add-synapse.md:183` — example expected-improvement line
  reworded ("12% reduction in O1's sum-of-squared error (exact for `MSE`; a
  ranking signal for other costs)").
- `docs/discoveries/redundant-path.md:47` — improvement-estimation flowchart
  node now says SSE original vs renormalised with the MSE caveat.
- `docs/discoveries/redundant-path.md:121` — example wording reworded from
  "MSE comparison" to "sum-of-squared-error comparison" with the same caveat.
- `docs/discoveries/output-bias-drift.md:108-110` — Wikipedia reference
  softened from "the loss metric that output bias drift directly inflates" to
  acknowledge that the inflation is exact for `MSE` and a ranking signal for
  the other costs.

Audit completed across `docs/discoveries/*.md` for `MSE` / `mean squared
error` / `sum-of-squared` / `loss reduction` / `least squares` claims. The
remaining `least squares` references describe the regression method itself,
not a loss claim, and remain accurate.

## Test Plan

- [x] Docs-only change; `quality.sh`'s spell-check / markdown lint will run
      on CI.
- [x] Verified all four discovery markdown files render with their existing
      Mermaid blocks intact (no syntax changes inside fenced ` ```mermaid `
      blocks beyond extending an existing flowchart-node label).
- [x] Cross-referenced the new wording against `docs/COST_FUNCTION_NOTES.md`
      §4 (per-cost behaviour) and §6 (concrete bugs surfaced).



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1251 -->