### PR TITLE
Skip 1-in/1-out collapse when bypass weight near-zero (Issue #1270)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,6 +652,7 @@ Key environment variables that control library behaviour:
 | `NEAT_AI_DISCOVERY_DROUGHT_LOG_THRESHOLD` | Consecutive trailing empty discovery passes at which the drought diagnostic warn log fires and the `droughtDiagnostic` payload populates on `synapseMetadata` / `neuronMetadata`. Default `5`, must be `>= 1` (Issue #1202). |
 | `NEAT_AI_DISCOVERY_MODULE_STARVATION_FAILURE_STREAK` | Consecutive per-(creature, module) failure count at which a single discovery module is temporarily disabled for that creature. Default `15`, clamped to `[1, 1000]` (Issue #1273). |
 | `NEAT_AI_DISCOVERY_MODULE_STARVATION_COOLDOWN_EPOCHS` | Epochs that a starved module remains disabled before being re-armed. Default `10`, clamped to `[1, 10_000]` (Issue #1273). |
+| `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE` | Minimum absolute bypass-synapse weight required to emit a 1-in/1-out hidden-neuron collapse candidate. Bypass weights below this floor signal the chain `a→h→b` was contributing nothing meaningful through `h`, so the 4-op coordinated collapse is rejected and recorded under `coordinated_collapse_bypass_weight_below_floor`. Default `0.01`, clamped to `[0.0, 0.1]` (Issue #1270). |
 
 See [README.md — Troubleshooting](README.md#troubleshooting) and
 [README.md — GPU Performance Tuning](README.md#gpu-performance-tuning) for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.72"
+version = "0.74.73"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.72"
+version = "0.74.73"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1270.md
+++ b/docs/archive/pr-summaries/pr-summary-1270.md
@@ -1,0 +1,98 @@
+## Summary
+
+Adds a bypass-weight floor to the 1-in/1-out hidden-neuron collapse detector
+so it stops emitting 4-op coordinated-structural candidates whose
+`addSynapse(a→b, weight=w)` would carry `|w|` below a meaningful threshold.
+When the bypass weight is near-zero, the chain `a→h→b` was contributing
+essentially nothing through `h`, so the proposal is functionally equivalent
+to a 1-op `remove-neuron` but still carries the much higher implementation-
+risk profile of a 4-op coordinated change. GRQ-sampler creature `bcbca347`
+captured 41 consecutive such failures (bypass weights as low as `2.1e-3`
+producing actual error changes ~6,500× worse than predicted).
+
+The new compile-time constant `MIN_BYPASS_WEIGHT_FOR_COLLAPSE` defaults to
+`0.01` and is overridable via
+`NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (clamped to `[0.0, 0.1]`).
+Rejected chains are recorded under the new stable rejection reason
+`coordinated_collapse_bypass_weight_below_floor` on the synapse metadata's
+`rejection_breakdown`, so the drop surfaces in the drought diagnostic
+without re-running analysis.
+
+Closes #1270.
+
+## Evidence
+
+Backend-only Rust change. No web UI to screenshot; verified via the new
+unit tests plus the full `quality.sh` gate (Clippy, full test suite, doc
+build, release build).
+
+```mermaid
+flowchart LR
+    A[detect_collapsible_hidden_neurons] --> B{|weight| >= MIN_BYPASS_WEIGHT_FOR_COLLAPSE?}
+    B -- No --> C[Reject + bypass_weight_below_floor_drops++]
+    C --> M[Metadata: rejection_breakdown[coordinated_collapse_bypass_weight_below_floor]]
+    B -- Yes --> D[Emit 4-op coordinated candidate]
+```
+
+### Filter placement
+
+The new floor is checked **after** the optimal bypass weight is computed
+and **before** the `improvement > 0` gate, so the rejection is recorded
+exactly when the dispatch-side counter says — not silently absorbed by a
+later filter.
+
+| Stage | Filter | Issue |
+|-------|--------|-------|
+| Pre-merge | `expected_creature_score_gain > 0.0` | existing |
+| Per-merge | `COORDINATED_MIN_EXPECTED_GAIN` (1e-5) | #1110 |
+| Post-discount | `COORDINATED_POST_DISCOUNT_NOISE_FLOOR_4PLUS_OPS` (5e-6) | #1128, #1272 |
+| **Per-candidate (new)** | **`MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (0.01)** | **#1270** |
+
+The new filter is orthogonal: `COORDINATED_MIN_EXPECTED_GAIN` and the
+post-discount tiers filter by *predicted gain*; this filter targets the
+failure mode where the bypass weight itself signals the collapse is risky
+regardless of predicted gain.
+
+## Test Plan
+
+Added inline unit tests in `src/analysis/synapse/structural_patterns.rs`
+(four tests, all passing under `cargo test --lib`):
+
+- `rejects_collapse_when_bypass_weight_below_default_floor` — synthetic
+  chain whose computed bypass weight is `0.005`; expects empty candidate
+  list and `bypass_weight_below_floor_drops == 1` (acceptance criterion).
+- `reproduces_bcbca347_failure_cache_pattern` — regression test for the
+  `bcbca347` failure-cache pattern at bypass weight `0.0021`; asserts no
+  candidate is emitted and the counter is incremented (acceptance
+  criterion).
+- `emits_candidate_when_bypass_weight_above_floor` — guards against the
+  floor accidentally rejecting useful candidates: bypass weight `0.05`
+  still produces exactly one collapse candidate, zero rejections.
+- `env_var_override_disables_floor` — sets
+  `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE=0` and verifies the
+  rejection counter stays at zero so legacy tests can opt out of the new
+  floor.
+
+The new tests use `RecordCache::with_loader` for a fully in-memory
+fixture and serialise env-var mutation via a static `Mutex`-backed RAII
+guard so they remain stable under `--test-threads=2`.
+
+All existing tests continue to pass — including the
+`collapse_hidden_neuron_with_identity_squash` integration test in
+`tests/synapse/issue_522_synapse_structural_patterns.rs`, which uses a
+bypass weight (~1.0) well above the new floor.
+
+## Files Touched
+
+- `src/analysis/constants/candidate_scoring.rs` — new constant, clamp
+  bounds, and `min_bypass_weight_for_collapse()` helper.
+- `src/analysis/diagnostics/rejection_reasons.rs` — new rejection reason
+  string, `ALL_REJECTION_REASONS` entry, and `friendly_reason` arm.
+- `src/analysis/synapse/structural_patterns.rs` — `CollapseDetectionOutcome`
+  return type, bypass-weight skip, in-line unit tests.
+- `src/analysis/synapse/results.rs` — destructure new outcome and pipe
+  drop count into `MetadataParams`.
+- `src/analysis/synapse/post_processing.rs` — new `MetadataParams` field
+  and seeding into `rejection_breakdown` in `build_metadata`.
+- `AGENTS.md` — env-var documentation row.
+- `Cargo.toml` — patch version bump `0.74.71 → 0.74.72`.

--- a/src/analysis/constants/candidate_scoring.rs
+++ b/src/analysis/constants/candidate_scoring.rs
@@ -1018,6 +1018,68 @@ pub fn min_expected_creature_score_gain() -> f32 {
 }
 
 // =============================================================================
+// Bypass-Weight Floor for Hidden-Neuron Collapse (Issue #1270)
+// =============================================================================
+
+/// Minimum absolute bypass-synapse weight required to emit a 1-in/1-out hidden
+/// neuron collapse candidate (Issue #1270).
+///
+/// `detect_collapsible_hidden_neurons` proposes a 4-op coordinated structural
+/// change (`removeSynapse(a→h)`, `removeSynapse(h→b)`, `removeNeuron(h)`,
+/// `addSynapse(a→b, weight=w)`). When `|w|` is below this floor the chain
+/// `a→h→b` was contributing essentially nothing through `h`, so the candidate
+/// is functionally equivalent to a 1-op `remove-neuron` but still carries the
+/// much higher implementation-risk profile of a 4-op coordinated change.
+///
+/// GRQ-sampler commit `e85c5d2` (creature `bcbca347`) captured 41 consecutive
+/// such failures: a bypass weight of `0.0021` produced an actual error
+/// reduction of `-0.0033` (~6,500× worse than predicted), and a bypass weight
+/// of `-0.000028` produced `-0.00083` (~1,600× worse). The
+/// `COORDINATED_MIN_EXPECTED_GAIN` (#1110) and per-op
+/// `COORDINATED_POST_DISCOUNT_NOISE_FLOOR_*` (#1128, #1272) floors filter on
+/// predicted gain; this floor targets the orthogonal failure mode where the
+/// bypass weight itself signals the collapse is risky regardless of predicted
+/// gain.
+///
+/// Overridable via the `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE`
+/// environment variable.
+///
+/// ## Valid Range
+/// Must be >= 0.0. Values above 0.1 may filter genuinely useful collapses.
+pub const MIN_BYPASS_WEIGHT_FOR_COLLAPSE: f32 = 0.01;
+
+/// Lower clamp for the `MIN_BYPASS_WEIGHT_FOR_COLLAPSE` env-var override
+/// (Issue #1270). `0.0` is accepted as a "disable the floor" value for tests
+/// that exercise the pre-#1270 contract at tiny magnitudes.
+pub const MIN_BYPASS_WEIGHT_FOR_COLLAPSE_FLOOR: f32 = 0.0;
+
+/// Upper clamp for the `MIN_BYPASS_WEIGHT_FOR_COLLAPSE` env-var override
+/// (Issue #1270).
+pub const MIN_BYPASS_WEIGHT_FOR_COLLAPSE_CEILING: f32 = 0.1;
+
+/// Returns the effective minimum absolute bypass weight required for the
+/// 1-in/1-out hidden neuron collapse candidate (Issue #1270).
+///
+/// Reads `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE` at call time so
+/// tests and operators can override the default without recompiling. Values
+/// outside `[MIN_BYPASS_WEIGHT_FOR_COLLAPSE_FLOOR,
+/// MIN_BYPASS_WEIGHT_FOR_COLLAPSE_CEILING]` are clamped. Unparsable,
+/// non-finite, or negative values fall back to
+/// [`MIN_BYPASS_WEIGHT_FOR_COLLAPSE`].
+#[must_use]
+pub fn min_bypass_weight_for_collapse() -> f32 {
+    std::env::var("NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE")
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .unwrap_or(MIN_BYPASS_WEIGHT_FOR_COLLAPSE)
+        .clamp(
+            MIN_BYPASS_WEIGHT_FOR_COLLAPSE_FLOOR,
+            MIN_BYPASS_WEIGHT_FOR_COLLAPSE_CEILING,
+        )
+}
+
+// =============================================================================
 // Coordinated Candidate Minimum Expected Gain (Issue #1110)
 // =============================================================================
 

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -75,6 +75,17 @@ pub const REJECTION_SAME_TARGET_SQUASH_DUPLICATE: &str = "same_target_squash_dup
 /// last operation's target neuron in the current batch (Issue #1271).
 pub const REJECTION_COORDINATED_TARGET_CAP_EXCEEDED: &str = "coordinated_target_cap_exceeded";
 
+/// 1-in/1-out hidden-neuron collapse candidate was dropped because the
+/// computed bypass synapse weight had `|weight| <
+/// MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (Issue #1270).
+///
+/// At near-zero bypass weights the chain `a→h→b` was contributing essentially
+/// nothing through the hidden neuron, so the 4-op coordinated collapse is
+/// functionally equivalent to a 1-op `remove-neuron` but still carries the
+/// implementation-risk profile of a 4-op coordinated change.
+pub const REJECTION_COORDINATED_COLLAPSE_BYPASS_WEIGHT_BELOW_FLOOR: &str =
+    "coordinated_collapse_bypass_weight_below_floor";
+
 /// Discovery module was skipped because the per-(creature, module) starvation
 /// tracker has the module in active cooldown after
 /// `MODULE_STARVATION_FAILURE_STREAK` consecutive failures (Issue #1273).
@@ -155,6 +166,7 @@ pub const ALL_REJECTION_REASONS: &[&str] = &[
     REJECTION_PER_TARGET_CAP,
     REJECTION_SAME_TARGET_SQUASH_DUPLICATE,
     REJECTION_COORDINATED_TARGET_CAP_EXCEEDED,
+    REJECTION_COORDINATED_COLLAPSE_BYPASS_WEIGHT_BELOW_FLOOR,
     REJECTION_MODULE_STARVED,
     REJECTION_NO_SAMPLES,
     REJECTION_ZERO_IMPROVEMENT,
@@ -314,6 +326,10 @@ fn friendly_reason(reason: &str) -> String {
         REJECTION_COORDINATED_TARGET_CAP_EXCEEDED => {
             "per-final-target coordinated-structural cap".to_string()
         }
+        REJECTION_COORDINATED_COLLAPSE_BYPASS_WEIGHT_BELOW_FLOOR => format!(
+            "hidden-neuron collapse bypass-weight floor of {}",
+            crate::analysis::constants::min_bypass_weight_for_collapse()
+        ),
         REJECTION_MODULE_STARVED => "per-creature module starvation cooldown".to_string(),
         REJECTION_NO_SAMPLES => "no overlapping discovery samples".to_string(),
         REJECTION_ZERO_IMPROVEMENT => "zero consistent improvement in GPU stats".to_string(),

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -618,6 +618,10 @@ pub(crate) struct MetadataParams<'a> {
     /// Issue #1143: count of new add-synapse sources dropped because their
     /// target neuron was already saturated.
     pub target_saturated_drops: u32,
+    /// Issue #1270: count of 1-in/1-out hidden-neuron collapse candidates
+    /// rejected by the bypass-weight floor in
+    /// `detect_collapsible_hidden_neurons`.
+    pub collapse_bypass_below_floor_drops: u32,
 }
 
 /// Build the analysis metadata from collected atomic flags and timing data.
@@ -664,6 +668,13 @@ pub(crate) fn build_metadata(
             b.record_many_u32(
                 crate::analysis::diagnostics::rejection_reasons::REJECTION_TARGET_SATURATED,
                 params.target_saturated_drops,
+            );
+            // Issue #1270: record bypass-weight-floor drops from the
+            // hidden-neuron collapse detector so the dispatch-side counter
+            // shows up in the drought diagnostic.
+            b.record_many_u32(
+                crate::analysis::diagnostics::rejection_reasons::REJECTION_COORDINATED_COLLAPSE_BYPASS_WEIGHT_BELOW_FLOOR,
+                params.collapse_bypass_below_floor_drops,
             );
             b
         },

--- a/src/analysis/synapse/results.rs
+++ b/src/analysis/synapse/results.rs
@@ -49,10 +49,13 @@ pub(super) fn finalise_synapse_results(
         log_analysis_timeout("synapse", completed, params.total_focus_count);
     }
 
-    // Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425)
-    let collapse_candidates =
+    // Collapse 1-in/1-out hidden neurons into direct synapses (Issue #425).
+    // Issue #1270: also surfaces the count of chains rejected by the bypass-
+    // weight floor so the metadata's rejection_breakdown reports the drop.
+    let collapse_outcome =
         structural_patterns::detect_collapsible_hidden_neurons(params.input, params.cache.as_ref());
-    coordinated_structural_results.extend(collapse_candidates);
+    coordinated_structural_results.extend(collapse_outcome.candidates);
+    let collapse_bypass_below_floor_drops = collapse_outcome.bypass_weight_below_floor_drops;
 
     // Post-processing: impact discounting, sorting, diversification, truncation
     let pp_metrics = post_processing::apply_post_processing(
@@ -89,6 +92,7 @@ pub(super) fn finalise_synapse_results(
         mcmc_summary: Some(params.mcmc_summary),
         calibration_corrections: pp_metrics.calibration_corrections,
         target_saturated_drops: params.diagnostics.target_saturated_drop_count(),
+        collapse_bypass_below_floor_drops,
     });
 
     Ok(AnalyzeSynapsesResult {

--- a/src/analysis/synapse/structural_patterns.rs
+++ b/src/analysis/synapse/structural_patterns.rs
@@ -8,13 +8,28 @@
 
 use super::scoring::compute_synapse_improvement_and_count;
 use crate::analysis::cache::RecordCache;
-use crate::analysis::constants::MIN_NEURON_SAMPLE_COUNT;
+use crate::analysis::constants::{MIN_NEURON_SAMPLE_COUNT, min_bypass_weight_for_collapse};
 use crate::analysis::diagnostics::TargetMap;
 use crate::analysis::samples::{EPSILON, HelpfulSample};
 use crate::analysis::scoring::weights::calculate_optimal_outgoing_weight;
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, SynapseJson};
 use std::collections::{HashMap, HashSet};
+
+/// Output of [`detect_collapsible_hidden_neurons`] paired with the count of
+/// candidates rejected by the bypass-weight floor (Issue #1270).
+///
+/// Callers should record `bypass_weight_below_floor_drops` against
+/// [`crate::analysis::diagnostics::rejection_reasons::REJECTION_COORDINATED_COLLAPSE_BYPASS_WEIGHT_BELOW_FLOOR`]
+/// on the synapse metadata's `rejection_breakdown` so the rejection surfaces
+/// in the drought diagnostic.
+#[derive(Debug, Default)]
+pub(crate) struct CollapseDetectionOutcome {
+    pub candidates: Vec<CoordinatedStructuralCandidateJson>,
+    /// Number of 1-in/1-out chains rejected because the computed bypass
+    /// weight had `|weight| < MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (Issue #1270).
+    pub bypass_weight_below_floor_drops: u32,
+}
 
 // =============================================================================
 // Noisy vs Trusted Input Folding (Issue #165)
@@ -237,8 +252,10 @@ pub(crate) fn detect_noisy_vs_trusted(
 pub(crate) fn detect_collapsible_hidden_neurons(
     input: &crate::AnalyzeSynapsesInput,
     cache: &RecordCache,
-) -> Vec<CoordinatedStructuralCandidateJson> {
+) -> CollapseDetectionOutcome {
     let mut results = Vec::new();
+    let mut bypass_weight_below_floor_drops: u32 = 0;
+    let bypass_floor = min_bypass_weight_for_collapse();
 
     // Build incoming/outgoing synapse lists per neuron (using references to avoid cloning).
     let mut incoming: HashMap<&str, Vec<&SynapseJson>> = HashMap::new();
@@ -368,6 +385,19 @@ pub(crate) fn detect_collapsible_hidden_neurons(
             continue;
         };
 
+        // Issue #1270: skip 1-in/1-out collapse candidates whose computed
+        // bypass weight is below the meaningful-weight floor. At near-zero
+        // bypass weights the chain `a→h→b` was contributing essentially
+        // nothing through `h`, so the 4-op coordinated change is functionally
+        // equivalent to a 1-op `remove-neuron` but carries the much higher
+        // implementation-risk profile of a 4-op coordinated candidate. The
+        // dropped count is propagated to the caller via
+        // [`CollapseDetectionOutcome`] for the rejection breakdown.
+        if weight.abs() < bypass_floor {
+            bypass_weight_below_floor_drops = bypass_weight_below_floor_drops.saturating_add(1);
+            continue;
+        }
+
         let (improvement, _improved, _worsened, _total, _magnitude) =
             compute_synapse_improvement_and_count(&samples, weight, baseline_sq, None);
         if improvement <= 0.0 {
@@ -401,5 +431,266 @@ pub(crate) fn detect_collapsible_hidden_neurons(
         });
     }
 
-    results
+    CollapseDetectionOutcome {
+        candidates: results,
+        bypass_weight_below_floor_drops,
+    }
+}
+
+// =============================================================================
+// Tests (Issue #1270)
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the 1-in/1-out hidden neuron collapse detector.
+    //!
+    //! These exercise the bypass-weight floor introduced in Issue #1270
+    //! directly via a synthetic [`RecordCache`], avoiding the GPU / parquet
+    //! setup required by the integration tests in
+    //! `tests/synapse/issue_522_synapse_structural_patterns.rs`.
+    use super::*;
+    use crate::AnalyzeSynapsesInput;
+    use crate::ffi_types::{CreatureJson, NeuronJson, SynapseJson};
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+
+    /// Serialise tests that mutate the `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE`
+    /// env variable so they do not race with other tests in the same process.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// RAII guard that overrides `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE`
+    /// during a test and restores the previous value on drop.
+    struct BypassFloorGuard {
+        previous: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl BypassFloorGuard {
+        fn new(value: &str) -> Self {
+            let lock = env_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let previous = std::env::var("NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE").ok();
+            // SAFETY: env mutation is serialised via the static lock above.
+            unsafe {
+                std::env::set_var("NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE", value);
+            }
+            Self {
+                previous,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for BypassFloorGuard {
+        fn drop(&mut self) {
+            // SAFETY: env mutation is serialised via the held lock.
+            unsafe {
+                match &self.previous {
+                    Some(prev) => {
+                        std::env::set_var("NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE", prev);
+                    }
+                    None => {
+                        std::env::remove_var("NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Build a minimal `input-0 → hidden-0 → output-0` chain whose collapse
+    /// would emit a bypass synapse `input-0 → output-0` with computed
+    /// `weight ≈ target_bypass_weight`.
+    ///
+    /// Constructs `n_samples` observations with activations evenly spaced in
+    /// `[-1, 1]`. The chain is configured as a pure passthrough
+    /// (`h_act = a_act`, intermediate squash IDENTITY, bias 0). With the
+    /// existing `h → b` synapse weight fixed at 0.5, the target neuron's
+    /// average error is set to `(target_bypass_weight - 0.5) * a_act`, which
+    /// makes the function's least-squares fit produce
+    /// `weight ≈ target_bypass_weight`.
+    fn build_collapse_input(
+        target_bypass_weight: f32,
+        n_samples: u32,
+    ) -> (AnalyzeSynapsesInput, RecordCache) {
+        let creature = CreatureJson {
+            input: 1,
+            output: 1,
+            neurons: vec![
+                NeuronJson {
+                    uuid: "hidden-0".to_string(),
+                    neuron_type: "hidden".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+                NeuronJson {
+                    uuid: "output-0".to_string(),
+                    neuron_type: "output".to_string(),
+                    squash: "IDENTITY".to_string(),
+                    bias: 0.0,
+                },
+            ],
+            synapses: vec![
+                SynapseJson {
+                    from_uuid: "input-0".to_string(),
+                    to_uuid: "hidden-0".to_string(),
+                    weight: 1.0,
+                    synapse_type: None,
+                },
+                SynapseJson {
+                    from_uuid: "hidden-0".to_string(),
+                    to_uuid: "output-0".to_string(),
+                    weight: 0.5,
+                    synapse_type: None,
+                },
+            ],
+        };
+
+        let input = AnalyzeSynapsesInput {
+            parquet_file: "<in-memory>".to_string(),
+            creature,
+            focus_neurons: vec!["output-0".to_string()],
+            max_candidates: None,
+            analysis_deadline_ms: None,
+            random_seed: Some(42),
+            temperature: 1.0,
+            failure_cache: None,
+            discovery_outcome_log: None,
+        };
+
+        // Build per-neuron record vectors and bind them into the synthetic
+        // record cache loader closure.
+        let mut input0 = Vec::with_capacity(n_samples as usize);
+        let mut hidden0 = Vec::with_capacity(n_samples as usize);
+        let mut output0 = Vec::with_capacity(n_samples as usize);
+        let b_syn_weight = 0.5_f32;
+        for i in 0..n_samples {
+            let a_act = -1.0
+                + (2.0 * f32::from(u16::try_from(i).unwrap_or(0)))
+                    / f32::from(u16::try_from(n_samples - 1).unwrap_or(1));
+            let h_act = a_act; // pure passthrough
+            let target_err = (target_bypass_weight - b_syn_weight) * a_act;
+            input0.push(DiscoverRecord::new(
+                i,
+                "input-0".to_string(),
+                Some(a_act),
+                a_act,
+                Vec::new(),
+            ));
+            hidden0.push(DiscoverRecord::new(
+                i,
+                "hidden-0".to_string(),
+                Some(h_act),
+                h_act,
+                Vec::new(),
+            ));
+            output0.push(DiscoverRecord::new(
+                i,
+                "output-0".to_string(),
+                Some(0.5 * h_act),
+                0.5 * h_act,
+                vec![target_err],
+            ));
+        }
+
+        let cache = RecordCache::with_loader(
+            "<in-memory>",
+            Arc::new(move |_path: &str, uuid: &str| match uuid {
+                "input-0" => Ok(input0.clone()),
+                "hidden-0" => Ok(hidden0.clone()),
+                "output-0" => Ok(output0.clone()),
+                other => Err(anyhow::anyhow!("unexpected uuid {other}")),
+            }),
+        );
+
+        (input, cache)
+    }
+
+    /// Acceptance-criterion test: a synthetic 1-in/1-out chain whose computed
+    /// bypass weight is `0.005` must be rejected and the rejection counter
+    /// incremented.
+    #[test]
+    fn rejects_collapse_when_bypass_weight_below_default_floor() {
+        let _guard = BypassFloorGuard::new("0.01");
+
+        let (input, cache) = build_collapse_input(0.005, 12);
+        let outcome = detect_collapsible_hidden_neurons(&input, &cache);
+
+        assert!(
+            outcome.candidates.is_empty(),
+            "Expected no collapse candidates with bypass weight 0.005 under a 0.01 floor; got: {:?}",
+            outcome.candidates
+        );
+        assert_eq!(
+            outcome.bypass_weight_below_floor_drops, 1,
+            "Expected exactly one bypass-weight-floor rejection"
+        );
+    }
+
+    /// Regression test for the GRQ-sampler creature `bcbca347` failure-cache
+    /// pattern: bypass weight `0.0021` must not produce a collapse candidate.
+    #[test]
+    fn reproduces_bcbca347_failure_cache_pattern() {
+        let _guard = BypassFloorGuard::new("0.01");
+
+        let (input, cache) = build_collapse_input(0.0021, 12);
+        let outcome = detect_collapsible_hidden_neurons(&input, &cache);
+
+        assert!(
+            outcome.candidates.is_empty(),
+            "Bypass weight 0.0021 (bcbca347 failure pattern) should be rejected"
+        );
+        assert_eq!(
+            outcome.bypass_weight_below_floor_drops, 1,
+            "bcbca347-style bypass weight must increment the rejection counter"
+        );
+    }
+
+    /// A bypass weight above the floor should still be emitted. This guards
+    /// against the floor accidentally rejecting legitimately useful
+    /// candidates after the Issue #1270 change.
+    #[test]
+    fn emits_candidate_when_bypass_weight_above_floor() {
+        let _guard = BypassFloorGuard::new("0.01");
+
+        // Computed weight ~0.05, comfortably above the 0.01 default floor.
+        let (input, cache) = build_collapse_input(0.05, 12);
+        let outcome = detect_collapsible_hidden_neurons(&input, &cache);
+
+        assert_eq!(
+            outcome.bypass_weight_below_floor_drops, 0,
+            "Above-floor bypass weight must not trigger the rejection counter"
+        );
+        assert_eq!(
+            outcome.candidates.len(),
+            1,
+            "Expected exactly one collapse candidate, got {} (candidates: {:?})",
+            outcome.candidates.len(),
+            outcome.candidates,
+        );
+    }
+
+    /// The env-var override (`NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE
+    /// = 0`) must disable the floor entirely so legacy callers that depend on
+    /// the pre-#1270 behaviour can opt out for tests.
+    #[test]
+    fn env_var_override_disables_floor() {
+        let _guard = BypassFloorGuard::new("0");
+
+        let (input, cache) = build_collapse_input(0.005, 12);
+        let outcome = detect_collapsible_hidden_neurons(&input, &cache);
+
+        assert_eq!(
+            outcome.bypass_weight_below_floor_drops, 0,
+            "Disabling the floor must suppress the rejection counter"
+        );
+        // The candidate may or may not survive the `improvement > 0` check
+        // — that path is unaffected by Issue #1270. We only assert the
+        // dispatch-side counter stays zero when the floor is disabled.
+    }
 }


### PR DESCRIPTION
## Summary

Adds a bypass-weight floor to the 1-in/1-out hidden-neuron collapse detector
so it stops emitting 4-op coordinated-structural candidates whose
`addSynapse(a→b, weight=w)` would carry `|w|` below a meaningful threshold.
When the bypass weight is near-zero, the chain `a→h→b` was contributing
essentially nothing through `h`, so the proposal is functionally equivalent
to a 1-op `remove-neuron` but still carries the much higher implementation-
risk profile of a 4-op coordinated change. GRQ-sampler creature `bcbca347`
captured 41 consecutive such failures (bypass weights as low as `2.1e-3`
producing actual error changes ~6,500× worse than predicted).

The new compile-time constant `MIN_BYPASS_WEIGHT_FOR_COLLAPSE` defaults to
`0.01` and is overridable via
`NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (clamped to `[0.0, 0.1]`).
Rejected chains are recorded under the new stable rejection reason
`coordinated_collapse_bypass_weight_below_floor` on the synapse metadata's
`rejection_breakdown`, so the drop surfaces in the drought diagnostic
without re-running analysis.

Closes #1270.

## Evidence

Backend-only Rust change. No web UI to screenshot; verified via the new
unit tests plus the full `quality.sh` gate (Clippy, full test suite, doc
build, release build).

```mermaid
flowchart LR
    A[detect_collapsible_hidden_neurons] --> B{|weight| >= MIN_BYPASS_WEIGHT_FOR_COLLAPSE?}
    B -- No --> C[Reject + bypass_weight_below_floor_drops++]
    C --> M[Metadata: rejection_breakdown[coordinated_collapse_bypass_weight_below_floor]]
    B -- Yes --> D[Emit 4-op coordinated candidate]
```

### Filter placement

The new floor is checked **after** the optimal bypass weight is computed
and **before** the `improvement > 0` gate, so the rejection is recorded
exactly when the dispatch-side counter says — not silently absorbed by a
later filter.

| Stage | Filter | Issue |
|-------|--------|-------|
| Pre-merge | `expected_creature_score_gain > 0.0` | existing |
| Per-merge | `COORDINATED_MIN_EXPECTED_GAIN` (1e-5) | #1110 |
| Post-discount | `COORDINATED_POST_DISCOUNT_NOISE_FLOOR_4PLUS_OPS` (5e-6) | #1128, #1272 |
| **Per-candidate (new)** | **`MIN_BYPASS_WEIGHT_FOR_COLLAPSE` (0.01)** | **#1270** |

The new filter is orthogonal: `COORDINATED_MIN_EXPECTED_GAIN` and the
post-discount tiers filter by *predicted gain*; this filter targets the
failure mode where the bypass weight itself signals the collapse is risky
regardless of predicted gain.

## Test Plan

Added inline unit tests in `src/analysis/synapse/structural_patterns.rs`
(four tests, all passing under `cargo test --lib`):

- `rejects_collapse_when_bypass_weight_below_default_floor` — synthetic
  chain whose computed bypass weight is `0.005`; expects empty candidate
  list and `bypass_weight_below_floor_drops == 1` (acceptance criterion).
- `reproduces_bcbca347_failure_cache_pattern` — regression test for the
  `bcbca347` failure-cache pattern at bypass weight `0.0021`; asserts no
  candidate is emitted and the counter is incremented (acceptance
  criterion).
- `emits_candidate_when_bypass_weight_above_floor` — guards against the
  floor accidentally rejecting useful candidates: bypass weight `0.05`
  still produces exactly one collapse candidate, zero rejections.
- `env_var_override_disables_floor` — sets
  `NEAT_AI_DISCOVERY_MIN_BYPASS_WEIGHT_FOR_COLLAPSE=0` and verifies the
  rejection counter stays at zero so legacy tests can opt out of the new
  floor.

The new tests use `RecordCache::with_loader` for a fully in-memory
fixture and serialise env-var mutation via a static `Mutex`-backed RAII
guard so they remain stable under `--test-threads=2`.

All existing tests continue to pass — including the
`collapse_hidden_neuron_with_identity_squash` integration test in
`tests/synapse/issue_522_synapse_structural_patterns.rs`, which uses a
bypass weight (~1.0) well above the new floor.

## Files Touched

- `src/analysis/constants/candidate_scoring.rs` — new constant, clamp
  bounds, and `min_bypass_weight_for_collapse()` helper.
- `src/analysis/diagnostics/rejection_reasons.rs` — new rejection reason
  string, `ALL_REJECTION_REASONS` entry, and `friendly_reason` arm.
- `src/analysis/synapse/structural_patterns.rs` — `CollapseDetectionOutcome`
  return type, bypass-weight skip, in-line unit tests.
- `src/analysis/synapse/results.rs` — destructure new outcome and pipe
  drop count into `MetadataParams`.
- `src/analysis/synapse/post_processing.rs` — new `MetadataParams` field
  and seeding into `rejection_breakdown` in `build_metadata`.
- `AGENTS.md` — env-var documentation row.
- `Cargo.toml` — patch version bump `0.74.71 → 0.74.72`.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1270 -->