### PR TITLE
docs: add /// summaries to public FFI structs/enums (Issue #1257)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.64"
+version = "0.74.65"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1257.md
+++ b/docs/archive/pr-summaries/pr-summary-1257.md
@@ -1,0 +1,42 @@
+## Summary
+
+Added one-line `///` item-level summaries to the public FFI request/response
+structs and enums that ship with documented fields but no item-level rustdoc
+header. `cargo doc` and IDE hover now show a meaningful description for each
+type instead of a bare name. Closes #1257.
+
+Items documented:
+
+- `src/ffi_types/responses/analysis.rs` — `AnalyzeParallelOutput`,
+  `SynapseDiagnosticJson`, `SynapseDiagnosticReasonJson`,
+  `SynapseDiagnosticDetailJson`, `NeuronDiagnosticJson`,
+  `NeuronDiagnosticReasonJson`, `NeuronDiagnosticDetailJson`.
+- `src/ffi_types/responses/export.rs` — `MergeParquetOutput`.
+- `src/ffi_types/responses/mod.rs` — `GetVersionOutput`,
+  `RankFocusNeuronsOutput`.
+- `src/ffi_types/responses/gpu.rs` — `CheckGpuOutput`.
+- `src/ffi_types/mod.rs` — `NeuronJson`, `SynapseJson`, `NeuronStatsJson`.
+- `src/ffi_types/requests.rs` — `AnalyzeParallelInput`.
+- `src/parquet_format/writer.rs` — `ParquetRecordWriter` and its `pub fn new`.
+
+This is a pure doc-only change — no behaviour or wire format changes.
+
+## Evidence
+
+CLI/library change with no UI to screenshot. Verification is via the docs
+build, which compiles all `///` text as rustdoc:
+
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` succeeds, proving every
+  added summary parses cleanly and all intra-doc links resolve.
+- `./quality.sh` passed end-to-end: `cargo build`, `cargo clippy
+  --all-targets --all-features -- -D warnings`, `cargo check`, the full test
+  suite (`cargo test --lib --tests --all-features`), `cargo doc`, and the
+  release build all completed successfully.
+
+## Test Plan
+
+- Existing unit and integration tests continue to pass (`cargo test --lib
+  --tests --all-features`). No tests were modified — the change is
+  documentation-only and is validated by the doc build inside `quality.sh`.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` exercises every added
+  `///` block; any malformed rustdoc or broken intra-doc link would fail it.

--- a/src/ffi_types/mod.rs
+++ b/src/ffi_types/mod.rs
@@ -91,6 +91,8 @@ pub struct CreatureJson {
     pub output: usize,
 }
 
+/// JSON representation of a single neuron on the FFI boundary — identity,
+/// type, activation function (squash), and bias.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NeuronJson {
     /// Stable neuron identity string. Must be a UUID or descriptive identifier
@@ -132,6 +134,9 @@ where
     Ok(trimmed.to_ascii_uppercase())
 }
 
+/// JSON representation of a single synapse on the FFI boundary — source
+/// and target neuron identities, weight, and optional IF-neuron branch
+/// classification.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct SynapseJson {
     /// Source neuron identity string. Must be a UUID or descriptive identifier.
@@ -181,6 +186,10 @@ pub struct TrainingRecord {
     pub neuron_data: Option<Vec<NeuronData>>,
 }
 
+/// JSON-serialised summary statistics for a single neuron — error / activation
+/// means and variances plus spike and activation-range counters. Attached to
+/// candidate payloads so the host can reason about target-neuron behaviour
+/// without re-reading parquet.
 #[derive(Debug, Serialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct NeuronStatsJson {

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -22,6 +22,10 @@ pub struct RecordDiscoveryInput {
     pub timeout_seconds: Option<u64>,
 }
 
+/// FFI request payload for
+/// [`crate::ffi_internal::analyze_parallel_internal`] — the parquet file,
+/// creature, focus neurons, and tuning knobs that govern combined
+/// synapse + neuron analysis.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeParallelInput {

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -14,6 +14,10 @@ use crate::{
     SynapseWeightUpdateCandidateJson,
 };
 
+/// FFI response payload returned by
+/// [`crate::ffi_internal::analyze_parallel_internal`] — the helpful/harmful
+/// synapse and neuron candidates plus observability metadata serialised to
+/// the TypeScript host.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeParallelOutput {
@@ -314,6 +318,9 @@ pub struct NeuronAnalysisMetadataJson {
 // Diagnostic types
 // ============================================================================
 
+/// Per-target diagnostic surfaced in
+/// [`AnalyzeParallelOutput::synapse_diagnostics`] when synapse analysis
+/// produced no candidate for a focus neuron, explaining why.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SynapseDiagnosticJson {
@@ -326,6 +333,8 @@ pub struct SynapseDiagnosticJson {
     pub detail: Option<SynapseDiagnosticDetailJson>,
 }
 
+/// Stable reason code carried by [`SynapseDiagnosticJson::reason`] explaining
+/// why synapse analysis produced no candidate for a given focus neuron.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SynapseDiagnosticReasonJson {
@@ -339,6 +348,8 @@ pub enum SynapseDiagnosticReasonJson {
     NoTargetRecords,
 }
 
+/// Optional detail attached to [`SynapseDiagnosticJson::detail`] — extra
+/// per-source observability for the closest-rejected synapse candidate.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SynapseDiagnosticDetailJson {
@@ -360,6 +371,9 @@ pub struct SynapseDiagnosticDetailJson {
     pub suggested_weight: Option<f32>,
 }
 
+/// Per-target diagnostic surfaced in
+/// [`AnalyzeParallelOutput::neuron_diagnostics`] when neuron analysis produced
+/// no candidate for a focus neuron, explaining why.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NeuronDiagnosticJson {
@@ -372,6 +386,8 @@ pub struct NeuronDiagnosticJson {
     pub detail: Option<NeuronDiagnosticDetailJson>,
 }
 
+/// Stable reason code carried by [`NeuronDiagnosticJson::reason`] explaining
+/// why neuron analysis produced no candidate for a given focus neuron.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NeuronDiagnosticReasonJson {
@@ -394,6 +410,8 @@ pub enum NeuronDiagnosticReasonJson {
     ConstantNeuronFiltered,
 }
 
+/// Optional detail attached to [`NeuronDiagnosticJson::detail`] — extra
+/// per-source observability for the closest-rejected neuron candidate.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NeuronDiagnosticDetailJson {

--- a/src/ffi_types/responses/export.rs
+++ b/src/ffi_types/responses/export.rs
@@ -44,6 +44,8 @@ pub struct ExportVisualisationStats {
 // Merge Parquet output
 // ============================================================================
 
+/// FFI response payload returned by the `merge_parquet` FFI entry point —
+/// success flag, merged output file path, and structured error fields.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MergeParquetOutput {

--- a/src/ffi_types/responses/gpu.rs
+++ b/src/ffi_types/responses/gpu.rs
@@ -78,6 +78,9 @@ pub struct AnalysisTimingJson {
     pub cpu: CpuTimingBreakdownJson,
 }
 
+/// FFI response payload returned by the `check_gpu_available` FFI entry
+/// point — whether a usable GPU was detected, plus a human-readable reason
+/// and structured error fields when the probe failed.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CheckGpuOutput {

--- a/src/ffi_types/responses/mod.rs
+++ b/src/ffi_types/responses/mod.rs
@@ -46,6 +46,8 @@ pub struct RecordDiscoveryOutput {
     pub retryable: Option<bool>,
 }
 
+/// FFI response payload returned by the `get_version` FFI entry point —
+/// the library crate version plus the FFI schema version.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetVersionOutput {
@@ -63,6 +65,9 @@ pub struct GetVersionOutput {
     pub retryable: Option<bool>,
 }
 
+/// FFI response payload returned by the `rank_focus_neurons` FFI entry
+/// point — ranked neurons, removal candidates, coordinated structural
+/// candidates, and observability fields for the chosen loading mode.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RankFocusNeuronsOutput {

--- a/src/parquet_format/writer.rs
+++ b/src/parquet_format/writer.rs
@@ -38,6 +38,13 @@ pub(crate) fn write_records_to_parquet_with_limit(
     writer.finish()
 }
 
+/// Streaming writer for discovery [`DiscoverRecord`]s into a Parquet file.
+///
+/// Buffers records into batches bounded by configured per-batch UUID byte and
+/// error-value limits so a single record batch never exceeds Arrow's offset
+/// constraints. Drive it by constructing one via [`Self::new`], pushing
+/// records with [`Self::write_records`], and finalising the file with
+/// [`Self::finish`].
 pub struct ParquetRecordWriter {
     writer: ArrowWriter<File>,
     schema: Arc<arrow::datatypes::Schema>,
@@ -48,6 +55,12 @@ pub struct ParquetRecordWriter {
 }
 
 impl ParquetRecordWriter {
+    /// Create a new writer targeting `file_path`.
+    ///
+    /// Validates the byte/value batch limits and `total_capacity` (must be
+    /// non-zero and within Arrow's `i32::MAX` offset budget) before creating
+    /// the underlying Parquet file. Returns an error if the file cannot be
+    /// created or the limits are invalid.
     pub fn new(
         file_path: &str,
         max_uuid_bytes_per_batch: usize,


### PR DESCRIPTION
## Summary

Added one-line `///` item-level summaries to the public FFI request/response
structs and enums that ship with documented fields but no item-level rustdoc
header. `cargo doc` and IDE hover now show a meaningful description for each
type instead of a bare name. Closes #1257.

Items documented:

- `src/ffi_types/responses/analysis.rs` — `AnalyzeParallelOutput`,
  `SynapseDiagnosticJson`, `SynapseDiagnosticReasonJson`,
  `SynapseDiagnosticDetailJson`, `NeuronDiagnosticJson`,
  `NeuronDiagnosticReasonJson`, `NeuronDiagnosticDetailJson`.
- `src/ffi_types/responses/export.rs` — `MergeParquetOutput`.
- `src/ffi_types/responses/mod.rs` — `GetVersionOutput`,
  `RankFocusNeuronsOutput`.
- `src/ffi_types/responses/gpu.rs` — `CheckGpuOutput`.
- `src/ffi_types/mod.rs` — `NeuronJson`, `SynapseJson`, `NeuronStatsJson`.
- `src/ffi_types/requests.rs` — `AnalyzeParallelInput`.
- `src/parquet_format/writer.rs` — `ParquetRecordWriter` and its `pub fn new`.

This is a pure doc-only change — no behaviour or wire format changes.

## Evidence

CLI/library change with no UI to screenshot. Verification is via the docs
build, which compiles all `///` text as rustdoc:

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` succeeds, proving every
  added summary parses cleanly and all intra-doc links resolve.
- `./quality.sh` passed end-to-end: `cargo build`, `cargo clippy
  --all-targets --all-features -- -D warnings`, `cargo check`, the full test
  suite (`cargo test --lib --tests --all-features`), `cargo doc`, and the
  release build all completed successfully.

## Test Plan

- Existing unit and integration tests continue to pass (`cargo test --lib
  --tests --all-features`). No tests were modified — the change is
  documentation-only and is validated by the doc build inside `quality.sh`.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` exercises every added
  `///` block; any malformed rustdoc or broken intra-doc link would fail it.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1257 -->