### PR TITLE
docs: document supported cost functions and cost-agnostic invariants (#1248)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.62"
+version = "0.74.63"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/README.md
+++ b/README.md
@@ -126,6 +126,32 @@ the discovery optimisation is skipped.
 For GPU performance tuning, troubleshooting, and debugging, see
 [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md).
 
+## 🎚️ Supported Cost Functions
+
+NEAT-AI-Discovery is **cost-agnostic by construction** — the analysis pipeline
+consumes the per-neuron residuals captured in `DiscoverRecord.errors` and never
+references NEAT-AI's configured cost function by name. Every NEAT-AI built-in
+cost is supported:
+
+| Cost | Per-output residual semantics | Discovery support |
+|------|--------------------------------|-------------------|
+| `MSE` | linear residual (`target − output`) | ✅ reference contract |
+| `MAE` | linear residual via the `|·|` chain rule | ✅ supported |
+| `MAPE` | percentage residual `(target − output)/|target|` | ✅ supported (Issue #1250 gates non-linear-residual sites) |
+| `MSLE` | `log(1+target) − log(1+output)` on `target ≥ 0` | ✅ supported (Issue #1250 gates non-linear-residual sites) |
+| `HINGE` | `max(0, 1 − y·ŷ) · −y` — zero on margined samples | ⚠️ supported, residual sums under-report neuron error on sparse hinge errors |
+| `CROSS_ENTROPY` | soft-max gradient `output − target` (linear) | ✅ supported |
+| `CATEGORICAL_ERROR` | quantised misclassification flag `{0, 1}` | ⚠️ supported with degraded distribution stats (Issue #1247 hardening) |
+
+> [!NOTE]
+> 📐 Where discovery reports an "expected improvement" it is **sum-of-squared
+> residual (SSE) reduction** computed from the per-neuron `errors` slot. SSE
+> equals the network's loss reduction exactly only when NEAT-AI's cost is
+> `MSE`; under the other six costs it is a useful ranking signal but not the
+> configured loss reduction. See [docs/COST_FUNCTION_NOTES.md](docs/COST_FUNCTION_NOTES.md)
+> for the per-consumer audit, the cost-agnostic invariants, and the checklist
+> for adding a new cost to NEAT-AI.
+
 ## 🔬 Discovery → Evolution Pipeline
 
 The discovery process works as follows:
@@ -534,6 +560,7 @@ graph TD
 | [docs/ANALYSIS_DEEP_DIVE.md](docs/ANALYSIS_DEEP_DIVE.md) | Detailed analysis workflow and detection algorithms |
 | [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) | GPU performance tuning, troubleshooting, and debugging |
 | [docs/FFI_API.md](docs/FFI_API.md) | Full FFI API reference and JSON interface |
+| [docs/COST_FUNCTION_NOTES.md](docs/COST_FUNCTION_NOTES.md) | Cost-agnostic invariants, per-cost behaviour catalogue, and per-consumer audit |
 | [docs/STREAMING_GUIDE.md](docs/STREAMING_GUIDE.md) | Step-by-step streaming recording API guide with TypeScript examples |
 | [docs/CACHE_TUNING.md](docs/CACHE_TUNING.md) | Cache tier tuning, diagnostics, and example configurations |
 | [docs/BENCHMARKS.md](docs/BENCHMARKS.md) | Benchmark regression tracking and comparison workflow |

--- a/docs/DISCOVERY_TYPES.md
+++ b/docs/DISCOVERY_TYPES.md
@@ -104,6 +104,38 @@ graph LR
     style TS fill:#eaf2f8,stroke:#3498db,color:#333
 ```
 
+### 🎚️ Cost-Function Compatibility
+
+Every discovery type listed below is **cost-agnostic by construction** — it
+consumes the per-neuron residuals from `DiscoverRecord.errors` rather than
+NEAT-AI's configured cost function. All seven NEAT-AI built-in cost functions
+are supported:
+
+`MSE`, `MAE`, `MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`, `CATEGORICAL_ERROR`.
+
+Where individual modules report an "expected improvement" the number is
+**sum-of-squared residual (SSE) reduction** computed against the recorded
+residuals. SSE reduction equals the network's actual loss reduction only when
+the cost is `MSE`; under the other six costs it is a useful ranking signal but
+not the configured loss reduction.
+
+Two per-cost caveats are worth flagging here:
+
+- `CATEGORICAL_ERROR` produces quantised `{0, 1}` residuals — distribution-
+  sensitive detectors (`bimodal_neuron`, `sample_weighted`, `fan_in`,
+  `monotonicity`, `error_distribution`) have been hardened for this regime
+  (Issue #1247). `monotonicity` explicitly skips affected neurons via
+  `analysis::quantised_error::is_quantised_zero_one`.
+- The two `activation + error ≈ target` reconstruction sites
+  (`output_squash_mismatch`, `high_error_squash_exploration`) accept a
+  `CostFunctionHint` and gate themselves off for non-linear-residual costs
+  (`MAPE`, `MSLE`, `HINGE`, `CATEGORICAL_ERROR`) when the caller passes one
+  (Issue #1250).
+
+For the full per-consumer audit, the per-cost validity matrix, and the
+checklist for adding a new cost to NEAT-AI, see
+[COST_FUNCTION_NOTES.md](COST_FUNCTION_NOTES.md).
+
 ---
 
 ## 📋 Discovery Type Summary

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -489,6 +489,48 @@ if (estimatedBytes > FLUSH_THRESHOLD) {
 - **No mixing**: Never mix data from different training records within a single discovery record write
 - **Matching by obs_index**: TypeScript matches records across neurons by `obs_index` (not by array position)
 
+### 🎚️ Cost-Agnostic Error Contract
+
+The `errors` array on each recorded neuron row is the **per-neuron residual**
+that NEAT-AI's cost function produced for that output neuron on that training
+record. Discovery is **cost-agnostic by construction** — it consumes the
+residuals and never inspects which cost function NEAT-AI is using. All seven
+built-in NEAT-AI costs are supported:
+
+- `MSE`, `MAE`, `MAPE`, `MSLE`, `HINGE`, `CROSS_ENTROPY`, `CATEGORICAL_ERROR`
+
+A new NEAT-AI cost is compatible with discovery as long as it preserves these
+invariants:
+
+1. **One error slot per output neuron.** `errors.len()` equals the number of
+   output neurons of the network for output records, and is otherwise empty.
+2. **Finite errors mean "this observation contributed to the loss."** A
+   non-finite (`NaN`/`±∞`) entry is treated as "skip this observation" by every
+   consumer.
+3. **Zero error means "perfect prediction at this sample."** Consumers that
+   sum or square errors assume `0` carries no information.
+4. **Magnitude is monotonically related to "how wrong" the network was.**
+   Bigger `|error|` ⇒ worse prediction.
+5. **`errors[i]` is well-defined for the i-th output neuron and only that
+   neuron.** Cross-output indexing is not supported.
+
+Per-cost caveats — these are well-understood and have callouts in the relevant
+modules:
+
+- `CATEGORICAL_ERROR` carries no sign information and quantises `errors[i]` to
+  `{0, 1}`; SSE-based "expected improvement" values are valid for ranking but
+  not for absolute loss reduction (Issue #1247 hardening; see `monotonicity.rs`
+  for the explicit `is_quantised_zero_one` gate).
+- `HINGE` is sparse at zero on correctly-margined samples — mean residual
+  consumers under-report neuron error.
+- `MAPE` and `MSLE` are non-linear residuals; the two `activation + error ≈
+  target` sites are gated off when callers pass a
+  `CostFunctionHint::NonLinearResidual` (Issue #1250).
+
+See [COST_FUNCTION_NOTES.md](COST_FUNCTION_NOTES.md) for the per-consumer
+audit, the per-cost validity matrix, and the checklist for adding a new cost
+to NEAT-AI.
+
 ### ➡️ Forward-only Activation Order (no feedback)
 
 Discovery assumes **forward-only** networks (no recurrent feedback). This is critical for both recording and for applying discovery candidates:

--- a/docs/archive/pr-summaries/pr-summary-1248.md
+++ b/docs/archive/pr-summaries/pr-summary-1248.md
@@ -1,0 +1,64 @@
+## Summary
+
+Updated the public-facing discovery documentation to reflect which NEAT-AI
+cost functions discovery supports and to make the cost-agnostic contract
+explicit. The discovery pipeline already consumes per-neuron residuals
+rather than the configured cost — this PR documents that contract so callers
+know what they are getting. Closes #1248.
+
+The four `docs/discoveries/*.md` files that previously claimed
+"reduction in MSE" were already reworded by #1251 (the audit-delivery
+follow-up); this PR completes the documentation pass by:
+
+- Adding a "Supported cost functions" section to `README.md` listing all
+  seven NEAT-AI built-in costs and noting that discovery is cost-agnostic by
+  construction.
+- Documenting the cost-agnostic error contract in `docs/FFI_API.md` with the
+  five invariants from `COST_FUNCTION_NOTES.md §2` and a brief per-cost
+  caveat callout.
+- Adding a "Cost-Function Compatibility" subsection to the
+  `docs/DISCOVERY_TYPES.md` overview, linking to `COST_FUNCTION_NOTES.md`.
+- Adding a `docs/COST_FUNCTION_NOTES.md` entry to the README's
+  *Additional Documentation* index.
+
+## Evidence
+
+Docs-only change — no code paths affected.
+
+```mermaid
+flowchart LR
+    A["NEAT-AI Cost<br/>(MSE/MAE/MAPE/MSLE/<br/>HINGE/CE/CAT_ERR)"] --> B["DiscoverRecord.errors<br/>(per-neuron residual)"]
+    B --> C["Discovery consumers<br/>(RESIDUAL / MAGNITUDE / SQUARED / DISTRIBUTION / PRESENCE)"]
+    C --> D["Mutation candidates<br/>(cost-agnostic by construction)"]
+```
+
+`markdownlint-cli2` run on the touched files reports `0 error(s)` across all
+59 monitored markdown files.
+
+Files updated:
+
+- `README.md` — new `🎚️ Supported Cost Functions` section plus
+  `COST_FUNCTION_NOTES.md` entry in the *Additional Documentation* table.
+- `docs/FFI_API.md` — new `🎚️ Cost-Agnostic Error Contract` subsection under
+  *Critical Requirements*, listing the five invariants and per-cost caveats,
+  with a link to `COST_FUNCTION_NOTES.md`.
+- `docs/DISCOVERY_TYPES.md` — new `🎚️ Cost-Function Compatibility` subsection
+  under *Overview*, with the supported cost list and a link to
+  `COST_FUNCTION_NOTES.md`.
+
+Cross-referenced against `docs/COST_FUNCTION_NOTES.md` §2 (cost-agnostic
+invariants), §4 (per-cost behaviour summary), and §6 (concrete bugs surfaced
+by the audit, including Issue #1247 and Issue #1250 cited in the new callouts).
+
+## Test Plan
+
+- [x] `markdownlint-cli2 < /dev/null` — 0 errors across all 59 monitored
+      `.md` files.
+- [x] Spot-checked the updated files for Mermaid block integrity: no fenced
+      ` ```mermaid ` blocks were modified.
+- [x] Australian English spelling verified across the added prose (no
+      `analyze` / `color` / `behavior` / `favor` / `minimize` / `maximize` /
+      `optimize` / `organiz` / `defens` matches in the diff).
+- [x] Verified the existing rewordings from #1251 in `add-neuron.md`,
+      `add-synapse.md`, `redundant-path.md`, and `output-bias-drift.md`
+      remain consistent with the new top-level wording.


### PR DESCRIPTION
## Summary

Updated the public-facing discovery documentation to reflect which NEAT-AI
cost functions discovery supports and to make the cost-agnostic contract
explicit. The discovery pipeline already consumes per-neuron residuals
rather than the configured cost — this PR documents that contract so callers
know what they are getting. Closes #1248.

The four `docs/discoveries/*.md` files that previously claimed
"reduction in MSE" were already reworded by #1251 (the audit-delivery
follow-up); this PR completes the documentation pass by:

- Adding a "Supported cost functions" section to `README.md` listing all
  seven NEAT-AI built-in costs and noting that discovery is cost-agnostic by
  construction.
- Documenting the cost-agnostic error contract in `docs/FFI_API.md` with the
  five invariants from `COST_FUNCTION_NOTES.md §2` and a brief per-cost
  caveat callout.
- Adding a "Cost-Function Compatibility" subsection to the
  `docs/DISCOVERY_TYPES.md` overview, linking to `COST_FUNCTION_NOTES.md`.
- Adding a `docs/COST_FUNCTION_NOTES.md` entry to the README's
  *Additional Documentation* index.

## Evidence

Docs-only change — no code paths affected.

```mermaid
flowchart LR
    A["NEAT-AI Cost<br/>(MSE/MAE/MAPE/MSLE/<br/>HINGE/CE/CAT_ERR)"] --> B["DiscoverRecord.errors<br/>(per-neuron residual)"]
    B --> C["Discovery consumers<br/>(RESIDUAL / MAGNITUDE / SQUARED / DISTRIBUTION / PRESENCE)"]
    C --> D["Mutation candidates<br/>(cost-agnostic by construction)"]
```

`markdownlint-cli2` run on the touched files reports `0 error(s)` across all
59 monitored markdown files.

Files updated:

- `README.md` — new `🎚️ Supported Cost Functions` section plus
  `COST_FUNCTION_NOTES.md` entry in the *Additional Documentation* table.
- `docs/FFI_API.md` — new `🎚️ Cost-Agnostic Error Contract` subsection under
  *Critical Requirements*, listing the five invariants and per-cost caveats,
  with a link to `COST_FUNCTION_NOTES.md`.
- `docs/DISCOVERY_TYPES.md` — new `🎚️ Cost-Function Compatibility` subsection
  under *Overview*, with the supported cost list and a link to
  `COST_FUNCTION_NOTES.md`.

Cross-referenced against `docs/COST_FUNCTION_NOTES.md` §2 (cost-agnostic
invariants), §4 (per-cost behaviour summary), and §6 (concrete bugs surfaced
by the audit, including Issue #1247 and Issue #1250 cited in the new callouts).

## Test Plan

- [x] `markdownlint-cli2 < /dev/null` — 0 errors across all 59 monitored
      `.md` files.
- [x] Spot-checked the updated files for Mermaid block integrity: no fenced
      ` ```mermaid ` blocks were modified.
- [x] Australian English spelling verified across the added prose (no
      `analyze` / `color` / `behavior` / `favor` / `minimize` / `maximize` /
      `optimize` / `organiz` / `defens` matches in the diff).
- [x] Verified the existing rewordings from #1251 in `add-neuron.md`,
      `add-synapse.md`, `redundant-path.md`, and `output-bias-drift.md`
      remain consistent with the new top-level wording.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1248 -->