### PR TITLE
Fix influence calc: squash-bounded contribution + consumer gates (Issue #1300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.74.74]
+
+### Fixed
+
+#### Squash-bounded impact attribution and consumer-gate model (Issue #1300)
+
+Mirrors `NEAT-AI-Explore#266`. Three correctness gaps in the impact calculation:
+
+- **Squash-bounded contribution.** Per-synapse contribution now respects the
+  downstream squash's emit magnitude (`squash_emit_magnitude` in
+  `src/activations.rs`). For threshold squashes (STEP/BIPOLAR) the previous
+  behaviour returned the full `child_impact` for every inbound synapse —
+  overstating influence by `N×` for `N` inbound synapses. Threshold squashes
+  now normalise by total inbound weight and apply the emit cap, same as Linear
+  bounded squashes (TANH, LOGISTIC, HARD_TANH, ...).
+- **Min-gate awareness.** New `ConsumerContract` / `OutputGate` API and
+  `compute_impacts_with_contract` let callers declare downstream
+  `min(output, constant)` / `max(output, constant)` gates. Output impacts are
+  scaled by the gate's pass-through probability computed from records.
+- **Auto-derived regime thresholds.** New
+  `derive_regime_threshold_from_records` helper picks a percentile from the
+  recorded distribution so callers do not need to hard-code constants.
+
+See `docs/IMPACT_CALCULATION.md` for the updated semantics.
+
 ## [v0.72.34]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.73"
+version = "0.74.74"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.73"
+version = "0.74.74"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/IMPACT_CALCULATION.md
+++ b/docs/IMPACT_CALCULATION.md
@@ -394,6 +394,79 @@ when available. Different squash functions use different impact formulas:
 > weights (`|w|/T × child_impact`) as documented. Previously, it incorrectly used
 > absolute weights (`|w| × child_impact`), causing hidden neurons to get impact >= 1.0.
 
+> **Issue #1300 fix (mirrors `NEAT-AI-Explore#266`)**: Two further correctness gaps
+> have been addressed:
+>
+> 1. **Squash-bounded contribution.** The sum of inbound contributions to a neuron
+>    cannot exceed the downstream squash's *emit magnitude* (`M`). For bounded
+>    squashes (TANH, LOGISTIC, HARD_TANH, STEP, BIPOLAR, RELU6, ...), the sum is
+>    capped at `M` even when the neuron feeds multiple outputs (so `child_impact > 1`).
+>    Threshold squashes (STEP/BIPOLAR) previously returned the full `child_impact`
+>    for *every* inbound synapse — overstating influence by a factor of `N` for
+>    `N` inbound synapses. They now normalise by total inbound weight and apply
+>    the same emit-magnitude cap as Linear bounded squashes.
+> 2. **Downstream consumer gates.** A new `ConsumerContract` API lets callers
+>    declare external `min(output, constant)` / `max(output, constant)` gates so
+>    impact attribution is scaled by the gate's pass-through probability. Outputs
+>    not in the contract default to a fully-open gate (no change in behaviour).
+>    A helper `derive_regime_threshold_from_records` picks a percentile from the
+>    recorded activation distribution when no external constant is known.
+
+### 🛡️ Squash emit magnitude (Issue #1300)
+
+| Squash | Output range | `squash_emit_magnitude` |
+|--------|--------------|-------------------------|
+| `TANH`, `LOGISTIC`, `HARD_TANH`, `SOFTSIGN`, `BIPOLAR_SIGMOID`, `ISRU` | bounded `±1` | `Some(1.0)` |
+| `STEP`, `BIPOLAR`, `GAUSSIAN` | `{0, 1}` / `{-1, 1}` / `(0, 1]` | `Some(1.0)` |
+| `ARCTAN` | `(-π/2, π/2)` | `Some(π/2)` |
+| `RELU6` | `[0, 6]` | `Some(6.0)` |
+| `IDENTITY`, `RELU`, `LEAKYRELU`, `ELU`, `SELU`, `CUBE`, `SQUARE`, ... | unbounded | `None` |
+| `MINIMUM`, `MAXIMUM`, `IF`, `HYPOT`, `MEAN` | aggregate (selection stats handle these) | `None` |
+
+The bounding formula for a per-synapse contribution `c` into a child neuron with
+emit magnitude `M` and currently-accumulated `child_impact`:
+
+$$
+c_{\text{bounded}} = \begin{cases}
+c & \text{if } M = \infty \text{ or } \text{child\_impact} \le M \\
+c \cdot \dfrac{M}{\text{child\_impact}} & \text{otherwise}
+\end{cases}
+$$
+
+This preserves the relative shares of inbound synapses while ensuring the
+total influence respects the squash's saturation ceiling.
+
+### 🔁 Consumer contracts (Issue #1300)
+
+```rust
+use neat_ai_discovery::focus::{
+    ConsumerContract, OutputGate, compute_impacts_with_contract,
+};
+
+let contract = ConsumerContract::new()
+    .with_gate("volume-output", OutputGate::MinAgainstConstant(0.25));
+let impacts = compute_impacts_with_contract(&creature, Some(&records), Some(&contract))?;
+```
+
+When the gate is `MinAgainstConstant(t)`, the network output only drives the
+downstream consumer in the regime where `output < t`. The impact attribution is
+scaled by the fraction of recorded observations satisfying that condition.
+`MaxAgainstConstant(t)` is the symmetric case (gate fires when `output > t`).
+`Identity` is the no-op gate (equivalent to omitting the output from the
+contract). The above flow is depicted below.
+
+```mermaid
+flowchart LR
+    A[Recorded output<br/>activations] --> B{Gate?}
+    B -- "Identity" --> C[Factor = 1.0]
+    B -- "min(out, t)" --> D[Factor = P(out < t)]
+    B -- "max(out, t)" --> E[Factor = P(out > t)]
+    C --> F[Scale output<br/>initial impact]
+    D --> F
+    E --> F
+    F --> G[Backward propagate<br/>through network]
+```
+
 | Squash Function | Impact Model | Accuracy | Notes |
 |-----------------|--------------|----------|-------|
 | **IDENTITY** | Linear (normalised) | ✅ Accurate | Mathematically exact |

--- a/docs/archive/pr-summaries/pr-summary-1300.md
+++ b/docs/archive/pr-summaries/pr-summary-1300.md
@@ -1,0 +1,83 @@
+## Summary
+
+Fixes three correctness gaps in Discovery's impact attribution that mirror
+`NEAT-AI-Explore#266`. The previous attribution used pre-squash magnitudes and
+overstated influence whenever a downstream neuron was saturated, gave every
+inbound synapse to a STEP/BIPOLAR neuron the full `child_impact` (sum
+`= N × child_impact`), and had no way to model external `min(output, constant)`
+gates. Fixes #1300.
+
+- New `squash_emit_magnitude` helper in `src/activations.rs` exposes the
+  emit ceiling (`Some(M)`) for bounded squashes (TANH/LOGISTIC/HARD_TANH/STEP/
+  BIPOLAR/RELU6/...) and `None` for unbounded ones (IDENTITY/RELU/ELU/...).
+- `src/focus/impact.rs` now applies a squash-bounded cap in
+  `compute_impact_with_shared_cache` for both `Linear` and `Threshold`
+  branches. Threshold squashes additionally switch from
+  `contribution = child_impact` to the normalised
+  `contribution = (|w|/T) × min(M, child_impact)`.
+- New `ConsumerContract` / `OutputGate` types and
+  `compute_impacts_with_contract` entry point let callers declare downstream
+  `MinAgainstConstant` / `MaxAgainstConstant` / `Identity` gates. Output
+  impact is scaled by the gate's pass-through probability computed from
+  recorded activations.
+- New `derive_regime_threshold_from_records` helper picks a percentile from
+  the recorded activation distribution (replaces hard-coded "low volume"
+  constants).
+- `docs/IMPACT_CALCULATION.md` documents the new semantics with a Mermaid
+  flowchart of the consumer-gate pipeline and a squash emit-magnitude table.
+- One existing test (`test_step_neuron_uses_full_impact_not_normalised`) was
+  renamed and updated to assert the new, correct squash-bounded behaviour;
+  the change is documented in-place explaining why the old assertion was the
+  bug.
+
+## Evidence
+
+This is a backend / library change — no UI to screenshot. Verification is
+via the unit + integration test suite.
+
+- 9 new tests in `tests/regression/regression_issue_1300.rs` cover:
+  - the squash emit-magnitude lookup (bounded ±1, RELU6=6.0, unbounded → None,
+    aggregate → None, case-insensitive);
+  - TANH inbound contributions staying inside `[-1, 1]` when the TANH feeds
+    multiple outputs (`child_impact > 1`);
+  - STEP inbound contributions staying bounded at the STEP emit magnitude
+    (this was the `N × child_impact` overstatement);
+  - sole-inbound synapse retaining its full impact (no behaviour change for
+    the common case);
+  - `MinAgainstConstant` gate masking impact in the regime where the network
+    output does not drive the consumer (verified against records crafted so
+    20/100 observations are below the gate threshold);
+  - `Identity` gate leaving impact unchanged versus no contract;
+  - regime threshold derivation at the min/max/p25 percentiles, with
+    empty-records and non-finite-input edge cases.
+- The full library + integration suite (`cargo test --tests --all-features`)
+  passes: 30 test binaries report `0 failed` across ~1500 tests.
+- `cargo clippy --all-targets --all-features -- -D warnings` is clean.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` is clean.
+
+```mermaid
+flowchart LR
+    A[Recorded output<br/>activations] --> B{Consumer gate?}
+    B -- "Identity" --> C[Factor = 1.0]
+    B -- "min(out, t)" --> D[Factor = P(out < t)]
+    B -- "max(out, t)" --> E[Factor = P(out > t)]
+    C --> F[Scale output<br/>initial impact]
+    D --> F
+    E --> F
+    F --> G[Backward propagate<br/>through network<br/>with squash-bounded cap]
+```
+
+## Test Plan
+
+- [x] `cargo test --test regression regression_issue_1300` — 9 new tests pass.
+- [x] `cargo test --test activation` — 105 tests pass (existing STEP/BIPOLAR
+      tests with looser assertions still pass under new normalisation).
+- [x] `cargo test --test analysis impact_calculation` — 9 tests pass
+      (`test_step_neuron_contribution_is_squash_bounded` replaces the old
+      `test_step_neuron_uses_full_impact_not_normalised` and locks in the
+      Issue #1300 fix).
+- [x] `cargo test --test focus` — 126 tests pass.
+- [x] `cargo test --tests --all-features` — full integration suite passes.
+- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
+- [x] `cargo fmt --all -- --check` — clean.
+- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.

--- a/src/activations.rs
+++ b/src/activations.rs
@@ -407,6 +407,49 @@ pub fn target_simulation_fn(name: &str) -> Option<fn(f32) -> f32> {
     }
 }
 
+/// Returns the maximum absolute output magnitude for bounded scalar squashes (Issue #1300).
+///
+/// This is used by the impact calculation to bound per-synapse contributions so the sum
+/// of inbound contributions into a neuron cannot exceed what the squash can actually emit
+/// (the "saturation ceiling"). For example, a TANH neuron emits values in `[-1, 1]`, so the
+/// magnitude is `1.0`; ten upstream synapses each feeding pre-activation `10` still share
+/// the same `±1` emit ceiling rather than each independently contributing `10`.
+///
+/// # Return value
+///
+/// - `Some(M)` where `M > 0` is the largest `|f(x)|` the squash can produce.
+/// - `None` for unbounded squashes (IDENTITY, RELU, ELU, LEAKYRELU, SELU, EXPONENTIAL,
+///   SOFTPLUS, CUBE, SQUARE, etc.) and aggregate squashes (MIN/MAX/IF/HYPOT — handled by
+///   selection statistics instead).
+///
+/// # Notes
+///
+/// - `STEP` outputs `{0, 1}` → magnitude `1.0`.
+/// - `BIPOLAR` outputs `{-1, +1}` → magnitude `1.0`.
+/// - `HARD_TANH`/`CLIPPED` clamps to `[-1, 1]` → magnitude `1.0`.
+/// - `GAUSSIAN` outputs `(0, 1]` → magnitude `1.0`.
+/// - `ARCTAN` outputs `(-π/2, π/2)` → magnitude `π/2 ≈ 1.5708`.
+/// - `RELU6` clamps to `[0, 6]` → magnitude `6.0`.
+#[must_use]
+pub fn squash_emit_magnitude(name: &str) -> Option<f32> {
+    let n = normalise_squash_name(name);
+    match n.as_ref() {
+        // Bounded to ±1
+        "TANH" | "LOGISTIC" | "HARD_TANH" | "CLIPPED" | "SOFTSIGN" | "BIPOLAR_SIGMOID" | "ISRU"
+        | "STEP" | "BIPOLAR" | "GAUSSIAN" => Some(1.0),
+        // ARCTAN: (-π/2, π/2)
+        "ARCTAN" => Some(std::f32::consts::FRAC_PI_2),
+        // RELU6: [0, 6]
+        "RELU6" => Some(6.0),
+        // LOGSIGMOID: (-∞, 0]; unbounded below — treat as unbounded.
+        // Unbounded scalar squashes: IDENTITY, RELU, LEAKYRELU, ELU, SELU,
+        // EXPONENTIAL, SOFTPLUS, CUBE, SQUARE, SINE, COSINE, TAN, MISH, SWISH,
+        // GELU, ABSOLUTE, STDINVERSE, SQRT, BENT_IDENTITY, COMPLEMENT/INVERSE.
+        // Aggregate squashes (MIN/MAX/IF/HYPOT/MEAN) — handled by selection stats.
+        _ => None,
+    }
+}
+
 /// Returns an approximate inverse function for monotonic activations (Issue #906).
 ///
 /// When `target_value` is missing but `target_activation` is available, the inverse function

--- a/src/focus/impact.rs
+++ b/src/focus/impact.rs
@@ -6,12 +6,36 @@
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use super::ranking::{RecordProvider, SelectionStats};
+use crate::activations::squash_emit_magnitude;
 use crate::{CreatureJson, NeuronJson, SynapseJson};
 use anyhow::Result;
 use rayon::prelude::*;
 
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
+
+/// Apply the squash-bounded contribution cap (Issue #1300).
+///
+/// When the downstream neuron's squash has a bounded emit magnitude `M`, the sum of
+/// inbound contributions cannot exceed `M` (the saturation ceiling). The current per-
+/// synapse contribution `raw` is part of a sum that — without capping — equals
+/// `child_impact`. We rescale by `min(1, M / child_impact)` so the cap holds.
+///
+/// For unbounded squashes (IDENTITY, RELU, ELU, ...), `squash_emit_magnitude` returns
+/// `None` and the contribution is returned unchanged.
+fn apply_squash_bounding(raw: f32, child_impact: f32, squash: &str) -> f32 {
+    match squash_emit_magnitude(squash) {
+        Some(m) => {
+            if child_impact <= m {
+                raw
+            } else {
+                // Rescale: sum across inbound was child_impact, cap at m.
+                raw * (m / child_impact)
+            }
+        }
+        None => raw,
+    }
+}
 
 /// Categorise squash functions for impact calculation.
 /// See `docs/IMPACT_CALCULATION.md` for detailed explanation.
@@ -431,6 +455,49 @@ struct ImpactContext {
     /// When available, provides actual win probabilities for MIN/MAX/IF synapses
     /// instead of the conservative 1/N equal probability fallback.
     selection_stats: Option<SelectionStats>,
+    /// Per-output gate pass-through probability (Issue #1300).
+    /// When an output is gated by a downstream `min`/`max`, its initial impact
+    /// is scaled by the fraction of observations where the gate lets the
+    /// output drive the downstream value. Outputs not in the map default to
+    /// `1.0` (no gating).
+    output_gate_factors: HashMap<String, f32>,
+}
+
+/// Build the per-output gate pass-through probability map (Issue #1300).
+///
+/// When a contract is provided and records are available, each gated output
+/// gets its pass-through probability computed from the recorded activation
+/// distribution. Outputs absent from the contract — or with `Identity` gates
+/// — get factor `1.0`. The contract takes effect only on the outputs listed
+/// in it, so the existing behaviour is preserved when no contract is passed.
+fn build_output_gate_factors(
+    outputs: &HashSet<String>,
+    grouped_records: Option<&dyn RecordProvider>,
+    contract: Option<&ConsumerContract>,
+) -> HashMap<String, f32> {
+    let mut factors: HashMap<String, f32> = HashMap::new();
+    let Some(contract) = contract else {
+        return factors;
+    };
+    for output_uuid in outputs {
+        let gate = contract
+            .gates
+            .get(output_uuid)
+            .copied()
+            .unwrap_or(OutputGate::Identity);
+        if matches!(gate, OutputGate::Identity) {
+            continue;
+        }
+        let prob = match grouped_records {
+            Some(records) => match records.get(output_uuid).ok().flatten() {
+                Some(arc) => gate_pass_probability(gate, arc.as_ref()),
+                None => 1.0,
+            },
+            None => 1.0,
+        };
+        factors.insert(output_uuid.clone(), prob);
+    }
+    factors
 }
 
 fn build_adjacency(creature: &CreatureJson) -> HashMap<String, Vec<(String, f32)>> {
@@ -476,6 +543,16 @@ fn compute_impacts_internal_with_stats(
     creature: &CreatureJson,
     grouped_records: Option<&dyn RecordProvider>,
 ) -> Result<HashMap<String, f32>> {
+    compute_impacts_internal_with_stats_and_contract(creature, grouped_records, None)
+}
+
+/// Variant of [`compute_impacts_internal_with_stats`] that additionally accepts a
+/// [`ConsumerContract`] to model downstream gates (Issue #1300).
+fn compute_impacts_internal_with_stats_and_contract(
+    creature: &CreatureJson,
+    grouped_records: Option<&dyn RecordProvider>,
+    contract: Option<&ConsumerContract>,
+) -> Result<HashMap<String, f32>> {
     let adjacency = build_adjacency(creature);
     let squash_map = super::gradient::build_squash_map(creature);
 
@@ -508,6 +585,11 @@ fn compute_impacts_internal_with_stats(
         .map(|records| compute_selection_stats(creature, records))
         .transpose()?;
 
+    // Issue #1300: Compute per-output gate pass-through probabilities when a
+    // consumer contract is provided. Outputs without an explicit gate (or with
+    // OutputGate::Identity) default to 1.0 (unmasked).
+    let output_gate_factors = build_output_gate_factors(&outputs, grouped_records, contract);
+
     let ctx = ImpactContext {
         adjacency,
         inbound_count,
@@ -515,6 +597,7 @@ fn compute_impacts_internal_with_stats(
         squash_map,
         outputs,
         selection_stats,
+        output_gate_factors,
     };
 
     // Parallel impact computation using thread-local caches
@@ -569,7 +652,9 @@ fn compute_impact_with_shared_cache(
     }
 
     let impact = if ctx.outputs.contains(uuid) {
-        1.0
+        // Issue #1300: Scale by downstream consumer gate factor. Defaults to
+        // 1.0 when no contract is supplied or the gate is fully open.
+        ctx.output_gate_factors.get(uuid).copied().unwrap_or(1.0)
     } else if let Some(edges) = ctx.adjacency.get(uuid) {
         // Sum across all outgoing edges
         let mut total_impact = 0.0;
@@ -610,14 +695,43 @@ fn compute_impact_with_shared_cache(
                         .unwrap_or(1.0)
                         .max(weight.abs()); // Bounds ratio to [0,1]: total >= weight.abs() always
 
-                    if total <= 0.0 {
+                    let raw = if total <= 0.0 {
                         // All weights are zero (including this one) → zero contribution
                         0.0
                     } else {
                         (weight.abs() / total) * child_impact
+                    };
+                    // Issue #1300: Apply squash-bounded cap so the sum of inbound
+                    // contributions cannot exceed the downstream squash's emit magnitude
+                    // (e.g. TANH/LOGISTIC capped at ±1 even when child_impact > 1 because
+                    // the neuron feeds multiple outputs).
+                    apply_squash_bounding(raw, child_impact, squash)
+                }
+                SquashCategory::Threshold => {
+                    // Issue #1300: Threshold squashes (STEP/BIPOLAR) previously returned
+                    // the unnormalised `child_impact` for every inbound synapse, so the
+                    // sum across `N` inbound synapses was `N × child_impact`. This
+                    // overstated influence whenever multiple inputs feed the threshold.
+                    //
+                    // New behaviour: normalise by total inbound weight (same as Linear)
+                    // and apply the squash emit magnitude cap. The "any synapse can flip
+                    // the output" intent is preserved by the cap at `min(M, child_impact)`
+                    // — each synapse still receives its weighted share of the full
+                    // emit-bounded influence.
+                    let total = ctx
+                        .total_inbound_weight
+                        .get(to_uuid)
+                        .copied()
+                        .unwrap_or(1.0)
+                        .max(weight.abs());
+
+                    if total <= 0.0 {
+                        0.0
+                    } else {
+                        let raw = (weight.abs() / total) * child_impact;
+                        apply_squash_bounding(raw, child_impact, squash)
                     }
                 }
-                SquashCategory::Threshold => child_impact,
                 SquashCategory::Selection => {
                     if let Some(ref stats) = ctx.selection_stats {
                         let key = (uuid.to_string(), to_uuid.clone());
@@ -645,6 +759,139 @@ fn compute_impact_with_shared_cache(
     shared_cache.insert(uuid.to_string(), impact);
 
     impact
+}
+
+/// Downstream consumer gate model (Issue #1300).
+///
+/// Discovery's impact attribution assumes a network's output drives downstream
+/// consumers directly. In practice, consumers often combine outputs with `min(...)`
+/// gates (e.g. a trading pipeline applies the Volume recommendation only when
+/// volume is below a threshold). An output gated by a `min` only drives the
+/// downstream value when the network's output is the smaller operand;
+/// attributing influence across the masked regime overstates the output's effect.
+///
+/// A `ConsumerContract` lets callers describe these external gates so that the
+/// impact attribution scales each output's initial impact by the probability the
+/// gate lets the network's output through. Without a contract the existing
+/// "all outputs are unmasked" behaviour is preserved.
+#[derive(Debug, Clone, Default)]
+pub struct ConsumerContract {
+    /// Per-output gate type, keyed by output neuron UUID.
+    pub gates: HashMap<String, OutputGate>,
+}
+
+/// Downstream gate applied to a single output neuron (Issue #1300).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OutputGate {
+    /// No gating; output drives downstream directly. Equivalent to omitting the
+    /// output from the contract.
+    Identity,
+    /// Output is consumed by `min(output, threshold)`. Influence is only
+    /// attributed when the output's activation is `< threshold`. Use
+    /// [`derive_regime_threshold_from_records`] to pick `threshold` from the
+    /// recorded distribution when no external constant is known.
+    MinAgainstConstant(f32),
+    /// Output is consumed by `max(output, threshold)`. Influence is only
+    /// attributed when the output's activation is `> threshold`.
+    MaxAgainstConstant(f32),
+}
+
+impl ConsumerContract {
+    /// Construct an empty contract — equivalent to passing no contract at all.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            gates: HashMap::new(),
+        }
+    }
+
+    /// Register a gate for the given output neuron UUID.
+    pub fn with_gate(mut self, output_uuid: impl Into<String>, gate: OutputGate) -> Self {
+        self.gates.insert(output_uuid.into(), gate);
+        self
+    }
+}
+
+/// Derive a regime threshold from a recorded distribution (Issue #1300).
+///
+/// `percentile` should be in `[0.0, 1.0]`. Returns `None` when the records contain
+/// no finite activations. Non-finite activations (NaN/Inf) are filtered out before
+/// the percentile is taken.
+///
+/// Typical use: when modelling a `min(output, constant)` consumer gate but no
+/// explicit constant is known, pick the threshold from the recorded distribution
+/// (e.g. the 25th percentile so "low" inputs trigger the gate).
+#[must_use]
+pub fn derive_regime_threshold_from_records(
+    records: &[crate::types::DiscoverRecord],
+    percentile: f32,
+) -> Option<f32> {
+    let mut values: Vec<f32> = records
+        .iter()
+        .map(|r| r.activation)
+        .filter(|v| v.is_finite())
+        .collect();
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f32::total_cmp);
+    let p = percentile.clamp(0.0, 1.0);
+    let len = values.len();
+    let span = (len - 1) as f32;
+    // `round()` gives a non-negative finite scalar in `[0, span]`; the cast is
+    // intentional (Issue #873) and bounded by `min(len - 1)`.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let idx = ((p * span).round() as usize).min(len - 1);
+    Some(values[idx])
+}
+
+/// Compute the gate pass-through probability from records (Issue #1300).
+///
+/// Returns the fraction of observations where the gate would "let through" the
+/// network output — that is, the regime where the network output actually drives
+/// the downstream value. Returns `1.0` for [`OutputGate::Identity`] or when no
+/// records are available (conservative: assume the gate is open).
+fn gate_pass_probability(gate: OutputGate, records: &[crate::types::DiscoverRecord]) -> f32 {
+    if matches!(gate, OutputGate::Identity) || records.is_empty() {
+        return 1.0;
+    }
+    let finite: Vec<f32> = records
+        .iter()
+        .map(|r| r.activation)
+        .filter(|v| v.is_finite())
+        .collect();
+    if finite.is_empty() {
+        return 1.0;
+    }
+    let n = finite.len() as f32;
+    let matching = match gate {
+        OutputGate::Identity => return 1.0,
+        OutputGate::MinAgainstConstant(threshold) => {
+            finite.iter().filter(|&&v| v < threshold).count()
+        }
+        OutputGate::MaxAgainstConstant(threshold) => {
+            finite.iter().filter(|&&v| v > threshold).count()
+        }
+    };
+    matching as f32 / n
+}
+
+/// Compute impacts with optional activation-based selection statistics AND a
+/// downstream consumer contract (Issue #1300).
+///
+/// When `contract` is provided, each output's initial impact is scaled by the
+/// probability that the downstream gate lets the output through. Outputs whose
+/// gate is `Identity` (or absent from the contract) keep impact `= 1.0`.
+///
+/// # Errors
+///
+/// Returns an error if the underlying selection-stats computation fails.
+pub fn compute_impacts_with_contract(
+    creature: &CreatureJson,
+    grouped_records: Option<&dyn RecordProvider>,
+    contract: Option<&ConsumerContract>,
+) -> Result<HashMap<String, f32>> {
+    compute_impacts_internal_with_stats_and_contract(creature, grouped_records, contract)
 }
 
 /// Public version that computes impacts with activation-based selection statistics.

--- a/src/focus/mod.rs
+++ b/src/focus/mod.rs
@@ -40,7 +40,8 @@ pub use gradient::{GradientFlowStats, compute_gradient_flow_stats};
 
 // From impact
 pub use impact::{
-    compute_impacts_public, compute_impacts_with_activations, compute_selection_stats,
+    ConsumerContract, OutputGate, compute_impacts_public, compute_impacts_with_activations,
+    compute_impacts_with_contract, compute_selection_stats, derive_regime_threshold_from_records,
 };
 
 // From ranking

--- a/tests/analysis/impact_calculation_production.rs
+++ b/tests/analysis/impact_calculation_production.rs
@@ -28,20 +28,27 @@ use neat_ai_discovery::parquet_format::write_records_to_parquet;
 use neat_ai_discovery::types::DiscoverRecord;
 use tempfile::NamedTempFile;
 
-/// Production pattern: STEP neuron gets full impact (no normalisation)
+/// Production pattern: STEP neuron contribution is squash-bounded (Issue #1300).
 ///
-/// From actual production data where STEP neurons were incorrectly diluted.
-/// Any synapse to a STEP neuron could flip the output, so each gets full impact.
+/// **Updated for Issue #1300 (May 2026)**: Previously this test locked in the OLD
+/// behaviour where every inbound synapse to a STEP neuron received the full
+/// `child_impact` (sum over N inbound = `N × child_impact`). That overstated the
+/// influence of small competing synapses and ignored the squash's emit ceiling.
+///
+/// Per Issue #1300, the threshold path now normalises by total inbound weight
+/// and caps by the squash's emit magnitude (`M = 1.0` for STEP). A tiny synapse
+/// (weight 0.001) competing with a large one (weight 100) gets its proportional
+/// share, not the full `child_impact`. The "any synapse can flip the output"
+/// intent is preserved by the cap at `min(M, child_impact)` — each synapse
+/// still receives its weighted share of the full emit-bounded influence.
 #[test]
-fn test_step_neuron_uses_full_impact_not_normalised() {
-    // A synapse to a STEP output neuron should have full downstream impact
-    // because any synapse could cause the threshold to be crossed
+fn test_step_neuron_contribution_is_squash_bounded() {
     let creature = CreatureJson {
         input: 1,
         output: 1,
         neurons: vec![
             hidden("candidate", "IDENTITY"),
-            output("step-output", "STEP"), // STEP = threshold function
+            output("step-output", "STEP"),
         ],
         synapses: vec![
             synapse("input-0", "candidate", 1.0),
@@ -53,12 +60,18 @@ fn test_step_neuron_uses_full_impact_not_normalised() {
     let impacts = compute_impacts_public(&creature);
     let candidate_impact = *impacts.get("candidate").unwrap_or(&0.0);
 
-    // For STEP targets, we use full impact (no normalisation)
-    // because any synapse could flip the output
+    // New normalised + squash-bounded behaviour (Issue #1300):
+    //   T_step = 0.001 + 100.0 = 100.001
+    //   candidate contribution = (0.001 / 100.001) × 1.0 ≈ 9.99e-6
+    //   capped at min(M=1.0, child_impact=1.0) — no further scaling.
     assert!(
-        (candidate_impact - 1.0).abs() < 0.001,
-        "STEP target should give full impact (1.0), got {candidate_impact:.4}. \
-         Threshold functions don't dilute impact."
+        candidate_impact > 0.0,
+        "candidate must keep positive influence under squash bounding, got {candidate_impact}"
+    );
+    assert!(
+        candidate_impact < 1e-4,
+        "candidate's tiny weight (0.001) versus competing weight (100) should yield a \
+         proportionally tiny squash-bounded impact, got {candidate_impact}"
     );
 }
 

--- a/tests/regression/main.rs
+++ b/tests/regression/main.rs
@@ -4,6 +4,7 @@
 mod common;
 
 mod issue_576_benchmark_regression_tracking;
+mod regression_issue_1300;
 mod regression_v0_1_123;
 mod regression_v0_1_126;
 mod regression_v0_1_127;

--- a/tests/regression/regression_issue_1300.rs
+++ b/tests/regression/regression_issue_1300.rs
@@ -1,0 +1,392 @@
+//! Regression tests for Issue #1300: squash-bounded influence and min-gate awareness.
+//!
+//! Mirrors the fix from NEAT-AI-Explore#266. The impact attribution previously had
+//! three correctness gaps that this fix addresses:
+//!
+//! 1. **Squash-bounded contribution** — the sum of inbound contributions to a neuron
+//!    must respect the downstream squash's emit magnitude (e.g. TANH caps at ±1).
+//!    Previously, threshold squashes (STEP/BIPOLAR) returned the full `child_impact`
+//!    for every inbound synapse, so the sum was `N × child_impact`. The new code
+//!    normalises by inbound weights and caps by the squash's emit magnitude.
+//!
+//! 2. **Min-gate awareness via consumer contract** — outputs gated by an external
+//!    `min(output, constant)` only drive the downstream value when the network
+//!    output is the smaller operand. The new `ConsumerContract` API lets callers
+//!    declare such gates so impact attribution scales by the gate's pass-through
+//!    probability.
+//!
+//! 3. **Auto-derived regime thresholds** — `derive_regime_threshold_from_records`
+//!    picks a percentile from the recorded distribution, so callers do not need
+//!    to hard-code a "low volume" constant.
+
+#![allow(clippy::cast_precision_loss)] // Intentional u32→f32 casts for test data construction
+
+use neat_ai_discovery::activations::squash_emit_magnitude;
+use neat_ai_discovery::focus::{
+    ConsumerContract, OutputGate, compute_impacts_public, compute_impacts_with_contract,
+    derive_regime_threshold_from_records,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn hidden(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "hidden".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn input_n(uuid: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "input".to_string(),
+        squash: "IDENTITY".to_string(),
+        bias: 0.0,
+    }
+}
+
+fn output(uuid: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: "output".to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Squash emit magnitude lookup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn squash_emit_magnitude_known_bounds() {
+    // Bounded ±1 squashes
+    assert_eq!(squash_emit_magnitude("TANH"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("LOGISTIC"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("HARD_TANH"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("CLIPPED"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("SOFTSIGN"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("STEP"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("BIPOLAR"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("GAUSSIAN"), Some(1.0));
+
+    // RELU6 clamps to [0, 6]
+    assert_eq!(squash_emit_magnitude("RELU6"), Some(6.0));
+
+    // Unbounded squashes
+    assert_eq!(squash_emit_magnitude("IDENTITY"), None);
+    assert_eq!(squash_emit_magnitude("RELU"), None);
+    assert_eq!(squash_emit_magnitude("ELU"), None);
+    assert_eq!(squash_emit_magnitude("LEAKYRELU"), None);
+    assert_eq!(squash_emit_magnitude("CUBE"), None);
+    assert_eq!(squash_emit_magnitude("SQUARE"), None);
+
+    // Aggregate squashes — selection stats handle these.
+    assert_eq!(squash_emit_magnitude("MINIMUM"), None);
+    assert_eq!(squash_emit_magnitude("MAXIMUM"), None);
+    assert_eq!(squash_emit_magnitude("IF"), None);
+
+    // Case-insensitive lookup.
+    assert_eq!(squash_emit_magnitude("tanh"), Some(1.0));
+    assert_eq!(squash_emit_magnitude("Tanh"), Some(1.0));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Squash-bounded contribution: TANH feeding many outputs
+// ---------------------------------------------------------------------------
+
+/// A saturated TANH hidden neuron that feeds many outputs would previously
+/// accumulate `child_impact = N × 1.0 = N` from N outputs, and the sum of
+/// inbound contributions could exceed ±1 — but TANH cannot emit more than ±1.
+///
+/// Acceptance criterion (Issue #1300): the sum of inbound contributions to a
+/// bounded-squash neuron stays inside `[-M, M]` where `M` is the squash's emit
+/// magnitude.
+#[test]
+fn tanh_inbound_contributions_stay_inside_emit_range() {
+    // Network: many inputs each feed a single TANH hidden with weight `10` (so
+    // it would saturate). The TANH then feeds 5 outputs with weight `1` each.
+    // child_impact(TANH) = 5 outputs × 1.0 = 5.0 (multi-output hub).
+    // Without squash bounding, sum_inbound = child_impact = 5.0 > 1.0.
+    // With the fix, sum_inbound is capped at M = 1.0.
+    let num_inputs = 10;
+    let num_outputs = 5;
+
+    let mut neurons = vec![hidden("tanh-hub", "TANH")];
+    let mut synapses = Vec::new();
+    for i in 0..num_inputs {
+        neurons.push(input_n(&format!("input-{i}")));
+        synapses.push(synapse(&format!("input-{i}"), "tanh-hub", 10.0));
+    }
+    for o in 0..num_outputs {
+        let uuid = format!("output-{o}");
+        neurons.push(output(&uuid, "IDENTITY"));
+        synapses.push(synapse("tanh-hub", &uuid, 1.0));
+    }
+    let creature = CreatureJson {
+        input: num_inputs,
+        output: num_outputs,
+        neurons,
+        synapses,
+    };
+
+    let impacts = compute_impacts_public(&creature);
+
+    // Sum of inbound impacts to the TANH hub = sum of input neurons' impacts
+    // (each input has only one path, through the TANH).
+    let sum_inbound: f32 = (0..num_inputs)
+        .map(|i| impacts.get(&format!("input-{i}")).copied().unwrap_or(0.0))
+        .sum();
+
+    let m = squash_emit_magnitude("TANH").unwrap();
+    assert!(
+        sum_inbound <= m + 1e-5,
+        "sum of inbound contributions to TANH ({sum_inbound}) must not exceed emit magnitude {m}"
+    );
+}
+
+/// STEP/BIPOLAR previously returned `child_impact` for every inbound synapse —
+/// so 10 inbound synapses to a STEP feeding one output would each get
+/// `child_impact = 1.0`, summing to `10.0`. With Issue #1300, the sum is
+/// bounded by `STEP`'s emit magnitude (`1.0`).
+#[test]
+fn step_inbound_contributions_stay_bounded() {
+    let num_inputs = 10;
+    let mut neurons = vec![hidden("step-hub", "STEP"), output("output-0", "IDENTITY")];
+    let mut synapses = Vec::new();
+    for i in 0..num_inputs {
+        neurons.push(input_n(&format!("input-{i}")));
+        synapses.push(synapse(&format!("input-{i}"), "step-hub", 1.0));
+    }
+    synapses.push(synapse("step-hub", "output-0", 1.0));
+
+    let creature = CreatureJson {
+        input: num_inputs,
+        output: 1,
+        neurons,
+        synapses,
+    };
+
+    let impacts = compute_impacts_public(&creature);
+
+    let sum_inbound: f32 = (0..num_inputs)
+        .map(|i| impacts.get(&format!("input-{i}")).copied().unwrap_or(0.0))
+        .sum();
+
+    let m = squash_emit_magnitude("STEP").unwrap();
+    assert!(
+        sum_inbound <= m + 1e-5,
+        "sum of inbound contributions to STEP ({sum_inbound}) must not exceed emit magnitude {m}"
+    );
+}
+
+/// Sole-input case: a single synapse to a bounded squash should still get its
+/// full impact (the cap is per-aggregate, not per-synapse).
+#[test]
+fn sole_inbound_synapse_unaffected_by_squash_bounding() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![hidden("tanh-1", "TANH"), output("output-0", "IDENTITY")],
+        synapses: vec![
+            synapse("input-0", "tanh-1", 1.0),
+            synapse("tanh-1", "output-0", 1.0),
+        ],
+    };
+    let impacts = compute_impacts_public(&creature);
+    let tanh_impact = impacts.get("tanh-1").copied().unwrap_or(0.0);
+
+    // Sole synapse feeding sole output: impact = 1.0 (unaffected by capping).
+    assert!(
+        (tanh_impact - 1.0).abs() < 1e-5,
+        "sole-input TANH should retain full impact 1.0, got {tanh_impact}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Min-gate (consumer contract) awareness
+// ---------------------------------------------------------------------------
+
+/// In-memory `RecordProvider` for testing.
+struct MapRecordProvider {
+    inner: HashMap<String, Arc<Vec<DiscoverRecord>>>,
+}
+
+impl MapRecordProvider {
+    fn new(map: HashMap<String, Vec<DiscoverRecord>>) -> Self {
+        Self {
+            inner: map.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
+        }
+    }
+}
+
+impl neat_ai_discovery::focus::RecordProvider for MapRecordProvider {
+    fn get(&self, neuron_uuid: &str) -> anyhow::Result<Option<Arc<Vec<DiscoverRecord>>>> {
+        Ok(self.inner.get(neuron_uuid).cloned())
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+#[test]
+fn min_gate_against_constant_masks_impact_outside_regime() {
+    // Network: input -> hidden -> output. Without a contract, hidden has
+    // impact 1.0. With a `MinAgainstConstant(threshold)` gate that lets
+    // 20% of observations through, hidden's impact must scale to 0.2.
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            hidden("hidden-1", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+    };
+
+    // 100 observations: 20 below the gate threshold (gate lets them through),
+    // 80 above (gate masks the network output).
+    let mut output_records = Vec::new();
+    for i in 0..100u32 {
+        let activation = if i < 20 { 0.1 } else { 1.0 };
+        output_records.push(DiscoverRecord::new(
+            i,
+            "output-0".to_string(),
+            Some(activation),
+            activation,
+            vec![0.0],
+        ));
+    }
+    let mut hidden_records = Vec::new();
+    for i in 0..100u32 {
+        hidden_records.push(DiscoverRecord::new(
+            i,
+            "hidden-1".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.0],
+        ));
+    }
+    let mut input_records = Vec::new();
+    for i in 0..100u32 {
+        input_records.push(DiscoverRecord::new(
+            i,
+            "input-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![],
+        ));
+    }
+    let mut map: HashMap<String, Vec<DiscoverRecord>> = HashMap::new();
+    map.insert("output-0".to_string(), output_records);
+    map.insert("hidden-1".to_string(), hidden_records);
+    map.insert("input-0".to_string(), input_records);
+    let provider = MapRecordProvider::new(map);
+
+    // Baseline: no contract → hidden impact = 1.0.
+    let baseline = compute_impacts_with_contract(&creature, Some(&provider), None).unwrap();
+    let baseline_hidden = baseline.get("hidden-1").copied().unwrap_or(0.0);
+    assert!(
+        (baseline_hidden - 1.0).abs() < 1e-5,
+        "baseline hidden impact should be 1.0, got {baseline_hidden}"
+    );
+
+    // With gate: only 20/100 = 0.2 of observations let the output drive.
+    let contract =
+        ConsumerContract::new().with_gate("output-0", OutputGate::MinAgainstConstant(0.5));
+    let gated = compute_impacts_with_contract(&creature, Some(&provider), Some(&contract)).unwrap();
+    let gated_hidden = gated.get("hidden-1").copied().unwrap_or(0.0);
+    assert!(
+        (gated_hidden - 0.2).abs() < 1e-3,
+        "gated hidden impact should be 0.2 (gate pass = 0.2), got {gated_hidden}"
+    );
+}
+
+#[test]
+fn identity_gate_does_not_change_impact() {
+    let creature = CreatureJson {
+        input: 1,
+        output: 1,
+        neurons: vec![
+            hidden("hidden-1", "IDENTITY"),
+            output("output-0", "IDENTITY"),
+        ],
+        synapses: vec![
+            synapse("input-0", "hidden-1", 1.0),
+            synapse("hidden-1", "output-0", 1.0),
+        ],
+    };
+    let contract = ConsumerContract::new().with_gate("output-0", OutputGate::Identity);
+    let with_identity = compute_impacts_with_contract(&creature, None, Some(&contract)).unwrap();
+    let without = compute_impacts_with_contract(&creature, None, None).unwrap();
+    for uuid in ["hidden-1", "output-0"] {
+        let a = with_identity.get(uuid).copied().unwrap_or(0.0);
+        let b = without.get(uuid).copied().unwrap_or(0.0);
+        assert!((a - b).abs() < 1e-5, "{uuid}: identity gate changed impact");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Auto-derived regime threshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn derive_regime_threshold_percentile_basic() {
+    let records: Vec<DiscoverRecord> = (0..100u32)
+        .map(|i| DiscoverRecord::new(i, "n".to_string(), Some(i as f32), i as f32, vec![]))
+        .collect();
+
+    // 0.0 → minimum
+    assert_eq!(
+        derive_regime_threshold_from_records(&records, 0.0),
+        Some(0.0)
+    );
+    // 1.0 → maximum
+    assert_eq!(
+        derive_regime_threshold_from_records(&records, 1.0),
+        Some(99.0)
+    );
+    // 0.25 → ~25
+    let p25 = derive_regime_threshold_from_records(&records, 0.25).unwrap();
+    assert!((p25 - 25.0).abs() <= 1.0, "p25 should be ~25, got {p25}");
+}
+
+#[test]
+fn derive_regime_threshold_empty_returns_none() {
+    assert_eq!(derive_regime_threshold_from_records(&[], 0.5), None);
+}
+
+#[test]
+fn derive_regime_threshold_filters_non_finite() {
+    let records = vec![
+        DiscoverRecord::new(0, "n".into(), None, f32::NAN, vec![]),
+        DiscoverRecord::new(1, "n".into(), None, f32::INFINITY, vec![]),
+        DiscoverRecord::new(2, "n".into(), None, 5.0, vec![]),
+    ];
+    assert_eq!(
+        derive_regime_threshold_from_records(&records, 0.0),
+        Some(5.0)
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three correctness gaps in Discovery's impact attribution that mirror
`NEAT-AI-Explore#266`. The previous attribution used pre-squash magnitudes and
overstated influence whenever a downstream neuron was saturated, gave every
inbound synapse to a STEP/BIPOLAR neuron the full `child_impact` (sum
`= N × child_impact`), and had no way to model external `min(output, constant)`
gates. Fixes #1300.

- New `squash_emit_magnitude` helper in `src/activations.rs` exposes the
  emit ceiling (`Some(M)`) for bounded squashes (TANH/LOGISTIC/HARD_TANH/STEP/
  BIPOLAR/RELU6/...) and `None` for unbounded ones (IDENTITY/RELU/ELU/...).
- `src/focus/impact.rs` now applies a squash-bounded cap in
  `compute_impact_with_shared_cache` for both `Linear` and `Threshold`
  branches. Threshold squashes additionally switch from
  `contribution = child_impact` to the normalised
  `contribution = (|w|/T) × min(M, child_impact)`.
- New `ConsumerContract` / `OutputGate` types and
  `compute_impacts_with_contract` entry point let callers declare downstream
  `MinAgainstConstant` / `MaxAgainstConstant` / `Identity` gates. Output
  impact is scaled by the gate's pass-through probability computed from
  recorded activations.
- New `derive_regime_threshold_from_records` helper picks a percentile from
  the recorded activation distribution (replaces hard-coded "low volume"
  constants).
- `docs/IMPACT_CALCULATION.md` documents the new semantics with a Mermaid
  flowchart of the consumer-gate pipeline and a squash emit-magnitude table.
- One existing test (`test_step_neuron_uses_full_impact_not_normalised`) was
  renamed and updated to assert the new, correct squash-bounded behaviour;
  the change is documented in-place explaining why the old assertion was the
  bug.

## Evidence

This is a backend / library change — no UI to screenshot. Verification is
via the unit + integration test suite.

- 9 new tests in `tests/regression/regression_issue_1300.rs` cover:
  - the squash emit-magnitude lookup (bounded ±1, RELU6=6.0, unbounded → None,
    aggregate → None, case-insensitive);
  - TANH inbound contributions staying inside `[-1, 1]` when the TANH feeds
    multiple outputs (`child_impact > 1`);
  - STEP inbound contributions staying bounded at the STEP emit magnitude
    (this was the `N × child_impact` overstatement);
  - sole-inbound synapse retaining its full impact (no behaviour change for
    the common case);
  - `MinAgainstConstant` gate masking impact in the regime where the network
    output does not drive the consumer (verified against records crafted so
    20/100 observations are below the gate threshold);
  - `Identity` gate leaving impact unchanged versus no contract;
  - regime threshold derivation at the min/max/p25 percentiles, with
    empty-records and non-finite-input edge cases.
- The full library + integration suite (`cargo test --tests --all-features`)
  passes: 30 test binaries report `0 failed` across ~1500 tests.
- `cargo clippy --all-targets --all-features -- -D warnings` is clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` is clean.

```mermaid
flowchart LR
    A[Recorded output<br/>activations] --> B{Consumer gate?}
    B -- "Identity" --> C[Factor = 1.0]
    B -- "min(out, t)" --> D[Factor = P(out < t)]
    B -- "max(out, t)" --> E[Factor = P(out > t)]
    C --> F[Scale output<br/>initial impact]
    D --> F
    E --> F
    F --> G[Backward propagate<br/>through network<br/>with squash-bounded cap]
```

## Test Plan

- [x] `cargo test --test regression regression_issue_1300` — 9 new tests pass.
- [x] `cargo test --test activation` — 105 tests pass (existing STEP/BIPOLAR
      tests with looser assertions still pass under new normalisation).
- [x] `cargo test --test analysis impact_calculation` — 9 tests pass
      (`test_step_neuron_contribution_is_squash_bounded` replaces the old
      `test_step_neuron_uses_full_impact_not_normalised` and locks in the
      Issue #1300 fix).
- [x] `cargo test --test focus` — 126 tests pass.
- [x] `cargo test --tests --all-features` — full integration suite passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.



---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1300 -->