### PR TITLE
fix: harden discovery for CATEGORICAL_ERROR's quantised {0,1} regime (Issue #1247)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.60"
+version = "0.74.61"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/COST_FUNCTION_NOTES.md
+++ b/docs/COST_FUNCTION_NOTES.md
@@ -339,6 +339,15 @@ remains a documentation deliverable:
    `batch_successful/detection.rs:189-203`,
    `compound_degradation.rs:277-288`,
    `synapse/post_processing.rs:131-138`.
+   See also **#1247** — hardened the distribution-sensitive detectors
+   (`scoring/error_distribution.rs`, `detection/bimodal_neuron.rs`,
+   `recommendation/sample_weighted.rs`, `recommendation/fan_in.rs`,
+   `detection/monotonicity.rs`) for the quantised `{0, 1}` regime.
+   `monotonicity.rs` now skips affected neurons via the new
+   `analysis::quantised_error::is_quantised_zero_one` helper; the
+   remaining modules document degraded-but-well-formed behaviour and
+   carry regression tests under
+   `tests/{detection,recommendation,scoring}/issue_1247_*`.
 2. **#1250 — `activation + error = implied target` is invalid for
    non-linear-residual costs** — affects `output_squash_mismatch.rs:221`
    and `high_error_squash_exploration.rs:141`. **Resolved**: both sites

--- a/docs/archive/pr-summaries/pr-summary-1247.md
+++ b/docs/archive/pr-summaries/pr-summary-1247.md
@@ -1,0 +1,90 @@
+## Summary
+
+Hardened the distribution-sensitive discovery modules flagged by the
+#1245 audit against `CATEGORICAL_ERROR`'s quantised `{0, 1}` output
+errors so the pipeline produces well-formed candidates instead of
+NaN-bearing or mass-flagged ones. Closes #1247.
+
+### What changed
+
+- **New** `src/analysis/quantised_error.rs` — runtime predicate
+  `is_quantised_zero_one(errors: &[f32]) -> bool` that detects the
+  Bernoulli-style regime (every finite entry ≈ `0` or `1`, with at
+  least 5 % mass at each mode). Used by detectors that must skip the
+  regime.
+- **Guarded** `src/analysis/detection/monotonicity.rs` — neurons whose
+  recorded errors are quantised `{0, 1}` are skipped, because Spearman
+  rank correlation on two tied groups would otherwise mass-flag every
+  CATEGORICAL_ERROR-driven hidden neuron as non-monotonic.
+- **Documented degraded-but-well-formed behaviour** in
+  `error_distribution.rs`, `sample_weighted.rs`, `fan_in.rs`, and
+  `bimodal_neuron.rs`. The existing `is_finite` / `variance > eps`
+  guards already prevent NaN and division-by-zero — the doc comments
+  capture *what* the modules report on Bernoulli input so callers know
+  not to mis-interpret the numbers.
+- **`docs/COST_FUNCTION_NOTES.md`** updated to record the #1247
+  resolution under §6.
+
+### Why guard monotonicity but not the others?
+
+`monotonicity.rs` consumes the error series ordinally — ranks collapse
+under `{0, 1}` and the detector emits false positives. The other four
+modules consume errors as magnitudes, weights, or moment-based
+statistics that remain well-formed under Bernoulli input (the variance
+is `p(1−p)`, the skewness has a closed form, etc.). Skipping them
+would lose useful ranking signal; documenting the degraded
+interpretation preserves it.
+
+## Evidence
+
+This is a backend-only change with no UI to screenshot.
+
+- All new tests pass: 7 detection + 7 recommendation + 5 scoring +
+  13 unit tests inside `analysis::quantised_error`.
+- Existing `tests/cost_compatibility/end_to_end.rs` already covers the
+  full `record_discovery → analyze_parallel` pipeline for
+  `CATEGORICAL_ERROR` (including a dedicated quantised `{0, 1}`
+  variance test from #1246 acceptance criterion #6), and the existing
+  `tests/detection/issue_643_activation_error_monotonicity.rs` suite
+  still passes — the new guard does not regress continuous-error
+  detection.
+- `./quality.sh < /dev/null` passes.
+
+```mermaid
+flowchart LR
+    A["DiscoverRecord.errors[]"] --> B{"is_quantised_zero_one?"}
+    B -- "yes (CATEGORICAL_ERROR)" --> C["monotonicity.rs: skip neuron"]
+    B -- "no (continuous)" --> D["monotonicity.rs: Spearman rho"]
+    B -. "doc-noted regime" .-> E["error_distribution / sample_weighted /<br/>fan_in / bimodal_neuron<br/>(well-formed output)"]
+```
+
+## Test Plan
+
+- `tests/detection/issue_1247_categorical_error_hardening.rs`
+  - `monotonicity_skips_quantised_zero_one_regime`
+  - `monotonicity_handles_zero_variance_error_batch_without_nan`
+  - `monotonicity_still_flags_continuous_non_monotonic_neuron`
+    (regression guard for the new guard)
+  - `bimodal_neuron_handles_quantised_pre_activation_without_nan`
+  - `bimodal_neuron_handles_constant_value_without_nan`
+  - `quantised_helper_recognises_balanced_categorical_error_batch`
+  - `quantised_helper_rejects_continuous_residuals`
+- `tests/recommendation/issue_1247_categorical_error_hardening.rs`
+  - `sample_weights_finite_for_quantised_errors`
+  - `sample_weights_uniform_for_all_zero_errors`
+  - `stratify_handles_quantised_errors_without_nan`
+  - `stratify_handles_all_zero_error_batch`
+  - `fan_in_handles_quantised_errors_without_nan`
+  - `fan_in_handles_all_zero_output_errors`
+  - `detect_high_error_neurons_finite_under_quantised_regime`
+- `tests/scoring/issue_1247_categorical_error_hardening.rs`
+  - `distribution_stats_finite_for_quantised_zero_one_batch`
+  - `distribution_stats_safe_for_zero_variance_batch`
+  - `is_likely_bimodal_does_not_panic_on_quantised_batch`
+  - `detect_error_modes_finite_for_quantised_batch`
+  - `outlier_counting_safe_on_constant_batch`
+- `src/analysis/quantised_error.rs` — 13 inline unit tests covering
+  detector boundary conditions (empty, all-zero, all-one, balanced,
+  unbalanced, single-outlier, continuous, signed-residual,
+  non-finite-mixed, round-off-tolerance, custom-fraction).
+- `./quality.sh < /dev/null` — full quality gate green.

--- a/src/analysis/detection/bimodal_neuron.rs
+++ b/src/analysis/detection/bimodal_neuron.rs
@@ -29,6 +29,19 @@
 //!
 //! When bimodality is detected, we recommend adding a new neuron to split the
 //! bimodal neuron. Each candidate includes bias offsets targeting each mode.
+//!
+//! ## `CATEGORICAL_ERROR` / quantised error regime (Issue #1247)
+//!
+//! This detector inspects the recorded **pre-activation value**
+//! (`DiscoverRecord.value`), not the error field, so it is *not*
+//! sensitive to the `CATEGORICAL_ERROR` `{0, 1}` regime described in
+//! `docs/COST_FUNCTION_NOTES.md`. The cluster coherence and gap-ratio
+//! guards (`MIN_GAP_RATIO`, `MAX_CLUSTER_VARIANCE_RATIO`) keep the
+//! detector well-formed even when the pre-activation distribution
+//! happens to collapse to two points: each cluster has zero internal
+//! variance, which still satisfies the coherence test, and the
+//! candidate's `bimodality_score` and `estimated_improvement` remain
+//! finite.
 
 #![allow(
     clippy::cast_possible_truncation,

--- a/src/analysis/detection/monotonicity.rs
+++ b/src/analysis/detection/monotonicity.rs
@@ -24,6 +24,23 @@
 //! - `addNeuron`: Split the non-monotonic neuron so each sub-neuron handles one
 //!   direction of the activation-error mapping
 //! - `changeSquash`: Change the activation function to better fit the data
+//!
+//! ## Quantised `{0, 1}` Error Regime (Issue #1247)
+//!
+//! Spearman's rank correlation requires the error series to carry
+//! ordinal information. Under `CATEGORICAL_ERROR`, output errors are
+//! quantised misclassification flags (`0` or `1`) and the rank vector
+//! collapses to two tied groups, producing a near-zero rho regardless
+//! of any real activation-error relationship. Detecting "non-monotonic"
+//! on that signal would flag every `CATEGORICAL_ERROR`-driven hidden
+//! neuron.
+//!
+//! When [`is_quantised_zero_one`] reports the regime, this detector
+//! skips the affected neuron and emits no candidate. The decision is
+//! made per-neuron — a creature trained under a continuous cost still
+//! exercises the full detector — and is documented as the "skip
+//! cleanly with a diagnostic" branch from Issue #1247's acceptance
+//! criteria.
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use std::collections::HashSet;
@@ -33,6 +50,7 @@ use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, Cre
 
 use super::stats::spearman_rank_correlation;
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES_FOR_DETECTION;
+use crate::analysis::quantised_error::is_quantised_zero_one;
 
 /// Minimum |rho| below which a neuron is considered non-monotonic.
 /// Spearman's rho ranges from -1.0 (perfectly decreasing) to +1.0 (perfectly increasing).
@@ -103,6 +121,14 @@ pub fn detect_non_monotonic_neurons(
 
         // Use absolute error values for monotonicity analysis
         let abs_errors: Vec<f32> = errors.iter().map(|e| e.abs()).collect();
+
+        // Skip neurons whose errors are quantised `{0, 1}` flags
+        // (CATEGORICAL_ERROR regime, Issue #1247). Rank-correlation on
+        // two tied groups is meaningless and would mass-flag every
+        // hidden neuron as non-monotonic.
+        if is_quantised_zero_one(&abs_errors) {
+            continue;
+        }
 
         let rho = spearman_rank_correlation(activations, &abs_errors);
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -50,6 +50,7 @@ pub mod gpu;
 pub mod module_weights;
 pub mod neuron;
 pub mod neuron_fingerprint;
+pub mod quantised_error;
 pub mod samples;
 pub mod scale_outcomes;
 pub mod shared;

--- a/src/analysis/quantised_error.rs
+++ b/src/analysis/quantised_error.rs
@@ -1,0 +1,219 @@
+//! Quantised `{0, 1}` error regime detection (Issue #1247).
+//!
+//! NEAT-AI's `CATEGORICAL_ERROR` cost (PR #2739) records output-neuron
+//! errors as quantised misclassification flags — every value is exactly
+//! `0` (correct prediction) or `1` (incorrect prediction). Detectors that
+//! rely on a continuous error signal (Spearman rank correlation, sample
+//! variance, SSE-style improvement ratios) degrade in well-defined but
+//! sometimes misleading ways under this regime.
+//!
+//! This helper lets distribution-sensitive detectors recognise the
+//! quantised regime cheaply at runtime so they can either:
+//!
+//! - **Skip** the detection for the affected target, **or**
+//! - **Switch** to a quantile- or presence-based alternative that
+//!   survives the regime.
+//!
+//! See `docs/COST_FUNCTION_NOTES.md` §4.7 for the full catalogue of
+//! affected consumers.
+//!
+//! ## Definition
+//!
+//! A slice of errors is considered to be in the "quantised `{0, 1}`"
+//! regime when:
+//!
+//! 1. Every finite entry is approximately `0.0` or `1.0` (within
+//!    [`QUANTISATION_TOLERANCE`]).
+//! 2. There is meaningful mass at both modes (at least
+//!    [`MIN_MODE_FRACTION`] of finite entries at each of `0` and `1`).
+//!
+//! Pure all-zero or all-one batches are *not* flagged as quantised —
+//! they are zero-variance regimes that detectors already handle via
+//! their existing `is_finite` / `variance > eps` guards. The quantised
+//! regime is the interesting case: errors look like a Bernoulli sample
+//! and the downstream detector's continuous-error assumption fails.
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)] // Counts converted to f32 for ratio comparisons.
+
+/// Absolute tolerance for "is this f32 value approximately `0.0` or
+/// `1.0`?" The recorded error comes from a `cost(target, output)` call
+/// whose output is forced to exact `0.0` / `1.0` by an argmax check, so
+/// the only deviation we expect is round-off through `f32`. A tolerance
+/// of `1e-6` rejects anything that has been arithmetically combined
+/// (e.g. averaged with a continuous residual) without flagging values
+/// that have only been copied.
+pub const QUANTISATION_TOLERANCE: f32 = 1e-6;
+
+/// Minimum fraction of finite errors that must sit at each mode for the
+/// slice to count as a "non-trivial" quantised batch. A batch where
+/// 99 % of errors are `0` and only one is `1` is statistically
+/// indistinguishable from "the network already learnt this output", so
+/// no special handling is warranted. The default of 5 % matches the
+/// minimum cluster fraction used by other discovery detectors.
+pub const MIN_MODE_FRACTION: f32 = 0.05;
+
+/// Returns `true` when `errors` is in the quantised `{0, 1}` regime.
+///
+/// See the module-level documentation for the precise definition. The
+/// function silently ignores non-finite entries; a slice that is
+/// entirely non-finite returns `false`.
+#[must_use]
+pub fn is_quantised_zero_one(errors: &[f32]) -> bool {
+    is_quantised_zero_one_with_fraction(errors, MIN_MODE_FRACTION)
+}
+
+/// Variant of [`is_quantised_zero_one`] that accepts a custom minority
+/// mode fraction. Intended for callers that want a stricter or looser
+/// threshold; production detectors should prefer the default.
+#[must_use]
+pub fn is_quantised_zero_one_with_fraction(errors: &[f32], min_mode_fraction: f32) -> bool {
+    let mut finite_count = 0usize;
+    let mut zero_count = 0usize;
+    let mut one_count = 0usize;
+
+    for &e in errors {
+        if !e.is_finite() {
+            continue;
+        }
+        finite_count += 1;
+        if e.abs() <= QUANTISATION_TOLERANCE {
+            zero_count += 1;
+        } else if (e - 1.0).abs() <= QUANTISATION_TOLERANCE {
+            one_count += 1;
+        } else {
+            // Any value that is neither approximately 0 nor approximately 1
+            // disqualifies the entire batch from the quantised regime.
+            return false;
+        }
+    }
+
+    // Need a meaningful number of samples and mass at both modes.
+    if finite_count == 0 {
+        return false;
+    }
+    let min_required = ((finite_count as f32) * min_mode_fraction).ceil() as usize;
+    let min_required = min_required.max(1);
+
+    zero_count >= min_required && one_count >= min_required
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_slice_is_not_quantised() {
+        assert!(!is_quantised_zero_one(&[]));
+    }
+
+    #[test]
+    fn all_zero_is_not_quantised() {
+        // A constant zero batch is a zero-variance regime, not a
+        // bimodal quantised one. Distinct detector code already
+        // handles "no signal" — we only flag the truly bimodal case.
+        let errors = [0.0_f32; 32];
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn all_one_is_not_quantised() {
+        let errors = [1.0_f32; 32];
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn balanced_zero_one_is_quantised() {
+        let errors: Vec<f32> = (0..32)
+            .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+            .collect();
+        assert!(is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn slightly_unbalanced_zero_one_is_quantised() {
+        // 28 zeros, 4 ones — still ≥5 % at the minority mode (4/32 = 12.5 %).
+        let mut errors = vec![0.0_f32; 28];
+        errors.extend([1.0_f32; 4]);
+        assert!(is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn single_outlier_is_not_quantised() {
+        // 99 zeros, 1 one — minority mode under 5 %, not flagged.
+        let mut errors = vec![0.0_f32; 99];
+        errors.push(1.0);
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn continuous_errors_are_not_quantised() {
+        let errors: Vec<f32> = (0..32).map(|i| (i as f32) / 31.0).collect();
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn signed_residuals_are_not_quantised() {
+        // -1, 0, 1 — sign-carrying residuals must NOT be confused with
+        // the unsigned quantised regime.
+        let errors: Vec<f32> = (0..32)
+            .map(|i| match i % 3 {
+                0 => -1.0,
+                1 => 0.0,
+                _ => 1.0,
+            })
+            .collect();
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn non_finite_entries_are_ignored() {
+        let mut errors: Vec<f32> = (0..30)
+            .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+            .collect();
+        errors.push(f32::NAN);
+        errors.push(f32::INFINITY);
+        errors.push(f32::NEG_INFINITY);
+        assert!(is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn all_non_finite_is_not_quantised() {
+        let errors = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn tolerance_accepts_round_off_noise() {
+        // Small f32 round-off around the modes must still register.
+        let mut errors: Vec<f32> = vec![1e-8_f32, -1e-8_f32, 1.0 - 1e-8, 1.0 + 1e-8];
+        errors.extend([0.0_f32; 8]);
+        errors.extend([1.0_f32; 8]);
+        assert!(is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn out_of_tolerance_disqualifies_batch() {
+        // A single 0.5 between batches of {0, 1} is enough to reject
+        // the regime — the batch has continuous structure.
+        let mut errors: Vec<f32> = (0..30)
+            .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+            .collect();
+        errors.push(0.5);
+        assert!(!is_quantised_zero_one(&errors));
+    }
+
+    #[test]
+    fn custom_fraction_is_respected() {
+        // 95 zeros, 5 ones — minority mode at 5 %.
+        let mut errors = vec![0.0_f32; 95];
+        errors.extend([1.0_f32; 5]);
+        // Default (5 %) flags it.
+        assert!(is_quantised_zero_one(&errors));
+        // 10 % minimum rejects it.
+        assert!(!is_quantised_zero_one_with_fraction(&errors, 0.10));
+    }
+}

--- a/src/analysis/recommendation/fan_in.rs
+++ b/src/analysis/recommendation/fan_in.rs
@@ -350,6 +350,21 @@ fn evaluate_fan_in_pair(
 /// Compute least-squares improvement for a single-input predictor:
 /// minimise Σ(error - w × activation)² → w = Σ(act × err) / Σ(act²),
 /// improvement = Σ(err²) - Σ(err - w × act)².
+///
+/// ## Quantised `{0, 1}` error regime (Issue #1247)
+///
+/// When errors are CATEGORICAL_ERROR-style misclassification flags the
+/// SSE collapses to `Σ e = error_count` (because `e² = e`). The
+/// least-squares slope `w` becomes a regression of the misclassification
+/// flag onto the activation, and `improvement` is bounded by the number
+/// of misclassified samples rather than a meaningful loss reduction.
+/// The return value remains **finite and non-negative** — `sum_act_sq`
+/// is already guarded against zero variance — so it stays usable as a
+/// *ranking* signal for fan-in pair selection, but downstream callers
+/// must not interpret the magnitude as "expected loss reduction" under
+/// this regime. The `is_quantised_zero_one` helper in
+/// `crate::analysis::quantised_error` lets callers detect the regime
+/// when they need to.
 fn compute_least_squares_improvement(activations: &[f32], errors: &[f32]) -> f32 {
     let n = activations.len().min(errors.len());
     if n < 2 {

--- a/src/analysis/recommendation/sample_weighted.rs
+++ b/src/analysis/recommendation/sample_weighted.rs
@@ -16,6 +16,30 @@
 //! Detection thresholds can be configured via `SampleWeightedConfig`:
 //! - `min_weighted_error`: Minimum weighted error to flag a neuron (default: 0.25)
 //! - `min_samples`: Minimum samples required for statistical reliability (default: 10)
+//!
+//! ## Quantised `{0, 1}` error regime (Issue #1247)
+//!
+//! Under `CATEGORICAL_ERROR`, the per-record absolute error collapses to
+//! `{0, 1}` — every "weight" is either zero (correctly-classified
+//! sample) or one (misclassified). The detector then reduces to:
+//!
+//! - `weighted_mean_error == misclassification_rate`
+//! - the stratified hard/easy split == correctly-classified vs
+//!   misclassified samples
+//! - `hard_to_easy_ratio` becomes unbounded when no sample is
+//!   correctly classified (already clamped to ≤ `10` downstream)
+//!
+//! The detector remains **finite and well-formed** — the existing
+//! `total <= EPSILON` and `easy_mean > EPSILON` guards prevent NaN /
+//! division-by-zero — and still produces a useful ranking signal
+//! (neurons with high misclassification rates outscore neurons with
+//! low ones). Magnitude is on a different scale to a continuous-error
+//! batch, so downstream `min_weighted_error` thresholds may need to
+//! be re-tuned for `CATEGORICAL_ERROR`. Detection is *degraded but
+//! well-formed* under this regime (Issue #1247).
+//!
+//! See `crate::analysis::quantised_error::is_quantised_zero_one` for
+//! the runtime predicate.
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use crate::types::DiscoverRecord;

--- a/src/analysis/scoring/error_distribution.rs
+++ b/src/analysis/scoring/error_distribution.rs
@@ -9,6 +9,31 @@
 //! The analysis computes distribution statistics including percentiles, skewness,
 //! and kurtosis to help identify non-uniform error patterns that may benefit from
 //! targeted discovery approaches.
+//!
+//! ## Quantised `{0, 1}` error regime (Issue #1247)
+//!
+//! Under `CATEGORICAL_ERROR` the underlying `avg_error` collapses to a
+//! Bernoulli sample over `{0, 1}`. The moment-based statistics still
+//! evaluate cleanly:
+//!
+//! - `variance = p(1 − p)` (finite, bounded by `0.25`)
+//! - `skewness = (1 − 2p) / sqrt(p(1 − p))` (finite when `p ∉ {0, 1}`)
+//! - `kurtosis = (1 − 6p(1 − p)) / (p(1 − p)) + 3` (finite when
+//!   `p ∉ {0, 1}`)
+//!
+//! The existing `std_dev > 1e-10` guard already handles the all-zero
+//! and all-one degenerate cases by emitting `skewness = 0` and
+//! `kurtosis = 3` (the Gaussian default) instead of dividing by zero.
+//! Percentile interpolation also remains exact because every value is
+//! one of `{0, 1}`.
+//!
+//! The Sarle bimodality coefficient computed by [`ErrorDistribution::is_likely_bimodal`]
+//! correctly identifies the `{0, 1}` regime as bimodal — that is the
+//! truth of the underlying distribution. Mode-detection histograms
+//! likewise return the two true modes. Detection is therefore
+//! **degraded but well-formed** under this regime; downstream
+//! interpretation of skewness / kurtosis values should be aware that
+//! the input is Bernoulli, not Gaussian.
 
 #![allow(
     clippy::cast_possible_truncation,

--- a/tests/detection/issue_1247_categorical_error_hardening.rs
+++ b/tests/detection/issue_1247_categorical_error_hardening.rs
@@ -1,0 +1,266 @@
+//! Tests for Issue #1247: harden discovery detection for `CATEGORICAL_ERROR`'s
+//! quantised `{0, 1}` output errors.
+//!
+//! Every module flagged by the #1245 audit as sensitive to the per-record
+//! error distribution must:
+//! - never return `NaN` or panic on the quantised `{0, 1}` regime,
+//! - never divide by zero on a zero-variance batch (all `0` or all `1`),
+//! - either skip cleanly with a diagnostic or produce well-formed output.
+//!
+//! These tests exercise the public API of each module directly with
+//! quantised fixtures so the contract is enforced even if the internal
+//! statistical helpers are refactored.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::detection::bimodal_neuron::detect_bimodal_neurons;
+use neat_ai_discovery::analysis::detection::monotonicity::detect_non_monotonic_neurons;
+use neat_ai_discovery::analysis::quantised_error::is_quantised_zero_one;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn make_creature(neurons: Vec<NeuronJson>, synapses: Vec<SynapseJson>) -> CreatureJson {
+    let input_count = neurons.iter().filter(|n| n.neuron_type == "input").count();
+    let output_count = neurons.iter().filter(|n| n.neuron_type == "output").count();
+    CreatureJson {
+        neurons,
+        synapses,
+        input: input_count,
+        output: output_count,
+    }
+}
+
+fn record(uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Monotonicity detector: must skip the quantised regime cleanly.
+// ---------------------------------------------------------------------------
+
+/// Hidden neuron whose recorded error vector is the `CATEGORICAL_ERROR`
+/// `{0, 1}` flag should be skipped by the monotonicity detector — rank
+/// correlation on two tied groups is meaningless and would otherwise
+/// mass-flag every `CATEGORICAL_ERROR`-driven hidden neuron.
+#[test]
+fn monotonicity_skips_quantised_zero_one_regime() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // Continuous activation paired with a quantised `{0, 1}` error
+    // series. About half the samples are misclassified.
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let activation = (i as f32) / 100.0;
+            let err = if i % 2 == 0 { 0.0 } else { 1.0 };
+            record("hidden-1", i, activation, vec![err])
+        })
+        .collect();
+
+    let candidates = detect_non_monotonic_neurons(&creature, &[("hidden-1".to_string(), records)]);
+
+    assert!(
+        candidates.is_empty(),
+        "Quantised {{0,1}} errors must skip monotonicity detection, got {} candidate(s)",
+        candidates.len(),
+    );
+}
+
+/// Even when every recorded error is `0` (or every error is `1`), the
+/// monotonicity detector must not panic or emit a NaN-bearing candidate.
+/// All-zero batches sit below the quantised regime threshold (no mass
+/// at both modes), so they fall through to the Spearman computation —
+/// which is already guarded against zero variance and returns `0.0`,
+/// causing the detector to *not* flag the neuron.
+#[test]
+fn monotonicity_handles_zero_variance_error_batch_without_nan() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    let records: Vec<DiscoverRecord> = (0..50)
+        .map(|i| record("hidden-1", i, (i as f32) / 50.0, vec![0.0]))
+        .collect();
+
+    let candidates = detect_non_monotonic_neurons(&creature, &[("hidden-1".to_string(), records)]);
+
+    for c in &candidates {
+        assert!(
+            c.monotonicity_score.is_finite(),
+            "monotonicity_score must be finite, got {}",
+            c.monotonicity_score,
+        );
+        assert!(
+            c.estimated_improvement.is_finite(),
+            "estimated_improvement must be finite, got {}",
+            c.estimated_improvement,
+        );
+    }
+}
+
+/// Hidden neuron with a *continuous* error series must still be
+/// processed by the monotonicity detector — the quantised-regime guard
+/// must not regress the existing non-monotonic detection.
+#[test]
+fn monotonicity_still_flags_continuous_non_monotonic_neuron() {
+    let creature = make_creature(
+        vec![
+            neuron("input-1", "input", "IDENTITY"),
+            neuron("hidden-1", "hidden", "LOGISTIC"),
+            neuron("output-1", "output", "IDENTITY"),
+        ],
+        vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.8),
+        ],
+    );
+
+    // V-shaped error curve: error is high at activation = 0 and
+    // activation = 1, low in the middle. Spearman rho ≈ 0.
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let act = (i as f32) / 100.0;
+            let err = (act - 0.5).abs() * 2.0;
+            record("hidden-1", i, act, vec![err])
+        })
+        .collect();
+
+    let candidates = detect_non_monotonic_neurons(&creature, &[("hidden-1".to_string(), records)]);
+
+    assert!(
+        !candidates.is_empty(),
+        "Continuous non-monotonic neuron should still be flagged (regression guard)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bimodal neuron detector: operates on `value`, not errors. Confirm that
+// the pre-activation `{0, 1}` case is handled cleanly.
+// ---------------------------------------------------------------------------
+
+/// A neuron whose pre-activation `value` is itself quantised `{0, 1}`
+/// is genuinely bimodal — the detector should either flag it cleanly
+/// or skip it cleanly, but never NaN or panic.
+#[test]
+fn bimodal_neuron_handles_quantised_pre_activation_without_nan() {
+    let neurons = vec![("bimodal-q".to_string(), "TANH".to_string(), 0.0)];
+
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let v = if i % 2 == 0 { 0.0 } else { 1.0 };
+            DiscoverRecord {
+                obs_index: i,
+                neuron_uuid: "bimodal-q".to_string(),
+                value: Some(v),
+                activation: v.tanh(),
+                errors: vec![],
+            }
+        })
+        .collect();
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("bimodal-q".to_string(), records)]);
+
+    for c in &candidates {
+        assert!(
+            c.bimodality_score.is_finite(),
+            "bimodality_score must be finite for quantised pre-activation, got {}",
+            c.bimodality_score,
+        );
+        assert!(
+            c.lower_mode_mean.is_finite(),
+            "lower_mode_mean must be finite",
+        );
+        assert!(
+            c.upper_mode_mean.is_finite(),
+            "upper_mode_mean must be finite",
+        );
+        assert!(
+            c.estimated_improvement.is_finite(),
+            "estimated_improvement must be finite, got {}",
+            c.estimated_improvement,
+        );
+    }
+}
+
+/// All pre-activations identical → no bimodality, no NaN, no panic.
+#[test]
+fn bimodal_neuron_handles_constant_value_without_nan() {
+    let neurons = vec![("constant".to_string(), "TANH".to_string(), 0.0)];
+
+    let records: Vec<DiscoverRecord> = (0..40)
+        .map(|i| DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: "constant".to_string(),
+            value: Some(0.5),
+            activation: 0.5_f32.tanh(),
+            errors: vec![],
+        })
+        .collect();
+
+    let candidates = detect_bimodal_neurons(&neurons, &[("constant".to_string(), records)]);
+
+    // Should not flag, but if it does, the values must still be finite.
+    for c in &candidates {
+        assert!(c.bimodality_score.is_finite());
+        assert!(c.estimated_improvement.is_finite());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// quantised_error helper used to drive the gating.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantised_helper_recognises_balanced_categorical_error_batch() {
+    let errors: Vec<f32> = (0..40)
+        .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+        .collect();
+    assert!(is_quantised_zero_one(&errors));
+}
+
+#[test]
+fn quantised_helper_rejects_continuous_residuals() {
+    let errors: Vec<f32> = (0..40).map(|i| (i as f32) * 0.01).collect();
+    assert!(!is_quantised_zero_one(&errors));
+}

--- a/tests/detection/main.rs
+++ b/tests/detection/main.rs
@@ -3,6 +3,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod issue_1247_categorical_error_hardening;
 mod issue_1250_implied_target_cost_hint;
 mod issue_341_dead_neuron_detection;
 mod issue_342_saturated_neuron_detection;

--- a/tests/recommendation/issue_1247_categorical_error_hardening.rs
+++ b/tests/recommendation/issue_1247_categorical_error_hardening.rs
@@ -1,0 +1,307 @@
+//! Tests for Issue #1247: harden the sample-weighted and fan-in
+//! recommendation paths against `CATEGORICAL_ERROR`'s quantised
+//! `{0, 1}` error regime.
+
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use neat_ai_discovery::analysis::recommendation::fan_in::detect_fan_in_candidates;
+use neat_ai_discovery::analysis::recommendation::sample_weighted::{
+    SampleWeightedConfig, compute_sample_weights, detect_high_error_neurons, stratify_samples,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_records(neuron_uuid: &str, errors: &[f32]) -> Vec<DiscoverRecord> {
+    errors
+        .iter()
+        .enumerate()
+        .map(|(i, &err)| DiscoverRecord {
+            obs_index: i as u32,
+            neuron_uuid: neuron_uuid.to_string(),
+            value: Some(0.5),
+            activation: 0.5,
+            errors: vec![err],
+        })
+        .collect()
+}
+
+/// Quantised `{0, 1}` errors must produce well-formed sample weights —
+/// finite, non-negative, and summing to approximately 1.0 — instead of
+/// NaN or division-by-zero artefacts.
+#[test]
+fn sample_weights_finite_for_quantised_errors() {
+    let errors: Vec<f32> = (0..40)
+        .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+        .collect();
+    let records = make_records("hidden-1", &errors);
+
+    let weights = compute_sample_weights(&records);
+
+    assert_eq!(weights.len(), records.len());
+    let total: f32 = weights.iter().sum();
+    assert!(
+        total.is_finite(),
+        "weight total must be finite, got {total}"
+    );
+    assert!(
+        (total - 1.0).abs() < 1e-4,
+        "weights must sum to 1.0, got {total}",
+    );
+    for (i, &w) in weights.iter().enumerate() {
+        assert!(w.is_finite(), "weight[{i}] is not finite: {w}");
+        assert!(w >= 0.0, "weight[{i}] is negative: {w}");
+    }
+}
+
+/// All-zero quantised batch (every sample correctly classified) must
+/// fall back to uniform weights without producing NaN or panicking.
+#[test]
+fn sample_weights_uniform_for_all_zero_errors() {
+    let records = make_records("hidden-1", &[0.0_f32; 32]);
+    let weights = compute_sample_weights(&records);
+
+    assert_eq!(weights.len(), 32);
+    let expected = 1.0 / 32.0;
+    for (i, &w) in weights.iter().enumerate() {
+        assert!(w.is_finite(), "weight[{i}] not finite: {w}");
+        assert!(
+            (w - expected).abs() < 1e-5,
+            "weight[{i}] = {w}, expected {expected}",
+        );
+    }
+}
+
+/// Stratification on a quantised `{0, 1}` batch must still produce
+/// finite means and a finite hard-to-easy ratio — even though the
+/// ratio is technically unbounded when every "easy" sample has zero
+/// error.
+#[test]
+fn stratify_handles_quantised_errors_without_nan() {
+    let errors: Vec<f32> = (0..40).map(|i| if i < 20 { 0.0 } else { 1.0 }).collect();
+    let records = make_records("hidden-1", &errors);
+
+    let stratified = stratify_samples(&records);
+
+    assert!(
+        stratified.easy_mean_error.is_finite(),
+        "easy_mean_error must be finite, got {}",
+        stratified.easy_mean_error,
+    );
+    assert!(
+        stratified.hard_mean_error.is_finite(),
+        "hard_mean_error must be finite, got {}",
+        stratified.hard_mean_error,
+    );
+    assert!(
+        stratified.hard_to_easy_ratio.is_finite(),
+        "hard_to_easy_ratio must be finite, got {}",
+        stratified.hard_to_easy_ratio,
+    );
+    assert!(
+        !stratified.easy_samples.is_empty(),
+        "stratification should populate the easy bucket",
+    );
+    assert!(
+        !stratified.hard_samples.is_empty(),
+        "stratification should populate the hard bucket",
+    );
+}
+
+/// All-zero (zero-variance) quantised batch must stratify cleanly via
+/// the existing "all values equal median" fallback rather than panic.
+#[test]
+fn stratify_handles_all_zero_error_batch() {
+    let records = make_records("hidden-1", &[0.0_f32; 20]);
+    let stratified = stratify_samples(&records);
+
+    assert!(stratified.easy_mean_error.is_finite());
+    assert!(stratified.hard_mean_error.is_finite());
+    assert!(stratified.hard_to_easy_ratio.is_finite());
+}
+
+// ---------------------------------------------------------------------------
+// fan-in detector — least-squares improvement against `{0, 1}` errors must
+// stay finite (and non-negative) even though the magnitude is bounded by
+// the misclassification count rather than the network's loss.
+// ---------------------------------------------------------------------------
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn record_with_value(
+    uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    errors: Vec<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+fn make_fan_in_creature() -> CreatureJson {
+    let neurons = vec![
+        neuron("input-a", "input", "IDENTITY"),
+        neuron("input-b", "input", "IDENTITY"),
+        neuron("output-0", "output", "IDENTITY"),
+    ];
+    let synapses = vec![
+        synapse("input-a", "output-0", 0.1),
+        synapse("input-b", "output-0", 0.1),
+    ];
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 2,
+        output: 1,
+    }
+}
+
+/// Quantised `CATEGORICAL_ERROR`-shaped errors on the output target
+/// must not produce NaN or panic anywhere in the fan-in pipeline. The
+/// least-squares improvement may be small but it must stay finite and
+/// non-negative.
+#[test]
+fn fan_in_handles_quantised_errors_without_nan() {
+    let creature = make_fan_in_creature();
+
+    let mut neuron_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for uuid in ["input-a", "input-b", "output-0"] {
+        let recs: Vec<DiscoverRecord> = (0..50)
+            .map(|i| {
+                let phase = (i as f32) * 0.21;
+                let act = match uuid {
+                    "input-a" => phase.sin(),
+                    "input-b" => (phase * 1.7).cos(),
+                    _ => 0.1 * phase.sin(),
+                };
+                let errors = if uuid == "output-0" {
+                    vec![if i % 2 == 0 { 0.0 } else { 1.0 }]
+                } else {
+                    vec![]
+                };
+                record_with_value(uuid, i, act, errors)
+            })
+            .collect();
+        neuron_records.push((uuid.to_string(), recs));
+    }
+
+    let candidates = detect_fan_in_candidates(&creature, &neuron_records);
+
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement.is_finite(),
+            "fan-in estimated_improvement must be finite, got {}",
+            c.estimated_improvement,
+        );
+        assert!(
+            c.estimated_improvement >= 0.0,
+            "fan-in estimated_improvement must be non-negative, got {}",
+            c.estimated_improvement,
+        );
+        for &w in &c.input_weights {
+            assert!(w.is_finite(), "fan-in input weight must be finite, got {w}");
+        }
+    }
+}
+
+/// All-zero (zero-variance) output errors must produce zero candidates
+/// without panicking — the existing `sum_act_sq < 1e-10` and
+/// per-target-error guards keep the pipeline well-formed.
+#[test]
+fn fan_in_handles_all_zero_output_errors() {
+    let creature = make_fan_in_creature();
+
+    let mut neuron_records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for uuid in ["input-a", "input-b", "output-0"] {
+        let recs: Vec<DiscoverRecord> = (0..50)
+            .map(|i| {
+                let phase = (i as f32) * 0.21;
+                let act = match uuid {
+                    "input-a" => phase.sin(),
+                    "input-b" => (phase * 1.7).cos(),
+                    _ => 0.0,
+                };
+                let errors = if uuid == "output-0" {
+                    vec![0.0]
+                } else {
+                    vec![]
+                };
+                record_with_value(uuid, i, act, errors)
+            })
+            .collect();
+        neuron_records.push((uuid.to_string(), recs));
+    }
+
+    let candidates = detect_fan_in_candidates(&creature, &neuron_records);
+
+    // No candidate should be emitted (no error signal), and any that
+    // happen to be emitted must still be finite.
+    for c in &candidates {
+        assert!(
+            c.estimated_improvement.is_finite(),
+            "estimated_improvement must be finite, got {}",
+            c.estimated_improvement,
+        );
+    }
+}
+
+/// End-to-end: `detect_high_error_neurons` on quantised input must
+/// produce candidates whose every numeric field is finite. The
+/// detector's `weighted_mean_error` collapses to the misclassification
+/// rate under the regime, which is a valid ranking signal.
+#[test]
+fn detect_high_error_neurons_finite_under_quantised_regime() {
+    let errors: Vec<f32> = (0..40)
+        .map(|i| if i % 2 == 0 { 0.0 } else { 1.0 })
+        .collect();
+    let records = make_records("hidden-1", &errors);
+    let config = SampleWeightedConfig {
+        // Lower the threshold so the misclassification-rate signal
+        // (≈0.5 under a 50/50 quantised batch) is above the gate.
+        min_weighted_error: 0.1,
+        min_samples: 10,
+    };
+
+    let candidates = detect_high_error_neurons(&[("hidden-1".to_string(), records)], &config);
+
+    for c in &candidates {
+        assert!(
+            c.weighted_mean_error.is_finite(),
+            "weighted_mean_error must be finite, got {}",
+            c.weighted_mean_error,
+        );
+        assert!(
+            c.high_error_proportion.is_finite(),
+            "high_error_proportion must be finite",
+        );
+        assert!(
+            c.hard_to_easy_ratio.is_finite(),
+            "hard_to_easy_ratio must be finite",
+        );
+        assert!(
+            c.estimated_improvement.is_finite(),
+            "estimated_improvement must be finite, got {}",
+            c.estimated_improvement,
+        );
+    }
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -4,6 +4,7 @@
 mod common;
 
 mod issue_1059_disable_batch_successful;
+mod issue_1247_categorical_error_hardening;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;

--- a/tests/scoring/issue_1247_categorical_error_hardening.rs
+++ b/tests/scoring/issue_1247_categorical_error_hardening.rs
@@ -1,0 +1,118 @@
+//! Tests for Issue #1247: harden `ErrorDistribution` and mode detection
+//! against the quantised `{0, 1}` regime produced by `CATEGORICAL_ERROR`.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::samples::HelpfulSample;
+use neat_ai_discovery::analysis::scoring::error_distribution::{
+    ErrorDistribution, detect_error_modes,
+};
+
+fn make_sample(error: f32) -> HelpfulSample {
+    HelpfulSample {
+        activation: 0.5,
+        avg_error: error,
+        target_value: None,
+        target_activation: None,
+    }
+}
+
+/// Distribution statistics on a balanced quantised `{0, 1}` batch must
+/// be entirely finite — no NaN from `0/0`, no `Inf` from a zero
+/// denominator.
+#[test]
+fn distribution_stats_finite_for_quantised_zero_one_batch() {
+    let samples: Vec<HelpfulSample> = (0..100)
+        .map(|i| make_sample(if i % 2 == 0 { 0.0 } else { 1.0 }))
+        .collect();
+
+    let dist = ErrorDistribution::from_samples(&samples)
+        .expect("distribution should be computed for non-empty samples");
+
+    assert!(dist.mean.is_finite(), "mean must be finite: {}", dist.mean);
+    assert!(dist.std_dev.is_finite(), "std_dev must be finite");
+    assert!(dist.variance.is_finite(), "variance must be finite");
+    assert!(dist.skewness.is_finite(), "skewness must be finite");
+    assert!(dist.kurtosis.is_finite(), "kurtosis must be finite");
+    for (i, p) in dist.percentiles.iter().enumerate() {
+        assert!(p.is_finite(), "percentile[{i}] must be finite: {p}");
+    }
+    assert!(dist.iqr.is_finite(), "iqr must be finite");
+
+    // Bernoulli(0.5) variance should be near 0.25 — sanity check that
+    // we are not silently returning zero.
+    assert!(
+        (dist.variance - 0.25).abs() < 0.05,
+        "Bernoulli(0.5) variance ≈ 0.25, got {}",
+        dist.variance,
+    );
+}
+
+/// Zero-variance batches (all-zero or all-one error) must not divide
+/// by zero. Skewness defaults to `0.0` and kurtosis to `3.0`.
+#[test]
+fn distribution_stats_safe_for_zero_variance_batch() {
+    for constant in [0.0_f32, 1.0_f32] {
+        let samples = vec![make_sample(constant); 32];
+        let dist = ErrorDistribution::from_samples(&samples)
+            .expect("non-empty sample should produce a distribution");
+
+        assert!(dist.mean.is_finite());
+        assert_eq!(dist.std_dev, 0.0);
+        assert_eq!(dist.variance, 0.0);
+        // Guard kicks in: skewness becomes 0, kurtosis defaults to 3.
+        assert_eq!(dist.skewness, 0.0);
+        assert!(dist.kurtosis.is_finite());
+    }
+}
+
+/// `is_likely_bimodal()` must give a finite answer (no NaN) on the
+/// quantised regime. The true distribution *is* bimodal, so flagging
+/// it is correct, but the contract here is purely that the function
+/// returns without panicking and never feeds NaN downstream.
+#[test]
+fn is_likely_bimodal_does_not_panic_on_quantised_batch() {
+    let samples: Vec<HelpfulSample> = (0..40)
+        .map(|i| make_sample(if i % 2 == 0 { 0.0 } else { 1.0 }))
+        .collect();
+    let dist = ErrorDistribution::from_samples(&samples).expect("distribution must compute");
+
+    let _ = dist.is_likely_bimodal();
+}
+
+/// Mode detection on a quantised `{0, 1}` batch must return modes whose
+/// numeric fields are all finite. We do not assert on the exact mode
+/// count — the histogram-based detector may collapse two adjacent
+/// bins into one or skip a bin under its "≥3 samples" guard — but
+/// whichever modes it returns must be well-formed.
+#[test]
+fn detect_error_modes_finite_for_quantised_batch() {
+    let samples: Vec<HelpfulSample> = (0..40)
+        .map(|i| make_sample(if i % 2 == 0 { 0.0 } else { 1.0 }))
+        .collect();
+
+    let modes = detect_error_modes(&samples);
+
+    for (i, m) in modes.iter().enumerate() {
+        assert!(m.centre.is_finite(), "mode[{i}].centre must be finite");
+        assert!(m.std_dev.is_finite(), "mode[{i}].std_dev must be finite");
+        assert!(
+            m.proportion.is_finite(),
+            "mode[{i}].proportion must be finite",
+        );
+        assert!(m.proportion >= 0.0 && m.proportion <= 1.0);
+    }
+}
+
+/// `count_outliers` and `filter_outliers` must not produce NaN
+/// thresholds on a constant batch — `percentile = constant`, the
+/// `.abs() > threshold.abs()` filter is well-defined.
+#[test]
+fn outlier_counting_safe_on_constant_batch() {
+    let samples = vec![make_sample(0.0); 32];
+    let dist =
+        ErrorDistribution::from_samples(&samples).expect("constant batch must produce a dist");
+
+    let outliers = dist.count_outliers(&samples, 90);
+    assert_eq!(outliers, 0, "constant batch should report zero outliers");
+}

--- a/tests/scoring/main.rs
+++ b/tests/scoring/main.rs
@@ -7,6 +7,7 @@ mod cross_validation_test;
 mod issue_1056_logistic_prediction_calibration;
 mod issue_1112_saturation_prediction_discount;
 mod issue_1203_adaptive_staleness_window;
+mod issue_1247_categorical_error_hardening;
 mod issue_192_error_distribution_analysis;
 mod issue_465_candidate_outcome_cache;
 mod issue_465_source_type_scoring;


### PR DESCRIPTION
## Summary

Hardened the distribution-sensitive discovery modules flagged by the
#1245 audit against `CATEGORICAL_ERROR`'s quantised `{0, 1}` output
errors so the pipeline produces well-formed candidates instead of
NaN-bearing or mass-flagged ones. Closes #1247.

### What changed

- **New** `src/analysis/quantised_error.rs` — runtime predicate
  `is_quantised_zero_one(errors: &[f32]) -> bool` that detects the
  Bernoulli-style regime (every finite entry ≈ `0` or `1`, with at
  least 5 % mass at each mode). Used by detectors that must skip the
  regime.
- **Guarded** `src/analysis/detection/monotonicity.rs` — neurons whose
  recorded errors are quantised `{0, 1}` are skipped, because Spearman
  rank correlation on two tied groups would otherwise mass-flag every
  CATEGORICAL_ERROR-driven hidden neuron as non-monotonic.
- **Documented degraded-but-well-formed behaviour** in
  `error_distribution.rs`, `sample_weighted.rs`, `fan_in.rs`, and
  `bimodal_neuron.rs`. The existing `is_finite` / `variance > eps`
  guards already prevent NaN and division-by-zero — the doc comments
  capture *what* the modules report on Bernoulli input so callers know
  not to mis-interpret the numbers.
- **`docs/COST_FUNCTION_NOTES.md`** updated to record the #1247
  resolution under §6.

### Why guard monotonicity but not the others?

`monotonicity.rs` consumes the error series ordinally — ranks collapse
under `{0, 1}` and the detector emits false positives. The other four
modules consume errors as magnitudes, weights, or moment-based
statistics that remain well-formed under Bernoulli input (the variance
is `p(1−p)`, the skewness has a closed form, etc.). Skipping them
would lose useful ranking signal; documenting the degraded
interpretation preserves it.

## Evidence

This is a backend-only change with no UI to screenshot.

- All new tests pass: 7 detection + 7 recommendation + 5 scoring +
  13 unit tests inside `analysis::quantised_error`.
- Existing `tests/cost_compatibility/end_to_end.rs` already covers the
  full `record_discovery → analyze_parallel` pipeline for
  `CATEGORICAL_ERROR` (including a dedicated quantised `{0, 1}`
  variance test from #1246 acceptance criterion #6), and the existing
  `tests/detection/issue_643_activation_error_monotonicity.rs` suite
  still passes — the new guard does not regress continuous-error
  detection.
- `./quality.sh < /dev/null` passes.

```mermaid
flowchart LR
    A["DiscoverRecord.errors[]"] --> B{"is_quantised_zero_one?"}
    B -- "yes (CATEGORICAL_ERROR)" --> C["monotonicity.rs: skip neuron"]
    B -- "no (continuous)" --> D["monotonicity.rs: Spearman rho"]
    B -. "doc-noted regime" .-> E["error_distribution / sample_weighted /<br/>fan_in / bimodal_neuron<br/>(well-formed output)"]
```

## Test Plan

- `tests/detection/issue_1247_categorical_error_hardening.rs`
  - `monotonicity_skips_quantised_zero_one_regime`
  - `monotonicity_handles_zero_variance_error_batch_without_nan`
  - `monotonicity_still_flags_continuous_non_monotonic_neuron`
    (regression guard for the new guard)
  - `bimodal_neuron_handles_quantised_pre_activation_without_nan`
  - `bimodal_neuron_handles_constant_value_without_nan`
  - `quantised_helper_recognises_balanced_categorical_error_batch`
  - `quantised_helper_rejects_continuous_residuals`
- `tests/recommendation/issue_1247_categorical_error_hardening.rs`
  - `sample_weights_finite_for_quantised_errors`
  - `sample_weights_uniform_for_all_zero_errors`
  - `stratify_handles_quantised_errors_without_nan`
  - `stratify_handles_all_zero_error_batch`
  - `fan_in_handles_quantised_errors_without_nan`
  - `fan_in_handles_all_zero_output_errors`
  - `detect_high_error_neurons_finite_under_quantised_regime`
- `tests/scoring/issue_1247_categorical_error_hardening.rs`
  - `distribution_stats_finite_for_quantised_zero_one_batch`
  - `distribution_stats_safe_for_zero_variance_batch`
  - `is_likely_bimodal_does_not_panic_on_quantised_batch`
  - `detect_error_modes_finite_for_quantised_batch`
  - `outlier_counting_safe_on_constant_batch`
- `src/analysis/quantised_error.rs` — 13 inline unit tests covering
  detector boundary conditions (empty, all-zero, all-one, balanced,
  unbalanced, single-outlier, continuous, signed-residual,
  non-finite-mixed, round-off-tolerance, custom-fraction).
- `./quality.sh < /dev/null` — full quality gate green.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1247 -->