### PR TITLE
ci: add timeout-minutes to every job across .github/workflows/

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -19,6 +19,10 @@ jobs:
   quality:
     name: Format, Clippy and Coverage
     runs-on: ubuntu-latest
+    # rustfmt + clippy + cargo-llvm-cov coverage build. Coverage
+    # instrumentation roughly doubles build time, so 45 minutes mirrors
+    # the heaviest cargo job (Issue #1287).
+    timeout-minutes: 45
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
     name: Auto-increment Versions
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # Cap runtime to surface wedged `cargo install` / `git fetch` steps
+    # as fast failures rather than letting them tie up a runner for the
+    # GitHub default 6h (Issue #1287).
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -159,6 +163,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     if: github.event_name == 'pull_request'
     needs: [version-increment, auto-format]
+    # Heaviest job: Rust compile, clippy, full test suite. 45 minutes
+    # leaves headroom for cold caches while still firing well before
+    # the 6h GitHub default (Issue #1287).
+    timeout-minutes: 45
     env:
       RUSTFLAGS: "-D warnings"
     
@@ -260,7 +268,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
-    
+    # File-presence and lightweight cargo check — 10 minutes is plenty
+    # while still capping wedged-runner exposure (Issue #1287).
+    timeout-minutes: 10
+
     steps:
     - name: Checkout code
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
@@ -333,6 +344,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
+    # rustfmt + commit-and-push; 15 minutes covers a cold toolchain
+    # install while still bounding hangs (Issue #1287).
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -404,7 +418,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
-    
+    # codespell over the tree — light job, 10 minute cap (Issue #1287).
+    timeout-minutes: 10
+
     steps:
     - name: Checkout code
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    # Secret-scan over the PR diff — light job, 10 minute cap
+    # (Issue #1287).
+    timeout-minutes: 10
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    # markdownlint-cli2 + optional Mermaid validation — light job,
+    # 10 minute cap (Issue #1287).
+    timeout-minutes: 10
     steps:
       # actions/checkout@v5
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   security:
     runs-on: ubuntu-latest
+    # cargo install cargo-audit + audit run + dependency-review.
+    # Compiling cargo-audit from source dominates runtime; 20 minutes
+    # covers a cold build while still bounding hangs (Issue #1287).
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       # Pinned to actions/checkout v6.0.2 (Node.js 24) to avoid the

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    # SAST scan over the tree — light job, 10 minute cap
+    # (Issue #1287).
+    timeout-minutes: 10
     container:
       # Pinned to semgrep/semgrep 1.163.0 (Issue #1258). The multi-arch
       # manifest digest below is immutable; Renovate's github-actions

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    # ShellCheck lint over all bash scripts — light job, 10 minute cap
+    # (Issue #1287).
+    timeout-minutes: 10
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/archive/pr-summaries/pr-summary-1287.md
+++ b/docs/archive/pr-summaries/pr-summary-1287.md
@@ -1,0 +1,62 @@
+# Add `timeout-minutes:` to every job across `.github/workflows/`
+
+## Summary
+
+Every job across the seven workflows in `.github/workflows/` was missing a
+`timeout-minutes:` field, so a wedged step could hold a runner for the GitHub
+default of 6 hours (360 minutes). This PR adds an explicit per-job
+`timeout-minutes:` to each job — light lint/scan jobs at 10 minutes,
+medium toolchain jobs at 15–20 minutes, and the heavy cargo build/test
+jobs at 45 minutes — so hangs surface as fast failures rather than
+tying up runner capacity for hours.
+
+Closes #1287.
+
+### Timeouts applied
+
+| Workflow | Job | timeout-minutes |
+| --- | --- | --- |
+| `ci.yml` | `version-increment` | 15 |
+| `ci.yml` | `quality` | 45 |
+| `ci.yml` | `validation` | 10 |
+| `ci.yml` | `auto-format` | 15 |
+| `ci.yml` | `spell-check` | 10 |
+| `cargo-quality.yml` | `quality` | 45 |
+| `gitleaks.yml` | `gitleaks` | 10 |
+| `markdown-lint.yml` | `markdownlint` | 10 |
+| `security.yml` | `security` | 20 |
+| `semgrep.yml` | `semgrep` | 10 |
+| `shellcheck.yml` | `shellcheck` | 10 |
+
+The `security` job in `ci.yml` is a reusable-workflow caller
+(`uses: ./.github/workflows/security.yml`) — it inherits its cap from
+the `timeout-minutes:` set inside `security.yml`, so no separate
+entry is needed at the call site.
+
+## Evidence
+
+Backend/CI-only change with no UI to screenshot. Verified by:
+
+1. Added a new test suite `tests/issue_1287_workflow_timeouts.rs` that
+   reads each workflow file and asserts every job block contains a
+   `timeout-minutes:` line at the expected per-job indent.
+2. Ran the test suite before the YAML edits — all 7 tests failed as
+   expected (TDD red).
+3. Applied the YAML edits — all 7 tests pass (TDD green).
+4. Confirmed adjacent workflow tests (`issue_1216_workflow_sha_pins`,
+   `issue_1258_container_image_digest_pins`,
+   `issue_1286_workflow_permissions`) still pass — the timeout additions
+   do not disturb SHA pinning, container-digest pinning, or the
+   top-level `permissions:` block.
+
+## Test Plan
+
+- [x] `cargo test --test issue_1287_workflow_timeouts` — 7 tests pass.
+- [x] `cargo test --test issue_1286_workflow_permissions` — 2 tests
+      pass (no regression in `permissions:` test).
+- [x] `cargo test --test issue_1216_workflow_sha_pins` — passes (SHA
+      pin test unaffected).
+- [x] `cargo test --test issue_1258_container_image_digest_pins` —
+      6 tests pass (container-digest test unaffected).
+- [x] `cargo fmt --all -- --check` — clean.
+- [x] `cargo clippy --tests --all-features -- -D warnings` — clean.

--- a/tests/issue_1287_workflow_timeouts.rs
+++ b/tests/issue_1287_workflow_timeouts.rs
@@ -1,0 +1,160 @@
+//! Issue #1287: every job declared across `.github/workflows/` must set
+//! an explicit `timeout-minutes:` field. Without one, a wedged step
+//! holds a runner for the GitHub default (6 hours / 360 minutes),
+//! tying up scarce CI capacity. An explicit cap surfaces hangs as
+//! fast failures.
+//!
+//! This test parses each workflow file as plain text (no YAML parser
+//! is in the dependency tree), locates every job block under `jobs:`,
+//! and asserts that the block contains a `timeout-minutes:` field
+//! before the next sibling job or end of file.
+//!
+//! Reusable workflows (the `security` job in `ci.yml` that delegates
+//! to `security.yml` via `uses:`) are excluded — they have no
+//! `runs-on:` and `timeout-minutes:` is set inside the reusable file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`  <job>:` at two-space indent under
+/// `jobs:`) and return the block body up to the next sibling job or end
+/// of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(&after[..bytes.len()]);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char and
+            // ends with `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+/// Returns true if `block` contains a `timeout-minutes:` line at the
+/// expected per-job indent (four spaces).
+fn has_timeout_minutes(block: &str) -> bool {
+    block.lines().any(|line| {
+        line.trim_start() == line.trim_start_matches(' ')
+            && line.starts_with("    timeout-minutes:")
+    })
+}
+
+#[test]
+fn ci_yml_jobs_declare_timeout_minutes() {
+    let body = read_workflow("ci.yml");
+    // The `security` job in ci.yml is a reusable-workflow caller
+    // (no runs-on); its timeout-minutes lives in security.yml.
+    for job_name in [
+        "version-increment",
+        "quality",
+        "validation",
+        "auto-format",
+        "spell-check",
+    ] {
+        let block = job_block(&body, job_name)
+            .unwrap_or_else(|| panic!("job `{job_name}` not found in ci.yml"));
+        assert!(
+            has_timeout_minutes(block),
+            "job `{job_name}` in ci.yml must declare `timeout-minutes:` \
+             to cap exposure to wedged runners (Issue #1287)",
+        );
+    }
+}
+
+#[test]
+fn cargo_quality_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("cargo-quality.yml");
+    let block = job_block(&body, "quality").expect("job `quality` not found in cargo-quality.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `quality` in cargo-quality.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}
+
+#[test]
+fn gitleaks_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("gitleaks.yml");
+    let block = job_block(&body, "gitleaks").expect("job `gitleaks` not found in gitleaks.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `gitleaks` in gitleaks.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}
+
+#[test]
+fn markdown_lint_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("markdown-lint.yml");
+    let block = job_block(&body, "markdownlint")
+        .expect("job `markdownlint` not found in markdown-lint.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `markdownlint` in markdown-lint.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}
+
+#[test]
+fn security_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("security.yml");
+    let block = job_block(&body, "security").expect("job `security` not found in security.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `security` in security.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}
+
+#[test]
+fn semgrep_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("semgrep.yml");
+    let block = job_block(&body, "semgrep").expect("job `semgrep` not found in semgrep.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `semgrep` in semgrep.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}
+
+#[test]
+fn shellcheck_yml_job_declares_timeout_minutes() {
+    let body = read_workflow("shellcheck.yml");
+    let block =
+        job_block(&body, "shellcheck").expect("job `shellcheck` not found in shellcheck.yml");
+    assert!(
+        has_timeout_minutes(block),
+        "job `shellcheck` in shellcheck.yml must declare \
+         `timeout-minutes:` (Issue #1287)",
+    );
+}


### PR DESCRIPTION
# Add `timeout-minutes:` to every job across `.github/workflows/`

## Summary

Every job across the seven workflows in `.github/workflows/` was missing a
`timeout-minutes:` field, so a wedged step could hold a runner for the GitHub
default of 6 hours (360 minutes). This PR adds an explicit per-job
`timeout-minutes:` to each job — light lint/scan jobs at 10 minutes,
medium toolchain jobs at 15–20 minutes, and the heavy cargo build/test
jobs at 45 minutes — so hangs surface as fast failures rather than
tying up runner capacity for hours.

Closes #1287.

### Timeouts applied

| Workflow | Job | timeout-minutes |
| --- | --- | --- |
| `ci.yml` | `version-increment` | 15 |
| `ci.yml` | `quality` | 45 |
| `ci.yml` | `validation` | 10 |
| `ci.yml` | `auto-format` | 15 |
| `ci.yml` | `spell-check` | 10 |
| `cargo-quality.yml` | `quality` | 45 |
| `gitleaks.yml` | `gitleaks` | 10 |
| `markdown-lint.yml` | `markdownlint` | 10 |
| `security.yml` | `security` | 20 |
| `semgrep.yml` | `semgrep` | 10 |
| `shellcheck.yml` | `shellcheck` | 10 |

The `security` job in `ci.yml` is a reusable-workflow caller
(`uses: ./.github/workflows/security.yml`) — it inherits its cap from
the `timeout-minutes:` set inside `security.yml`, so no separate
entry is needed at the call site.

## Evidence

Backend/CI-only change with no UI to screenshot. Verified by:

1. Added a new test suite `tests/issue_1287_workflow_timeouts.rs` that
   reads each workflow file and asserts every job block contains a
   `timeout-minutes:` line at the expected per-job indent.
2. Ran the test suite before the YAML edits — all 7 tests failed as
   expected (TDD red).
3. Applied the YAML edits — all 7 tests pass (TDD green).
4. Confirmed adjacent workflow tests (`issue_1216_workflow_sha_pins`,
   `issue_1258_container_image_digest_pins`,
   `issue_1286_workflow_permissions`) still pass — the timeout additions
   do not disturb SHA pinning, container-digest pinning, or the
   top-level `permissions:` block.

## Test Plan

- [x] `cargo test --test issue_1287_workflow_timeouts` — 7 tests pass.
- [x] `cargo test --test issue_1286_workflow_permissions` — 2 tests
      pass (no regression in `permissions:` test).
- [x] `cargo test --test issue_1216_workflow_sha_pins` — passes (SHA
      pin test unaffected).
- [x] `cargo test --test issue_1258_container_image_digest_pins` —
      6 tests pass (container-digest test unaffected).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --tests --all-features -- -D warnings` — clean.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1287 -->