### PR TITLE
fix: gate SSE-improvement scoring off for CATEGORICAL_ERROR (#1249)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.62"
+version = "0.74.63"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/COST_FUNCTION_NOTES.md
+++ b/docs/COST_FUNCTION_NOTES.md
@@ -95,8 +95,8 @@ Classifications:
 |-----------|-----------|-------|-----|-----|------|------|-------|----|---------|
 | `compound_degradation.rs:171` | `errors.sum / n` | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
 | `compound_degradation.rs:248` | `r.errors.first()` per obs | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
-| `compound_degradation.rs:277` | `Σ e²` (baseline SSE) | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
-| `compound_degradation.rs:282` | `(err − Δw·act)²` corrected SSE | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
+| `compound_degradation.rs:277` | `Σ e²` (baseline SSE) | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
+| `compound_degradation.rs:282` | `(err − Δw·act)²` corrected SSE | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
 | `correlated_error.rs:110` | `!errors.is_empty()` | PRESENCE | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `correlated_error.rs:128` | `errors.first()` for correlation | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
 | `error_plateau.rs:124` | `errors.first()` raw | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
@@ -138,8 +138,8 @@ Classifications:
 |-----------|-----------|-------|-----|-----|------|------|-------|----|---------|
 | `fan_in.rs:139` | presence | PRESENCE | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `fan_in.rs:156-157` | obs→error map | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-| `fan_in.rs:372` | `original_sse = Σ e²` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
-| `fan_in.rs:373-382` | residual SSE post-fit | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
+| `fan_in.rs:372` | `original_sse = Σ e²` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
+| `fan_in.rs:373-382` | residual SSE post-fit | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
 | `sample_weighted.rs:111-114` | mean error per record | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
 | `sample_weighted.rs:155-159` | mean error, then `.abs()` | RESIDUAL→MAGNITUDE | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
 | `sample_weighted.rs:258-262` | same pattern | RESIDUAL→MAGNITUDE | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
@@ -150,8 +150,8 @@ Classifications:
 | `output_bias_drift.rs:105` | `errors.first()` mean drift | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
 | `batch_successful/detection.rs:70` | presence | PRESENCE | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `batch_successful/detection.rs:100-101` | obs→error map | RESIDUAL | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ❌ |
-| `batch_successful/detection.rs:189` | `original_sse = Σ e²` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
-| `batch_successful/detection.rs:194-203` | `improvement = 1 − residual_sse/original_sse` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
+| `batch_successful/detection.rs:189` | `original_sse = Σ e²` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
+| `batch_successful/detection.rs:194-203` | `improvement = 1 − residual_sse/original_sse` | SQUARED | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ gated (#1249) |
 
 ### 3.3 `src/analysis/scoring/`
 
@@ -282,7 +282,18 @@ Concretely:
 - ❌ **All SQUARED consumers** (`fan_in.rs:372`,
   `batch_successful/detection.rs:189`, `compound_degradation.rs:277`,
   `synapse/post_processing.rs:135`) produce numbers that do not correspond
-  to NEAT-AI's loss.
+  to NEAT-AI's loss. **Fixed in Issue #1249** for the three sites whose
+  output is interpreted as "expected loss reduction": the fan-in
+  least-squares improvement, the batch-successful
+  `1 − residual_sse/original_sse` ratio, and the compound-degradation
+  weight correction all now invoke
+  `crate::analysis::quantised_error::is_quantised_zero_one` on the
+  target's recorded errors and gate the SSE-improvement code path off
+  when the regime is detected. `synapse/post_processing.rs:135` is
+  retained — under `CATEGORICAL_ERROR` it collapses to "fraction of
+  network misclassifications attributable to this neuron", which is
+  still a sensible cost-agnostic impact-scaling factor and gating it
+  off would silence the entire discovery pipeline.
 - ❌ **All RESIDUAL consumers used in correlation/regression**
   (`gradient_discovery.rs:115`, `compound_degradation.rs`,
   `correlated_error.rs:128`, `monotonicity.rs:92`, `weight_polarity_flip.rs`,
@@ -339,6 +350,22 @@ remains a documentation deliverable:
    `batch_successful/detection.rs:189-203`,
    `compound_degradation.rs:277-288`,
    `synapse/post_processing.rs:131-138`.
+   **Resolved**: the three sites whose output is treated as "expected
+   loss reduction" by the downstream candidate ranker
+   (`fan_in::compute_least_squares_improvement` /
+   `compute_two_input_regression`,
+   `batch_successful::detection::evaluate_individual`,
+   `compound_degradation::detect_weight_corrections`) now call
+   `analysis::quantised_error::is_quantised_zero_one` on the target
+   error series and gate the SSE-improvement code path off. The fourth
+   site (`synapse::post_processing::compute_neuron_error_sq_map`)
+   degrades cleanly to "fraction of network misclassifications" under
+   the regime, which is still a usable cost-agnostic scaling factor —
+   gating it off would silence the discovery pipeline, so the SSE-sum
+   path is retained with a documented degraded-but-well-formed
+   semantics. Regression tests live in
+   `tests/recommendation/issue_1249_categorical_error_sse_gating.rs`
+   and `tests/detection/issue_1249_categorical_error_sse_gating.rs`.
    See also **#1247** — hardened the distribution-sensitive detectors
    (`scoring/error_distribution.rs`, `detection/bimodal_neuron.rs`,
    `recommendation/sample_weighted.rs`, `recommendation/fan_in.rs`,

--- a/docs/archive/pr-summaries/pr-summary-1249.md
+++ b/docs/archive/pr-summaries/pr-summary-1249.md
@@ -1,0 +1,73 @@
+## Summary
+
+Gate the four SSE-based "expected improvement" code paths off at runtime
+when the target's recorded errors are in the quantised `{0, 1}` regime
+(`CATEGORICAL_ERROR`), using the existing
+`analysis::quantised_error::is_quantised_zero_one` helper that
+Issue #1247 introduced. Under `CATEGORICAL_ERROR` the identity
+`Σ e² = Σ e = error_count`, so `improvement = 1 − residual_sse/original_sse`
+no longer corresponds to NEAT-AI's loss reduction — emitting it would
+mislead the candidate ranker. Closes #1249.
+
+Three sites are gated (path off):
+
+- `recommendation/fan_in.rs` — `compute_least_squares_improvement` and
+  `compute_two_input_regression` both return early under the regime, so
+  the per-target `best_individual <= 0.0` guard drops every fan-in pair.
+- `recommendation/batch_successful/detection.rs` — `evaluate_individual`
+  returns `None` for quantised target errors.
+- `detection/compound_degradation.rs` — `detect_weight_corrections`
+  `continue`s over any synapse whose target neuron has quantised errors.
+
+The fourth site (`synapse/post_processing.rs::compute_neuron_error_sq_map`)
+is left in place with an updated doc comment: under the regime it
+collapses to "fraction of network misclassifications attributable to
+this neuron", which is still a sensible cost-agnostic impact-scaling
+factor — gating it off would zero every neuron's impact and silence the
+discovery pipeline.
+
+`docs/COST_FUNCTION_NOTES.md` §3 tables and §6.1 follow-up entry are
+updated to reflect the new ⚠️-gated semantics.
+
+## Evidence
+
+Backend-only change with no UI surface. Verified via TDD:
+
+```mermaid
+flowchart LR
+    A["DiscoverRecord.errors"] --> B["is_quantised_zero_one"]
+    B -- "true (CATEGORICAL_ERROR)" --> C["return 0.0 / None / continue"]
+    B -- "false" --> D["SSE-improvement formula"]
+    C --> E["No misleading candidate emitted"]
+    D --> F["Candidate ranked normally"]
+```
+
+- Confirmed each new test fails against the pre-fix code (verified by
+  `git stash`-ing the source change and re-running — the
+  compound-degradation test reported "got 1 candidate(s)" pre-fix,
+  "passed" post-fix; fan-in and batch-successful similarly reported
+  pre-fix candidates that disappear post-fix).
+- `./quality.sh` passes end-to-end (fmt, clippy
+  `-D warnings`, doc-build with `RUSTDOCFLAGS=-D warnings`, full test
+  suite with `--test-threads=2`, release build).
+- Anchor tests assert the continuous-error baseline still emits
+  candidates, so the gated tests cannot pass vacuously.
+
+## Test Plan
+
+- `tests/recommendation/issue_1249_categorical_error_sse_gating.rs`
+  - `fan_in_emits_candidates_for_continuous_errors` — baseline anchor:
+    continuous correlated errors produce ≥1 fan-in candidate.
+  - `fan_in_emits_no_candidates_for_quantised_errors` — quantised
+    `{0, 1}` target errors with strongly flag-correlated inputs emit
+    zero fan-in candidates after the gate.
+  - `batch_successful_emits_candidates_for_continuous_errors` —
+    baseline anchor.
+  - `batch_successful_emits_no_candidates_for_quantised_errors` —
+    quantised target errors emit zero individually-successful
+    candidates.
+- `tests/detection/issue_1249_categorical_error_sse_gating.rs`
+  - `compound_degradation_emits_for_continuous_errors` — baseline
+    anchor on the input → hidden → output topology with bias drift.
+  - `compound_degradation_skips_quantised_target_errors` — verifies
+    no compound candidate's `weight_to_uuid` is the quantised neuron.

--- a/src/analysis/detection/compound_degradation.rs
+++ b/src/analysis/detection/compound_degradation.rs
@@ -23,6 +23,7 @@
 
 use super::helpers::build_record_map;
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT as MIN_SAMPLES;
+use crate::analysis::quantised_error::is_quantised_zero_one;
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
 use std::collections::{HashMap, HashSet};
@@ -247,6 +248,18 @@ fn detect_weight_corrections(
             .filter(|r| r.errors.first().copied().unwrap_or(0.0).is_finite())
             .map(|r| (r.obs_index, r.errors.first().copied().unwrap_or(0.0)))
             .collect();
+
+        // Issue #1249: under `CATEGORICAL_ERROR` the target error is a
+        // quantised `{0, 1}` misclassification flag, so the
+        // `baseline_error_sq − corrected_error_sq` SSE-improvement
+        // estimate below collapses to the misclassification count
+        // rather than a loss reduction. Skip the weight correction —
+        // the emitted `setWeight` magnitude would not correspond to
+        // any real improvement.
+        let target_error_values: Vec<f32> = target_error_map.values().copied().collect();
+        if is_quantised_zero_one(&target_error_values) {
+            continue;
+        }
 
         // Compute correlation between source activation and target error
         // Optimal weight delta via least squares: Δw = Σ(act × err) / Σ(act²)

--- a/src/analysis/recommendation/batch_successful/detection.rs
+++ b/src/analysis/recommendation/batch_successful/detection.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::CreatureJson;
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+use crate::analysis::quantised_error::is_quantised_zero_one;
 use crate::types::DiscoverRecord;
 
 use super::IndividualCandidate;
@@ -167,6 +168,16 @@ fn evaluate_individual(
         .iter()
         .map(|idx| target_errors[idx])
         .collect();
+
+    // Issue #1249: the SSE-improvement ratio
+    // `1 − residual_sse / original_sse` collapses for `CATEGORICAL_ERROR`-
+    // style quantised `{0, 1}` errors (`Σe² = Σe = error_count`), so the
+    // emitted "improvement" no longer corresponds to NEAT-AI's loss
+    // reduction. Gate the path off and let the caller fall back to a
+    // cost-agnostic detector for the affected target.
+    if is_quantised_zero_one(&errors) {
+        return None;
+    }
 
     // Least-squares weight: w = Σ(act × err) / Σ(act²).
     let sum_act_sq: f64 = activations

--- a/src/analysis/recommendation/fan_in.rs
+++ b/src/analysis/recommendation/fan_in.rs
@@ -34,6 +34,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
 use crate::analysis::detection::stats::pearson_correlation;
+use crate::analysis::quantised_error::is_quantised_zero_one;
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
 
@@ -351,23 +352,28 @@ fn evaluate_fan_in_pair(
 /// minimise Σ(error - w × activation)² → w = Σ(act × err) / Σ(act²),
 /// improvement = Σ(err²) - Σ(err - w × act)².
 ///
-/// ## Quantised `{0, 1}` error regime (Issue #1247)
+/// ## Quantised `{0, 1}` error regime (Issue #1249)
 ///
-/// When errors are CATEGORICAL_ERROR-style misclassification flags the
+/// When errors are `CATEGORICAL_ERROR`-style misclassification flags the
 /// SSE collapses to `Σ e = error_count` (because `e² = e`). The
 /// least-squares slope `w` becomes a regression of the misclassification
-/// flag onto the activation, and `improvement` is bounded by the number
-/// of misclassified samples rather than a meaningful loss reduction.
-/// The return value remains **finite and non-negative** — `sum_act_sq`
-/// is already guarded against zero variance — so it stays usable as a
-/// *ranking* signal for fan-in pair selection, but downstream callers
-/// must not interpret the magnitude as "expected loss reduction" under
-/// this regime. The `is_quantised_zero_one` helper in
-/// `crate::analysis::quantised_error` lets callers detect the regime
-/// when they need to.
+/// flag onto the activation, and the SSE-improvement number is bounded
+/// by the misclassification count rather than NEAT-AI's loss reduction.
+/// Emitting such a value would mislead the downstream candidate ranker,
+/// so this helper returns `0.0` for the quantised regime — the
+/// `best_individual <= 0.0` guard in [`evaluate_fan_in_pair`] then drops
+/// every fan-in pair targeting the affected neuron. See
+/// `docs/COST_FUNCTION_NOTES.md` §4.7 for the per-cost catalogue.
 fn compute_least_squares_improvement(activations: &[f32], errors: &[f32]) -> f32 {
     let n = activations.len().min(errors.len());
     if n < 2 {
+        return 0.0;
+    }
+
+    // Issue #1249: quantised `{0, 1}` errors break the "improvement = SSE
+    // reduction" identity. Gate the fan-in path off rather than emit a
+    // misleading magnitude.
+    if is_quantised_zero_one(&errors[..n]) {
         return 0.0;
     }
 
@@ -407,6 +413,16 @@ fn compute_two_input_regression(
     let n = acts_a.len().min(acts_b.len()).min(errors.len());
     if n < 3 {
         return None; // Need at least 3 samples for 2-variable regression.
+    }
+
+    // Issue #1249: the SSE-improvement identity collapses for quantised
+    // `{0, 1}` errors. Gate the pair regression off in the same way as
+    // the single-input helper above; the per-input
+    // `compute_least_squares_improvement` already rejects each input,
+    // but this is defence-in-depth for callers that bypass the
+    // per-input check.
+    if is_quantised_zero_one(&errors[..n]) {
+        return None;
     }
 
     // Normal equations: [a'a, a'b; b'a, b'b] [wa; wb] = [a'e; b'e]

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -121,6 +121,17 @@ pub fn scale_by_error_fraction(
 ///
 /// Issue #730: Used to determine what fraction of total creature error each target
 /// neuron contributes, enabling creature-level prediction calibration.
+///
+/// ## Quantised `{0, 1}` error regime (Issue #1249)
+///
+/// Under `CATEGORICAL_ERROR` the per-neuron `Σ e² = Σ e` equals the
+/// neuron's misclassification count. The downstream consumer
+/// ([`scale_by_error_fraction`]) uses the **ratio**
+/// `target_error_sq / total_error_sq`, which under the regime collapses
+/// to "fraction of network misclassifications attributable to this
+/// neuron" — still a sensible cost-agnostic impact-scaling factor. The
+/// SSE sum is therefore retained on purpose; gating it off would zero
+/// every neuron's impact and silence the discovery pipeline.
 fn compute_neuron_error_sq_map<'a>(
     input: &'a crate::AnalyzeSynapsesInput,
     cache: &RecordCache,

--- a/tests/detection/issue_1249_categorical_error_sse_gating.rs
+++ b/tests/detection/issue_1249_categorical_error_sse_gating.rs
@@ -1,0 +1,150 @@
+//! Tests for Issue #1249 — compound bias/weight degradation must not
+//! emit `setWeight` corrections sized by the SSE-improvement formula
+//! when the target's errors are quantised `{0, 1}` flags.
+//!
+//! Under `CATEGORICAL_ERROR` the `baseline_error_sq` / `corrected_error_sq`
+//! difference no longer corresponds to the network's loss reduction, so
+//! the weight-correction phase of `detect_compound_bias_weight_degradations`
+//! must skip the affected synapse instead of producing a misleading
+//! `setWeight` recommendation.
+
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use neat_ai_discovery::analysis::detection::compound_degradation::detect_compound_bias_weight_degradations;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn record(
+    uuid: &str,
+    obs_index: u32,
+    activation: f32,
+    value: Option<f32>,
+    errors: Vec<f32>,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.to_string(),
+        value,
+        activation,
+        errors,
+    }
+}
+
+fn make_compound_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-a", "input", "IDENTITY", 0.0),
+            neuron("hidden-1", "hidden", "TANH", 0.0),
+            neuron("output-0", "output", "IDENTITY", 0.0),
+        ],
+        synapses: vec![
+            synapse("input-a", "hidden-1", 0.6),
+            synapse("hidden-1", "output-0", 0.5),
+        ],
+        input: 1,
+        output: 1,
+    }
+}
+
+fn build_records<F>(make_output_err: F) -> Vec<(String, Vec<DiscoverRecord>)>
+where
+    F: Fn(usize) -> f32,
+{
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for uuid in ["input-a", "hidden-1", "output-0"] {
+        let recs: Vec<DiscoverRecord> = (0..60)
+            .map(|i| {
+                let phase = (i as f32) * 0.21;
+                let act = match uuid {
+                    "input-a" => phase.sin(),
+                    "hidden-1" => (phase * 0.6).tanh(),
+                    _ => 0.0,
+                };
+                let value = match uuid {
+                    "hidden-1" => Some(phase * 0.6),
+                    _ => Some(act),
+                };
+                let errors = if uuid == "hidden-1" {
+                    // Drive the bias-drift signal so a BiasCorrection is
+                    // produced; the weight-correction phase is what we
+                    // are gating in this test.
+                    vec![0.4 * phase.sin() + 0.5]
+                } else if uuid == "output-0" {
+                    vec![make_output_err(i)]
+                } else {
+                    vec![]
+                };
+                record(uuid, i as u32, act, value, errors)
+            })
+            .collect();
+        records.push((uuid.to_string(), recs));
+    }
+    records
+}
+
+/// Sanity check: continuous output errors that correlate with the
+/// hidden activation must still produce at least one compound
+/// degradation candidate. Without this anchor, the "no candidate under
+/// quantised" assertion below would be vacuous.
+#[test]
+fn compound_degradation_emits_for_continuous_errors() {
+    let creature = make_compound_creature();
+    let records = build_records(|i| {
+        let phase = (i as f32) * 0.21;
+        // Strongly correlated continuous residual on the output.
+        0.8 * (phase * 0.6).tanh() + 0.4
+    });
+
+    let candidates = detect_compound_bias_weight_degradations(&creature, &records);
+    assert!(
+        !candidates.is_empty(),
+        "compound degradation continuous baseline must emit at least one candidate (got 0); without this the gate test below is vacuous",
+    );
+}
+
+/// Under the quantised `{0, 1}` regime the SSE-based weight-correction
+/// improvement is bounded by the misclassification count rather than a
+/// loss reduction (Issue #1249). The detector must therefore skip the
+/// weight correction whose **target** neuron has quantised errors —
+/// otherwise the emitted `setWeight` magnitude does not correspond to
+/// any real loss reduction. Weight corrections targeting neurons with
+/// continuous errors remain valid.
+#[test]
+fn compound_degradation_skips_quantised_target_errors() {
+    let creature = make_compound_creature();
+    let records = build_records(|i| if i % 2 == 0 { 0.0 } else { 1.0 });
+
+    let candidates = detect_compound_bias_weight_degradations(&creature, &records);
+
+    // Pre-fix the unfixed code emitted candidates whose `weight_to_uuid`
+    // was the quantised output neuron, sized by the SSE-improvement
+    // formula. Post-fix, no candidate may target a quantised-error
+    // neuron — other corrections (e.g. on the continuous-error hidden
+    // neuron) remain valid.
+    let targeting_quantised = candidates
+        .iter()
+        .filter(|c| c.weight_to_uuid == "output-0")
+        .count();
+    assert_eq!(
+        targeting_quantised, 0,
+        "weight correction targeting quantised neuron must be gated under Issue #1249, got {targeting_quantised} candidate(s)",
+    );
+}

--- a/tests/detection/main.rs
+++ b/tests/detection/main.rs
@@ -4,6 +4,7 @@
 mod common;
 
 mod issue_1247_categorical_error_hardening;
+mod issue_1249_categorical_error_sse_gating;
 mod issue_1250_implied_target_cost_hint;
 mod issue_341_dead_neuron_detection;
 mod issue_342_saturated_neuron_detection;

--- a/tests/recommendation/issue_1249_categorical_error_sse_gating.rs
+++ b/tests/recommendation/issue_1249_categorical_error_sse_gating.rs
@@ -1,0 +1,275 @@
+//! Tests for Issue #1249: SSE-based "expected improvement" calculations
+//! collapse under `CATEGORICAL_ERROR` (quantised `{0, 1}` flags).
+//!
+//! The fix gates the affected SSE-improvement code paths off at runtime
+//! when the target's recorded errors are in the quantised `{0, 1}`
+//! regime, using `analysis::quantised_error::is_quantised_zero_one` —
+//! the same helper that Issue #1247 introduced for the distribution-
+//! sensitive detectors.
+//!
+//! Two affected entry points are covered here directly via their public
+//! API:
+//!
+//! - `analysis::recommendation::fan_in::detect_fan_in_candidates` — the
+//!   private `compute_least_squares_improvement` helper returns `0.0`
+//!   for quantised target errors, which causes the
+//!   `best_individual <= 0.0` guard to drop every fan-in pair targeting
+//!   that neuron.
+//! - `analysis::recommendation::batch_successful::detect_individually_successful`
+//!   — the `evaluate_individual` helper returns `None` for quantised
+//!   target errors, so no individually-successful candidate is emitted.
+//!
+//! See `docs/COST_FUNCTION_NOTES.md` §4.7 for the per-cost catalogue.
+
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use neat_ai_discovery::analysis::recommendation::batch_successful::detect_individually_successful;
+use neat_ai_discovery::analysis::recommendation::fan_in::detect_fan_in_candidates;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn record(uuid: &str, obs_index: u32, activation: f32, errors: Vec<f32>) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// fan_in.rs — least-squares improvement must collapse to 0 for the quantised
+// regime. The downstream `best_individual <= 0.0` guard then drops every pair
+// targeting that neuron.
+// ---------------------------------------------------------------------------
+
+/// Build a creature with two correlated inputs and a single output. The
+/// inputs each correlate strongly with a continuous target error, so the
+/// fan-in detector should normally produce a candidate.
+fn make_two_input_fan_in_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("input-b", "input", "IDENTITY"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-a", "output-0", 0.05),
+            synapse("input-b", "output-0", 0.05),
+        ],
+        input: 2,
+        output: 1,
+    }
+}
+
+/// Build the neuron record set used by both the "continuous" and
+/// "quantised" sanity checks. `make_err` decides the recorded error
+/// shape on the output target, and `make_act` decides the input
+/// activations. Inputs must correlate with the target error for a
+/// fan-in candidate to survive the `INPUT_ERROR_CORRELATION_THRESHOLD`
+/// gate.
+fn build_fan_in_records<E, A>(make_err: E, make_act: A) -> Vec<(String, Vec<DiscoverRecord>)>
+where
+    E: Fn(usize) -> f32,
+    A: Fn(&str, usize) -> f32,
+{
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for uuid in ["input-a", "input-b", "output-0"] {
+        let recs: Vec<DiscoverRecord> = (0..60)
+            .map(|i| {
+                let act = make_act(uuid, i);
+                let errors = if uuid == "output-0" {
+                    vec![make_err(i)]
+                } else {
+                    vec![]
+                };
+                record(uuid, i as u32, act, errors)
+            })
+            .collect();
+        records.push((uuid.to_string(), recs));
+    }
+    records
+}
+
+/// Sanity check: with continuous (non-quantised) target errors that are
+/// strongly correlated with the inputs, the fan-in detector should emit
+/// at least one candidate. This anchors the "quantised" tests below —
+/// without this baseline, an absence of candidates would not prove the
+/// gate is doing any work.
+#[test]
+fn fan_in_emits_candidates_for_continuous_errors() {
+    let creature = make_two_input_fan_in_creature();
+
+    let records = build_fan_in_records(
+        |i| {
+            let phase = (i as f32) * 0.21;
+            // Continuous, correlated, signed residual.
+            0.5 * phase.sin() + 0.3 * (phase * 1.7).cos()
+        },
+        |uuid, i| {
+            let phase = (i as f32) * 0.21;
+            match uuid {
+                "input-a" => phase.sin(),
+                "input-b" => (phase * 1.7).cos(),
+                _ => 0.1 * phase.sin(),
+            }
+        },
+    );
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+    assert!(
+        !candidates.is_empty(),
+        "continuous fan-in baseline must emit at least one candidate (got 0); without this the gate test below is vacuous",
+    );
+}
+
+/// Under the quantised `{0, 1}` regime the SSE-based "expected
+/// improvement" is bounded by the misclassification count rather than a
+/// loss reduction (Issue #1249). The fan-in detector must therefore
+/// emit **zero** candidates against quantised target errors, even when
+/// the inputs would otherwise look like a strong fan-in pair.
+#[test]
+fn fan_in_emits_no_candidates_for_quantised_errors() {
+    let creature = make_two_input_fan_in_creature();
+
+    // Inputs deliberately correlate strongly with the misclassification
+    // flag while staying mutually decorrelated. Without the gate the
+    // SSE-improvement formula reports a sizeable "improvement" because
+    // `Σe² = Σe = error_count` and the residual nearly collapses
+    // against the flag-tracking inputs. The independent sinusoidal
+    // jitter keeps mutual correlation below the fan-in detector's
+    // redundancy threshold.
+    let records = build_fan_in_records(
+        |i| if i % 2 == 0 { 0.0 } else { 1.0 },
+        |uuid, i| {
+            let flag = if i % 2 == 0 { 0.0 } else { 1.0 };
+            match uuid {
+                "input-a" => flag + 0.6 * (i as f32 * 0.7).sin(),
+                "input-b" => flag + 0.6 * (i as f32 * 1.3).cos(),
+                _ => 0.0,
+            }
+        },
+    );
+
+    let candidates = detect_fan_in_candidates(&creature, &records);
+    assert!(
+        candidates.is_empty(),
+        "quantised {{0,1}} errors must gate off fan-in SSE improvement, got {} candidate(s)",
+        candidates.len(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// batch_successful::detection — `improvement = 1 - residual_sse/original_sse`
+// must not be returned when the target errors are quantised flags, since
+// the ratio no longer corresponds to NEAT-AI's loss reduction.
+// ---------------------------------------------------------------------------
+
+/// Build a creature with one input and one output (no existing synapse).
+/// The batch-successful detector would normally propose an `input → output`
+/// synapse if the input's activation correlates with the output error.
+fn make_individual_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-a", "input", "IDENTITY"),
+            neuron("output-0", "output", "IDENTITY"),
+        ],
+        synapses: vec![],
+        input: 1,
+        output: 1,
+    }
+}
+
+fn build_individual_records<E, A>(make_err: E, make_act: A) -> Vec<(String, Vec<DiscoverRecord>)>
+where
+    E: Fn(usize) -> f32,
+    A: Fn(usize) -> f32,
+{
+    let mut records: Vec<(String, Vec<DiscoverRecord>)> = Vec::new();
+    for uuid in ["input-a", "output-0"] {
+        let recs: Vec<DiscoverRecord> = (0..60)
+            .map(|i| {
+                let act = if uuid == "input-a" { make_act(i) } else { 0.0 };
+                let errors = if uuid == "output-0" {
+                    vec![make_err(i)]
+                } else {
+                    vec![]
+                };
+                record(uuid, i as u32, act, errors)
+            })
+            .collect();
+        records.push((uuid.to_string(), recs));
+    }
+    records
+}
+
+/// Sanity check: continuous, correlated errors produce at least one
+/// individually-successful candidate. Without this anchor the gating
+/// test below would be vacuous.
+#[test]
+fn batch_successful_emits_candidates_for_continuous_errors() {
+    let creature = make_individual_creature();
+
+    let records = build_individual_records(
+        |i| {
+            let phase = (i as f32) * 0.21;
+            // Strongly correlated continuous residual.
+            0.8 * phase.sin()
+        },
+        |i| (i as f32 * 0.21).sin(),
+    );
+
+    let candidates = detect_individually_successful(&creature, &records);
+    assert!(
+        !candidates.is_empty(),
+        "continuous batch-successful baseline must emit at least one candidate (got 0); without this the gate test is vacuous",
+    );
+}
+
+/// Quantised `{0, 1}` target errors must gate the SSE-improvement
+/// ratio off. The `improvement = 1 − residual_sse / original_sse`
+/// number is invalid under the regime (Σe² = Σe = misclassification
+/// count), so no individually-successful candidate may be emitted for
+/// that target.
+#[test]
+fn batch_successful_emits_no_candidates_for_quantised_errors() {
+    let creature = make_individual_creature();
+
+    // Input activation strongly tracks the misclassification flag —
+    // without the gate the SSE-improvement ratio would approach 1.0
+    // (`residual_sse → 0`) and produce a "highly successful" candidate
+    // that does not correspond to any real loss reduction.
+    let records = build_individual_records(
+        |i| if i % 2 == 0 { 0.0 } else { 1.0 },
+        |i| {
+            let flag = if i % 2 == 0 { 0.0 } else { 1.0 };
+            flag + 0.1 * (i as f32 * 0.13).sin()
+        },
+    );
+
+    let candidates = detect_individually_successful(&creature, &records);
+    assert!(
+        candidates.is_empty(),
+        "quantised {{0,1}} errors must gate off batch-successful SSE ratio, got {} candidate(s)",
+        candidates.len(),
+    );
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -5,6 +5,7 @@ mod common;
 
 mod issue_1059_disable_batch_successful;
 mod issue_1247_categorical_error_hardening;
+mod issue_1249_categorical_error_sse_gating;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;


### PR DESCRIPTION
## Summary

Gate the four SSE-based "expected improvement" code paths off at runtime
when the target's recorded errors are in the quantised `{0, 1}` regime
(`CATEGORICAL_ERROR`), using the existing
`analysis::quantised_error::is_quantised_zero_one` helper that
Issue #1247 introduced. Under `CATEGORICAL_ERROR` the identity
`Σ e² = Σ e = error_count`, so `improvement = 1 − residual_sse/original_sse`
no longer corresponds to NEAT-AI's loss reduction — emitting it would
mislead the candidate ranker. Closes #1249.

Three sites are gated (path off):

- `recommendation/fan_in.rs` — `compute_least_squares_improvement` and
  `compute_two_input_regression` both return early under the regime, so
  the per-target `best_individual <= 0.0` guard drops every fan-in pair.
- `recommendation/batch_successful/detection.rs` — `evaluate_individual`
  returns `None` for quantised target errors.
- `detection/compound_degradation.rs` — `detect_weight_corrections`
  `continue`s over any synapse whose target neuron has quantised errors.

The fourth site (`synapse/post_processing.rs::compute_neuron_error_sq_map`)
is left in place with an updated doc comment: under the regime it
collapses to "fraction of network misclassifications attributable to
this neuron", which is still a sensible cost-agnostic impact-scaling
factor — gating it off would zero every neuron's impact and silence the
discovery pipeline.

`docs/COST_FUNCTION_NOTES.md` §3 tables and §6.1 follow-up entry are
updated to reflect the new ⚠️-gated semantics.

## Evidence

Backend-only change with no UI surface. Verified via TDD:

```mermaid
flowchart LR
    A["DiscoverRecord.errors"] --> B["is_quantised_zero_one"]
    B -- "true (CATEGORICAL_ERROR)" --> C["return 0.0 / None / continue"]
    B -- "false" --> D["SSE-improvement formula"]
    C --> E["No misleading candidate emitted"]
    D --> F["Candidate ranked normally"]
```

- Confirmed each new test fails against the pre-fix code (verified by
  `git stash`-ing the source change and re-running — the
  compound-degradation test reported "got 1 candidate(s)" pre-fix,
  "passed" post-fix; fan-in and batch-successful similarly reported
  pre-fix candidates that disappear post-fix).
- `./quality.sh` passes end-to-end (fmt, clippy
  `-D warnings`, doc-build with `RUSTDOCFLAGS=-D warnings`, full test
  suite with `--test-threads=2`, release build).
- Anchor tests assert the continuous-error baseline still emits
  candidates, so the gated tests cannot pass vacuously.

## Test Plan

- `tests/recommendation/issue_1249_categorical_error_sse_gating.rs`
  - `fan_in_emits_candidates_for_continuous_errors` — baseline anchor:
    continuous correlated errors produce ≥1 fan-in candidate.
  - `fan_in_emits_no_candidates_for_quantised_errors` — quantised
    `{0, 1}` target errors with strongly flag-correlated inputs emit
    zero fan-in candidates after the gate.
  - `batch_successful_emits_candidates_for_continuous_errors` —
    baseline anchor.
  - `batch_successful_emits_no_candidates_for_quantised_errors` —
    quantised target errors emit zero individually-successful
    candidates.
- `tests/detection/issue_1249_categorical_error_sse_gating.rs`
  - `compound_degradation_emits_for_continuous_errors` — baseline
    anchor on the input → hidden → output topology with bias drift.
  - `compound_degradation_skips_quantised_target_errors` — verifies
    no compound candidate's `weight_to_uuid` is the quantised neuron.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1249 -->