### PR TITLE
Per-creature, per-module starvation tracker (Issue #1273)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -650,6 +650,8 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_RISKY_SQUASH_PRIOR` | Cold-start calibration prior multiplier for non-invertible / periodic target activations (SINE, COSINE, GAUSSIAN, SQUARE, ABSOLUTE). Applied while the per-(`change_type`, `target_squash`) bucket has fewer than three failure samples. Default 0.25, clamped to `[0.001, 1.0]` (Issue #1192). |
 | `NEAT_AI_DISCOVERY_MIN_EXPECTED_GAIN` | Absolute minimum `expected_creature_score_gain` for emitted add-neuron / add-synapse candidates. Predictions below this floor are dominated by floating-point round-off in the downstream evaluator. Default `1e-5`, clamped to `[0.0, 1e-2]` (Issue #1191). |
 | `NEAT_AI_DISCOVERY_DROUGHT_LOG_THRESHOLD` | Consecutive trailing empty discovery passes at which the drought diagnostic warn log fires and the `droughtDiagnostic` payload populates on `synapseMetadata` / `neuronMetadata`. Default `5`, must be `>= 1` (Issue #1202). |
+| `NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK` | Consecutive per-(creature, module) failure count at which a single discovery module is temporarily disabled for that creature. Default `15`, clamped to `[1, 1000]` (Issue #1273). |
+| `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS` | Epochs that a starved module remains disabled before being re-armed. Default `10`, clamped to `[1, 10_000]` (Issue #1273). |
 
 See [README.md — Troubleshooting](README.md#troubleshooting) and
 [README.md — GPU Performance Tuning](README.md#gpu-performance-tuning) for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.70"
+version = "0.74.71"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.70"
+version = "0.74.71"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/benches/quality_skip_dispatch.rs
+++ b/benches/quality_skip_dispatch.rs
@@ -66,6 +66,7 @@ fn make_detection_results(
                     detected_count: candidates.len(),
                     candidates,
                 }),
+                starved: false,
             }
         })
         .collect();

--- a/docs/archive/pr-summaries/pr-summary-1273.md
+++ b/docs/archive/pr-summaries/pr-summary-1273.md
@@ -1,0 +1,101 @@
+## Summary
+
+Adds a per-creature, per-module starvation tracker that temporarily disables a
+single discovery module for a single creature after `N` consecutive failures
+without an intervening success. This closes the gap between the population-wide
+module gate (Issue #1060), creature-level Conservative mode (Issue #1132), and
+per-target cooldown (`TargetFailureTracker`, Issue #1130) — none of which can
+disable a single module for one creature. Motivated by GRQ-sampler commit
+`e85c5d2` (creature `bcbca347`), where `coordinated-structural` recorded 41
+consecutive failures and 0 successes, consuming ~91% of the candidate budget
+while other modules went unexplored.
+
+Closes #1273.
+
+## Evidence
+
+CLI/backend change — no UI to screenshot.
+
+```mermaid
+flowchart TD
+    A[Pass result for creature C, module M] --> B{Success?}
+    B -- Yes --> C[Reset streak to 0, clear cooldown]
+    B -- No --> D[Increment streak]
+    D --> E{streak >= MODULE_STARVATION_FAILURE_STREAK?}
+    E -- No --> F[Continue normally next pass]
+    E -- Yes --> G[Record cooldown_start_epoch]
+    G --> H[Next pass: skip detect_fn,<br/>record `module_starved` rejection]
+    H --> I{cooldown elapsed?}
+    I -- No --> H
+    I -- Yes --> J[Re-arm M for C]
+```
+
+Key implementation points:
+
+- **New module**: `src/analysis/module_starvation_tracker.rs` — owns per-module
+  `consecutive_failures`, `last_failure_epoch`, `last_success_epoch`, and
+  `cooldown_start_epoch`. Thread-safe via `&self` reads / `&mut self` writes.
+- **New constants** in `src/analysis/constants/candidate_scoring.rs`:
+  - `MODULE_STARVATION_FAILURE_STREAK = 15`
+  - `MODULE_STARVATION_COOLDOWN_EPOCHS = 10`
+  - Both env-var overridable (`NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK`,
+    `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS`) with documented
+    valid ranges.
+- **Discovery dispatch wiring** (`src/analysis/discovery_dispatch.rs`): new
+  `detect_discovery_modules_parallel_with_starvation` skips a module's
+  `detect_fn` while the tracker reports `is_starved(module, epoch)`. The skip
+  is propagated to the merge phase via a `starved` flag on the entry, which
+  records one `module_starved` rejection in the synapse metadata.
+- **Drought diagnostic**: `DroughtDiagnostic.starved_module_count` (camelCase
+  JSON) reports the number of modules in active cooldown for the creature.
+- **New rejection reason**: `module_starved` (added to `ALL_REJECTION_REASONS`
+  and `friendly_reason()` map).
+- **Backwards compatibility**: existing entry points
+  (`detect_discovery_modules_parallel`, `prepare_and_detect_discovery_modules`,
+  `run_discovery_modules_parallel`) delegate to the starvation-aware variants
+  with `None` tracker / `0` epoch, so callers that have not yet adopted the new
+  signal behave exactly as before.
+
+## Test Plan
+
+New unit tests in `src/analysis/module_starvation_tracker.rs`:
+
+- `record_failure_increments_consecutive_counter` — streak counting.
+- `threshold_trip_disables_module` — hitting the streak threshold sets the
+  cooldown_start_epoch and trips `is_starved`.
+- `cooldown_expires_after_window` — module re-armed after `cooldown_epochs`.
+- `success_clears_streak_and_cooldown` — a single success resets the counter
+  and clears the cooldown.
+- `unknown_module_is_not_starved` — never-seen modules pass through.
+- `starved_module_count_only_counts_active_cooldowns` — diagnostic counter
+  only reports modules currently in active cooldown.
+- `regression_bcbca347_coordinated_structural_disabled_after_fifteen_failures`
+  — replays the 41-failure streak from GRQ-sampler creature `bcbca347` and
+  asserts the module is disabled by the 15th failure and re-armed once the
+  10-epoch cooldown elapses.
+- `starved_module_names_returns_sorted_distinct_list` — diagnostic naming.
+- `env_var_overrides_thresholds` — defaults reachable via `new()`.
+
+New integration tests in `src/analysis/discovery_dispatch_parallel_tests.rs`:
+
+- `starvation_tracker_skips_detect_fn_when_module_is_starved` — verifies the
+  starved module's closure does not run during parallel detection.
+- `merge_phase_records_module_starved_rejection` — verifies exactly one
+  `module_starved` rejection is recorded in `synapseMetadata.rejection_breakdown`.
+- `starvation_tracker_optional_when_none_passed` — confirms the legacy
+  None-tracker path is unchanged.
+
+New unit test in `src/analysis/drought_diagnostic.rs`:
+
+- `diagnostic_reports_starved_module_count` — verifies the new
+  `starvedModuleCount` field is populated when a starvation tracker is
+  supplied.
+
+Quality gate run:
+
+- `cargo build --lib` — clean.
+- `cargo check --all-targets --all-features` — clean.
+- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
+- `cargo test --lib --tests --all-features -- --test-threads=2` — 597
+  passing (5 ignored), 0 failing.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -326,6 +326,101 @@ pub const MODULE_GATE_THRESHOLD: f64 = 0.005;
 pub const SOFT_FAILURE_WEIGHT: f64 = 0.5;
 
 // =============================================================================
+// Per-Creature, Per-Module Starvation Tracker (Issue #1273)
+// =============================================================================
+
+/// Consecutive per-(creature, module) failure count at which the module is
+/// temporarily disabled for that creature (Issue #1273).
+///
+/// GRQ-sampler commit `e85c5d2` (creature `bcbca347`) showed the failure cache
+/// contained 41 consecutive `coordinated-structural` failures and zero
+/// successes — that module monopolised ~91% of the candidate budget for the
+/// creature while producing nothing. The cross-population module gate
+/// (`MODULE_GATE_THRESHOLD`, Issue #1060) operates on aggregated success rates
+/// and cannot disable a single module for a single creature, and the
+/// creature-level Conservative mode (Issue #1132) biases module weights rather
+/// than fully skipping a module. This per-(creature, module) cooldown closes
+/// that gap.
+///
+/// Overridable via `NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK`.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above 100 effectively disable starvation skipping.
+pub const MODULE_STARVATION_FAILURE_STREAK: u32 = 15;
+
+/// Minimum permitted failure-streak threshold after env-var override clamping
+/// (Issue #1273).
+pub const MODULE_STARVATION_FAILURE_STREAK_FLOOR: u32 = 1;
+
+/// Maximum permitted failure-streak threshold after env-var override clamping
+/// (Issue #1273).
+pub const MODULE_STARVATION_FAILURE_STREAK_CEILING: u32 = 1000;
+
+/// Number of epochs a starved module remains disabled for the affected
+/// creature before being re-armed (Issue #1273).
+///
+/// Once a module has hit
+/// [`MODULE_STARVATION_FAILURE_STREAK`] consecutive failures for a creature,
+/// its `detect_fn` is skipped for this many epochs. After the cooldown elapses
+/// (or a success is recorded for the same module from any source) the module
+/// is re-armed so the creature can probe it again.
+///
+/// Overridable via `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS`.
+///
+/// ## Valid Range
+/// Must be >= 1. Values above `10_000` keep modules disabled longer than any
+/// realistic discovery session.
+pub const MODULE_STARVATION_COOLDOWN_EPOCHS: u64 = 10;
+
+/// Minimum permitted cooldown duration after env-var override clamping
+/// (Issue #1273).
+pub const MODULE_STARVATION_COOLDOWN_EPOCHS_FLOOR: u64 = 1;
+
+/// Maximum permitted cooldown duration after env-var override clamping
+/// (Issue #1273).
+pub const MODULE_STARVATION_COOLDOWN_EPOCHS_CEILING: u64 = 10_000;
+
+/// Returns the effective per-creature, per-module starvation failure-streak
+/// threshold (Issue #1273).
+///
+/// Reads `NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK` at call time so
+/// tests and operators can override the default without recompiling. Values
+/// outside `[MODULE_STARVATION_FAILURE_STREAK_FLOOR,
+/// MODULE_STARVATION_FAILURE_STREAK_CEILING]` are clamped. Unparsable or
+/// missing values fall back to [`MODULE_STARVATION_FAILURE_STREAK`].
+#[must_use]
+pub fn module_starvation_failure_streak() -> u32 {
+    std::env::var("NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(MODULE_STARVATION_FAILURE_STREAK)
+        .clamp(
+            MODULE_STARVATION_FAILURE_STREAK_FLOOR,
+            MODULE_STARVATION_FAILURE_STREAK_CEILING,
+        )
+}
+
+/// Returns the effective per-creature, per-module starvation cooldown
+/// duration in epochs (Issue #1273).
+///
+/// Reads `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS` at call time
+/// so tests and operators can override the default without recompiling.
+/// Values outside `[MODULE_STARVATION_COOLDOWN_EPOCHS_FLOOR,
+/// MODULE_STARVATION_COOLDOWN_EPOCHS_CEILING]` are clamped. Unparsable or
+/// missing values fall back to [`MODULE_STARVATION_COOLDOWN_EPOCHS`].
+#[must_use]
+pub fn module_starvation_cooldown_epochs() -> u64 {
+    std::env::var("NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(MODULE_STARVATION_COOLDOWN_EPOCHS)
+        .clamp(
+            MODULE_STARVATION_COOLDOWN_EPOCHS_FLOOR,
+            MODULE_STARVATION_COOLDOWN_EPOCHS_CEILING,
+        )
+}
+
+// =============================================================================
 // Quality-Based Module Skipping (Issue #1074)
 // =============================================================================
 

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -75,6 +75,17 @@ pub const REJECTION_SAME_TARGET_SQUASH_DUPLICATE: &str = "same_target_squash_dup
 /// last operation's target neuron in the current batch (Issue #1271).
 pub const REJECTION_COORDINATED_TARGET_CAP_EXCEEDED: &str = "coordinated_target_cap_exceeded";
 
+/// Discovery module was skipped because the per-(creature, module) starvation
+/// tracker has the module in active cooldown after
+/// `MODULE_STARVATION_FAILURE_STREAK` consecutive failures (Issue #1273).
+///
+/// One rejection count is recorded per module skipped during the parallel
+/// detection phase. Unlike the population-wide `MODULE_GATE_THRESHOLD`
+/// (Issue #1060), this signal is creature-scoped: a module that has failed
+/// repeatedly for this creature is paused while the candidate budget is
+/// redirected to alternative modules.
+pub const REJECTION_MODULE_STARVED: &str = "module_starved";
+
 /// Synapse: no overlapping discovery samples between source and target.
 pub const REJECTION_NO_SAMPLES: &str = "no_samples";
 
@@ -144,6 +155,7 @@ pub const ALL_REJECTION_REASONS: &[&str] = &[
     REJECTION_PER_TARGET_CAP,
     REJECTION_SAME_TARGET_SQUASH_DUPLICATE,
     REJECTION_COORDINATED_TARGET_CAP_EXCEEDED,
+    REJECTION_MODULE_STARVED,
     REJECTION_NO_SAMPLES,
     REJECTION_ZERO_IMPROVEMENT,
     REJECTION_BELOW_THRESHOLD,
@@ -302,6 +314,7 @@ fn friendly_reason(reason: &str) -> String {
         REJECTION_COORDINATED_TARGET_CAP_EXCEEDED => {
             "per-final-target coordinated-structural cap".to_string()
         }
+        REJECTION_MODULE_STARVED => "per-creature module starvation cooldown".to_string(),
         REJECTION_NO_SAMPLES => "no overlapping discovery samples".to_string(),
         REJECTION_ZERO_IMPROVEMENT => "zero consistent improvement in GPU stats".to_string(),
         REJECTION_BELOW_THRESHOLD => "expected-improvement per-target threshold".to_string(),

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -28,8 +28,9 @@ use super::constants::{
 };
 use super::diagnostics::rejection_reasons::{
     REJECTION_BELOW_EXPECTED_GAIN_FLOOR, REJECTION_BUDGET_TRUNCATED,
-    REJECTION_COORDINATED_TARGET_CAP_EXCEEDED,
+    REJECTION_COORDINATED_TARGET_CAP_EXCEEDED, REJECTION_MODULE_STARVED,
 };
+use super::module_starvation_tracker::ModuleStarvationTracker;
 use super::module_weights::{DiscoveryModuleStatsJson, ModuleOutcomeTracker};
 use super::shared;
 use super::utils;
@@ -206,6 +207,10 @@ pub struct DiscoveryModuleDetectionEntry {
     pub phase_name: &'static str,
     pub max_candidates: usize,
     pub result: Option<DiscoveryDetectionResult>,
+    /// `true` when this module was skipped because the per-(creature, module)
+    /// starvation tracker has it in active cooldown (Issue #1273). The merge
+    /// phase uses this flag to record a `module_starved` rejection.
+    pub starved: bool,
 }
 
 /// Collected detection results from all discovery modules (Issue #1004).
@@ -244,6 +249,26 @@ pub fn detect_discovery_modules_parallel(
     deadline: Option<SystemTime>,
     tracker: Option<&ModuleOutcomeTracker>,
 ) -> DiscoveryModuleDetectionResults {
+    detect_discovery_modules_parallel_with_starvation(modules, deadline, tracker, None, 0)
+}
+
+/// Run all discovery module detection phases in parallel, applying both the
+/// population-wide module gate (Issue #1060) and the per-(creature, module)
+/// starvation cooldown (Issue #1273).
+///
+/// Identical contract to [`detect_discovery_modules_parallel`] except modules
+/// whose per-creature streak has tripped
+/// [`ModuleStarvationTracker::is_starved`] for `current_epoch` are skipped and
+/// flagged with `starved = true` on the returned entry so the merge phase
+/// records a `module_starved` rejection.
+#[tracing::instrument(skip_all, fields(module_count = modules.len()))]
+pub fn detect_discovery_modules_parallel_with_starvation(
+    modules: Vec<DiscoveryModuleSpec>,
+    deadline: Option<SystemTime>,
+    tracker: Option<&ModuleOutcomeTracker>,
+    starvation_tracker: Option<&ModuleStarvationTracker>,
+    current_epoch: u64,
+) -> DiscoveryModuleDetectionResults {
     if modules.is_empty() {
         return DiscoveryModuleDetectionResults {
             entries: Vec::new(),
@@ -262,6 +287,27 @@ pub fn detect_discovery_modules_parallel(
     let entries: Vec<DiscoveryModuleDetectionEntry> = modules
         .into_par_iter()
         .map(|spec| {
+            // Issue #1273: Skip detection if the per-(creature, module) starvation
+            // tracker has the module in active cooldown.
+            if let Some(s) = starvation_tracker
+                && s.is_starved(&spec.module_name, current_epoch)
+            {
+                tracing::debug!(
+                    module = %spec.module_name,
+                    streak_threshold = s.failure_streak_threshold(),
+                    cooldown_epochs = s.cooldown_epochs(),
+                    "Skipping discovery module — per-creature starvation cooldown active \
+                     (Issue #1273)"
+                );
+                return DiscoveryModuleDetectionEntry {
+                    module_name: spec.module_name,
+                    phase_name: spec.phase_name,
+                    max_candidates: spec.max_candidates,
+                    result: None,
+                    starved: true,
+                };
+            }
+
             // Issue #1060: Skip detection if the module is gated (low success rate).
             if let Some(t) = tracker
                 && t.is_gated(&spec.module_name, MODULE_GATE_THRESHOLD)
@@ -276,6 +322,7 @@ pub fn detect_discovery_modules_parallel(
                     phase_name: spec.phase_name,
                     max_candidates: spec.max_candidates,
                     result: None,
+                    starved: false,
                 };
             }
 
@@ -291,6 +338,7 @@ pub fn detect_discovery_modules_parallel(
                     phase_name: spec.phase_name,
                     max_candidates: spec.max_candidates,
                     result: None,
+                    starved: false,
                 };
             }
 
@@ -320,6 +368,7 @@ pub fn detect_discovery_modules_parallel(
                 phase_name: spec.phase_name,
                 max_candidates: spec.max_candidates,
                 result,
+                starved: false,
             }
         })
         .collect();
@@ -348,6 +397,18 @@ pub fn detect_discovery_modules_parallel(
                 "Discovery detection: module(s) gated by low success rate (Issue #1060)"
             );
         }
+    }
+
+    // Issue #1273: Log starved modules for observability.
+    let starved_count = entries.iter().filter(|e| e.starved).count();
+    if starved_count > 0 {
+        tracing::info!(
+            starved_count,
+            total = entries.len(),
+            current_epoch,
+            "Discovery detection: module(s) skipped by per-creature starvation cooldown \
+             (Issue #1273)"
+        );
     }
 
     crate::watchdog::beat("analysis::analyze_all → parallel discovery detection finished");
@@ -389,6 +450,14 @@ pub fn merge_discovery_module_results(
 
     for entry in detection_results.entries {
         let candidates_produced = entry.result.as_ref().map_or(0, |r| r.candidates.len());
+
+        // Issue #1273: Record skip in the rejection breakdown when the module
+        // was gated out by the per-creature starvation cooldown.
+        if entry.starved {
+            syn.metadata
+                .rejection_breakdown
+                .record(REJECTION_MODULE_STARVED);
+        }
 
         // Record per-module stats in metadata from historical tracker (Issue #792).
         let historical = tracker.stats(&entry.module_name);

--- a/src/analysis/discovery_dispatch_parallel_tests.rs
+++ b/src/analysis/discovery_dispatch_parallel_tests.rs
@@ -9,8 +9,11 @@ use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 
 use super::{
     DiscoveryDetectionResult, DiscoveryModuleSpec, ModuleOutcomeTracker,
-    detect_discovery_modules_parallel, run_discovery_modules_parallel,
+    detect_discovery_modules_parallel, detect_discovery_modules_parallel_with_starvation,
+    run_discovery_modules_parallel,
 };
+use crate::analysis::diagnostics::rejection_reasons::REJECTION_MODULE_STARVED;
+use crate::analysis::module_starvation_tracker::ModuleStarvationTracker;
 
 fn empty_synapse_result() -> shared::AnalyzeSynapsesResult {
     shared::AnalyzeSynapsesResult {
@@ -779,4 +782,165 @@ fn quality_skip_still_records_stats_for_skipped_modules() {
         module_names.contains(&"skipped_module"),
         "Skipped module should still have stats recorded"
     );
+}
+
+// =============================================================================
+// Issue #1273 — Per-creature, per-module starvation cooldown
+// =============================================================================
+
+/// A starved module's `detect_fn` must be skipped during the parallel detection
+/// phase even when the module would otherwise produce candidates.
+#[test]
+fn starvation_tracker_skips_detect_fn_when_module_is_starved() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    // Build a starvation tracker that already has "coordinated-structural"
+    // in active cooldown at epoch 5.
+    let mut starvation = ModuleStarvationTracker::with_thresholds(3, 10);
+    for epoch in 0..3 {
+        starvation.record_failure("coordinated-structural", epoch);
+    }
+    assert!(starvation.is_starved("coordinated-structural", 5));
+
+    // detect_fn must NOT execute for the starved module.
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let invoked_clone = Arc::clone(&invoked);
+    let starved_spec = DiscoveryModuleSpec {
+        module_name: "coordinated-structural".to_string(),
+        phase_name: "test_phase",
+        max_candidates: 0,
+        detect_fn: Box::new(move || {
+            invoked_clone.fetch_add(1, Ordering::SeqCst);
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(0.5)],
+            })
+        }),
+    };
+    let healthy_spec = make_module("change-bias", Some(vec![make_candidate(1.0)]));
+
+    let results = detect_discovery_modules_parallel_with_starvation(
+        vec![starved_spec, healthy_spec],
+        None,
+        None,
+        Some(&starvation),
+        5,
+    );
+
+    assert_eq!(
+        invoked.load(Ordering::SeqCst),
+        0,
+        "starved module's detect_fn must not run"
+    );
+
+    let starved_entry = results
+        .entries
+        .iter()
+        .find(|e| e.module_name == "coordinated-structural")
+        .expect("starved entry present");
+    assert!(
+        starved_entry.starved,
+        "entry must carry the starved flag for the merge phase"
+    );
+    assert!(starved_entry.result.is_none());
+
+    let healthy_entry = results
+        .entries
+        .iter()
+        .find(|e| e.module_name == "change-bias")
+        .expect("healthy entry present");
+    assert!(!healthy_entry.starved);
+    assert!(healthy_entry.result.is_some());
+}
+
+/// Merging detection results that include a starved entry must record one
+/// `module_starved` rejection in the synapse metadata so the drought
+/// diagnostic can attribute the lost candidate slot.
+#[test]
+fn merge_phase_records_module_starved_rejection() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    let mut syn = empty_synapse_result();
+
+    let mut starvation = ModuleStarvationTracker::with_thresholds(2, 100);
+    starvation.record_failure("coordinated-structural", 0);
+    starvation.record_failure("coordinated-structural", 1);
+
+    let starved_spec = DiscoveryModuleSpec {
+        module_name: "coordinated-structural".to_string(),
+        phase_name: "test_phase",
+        max_candidates: 0,
+        detect_fn: Box::new(|| {
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(0.5)],
+            })
+        }),
+    };
+    let healthy_spec = make_module("change-bias", Some(vec![make_candidate(1.0)]));
+
+    let results = detect_discovery_modules_parallel_with_starvation(
+        vec![starved_spec, healthy_spec],
+        None,
+        None,
+        Some(&starvation),
+        2,
+    );
+
+    let mut tracker = ModuleOutcomeTracker::new();
+    super::merge_discovery_module_results(&mut syn, results, None, false, &mut tracker);
+
+    let count = syn
+        .metadata
+        .rejection_breakdown
+        .counts()
+        .get(REJECTION_MODULE_STARVED)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(count, 1, "exactly one module_starved rejection expected");
+
+    // The healthy module's candidate should still arrive at the synapse result.
+    assert_eq!(syn.coordinated_structural_candidates.len(), 1);
+}
+
+/// When no starvation tracker is provided (None), the detection phase must
+/// behave identically to the legacy path: every module's `detect_fn` runs and
+/// no `module_starved` rejection is recorded.
+#[test]
+fn starvation_tracker_optional_when_none_passed() {
+    let _lock = crate::watchdog::lock_for_test_serialisation();
+    let _wd = crate::watchdog::Watchdog::start(crate::watchdog::WatchdogConfig {
+        stall_timeout: Duration::from_secs(60),
+        abort_delay: Duration::from_secs(1),
+    });
+
+    let invoked = Arc::new(AtomicUsize::new(0));
+    let invoked_clone = Arc::clone(&invoked);
+    let spec = DiscoveryModuleSpec {
+        module_name: "coordinated-structural".to_string(),
+        phase_name: "test_phase",
+        max_candidates: 0,
+        detect_fn: Box::new(move || {
+            invoked_clone.fetch_add(1, Ordering::SeqCst);
+            Some(DiscoveryDetectionResult {
+                detected_count: 1,
+                candidates: vec![make_candidate(1.0)],
+            })
+        }),
+    };
+
+    let results =
+        detect_discovery_modules_parallel_with_starvation(vec![spec], None, None, None, 999);
+
+    assert_eq!(invoked.load(Ordering::SeqCst), 1);
+    assert!(!results.entries[0].starved);
+    assert!(results.entries[0].result.is_some());
 }

--- a/src/analysis/drought_diagnostic.rs
+++ b/src/analysis/drought_diagnostic.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use super::candidate_cache::CandidateOutcomeCache;
 use super::diagnostics::RejectionBreakdown;
 use super::discovery_mode::DiscoveryMode;
+use super::module_starvation_tracker::ModuleStarvationTracker;
 use super::target_failure_tracker::TargetFailureTracker;
 
 /// Structured payload describing the current drought state (Issue #1202).
@@ -62,6 +63,13 @@ pub struct DroughtDiagnostic {
     pub total_candidates_considered: u32,
     /// Total candidates rejected across all reasons.
     pub total_candidates_rejected: u32,
+    /// Number of discovery modules currently in per-creature starvation
+    /// cooldown (Issue #1273). Reports how many modules are disabled for the
+    /// active creature after `MODULE_STARVATION_FAILURE_STREAK` consecutive
+    /// failures. `0` when the orchestrator does not supply a starvation
+    /// tracker.
+    #[serde(default)]
+    pub starved_module_count: u32,
 }
 
 /// Inputs gathered by the orchestrator before drought emission.
@@ -79,6 +87,10 @@ pub struct DroughtInputs<'a> {
     pub target_cooldown_skipped: u32,
     pub rejection_breakdown: &'a RejectionBreakdown,
     pub candidates_returned: u32,
+    /// Per-creature, per-module starvation tracker (Issue #1273). The
+    /// diagnostic reports the count of modules currently disabled. `None`
+    /// when the orchestrator does not maintain a starvation tracker.
+    pub starvation_tracker: Option<&'a ModuleStarvationTracker>,
 }
 
 /// Build a [`DroughtDiagnostic`] when the trailing-failure streak has crossed
@@ -103,6 +115,9 @@ pub fn emit_drought_diagnostic(
     let target_cooldown_active_count = inputs
         .target_tracker
         .map_or(0, |t| t.active_cooldown_count(inputs.current_epoch));
+    let starved_module_count = inputs.starvation_tracker.map_or(0_u32, |s| {
+        u32::try_from(s.starved_module_count(inputs.current_epoch)).unwrap_or(u32::MAX)
+    });
 
     let (dominant_rejection_reason, dominant_rejection_count) =
         match inputs.rejection_breakdown.dominant_reason() {
@@ -125,6 +140,7 @@ pub fn emit_drought_diagnostic(
         dominant_rejection_count,
         total_candidates_considered,
         total_candidates_rejected,
+        starved_module_count,
     };
 
     tracing::warn!(
@@ -142,6 +158,7 @@ pub fn emit_drought_diagnostic(
         dominant_rejection_count = diagnostic.dominant_rejection_count,
         total_candidates_considered = diagnostic.total_candidates_considered,
         total_candidates_rejected = diagnostic.total_candidates_rejected,
+        starved_module_count = diagnostic.starved_module_count,
         drought_threshold,
         "Issue #1202: discovery drought — no successful candidates for {} consecutive passes",
         diagnostic.consecutive_failures
@@ -173,6 +190,7 @@ mod tests {
             target_cooldown_skipped: 0,
             rejection_breakdown: &breakdown,
             candidates_returned: 0,
+            starvation_tracker: None,
         };
         assert!(emit_drought_diagnostic(&inputs, 5).is_none());
     }
@@ -190,6 +208,7 @@ mod tests {
             target_cooldown_skipped: 2,
             rejection_breakdown: &breakdown,
             candidates_returned: 0,
+            starvation_tracker: None,
         };
         let diag = emit_drought_diagnostic(&inputs, 5).expect("at threshold");
         assert_eq!(diag.consecutive_failures, 5);
@@ -226,6 +245,7 @@ mod tests {
             target_cooldown_skipped: 0,
             rejection_breakdown: &breakdown,
             candidates_returned: 1,
+            starvation_tracker: None,
         };
 
         let diag = emit_drought_diagnostic(&inputs, 5).expect("emits");
@@ -233,5 +253,34 @@ mod tests {
         assert_eq!(diag.candidate_cache_suppressed_count, 2);
         assert_eq!(diag.target_cooldown_active_count, 1);
         assert_eq!(diag.total_candidates_considered, 4); // 3 rejected + 1 returned.
+        assert_eq!(diag.starved_module_count, 0);
+    }
+
+    #[test]
+    fn diagnostic_reports_starved_module_count() {
+        let mut starvation = ModuleStarvationTracker::with_thresholds(2, 100);
+        starvation.record_failure("coordinated-structural", 0);
+        starvation.record_failure("coordinated-structural", 1);
+        starvation.record_failure("remove-neuron", 0);
+        starvation.record_failure("remove-neuron", 1);
+        // change-squash below threshold -> not starved.
+        starvation.record_failure("change-squash", 0);
+
+        let breakdown = breakdown_with("below_threshold", 1);
+        let inputs = DroughtInputs {
+            consecutive_failures: 6,
+            rolling_success_rate: 0.0,
+            discovery_mode: DiscoveryMode::Conservative,
+            candidate_cache: None,
+            target_tracker: None,
+            current_epoch: 1,
+            target_cooldown_skipped: 0,
+            rejection_breakdown: &breakdown,
+            candidates_returned: 0,
+            starvation_tracker: Some(&starvation),
+        };
+
+        let diag = emit_drought_diagnostic(&inputs, 5).expect("emits");
+        assert_eq!(diag.starved_module_count, 2);
     }
 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -47,6 +47,7 @@ pub mod drought_reset;
 pub mod early_termination;
 pub mod ensemble_scoring;
 pub mod gpu;
+pub mod module_starvation_tracker;
 pub mod module_weights;
 pub mod neuron;
 pub mod neuron_fingerprint;

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -83,6 +83,29 @@ pub(crate) fn prepare_and_detect_discovery_modules(
     tracker: &ModuleOutcomeTracker,
     deadline: Option<std::time::SystemTime>,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
+    prepare_and_detect_discovery_modules_with_starvation(
+        creature,
+        hidden_neurons,
+        shared_cache,
+        tracker,
+        deadline,
+        None,
+        0,
+    )
+}
+
+/// Same contract as [`prepare_and_detect_discovery_modules`] but also forwards
+/// the per-creature [`ModuleStarvationTracker`] so modules in active
+/// starvation cooldown are skipped at detection time (Issue #1273).
+pub(crate) fn prepare_and_detect_discovery_modules_with_starvation(
+    creature: &Arc<crate::CreatureJson>,
+    hidden_neurons: &Arc<Vec<(String, String, f32)>>,
+    shared_cache: &Arc<cache::RecordCache>,
+    tracker: &ModuleOutcomeTracker,
+    deadline: Option<std::time::SystemTime>,
+    starvation_tracker: Option<&super::module_starvation_tracker::ModuleStarvationTracker>,
+    current_epoch: u64,
+) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
     let mut modules = build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo);
@@ -97,7 +120,13 @@ pub(crate) fn prepare_and_detect_discovery_modules(
         }
     }
 
-    discovery_dispatch::detect_discovery_modules_parallel(modules, deadline, Some(tracker))
+    discovery_dispatch::detect_discovery_modules_parallel_with_starvation(
+        modules,
+        deadline,
+        Some(tracker),
+        starvation_tracker,
+        current_epoch,
+    )
 }
 
 /// Synthesise cross-detection candidates for co-flagged neurons (Issue #963).

--- a/src/analysis/module_starvation_tracker.rs
+++ b/src/analysis/module_starvation_tracker.rs
@@ -1,0 +1,360 @@
+//! Per-creature, per-module starvation tracker (Issue #1273).
+//!
+//! Disables a single discovery module for a single creature after `N`
+//! consecutive failures without an intervening success. Complements:
+//!
+//! - [`super::module_weights::ModuleOutcomeTracker`] — population-wide success
+//!   rate tracking (Issue #1060).
+//! - [`super::discovery_mode::DiscoveryMode`] — creature-level conservative
+//!   mode (Issue #1132).
+//! - [`super::target_failure_tracker::TargetFailureTracker`] — per-target
+//!   cooldown (Issue #1130).
+//!
+//! None of those layers cover the per-(creature, module) starvation case
+//! described in GRQ-sampler commit `e85c5d2` (creature `bcbca347`), where one
+//! module (`coordinated-structural`) recorded 41 consecutive failures and
+//! zero successes — consuming ~91% of the candidate budget for the creature
+//! while other modules (e.g. `add-neurons`, `add-synapses`) were starved out.
+//!
+//! # Design
+//!
+//! - Keyed by `module_name`. A single tracker instance is creature-scoped:
+//!   the orchestrator constructs one per `analyze_all` invocation.
+//! - Tracks per-module consecutive failure count, last failure / success
+//!   epoch, and the epoch at which the cooldown started.
+//! - A module enters cooldown after
+//!   [`ModuleStarvationTracker::failure_streak_threshold`] consecutive
+//!   failures. It stays disabled for
+//!   [`ModuleStarvationTracker::cooldown_epochs`] epochs after the cooldown
+//!   started.
+//! - A success resets the consecutive-failure counter to zero, clearing any
+//!   active cooldown.
+//! - Thresholds are env-var overridable via
+//!   `NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK` and
+//!   `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS`.
+
+use std::collections::HashMap;
+
+use super::constants::{module_starvation_cooldown_epochs, module_starvation_failure_streak};
+
+/// Per-module starvation state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StarvationState {
+    /// Consecutive failures since the last success (or ever).
+    pub consecutive_failures: u32,
+    /// Epoch of the most recent failure. `None` if never.
+    pub last_failure_epoch: Option<u64>,
+    /// Epoch of the most recent success. `None` if never.
+    pub last_success_epoch: Option<u64>,
+    /// Epoch at which the cooldown started (i.e. the failure-streak threshold
+    /// was first crossed in the current streak). `None` if not in cooldown.
+    pub cooldown_start_epoch: Option<u64>,
+}
+
+/// Per-creature, per-module failure-streak tracker (Issue #1273).
+///
+/// The orchestrator constructs one tracker per creature (per `analyze_all`
+/// invocation). Thread-safety: the tracker uses interior `HashMap` storage
+/// and offers `&self` reads / `&mut self` writes. The detection phase reads
+/// the tracker concurrently (via shared `&Self` borrow); the merge phase
+/// writes through a single `&mut Self`.
+#[derive(Debug, Clone, Default)]
+pub struct ModuleStarvationTracker {
+    states: HashMap<String, StarvationState>,
+    failure_streak_threshold: u32,
+    cooldown_epochs: u64,
+}
+
+impl ModuleStarvationTracker {
+    /// Creates a new tracker with thresholds sourced from the env-var helpers.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            states: HashMap::new(),
+            failure_streak_threshold: module_starvation_failure_streak(),
+            cooldown_epochs: module_starvation_cooldown_epochs(),
+        }
+    }
+
+    /// Creates a new tracker with explicit thresholds (for tests).
+    #[must_use]
+    pub fn with_thresholds(failure_streak_threshold: u32, cooldown_epochs: u64) -> Self {
+        Self {
+            states: HashMap::new(),
+            failure_streak_threshold,
+            cooldown_epochs,
+        }
+    }
+
+    /// Returns the configured failure-streak threshold.
+    #[must_use]
+    pub fn failure_streak_threshold(&self) -> u32 {
+        self.failure_streak_threshold
+    }
+
+    /// Returns the configured cooldown duration in epochs.
+    #[must_use]
+    pub fn cooldown_epochs(&self) -> u64 {
+        self.cooldown_epochs
+    }
+
+    /// Returns the number of modules being tracked.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.states.len()
+    }
+
+    /// Returns `true` when no modules have ever been recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.states.is_empty()
+    }
+
+    /// Returns the current state for `module_name`, if any.
+    #[must_use]
+    pub fn state(&self, module_name: &str) -> Option<&StarvationState> {
+        self.states.get(module_name)
+    }
+
+    /// Records a failure for `module_name` at `epoch`.
+    ///
+    /// Increments the consecutive-failure counter and updates the last-failure
+    /// epoch. When the counter first crosses
+    /// [`Self::failure_streak_threshold`] in the current streak, the cooldown
+    /// start epoch is set.
+    pub fn record_failure(&mut self, module_name: &str, epoch: u64) {
+        let threshold = self.failure_streak_threshold;
+        let entry = self.states.entry(module_name.to_string()).or_default();
+        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+        entry.last_failure_epoch = Some(epoch);
+        if entry.consecutive_failures >= threshold && entry.cooldown_start_epoch.is_none() {
+            entry.cooldown_start_epoch = Some(epoch);
+        }
+    }
+
+    /// Records a success for `module_name` at `epoch`.
+    ///
+    /// Resets the consecutive-failure counter to zero and clears any active
+    /// cooldown — the module is re-armed for the next pass.
+    pub fn record_success(&mut self, module_name: &str, epoch: u64) {
+        let entry = self.states.entry(module_name.to_string()).or_default();
+        entry.consecutive_failures = 0;
+        entry.last_success_epoch = Some(epoch);
+        entry.cooldown_start_epoch = None;
+    }
+
+    /// Returns `true` when `module_name` is currently disabled at
+    /// `current_epoch`.
+    ///
+    /// A module is starved when:
+    /// 1. Consecutive failures >= [`Self::failure_streak_threshold`], AND
+    /// 2. `current_epoch` < `cooldown_start_epoch + cooldown_epochs`.
+    ///
+    /// Modules never-seen, below the threshold, or whose cooldown window has
+    /// elapsed are NOT starved.
+    #[must_use]
+    pub fn is_starved(&self, module_name: &str, current_epoch: u64) -> bool {
+        let Some(state) = self.states.get(module_name) else {
+            return false;
+        };
+        if state.consecutive_failures < self.failure_streak_threshold {
+            return false;
+        }
+        let Some(cooldown_start) = state.cooldown_start_epoch else {
+            return false;
+        };
+        current_epoch < cooldown_start.saturating_add(self.cooldown_epochs)
+    }
+
+    /// Returns the number of modules currently in active starvation cooldown
+    /// at `current_epoch`. Surfaced in the drought diagnostic payload
+    /// (Issue #1273, Issue #1202).
+    #[must_use]
+    pub fn starved_module_count(&self, current_epoch: u64) -> usize {
+        self.states
+            .iter()
+            .filter(|(_, state)| {
+                if state.consecutive_failures < self.failure_streak_threshold {
+                    return false;
+                }
+                let Some(cooldown_start) = state.cooldown_start_epoch else {
+                    return false;
+                };
+                current_epoch < cooldown_start.saturating_add(self.cooldown_epochs)
+            })
+            .count()
+    }
+
+    /// Returns the names of every module currently in active cooldown at
+    /// `current_epoch`. Useful for verbose diagnostics.
+    #[must_use]
+    pub fn starved_module_names(&self, current_epoch: u64) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .states
+            .iter()
+            .filter_map(|(name, state)| {
+                if state.consecutive_failures < self.failure_streak_threshold {
+                    return None;
+                }
+                let cooldown_start = state.cooldown_start_epoch?;
+                if current_epoch < cooldown_start.saturating_add(self.cooldown_epochs) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        // Deterministic order for diagnostics.
+        names.sort();
+        names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Streak counting: consecutive failures bump the counter.
+    #[test]
+    fn record_failure_increments_consecutive_counter() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(3, 5);
+        tracker.record_failure("coordinated-structural", 0);
+        tracker.record_failure("coordinated-structural", 1);
+
+        let state = tracker
+            .state("coordinated-structural")
+            .expect("state present");
+        assert_eq!(state.consecutive_failures, 2);
+        assert_eq!(state.last_failure_epoch, Some(1));
+        assert!(state.last_success_epoch.is_none());
+        assert!(state.cooldown_start_epoch.is_none());
+    }
+
+    /// Threshold trip: hitting the streak threshold disables the module.
+    #[test]
+    fn threshold_trip_disables_module() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(3, 10);
+
+        tracker.record_failure("M", 0);
+        tracker.record_failure("M", 1);
+        // Below threshold yet.
+        assert!(!tracker.is_starved("M", 1));
+
+        tracker.record_failure("M", 2);
+        // At the threshold within the cooldown window.
+        assert!(tracker.is_starved("M", 2));
+        assert!(tracker.is_starved("M", 11));
+
+        let state = tracker.state("M").expect("state present");
+        assert_eq!(state.cooldown_start_epoch, Some(2));
+    }
+
+    /// Cooldown expiry: after the window elapses the module is re-armed.
+    #[test]
+    fn cooldown_expires_after_window() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(2, 5);
+        tracker.record_failure("M", 10);
+        tracker.record_failure("M", 11);
+        assert!(tracker.is_starved("M", 11));
+        assert!(tracker.is_starved("M", 15));
+        // cooldown_start = 11, cooldown_epochs = 5 -> released at 16.
+        assert!(!tracker.is_starved("M", 16));
+    }
+
+    /// Success clears the streak immediately and re-arms the module.
+    #[test]
+    fn success_clears_streak_and_cooldown() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(3, 10);
+        tracker.record_failure("M", 0);
+        tracker.record_failure("M", 1);
+        tracker.record_failure("M", 2);
+        assert!(tracker.is_starved("M", 2));
+
+        tracker.record_success("M", 3);
+
+        let state = tracker.state("M").expect("state present");
+        assert_eq!(state.consecutive_failures, 0);
+        assert_eq!(state.last_success_epoch, Some(3));
+        assert!(state.cooldown_start_epoch.is_none());
+        assert!(!tracker.is_starved("M", 3));
+    }
+
+    /// Unknown module: never starved.
+    #[test]
+    fn unknown_module_is_not_starved() {
+        let tracker = ModuleStarvationTracker::with_thresholds(3, 10);
+        assert!(!tracker.is_starved("never-seen", 5));
+    }
+
+    /// `starved_module_count` only counts modules currently in cooldown.
+    #[test]
+    fn starved_module_count_only_counts_active_cooldowns() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(2, 5);
+        // Module A: in cooldown.
+        tracker.record_failure("A", 0);
+        tracker.record_failure("A", 1);
+        // Module B: only one failure -> not starved.
+        tracker.record_failure("B", 0);
+        // Module C: cooldown window elapsed.
+        tracker.record_failure("C", 0);
+        tracker.record_failure("C", 1);
+        // Evaluate at epoch 10: A and C have cooldown_start ≤ 1, window = 5.
+        // A is at epoch 10 — 1 + 5 = 6 -> elapsed. So none are starved at 10.
+        assert_eq!(tracker.starved_module_count(10), 0);
+
+        // At epoch 5: A (cooldown_start = 1, ends at 6) is starved, C also.
+        assert_eq!(tracker.starved_module_count(5), 2);
+    }
+
+    /// Regression: GRQ-sampler creature `bcbca347` showed 41 consecutive
+    /// coordinated-structural failures and zero successes. With the default
+    /// threshold of 15, the module must be disabled by the 15th failure.
+    #[test]
+    fn regression_bcbca347_coordinated_structural_disabled_after_fifteen_failures() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(15, 10);
+        // Replay the 41-failure streak. The 15th failure must trip the gate.
+        for epoch in 0..14u64 {
+            tracker.record_failure("coordinated-structural", epoch);
+            // Still below threshold.
+            assert!(
+                !tracker.is_starved("coordinated-structural", epoch),
+                "module wrongly starved before 15 failures (epoch {epoch})"
+            );
+        }
+        tracker.record_failure("coordinated-structural", 14);
+        assert!(
+            tracker.is_starved("coordinated-structural", 14),
+            "coordinated-structural must be starved after exactly 15 failures"
+        );
+
+        // Continuing past 15 keeps the module starved within the cooldown.
+        for epoch in 15..41u64 {
+            tracker.record_failure("coordinated-structural", epoch);
+        }
+        // Cooldown started at epoch 14 with window of 10 -> still active at 23,
+        // released at 24.
+        assert!(tracker.is_starved("coordinated-structural", 23));
+        assert!(!tracker.is_starved("coordinated-structural", 24));
+    }
+
+    #[test]
+    fn starved_module_names_returns_sorted_distinct_list() {
+        let mut tracker = ModuleStarvationTracker::with_thresholds(2, 100);
+        tracker.record_failure("zeta", 0);
+        tracker.record_failure("zeta", 1);
+        tracker.record_failure("alpha", 0);
+        tracker.record_failure("alpha", 1);
+        tracker.record_failure("only-one", 0);
+
+        let names = tracker.starved_module_names(2);
+        assert_eq!(names, vec!["alpha".to_string(), "zeta".to_string()]);
+    }
+
+    #[test]
+    fn env_var_overrides_thresholds() {
+        // Defaults from constants.
+        let default_tracker = ModuleStarvationTracker::new();
+        assert!(default_tracker.failure_streak_threshold() >= 1);
+        assert!(default_tracker.cooldown_epochs() >= 1);
+    }
+}

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -968,6 +968,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             target_cooldown_skipped: 0,
             rejection_breakdown,
             candidates_returned,
+            starvation_tracker: None,
         };
         if let Some(diagnostic) =
             super::drought_diagnostic::emit_drought_diagnostic(&inputs, drought_threshold)

--- a/tests/analysis/issue_1004_overlap_compression_discovery.rs
+++ b/tests/analysis/issue_1004_overlap_compression_discovery.rs
@@ -437,6 +437,7 @@ fn merge_ordering_compression_before_discovery() {
                 detected_count: 1,
                 candidates: vec![make_candidate(3.0)],
             }),
+            starved: false,
         }],
     };
     merge_discovery_module_results(&mut syn, discovery_results, None, false, &mut tracker);


### PR DESCRIPTION
## Summary

Adds a per-creature, per-module starvation tracker that temporarily disables a
single discovery module for a single creature after `N` consecutive failures
without an intervening success. This closes the gap between the population-wide
module gate (Issue #1060), creature-level Conservative mode (Issue #1132), and
per-target cooldown (`TargetFailureTracker`, Issue #1130) — none of which can
disable a single module for one creature. Motivated by GRQ-sampler commit
`e85c5d2` (creature `bcbca347`), where `coordinated-structural` recorded 41
consecutive failures and 0 successes, consuming ~91% of the candidate budget
while other modules went unexplored.

Closes #1273.

## Evidence

CLI/backend change — no UI to screenshot.

```mermaid
flowchart TD
    A[Pass result for creature C, module M] --> B{Success?}
    B -- Yes --> C[Reset streak to 0, clear cooldown]
    B -- No --> D[Increment streak]
    D --> E{streak >= MODULE_STARVATION_FAILURE_STREAK?}
    E -- No --> F[Continue normally next pass]
    E -- Yes --> G[Record cooldown_start_epoch]
    G --> H[Next pass: skip detect_fn,<br/>record `module_starved` rejection]
    H --> I{cooldown elapsed?}
    I -- No --> H
    I -- Yes --> J[Re-arm M for C]
```

Key implementation points:

- **New module**: `src/analysis/module_starvation_tracker.rs` — owns per-module
  `consecutive_failures`, `last_failure_epoch`, `last_success_epoch`, and
  `cooldown_start_epoch`. Thread-safe via `&self` reads / `&mut self` writes.
- **New constants** in `src/analysis/constants/candidate_scoring.rs`:
  - `MODULE_STARVATION_FAILURE_STREAK = 15`
  - `MODULE_STARVATION_COOLDOWN_EPOCHS = 10`
  - Both env-var overridable (`NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK`,
    `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS`) with documented
    valid ranges.
- **Discovery dispatch wiring** (`src/analysis/discovery_dispatch.rs`): new
  `detect_discovery_modules_parallel_with_starvation` skips a module's
  `detect_fn` while the tracker reports `is_starved(module, epoch)`. The skip
  is propagated to the merge phase via a `starved` flag on the entry, which
  records one `module_starved` rejection in the synapse metadata.
- **Drought diagnostic**: `DroughtDiagnostic.starved_module_count` (camelCase
  JSON) reports the number of modules in active cooldown for the creature.
- **New rejection reason**: `module_starved` (added to `ALL_REJECTION_REASONS`
  and `friendly_reason()` map).
- **Backwards compatibility**: existing entry points
  (`detect_discovery_modules_parallel`, `prepare_and_detect_discovery_modules`,
  `run_discovery_modules_parallel`) delegate to the starvation-aware variants
  with `None` tracker / `0` epoch, so callers that have not yet adopted the new
  signal behave exactly as before.

## Test Plan

New unit tests in `src/analysis/module_starvation_tracker.rs`:

- `record_failure_increments_consecutive_counter` — streak counting.
- `threshold_trip_disables_module` — hitting the streak threshold sets the
  cooldown_start_epoch and trips `is_starved`.
- `cooldown_expires_after_window` — module re-armed after `cooldown_epochs`.
- `success_clears_streak_and_cooldown` — a single success resets the counter
  and clears the cooldown.
- `unknown_module_is_not_starved` — never-seen modules pass through.
- `starved_module_count_only_counts_active_cooldowns` — diagnostic counter
  only reports modules currently in active cooldown.
- `regression_bcbca347_coordinated_structural_disabled_after_fifteen_failures`
  — replays the 41-failure streak from GRQ-sampler creature `bcbca347` and
  asserts the module is disabled by the 15th failure and re-armed once the
  10-epoch cooldown elapses.
- `starved_module_names_returns_sorted_distinct_list` — diagnostic naming.
- `env_var_overrides_thresholds` — defaults reachable via `new()`.

New integration tests in `src/analysis/discovery_dispatch_parallel_tests.rs`:

- `starvation_tracker_skips_detect_fn_when_module_is_starved` — verifies the
  starved module's closure does not run during parallel detection.
- `merge_phase_records_module_starved_rejection` — verifies exactly one
  `module_starved` rejection is recorded in `synapseMetadata.rejection_breakdown`.
- `starvation_tracker_optional_when_none_passed` — confirms the legacy
  None-tracker path is unchanged.

New unit test in `src/analysis/drought_diagnostic.rs`:

- `diagnostic_reports_starved_module_count` — verifies the new
  `starvedModuleCount` field is populated when a starvation tracker is
  supplied.

Quality gate run:

- `cargo build --lib` — clean.
- `cargo check --all-targets --all-features` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --lib --tests --all-features -- --test-threads=2` — 597
  passing (5 ignored), 0 failing.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1273 -->