### PR TITLE
refactor: replace glob re-exports in src/lib.rs with explicit lists (#1256)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.63"
+version = "0.74.64"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1256.md
+++ b/docs/archive/pr-summaries/pr-summary-1256.md
@@ -1,0 +1,37 @@
+## Summary
+
+Replaced the two glob re-exports in `src/lib.rs` (`pub use ffi_types::*;` and
+`pub use ffi_internal::*;`) with explicit, alphabetically-sorted `pub use`
+lists. The crate's public API surface is now visible at a glance from the
+root module, so any new `pub` item added under `ffi_types/` or
+`ffi_internal/` is now an intentional API decision rather than an
+accidental leak. Closes #1256.
+
+The set of re-exported names is unchanged — `crate::TypeName` and
+`neat_ai_discovery::TypeName` paths used by integration tests continue to
+work. The list was enumerated from every `pub` item currently visible under
+`ffi_types` (incl. nested `responses::{analysis,export,gpu}`) and
+`ffi_internal`.
+
+## Evidence
+
+This is a backend / API-surface change with no UI to screenshot.
+
+- **`./quality.sh` passes** — fmt, clippy (`-D warnings`), `cargo check
+  --all-targets --all-features`, full test suite, doc build, and release
+  build all succeed.
+- **New regression test** — `tests/issue_1256_public_api_surface.rs`
+  imports every name on the explicit re-export list via the
+  `neat_ai_discovery::*` path. If anything is dropped from the explicit
+  list (or renamed) the test fails to compile, so the list is now
+  guarded by CI.
+- **Existing call sites still compile** — every `crate::TypeName` and
+  `neat_ai_discovery::TypeName` reference under `src/` and `tests/` was
+  enumerated before the change to confirm the explicit list covers it.
+
+## Test Plan
+
+- `cargo test --test issue_1256_public_api_surface --all-features --
+  --test-threads=2` — 3 passed, 0 failed.
+- `./quality.sh < /dev/null` — passes cleanly (fmt, clippy with
+  `-D warnings`, check, all tests, doc, release build).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,115 @@ pub mod streaming;
 pub mod types;
 mod watchdog;
 
-// Re-export all FFI boundary types so that `crate::TypeName` and
-// `neat_ai_discovery::TypeName` continue to work without any change
-// to existing code.
-pub use ffi_types::*;
+// Re-export the FFI boundary types so that `crate::TypeName` and
+// `neat_ai_discovery::TypeName` continue to work for existing callers
+// and integration tests.
+//
+// The list is intentionally explicit (Issue #1256): glob re-exports
+// make the crate's public API surface implicit, so any new `pub` item
+// added under `ffi_types` would silently leak. New items intended for
+// the public surface must be added to this list; otherwise leave them
+// `pub(crate)` or accessible only via the `ffi_types::` path.
+pub use ffi_types::{
+    // Response types — analysis (`ffi_types::responses::analysis`).
+    AcceptanceRateJson,
+    // Response types — GPU / timing (`ffi_types::responses::gpu`).
+    AnalysisTimingJson,
+    // Request types (`ffi_types::requests`).
+    AnalyzeAllInput,
+    AnalyzeNeuronsInput,
+    AnalyzeParallelInput,
+    AnalyzeParallelOutput,
+    AnalyzeSynapsesInput,
+    // Session types (`ffi_types::session`).
+    AppendRecordsInput,
+    AppendRecordsOutput,
+    CalibrationMissEntryJson,
+    CalibrationSummaryInput,
+    // Response types — export / parquet (`ffi_types::responses::export`).
+    CalibrationSummaryOutput,
+    CancelSessionInput,
+    CancelSessionOutput,
+    // Candidate types (`ffi_types::candidates`).
+    CandidateNeuronJson,
+    CandidateSynapseJson,
+    CheckGpuOutput,
+    // Cleanup request/response types (`ffi_types::cleanup`).
+    CleanOrphanedDirsInput,
+    CleanOrphanedDirsOutput,
+    CleanupDiscoveryDirInput,
+    CleanupDiscoveryDirOutput,
+    CoordinatedStructuralCandidateJson,
+    CoordinatedStructuralOpJson,
+    CpuTimingBreakdownJson,
+    // Core FFI types declared in `ffi_types/mod.rs`.
+    CreatureJson,
+    DiscoverRecordJson,
+    // Error classification (`ffi_types::error_classification`).
+    DiscoveryError,
+    DiscoveryErrorKind,
+    DiversityMetricJson,
+    ExportVisualisationSnapshotInput,
+    ExportVisualisationSnapshotOutput,
+    ExportVisualisationStats,
+    FinishSessionInput,
+    FinishSessionOutput,
+    // Response types — top-level (`ffi_types::responses`).
+    GetVersionOutput,
+    GpuAdapterInfoJson,
+    GpuTimingBreakdownJson,
+    McmcDiagnosticsJson,
+    MergeParquetInput,
+    MergeParquetOutput,
+    NeuronAnalysisMetadataJson,
+    NeuronData,
+    NeuronDiagnosticDetailJson,
+    NeuronDiagnosticJson,
+    NeuronDiagnosticReasonJson,
+    NeuronJson,
+    NeuronStatsJson,
+    ProposalQualityJson,
+    RankFocusNeuronsInput,
+    RankFocusNeuronsOutput,
+    RankedNeuronJson,
+    ReadDiscoveryInput,
+    ReadDiscoveryOutput,
+    RecordDiscoveryInput,
+    RecordDiscoveryOutput,
+    RemovalCandidateJson,
+    SCHEMA_VERSION,
+    ShaderTimingJson,
+    StartSessionInput,
+    StartSessionOutput,
+    StreamingObservation,
+    SynapseAnalysisMetadataJson,
+    SynapseDiagnosticDetailJson,
+    SynapseDiagnosticJson,
+    SynapseDiagnosticReasonJson,
+    SynapseJson,
+    SynapseWeightUpdateCandidateJson,
+    TrainingRecord,
+    classify_anyhow_error,
+    classify_error,
+    classify_panic,
+    error_fields,
+    error_fields_from_anyhow,
+    no_error_fields,
+    panic_error_fields,
+    // Forward-only validation helper.
+    validate_forward_only_synapses,
+};
 
-// Re-export all internal business-logic functions so that existing
+// Re-export the internal business-logic functions so that existing
 // integration tests (`neat_ai_discovery::*_internal`) continue to work.
-pub use ffi_internal::*;
+// The list is intentionally explicit (Issue #1256) — see the rationale
+// on the `ffi_types` re-export above.
+pub use ffi_internal::{
+    analyze_parallel_internal, check_gpu_available_internal,
+    export_visualisation_snapshot_internal, get_calibration_summary_internal,
+    get_library_version_internal, merge_discovery_parquet_internal, rank_focus_neurons_internal,
+    read_discovery_records, record_discovery_internal,
+};
 
 use std::sync::OnceLock;
 

--- a/tests/issue_1256_public_api_surface.rs
+++ b/tests/issue_1256_public_api_surface.rs
@@ -1,0 +1,113 @@
+//! Issue #1256 — verify the explicit public API surface from `src/lib.rs`.
+//!
+//! The crate root re-exports a curated list of FFI types and internal
+//! business-logic functions from `ffi_types` and `ffi_internal`. This test
+//! imports each name via the `neat_ai_discovery::TypeName` and
+//! `neat_ai_discovery::function_internal` paths so that any accidental removal
+//! from the explicit re-export lists produces a compile-time failure.
+//!
+//! If a name is intentionally removed from the public surface, this test
+//! must be updated in the same PR.
+
+#![allow(unused_imports)]
+
+// Core FFI types declared in `ffi_types/mod.rs`.
+use neat_ai_discovery::{
+    CreatureJson, NeuronData, NeuronJson, NeuronStatsJson, SCHEMA_VERSION, SynapseJson,
+    TrainingRecord,
+};
+
+// Candidate types.
+use neat_ai_discovery::{
+    CandidateNeuronJson, CandidateSynapseJson, CoordinatedStructuralCandidateJson,
+    CoordinatedStructuralOpJson, RankedNeuronJson, RemovalCandidateJson,
+    SynapseWeightUpdateCandidateJson,
+};
+
+// Cleanup request/response types.
+use neat_ai_discovery::{
+    CleanOrphanedDirsInput, CleanOrphanedDirsOutput, CleanupDiscoveryDirInput,
+    CleanupDiscoveryDirOutput,
+};
+
+// Error classification.
+use neat_ai_discovery::{
+    DiscoveryError, DiscoveryErrorKind, classify_anyhow_error, classify_error, classify_panic,
+    error_fields, error_fields_from_anyhow, no_error_fields, panic_error_fields,
+};
+
+// Forward-only validation helper.
+use neat_ai_discovery::validate_forward_only_synapses;
+
+// Request types.
+use neat_ai_discovery::{
+    AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeParallelInput, AnalyzeSynapsesInput,
+    CalibrationSummaryInput, ExportVisualisationSnapshotInput, MergeParquetInput,
+    RankFocusNeuronsInput, ReadDiscoveryInput, RecordDiscoveryInput,
+};
+
+// Response types (top-level).
+use neat_ai_discovery::{GetVersionOutput, RankFocusNeuronsOutput, RecordDiscoveryOutput};
+
+// Response types (analysis).
+use neat_ai_discovery::{
+    AcceptanceRateJson, AnalyzeParallelOutput, CalibrationMissEntryJson, DiversityMetricJson,
+    McmcDiagnosticsJson, NeuronAnalysisMetadataJson, NeuronDiagnosticDetailJson,
+    NeuronDiagnosticJson, NeuronDiagnosticReasonJson, ProposalQualityJson,
+    SynapseAnalysisMetadataJson, SynapseDiagnosticDetailJson, SynapseDiagnosticJson,
+    SynapseDiagnosticReasonJson,
+};
+
+// Response types (export / parquet).
+use neat_ai_discovery::{
+    CalibrationSummaryOutput, DiscoverRecordJson, ExportVisualisationSnapshotOutput,
+    ExportVisualisationStats, MergeParquetOutput, ReadDiscoveryOutput,
+};
+
+// Response types (GPU / timing).
+use neat_ai_discovery::{
+    AnalysisTimingJson, CheckGpuOutput, CpuTimingBreakdownJson, GpuAdapterInfoJson,
+    GpuTimingBreakdownJson, ShaderTimingJson,
+};
+
+// Session types.
+use neat_ai_discovery::{
+    AppendRecordsInput, AppendRecordsOutput, CancelSessionInput, CancelSessionOutput,
+    FinishSessionInput, FinishSessionOutput, StartSessionInput, StartSessionOutput,
+    StreamingObservation,
+};
+
+// Internal business-logic entry points (used by integration tests via
+// `neat_ai_discovery::*_internal`).
+use neat_ai_discovery::{
+    analyze_parallel_internal, check_gpu_available_internal,
+    export_visualisation_snapshot_internal, get_calibration_summary_internal,
+    get_library_version_internal, merge_discovery_parquet_internal, rank_focus_neurons_internal,
+    read_discovery_records, record_discovery_internal,
+};
+
+#[test]
+fn schema_version_re_exported_at_crate_root() {
+    // Exercise one re-exported constant so the test actually runs the code.
+    assert!(!SCHEMA_VERSION.is_empty());
+}
+
+#[test]
+fn creature_json_constructible_via_crate_root_path() {
+    let creature = CreatureJson {
+        neurons: Vec::new(),
+        synapses: Vec::new(),
+        input: 1,
+        output: 1,
+    };
+    assert_eq!(creature.input, 1);
+    assert_eq!(creature.output, 1);
+}
+
+#[test]
+fn classify_error_re_exported_at_crate_root() {
+    // The function returns a DiscoveryErrorKind; we only need a smoke check
+    // that the re-export compiles and the function is callable.
+    let kind = classify_error("file not found");
+    let _ = format!("{kind:?}");
+}


### PR DESCRIPTION
## Summary

Replaced the two glob re-exports in `src/lib.rs` (`pub use ffi_types::*;` and
`pub use ffi_internal::*;`) with explicit, alphabetically-sorted `pub use`
lists. The crate's public API surface is now visible at a glance from the
root module, so any new `pub` item added under `ffi_types/` or
`ffi_internal/` is now an intentional API decision rather than an
accidental leak. Closes #1256.

The set of re-exported names is unchanged — `crate::TypeName` and
`neat_ai_discovery::TypeName` paths used by integration tests continue to
work. The list was enumerated from every `pub` item currently visible under
`ffi_types` (incl. nested `responses::{analysis,export,gpu}`) and
`ffi_internal`.

## Evidence

This is a backend / API-surface change with no UI to screenshot.

- **`./quality.sh` passes** — fmt, clippy (`-D warnings`), `cargo check
  --all-targets --all-features`, full test suite, doc build, and release
  build all succeed.
- **New regression test** — `tests/issue_1256_public_api_surface.rs`
  imports every name on the explicit re-export list via the
  `neat_ai_discovery::*` path. If anything is dropped from the explicit
  list (or renamed) the test fails to compile, so the list is now
  guarded by CI.
- **Existing call sites still compile** — every `crate::TypeName` and
  `neat_ai_discovery::TypeName` reference under `src/` and `tests/` was
  enumerated before the change to confirm the explicit list covers it.

## Test Plan

- `cargo test --test issue_1256_public_api_surface --all-features --
  --test-threads=2` — 3 passed, 0 failed.
- `./quality.sh < /dev/null` — passes cleanly (fmt, clippy with
  `-D warnings`, check, all tests, doc, release build).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-1256 -->