### PR TITLE
build: deny unsafe_op_in_unsafe_fn at crate root (Issue #1255)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,14 @@ codegen-units = 1
 
 # Lint configuration — single source of truth (Issue #675, #876)
 # All clippy lints are configured here. quality.sh and CI just pass -D warnings.
+#
+# Rustc lints (Issue #1255) — enforce a deny floor at the crate root so CI
+# fails fast when a contributor introduces a bare `unsafe` op inside an
+# `unsafe fn`. The codebase already follows this style throughout
+# `src/ffi/utilities.rs` etc.; this lint makes the convention enforceable.
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
 [lints.clippy]
 uninlined_format_args = "deny"
 filter_next = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.66"
+version = "0.74.67"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1255.md
+++ b/docs/archive/pr-summaries/pr-summary-1255.md
@@ -1,0 +1,46 @@
+## Summary
+
+Added a `[lints.rust]` section to `Cargo.toml` that denies
+`unsafe_op_in_unsafe_fn` at the crate root, so CI fails fast if a
+contributor introduces a bare `unsafe` op inside an `unsafe fn` instead
+of wrapping it in its own `unsafe { ... }` block with a `// SAFETY:`
+comment. The codebase already follows that convention (e.g.
+`src/ffi/utilities.rs`); this change makes the project-wide style
+mechanically enforceable. Closes #1255.
+
+`missing_docs` is intentionally **not** added in this PR. The issue
+suggests starting it at `warn` with a later promotion to `deny`, but
+`quality.sh` exports `RUSTFLAGS="-D warnings"` globally, which would
+immediately escalate any `warn`-level lint to a build failure. Enabling
+`missing_docs` therefore requires a back-fill of the undocumented `pub`
+items in `src/ffi_types/responses/` and elsewhere first, which is out of
+scope for this lint-policy change and should be tracked as a follow-up.
+
+## Evidence
+
+This is a build-configuration change with no UI surface. Verified by:
+
+- `./quality.sh` ran to completion with all checks green (Bash syntax,
+  `cargo deny`, build, `cargo fmt`, `cargo clippy --all-targets
+  --all-features -- -D warnings`, `cargo check`, `cargo test`,
+  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`, release build).
+- The new test `tests/issue_1255_rustc_lints.rs` reads `Cargo.toml` and
+  asserts that `[lints.rust].unsafe_op_in_unsafe_fn = "deny"` is
+  present. Run in isolation: `1 passed; 0 failed`.
+
+```mermaid
+flowchart LR
+    A[Contributor adds bare unsafe op<br/>inside unsafe fn] --> B[cargo build / clippy]
+    B --> C{[lints.rust]<br/>unsafe_op_in_unsafe_fn<br/>= deny}
+    C -->|violated| D[CI fails fast]
+    C -->|honoured| E[Build green]
+```
+
+## Test Plan
+
+- Added `tests/issue_1255_rustc_lints.rs::cargo_toml_denies_unsafe_op_in_unsafe_fn`
+  which parses `Cargo.toml` and asserts the rustc lint is declared and
+  set to `deny`. Fails the build if the section is removed or weakened.
+- Ran the full `./quality.sh` gate locally — all stages pass on the
+  branch with the lint enabled, confirming the existing codebase already
+  satisfies `unsafe_op_in_unsafe_fn = "deny"`.

--- a/tests/issue_1255_rustc_lints.rs
+++ b/tests/issue_1255_rustc_lints.rs
@@ -1,0 +1,84 @@
+//! Issue #1255: `Cargo.toml` must declare a `[lints.rust]` section that
+//! denies `unsafe_op_in_unsafe_fn`, making the project-wide convention
+//! ("every `unsafe` op inside an `unsafe fn` is wrapped in its own
+//! `unsafe { ... }` block with a `// SAFETY:` comment") enforceable at
+//! the crate root.
+//!
+//! The test reads `Cargo.toml` as plain text so the library does not
+//! need to pull in a new TOML parser dependency just for this check.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn cargo_toml_denies_unsafe_op_in_unsafe_fn() {
+    let manifest_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let contents = fs::read_to_string(&manifest_path).expect("read Cargo.toml");
+
+    let section = extract_section(&contents, "[lints.rust]").expect(
+        "Cargo.toml must contain a [lints.rust] section that configures \
+         rustc lints at the crate root (Issue #1255)",
+    );
+
+    let value = field_value(section, "unsafe_op_in_unsafe_fn").expect(
+        "Cargo.toml [lints.rust] must configure `unsafe_op_in_unsafe_fn` \
+         (Issue #1255)",
+    );
+
+    assert_eq!(
+        value, "deny",
+        "Cargo.toml [lints.rust].unsafe_op_in_unsafe_fn must be \"deny\" so \
+         CI fails fast when a bare `unsafe` op inside an `unsafe fn` is \
+         introduced (Issue #1255), got: {value:?}"
+    );
+}
+
+/// Return the body of the named section (everything up to the next
+/// `[section]` header).
+fn extract_section<'a>(contents: &'a str, header: &str) -> Option<&'a str> {
+    let start = contents.find(header)?;
+    let after_header = &contents[start + header.len()..];
+    let mut end = after_header.len();
+    for (idx, line) in after_header.lines().enumerate() {
+        if idx == 0 {
+            continue;
+        }
+        if line.trim_start().starts_with('[') {
+            let mut offset = 0usize;
+            for (i, l) in after_header.lines().enumerate() {
+                if i == idx {
+                    break;
+                }
+                offset += l.len() + 1;
+            }
+            end = offset;
+            break;
+        }
+    }
+    Some(&after_header[..end])
+}
+
+/// Find a `key = "value"` declaration inside a TOML section body.
+fn field_value(section: &str, key: &str) -> Option<String> {
+    for line in section.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = rest.trim();
+        let value = value.split('#').next().unwrap_or("").trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))?;
+        return Some(value.to_string());
+    }
+    None
+}


### PR DESCRIPTION
## Summary

Added a `[lints.rust]` section to `Cargo.toml` that denies
`unsafe_op_in_unsafe_fn` at the crate root, so CI fails fast if a
contributor introduces a bare `unsafe` op inside an `unsafe fn` instead
of wrapping it in its own `unsafe { ... }` block with a `// SAFETY:`
comment. The codebase already follows that convention (e.g.
`src/ffi/utilities.rs`); this change makes the project-wide style
mechanically enforceable. Closes #1255.

`missing_docs` is intentionally **not** added in this PR. The issue
suggests starting it at `warn` with a later promotion to `deny`, but
`quality.sh` exports `RUSTFLAGS="-D warnings"` globally, which would
immediately escalate any `warn`-level lint to a build failure. Enabling
`missing_docs` therefore requires a back-fill of the undocumented `pub`
items in `src/ffi_types/responses/` and elsewhere first, which is out of
scope for this lint-policy change and should be tracked as a follow-up.

## Evidence

This is a build-configuration change with no UI surface. Verified by:

- `./quality.sh` ran to completion with all checks green (Bash syntax,
  `cargo deny`, build, `cargo fmt`, `cargo clippy --all-targets
  --all-features -- -D warnings`, `cargo check`, `cargo test`,
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`, release build).
- The new test `tests/issue_1255_rustc_lints.rs` reads `Cargo.toml` and
  asserts that `[lints.rust].unsafe_op_in_unsafe_fn = "deny"` is
  present. Run in isolation: `1 passed; 0 failed`.

```mermaid
flowchart LR
    A[Contributor adds bare unsafe op<br/>inside unsafe fn] --> B[cargo build / clippy]
    B --> C{[lints.rust]<br/>unsafe_op_in_unsafe_fn<br/>= deny}
    C -->|violated| D[CI fails fast]
    C -->|honoured| E[Build green]
```

## Test Plan

- Added `tests/issue_1255_rustc_lints.rs::cargo_toml_denies_unsafe_op_in_unsafe_fn`
  which parses `Cargo.toml` and asserts the rustc lint is declared and
  set to `deny`. Fails the build if the section is removed or weakened.
- Ran the full `./quality.sh` gate locally — all stages pass on the
  branch with the lint enabled, confirming the existing codebase already
  satisfies `unsafe_op_in_unsafe_fn = "deny"`.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1255 -->