### PR TITLE
ci: add concurrency groups to PR / branch workflows (#1288)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs on the same ref (Issue #1288).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ on:
       - Develop
   workflow_dispatch: # Allow manual trigger if needed
 
+# Cancel superseded runs on the same ref (Issue #1288). When a contributor
+# force-pushes a PR or lands several commits to Develop in quick succession,
+# in-flight runs are cancelled so the latest commit's checks finish sooner
+# and runner capacity is not wasted on stale builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Minimal top-level permissions — narrow the default GITHUB_TOKEN scope to
 # read-only for unprivileged jobs (quality, validation, spell-check). Jobs
 # that need write access (version-increment, auto-format) declare their own

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs on the same ref (Issue #1288).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [main, master, Develop]
 
+# Cancel superseded runs on the same ref (Issue #1288).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs on the same ref (Issue #1288).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs on the same ref (Issue #1288).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/archive/pr-summaries/pr-summary-1288.md
+++ b/docs/archive/pr-summaries/pr-summary-1288.md
@@ -1,0 +1,61 @@
+# Add concurrency groups to PR / branch workflows
+
+## Summary
+
+Added a workflow-level `concurrency:` block to every PR / branch workflow in
+`.github/workflows/` so superseded runs on the same ref are cancelled when a
+new commit lands. Without this, force-pushing a PR or landing several commits
+to `Develop` in quick succession left older runs churning while newer runs
+started — wasting runner capacity and, in `ci.yml`'s case, racing the
+`version-increment` job with the new push and producing a confusing commit
+cascade. Closes #1288.
+
+Affected workflows (all use the canonical group
+`${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`):
+
+- `ci.yml` (push to `Develop` + PR)
+- `cargo-quality.yml` (PR)
+- `gitleaks.yml` (PR)
+- `markdown-lint.yml` (PR + push to `main`/`master`/`Develop`)
+- `semgrep.yml` (PR)
+- `shellcheck.yml` (PR)
+
+`security.yml` is intentionally excluded — it is a reusable workflow invoked
+via `workflow_call`. Concurrency must live on the caller workflow, not the
+reusable callee.
+
+## Evidence
+
+CLI-only change — no UI to screenshot. Verified by:
+
+1. New integration test `tests/issue_1288_workflow_concurrency.rs` parses each
+   of the six workflow files and asserts:
+   - a top-level `concurrency:` block exists;
+   - the `group:` expression is the canonical
+     `${{ github.workflow }}-${{ github.ref }}`;
+   - `cancel-in-progress: true` is set.
+2. `./quality.sh` passes (fmt, clippy, check, all tests, doc build, release
+   build).
+
+```mermaid
+sequenceDiagram
+    participant Dev as Contributor
+    participant GH as GitHub
+    participant R1 as Run #1 (older commit)
+    participant R2 as Run #2 (newer commit)
+    Dev->>GH: push commit A
+    GH->>R1: start workflow
+    Dev->>GH: force-push commit B
+    GH->>R2: start workflow
+    Note over GH,R1: concurrency group<br/>workflow + ref matches
+    GH->>R1: cancel-in-progress
+    R2-->>GH: finish (latest result)
+```
+
+## Test Plan
+
+- Added `tests/issue_1288_workflow_concurrency.rs` with six tests — one per
+  affected workflow — each verifying the canonical concurrency block is
+  present.
+- All six tests pass: `cargo test --test issue_1288_workflow_concurrency`.
+- Full quality gate (`./quality.sh`) passes locally.

--- a/tests/issue_1288_workflow_concurrency.rs
+++ b/tests/issue_1288_workflow_concurrency.rs
@@ -1,0 +1,117 @@
+//! Issue #1288: every PR / branch workflow in `.github/workflows/` must
+//! declare a workflow-level `concurrency:` group that cancels superseded
+//! runs on the same ref. Without one, force-pushing a PR or landing
+//! several commits to `Develop` in quick succession leaves older runs
+//! churning while newer runs start — wasting runner capacity and, in
+//! `ci.yml`'s case, racing the `version-increment` job.
+//!
+//! The canonical group is `${{ github.workflow }}-${{ github.ref }}`
+//! with `cancel-in-progress: true`.
+//!
+//! Reusable workflows (`security.yml`, invoked via `workflow_call`) are
+//! excluded — concurrency must live on the caller workflow, not the
+//! reusable callee.
+//!
+//! This test parses each workflow file as plain text (no YAML parser
+//! is in the dependency tree) and asserts that a top-level
+//! `concurrency:` block exists with the expected `group:` expression
+//! and `cancel-in-progress: true`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate the top-level `concurrency:` block and return its body up to
+/// the next top-level key or end of file. Top-level keys start at
+/// column zero and end with `:`.
+fn concurrency_block(body: &str) -> Option<&str> {
+    let header = "\nconcurrency:";
+    let start = body.find(header)? + 1; // skip the leading newline
+    let after = &body[start..];
+    // Find the next top-level key (line starting with a non-space and
+    // ending with `:`), skipping the `concurrency:` header line itself.
+    let mut search_from = "concurrency:".len();
+    while let Some(nl) = after[search_from..].find('\n') {
+        let line_start = search_from + nl + 1;
+        if line_start >= after.len() {
+            return Some(after);
+        }
+        let line_end = after[line_start..]
+            .find('\n')
+            .map_or(after.len(), |n| line_start + n);
+        let line = &after[line_start..line_end];
+        // A sibling top-level key: non-space first char, ends with `:`,
+        // and is not a list item or comment.
+        if !line.is_empty()
+            && !line.starts_with(' ')
+            && !line.starts_with('#')
+            && line.trim_end().ends_with(':')
+        {
+            return Some(&after[..line_start]);
+        }
+        search_from = line_start;
+    }
+    Some(after)
+}
+
+const CANONICAL_GROUP: &str = "${{ github.workflow }}-${{ github.ref }}";
+
+fn assert_canonical_concurrency(file_name: &str) {
+    let body = read_workflow(file_name);
+    let block = concurrency_block(&body).unwrap_or_else(|| {
+        panic!(
+            "{file_name} must declare a top-level `concurrency:` block \
+             (Issue #1288)"
+        )
+    });
+    assert!(
+        block.contains(CANONICAL_GROUP),
+        "{file_name} concurrency block must use the canonical group \
+         expression `{CANONICAL_GROUP}` so superseded runs on the same \
+         ref are cancelled (Issue #1288). Found:\n{block}",
+    );
+    assert!(
+        block.contains("cancel-in-progress: true"),
+        "{file_name} concurrency block must set \
+         `cancel-in-progress: true` so superseded runs are actually \
+         cancelled (Issue #1288). Found:\n{block}",
+    );
+}
+
+#[test]
+fn ci_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("ci.yml");
+}
+
+#[test]
+fn cargo_quality_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("cargo-quality.yml");
+}
+
+#[test]
+fn gitleaks_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("gitleaks.yml");
+}
+
+#[test]
+fn markdown_lint_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("markdown-lint.yml");
+}
+
+#[test]
+fn semgrep_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("semgrep.yml");
+}
+
+#[test]
+fn shellcheck_yml_declares_concurrency_group() {
+    assert_canonical_concurrency("shellcheck.yml");
+}


### PR DESCRIPTION
# Add concurrency groups to PR / branch workflows

## Summary

Added a workflow-level `concurrency:` block to every PR / branch workflow in
`.github/workflows/` so superseded runs on the same ref are cancelled when a
new commit lands. Without this, force-pushing a PR or landing several commits
to `Develop` in quick succession left older runs churning while newer runs
started — wasting runner capacity and, in `ci.yml`'s case, racing the
`version-increment` job with the new push and producing a confusing commit
cascade. Closes #1288.

Affected workflows (all use the canonical group
`${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`):

- `ci.yml` (push to `Develop` + PR)
- `cargo-quality.yml` (PR)
- `gitleaks.yml` (PR)
- `markdown-lint.yml` (PR + push to `main`/`master`/`Develop`)
- `semgrep.yml` (PR)
- `shellcheck.yml` (PR)

`security.yml` is intentionally excluded — it is a reusable workflow invoked
via `workflow_call`. Concurrency must live on the caller workflow, not the
reusable callee.

## Evidence

CLI-only change — no UI to screenshot. Verified by:

1. New integration test `tests/issue_1288_workflow_concurrency.rs` parses each
   of the six workflow files and asserts:
   - a top-level `concurrency:` block exists;
   - the `group:` expression is the canonical
     `${{ github.workflow }}-${{ github.ref }}`;
   - `cancel-in-progress: true` is set.
2. `./quality.sh` passes (fmt, clippy, check, all tests, doc build, release
   build).

```mermaid
sequenceDiagram
    participant Dev as Contributor
    participant GH as GitHub
    participant R1 as Run #1 (older commit)
    participant R2 as Run #2 (newer commit)
    Dev->>GH: push commit A
    GH->>R1: start workflow
    Dev->>GH: force-push commit B
    GH->>R2: start workflow
    Note over GH,R1: concurrency group<br/>workflow + ref matches
    GH->>R1: cancel-in-progress
    R2-->>GH: finish (latest result)
```

## Test Plan

- Added `tests/issue_1288_workflow_concurrency.rs` with six tests — one per
  affected workflow — each verifying the canonical concurrency block is
  present.
- All six tests pass: `cargo test --test issue_1288_workflow_concurrency`.
- Full quality gate (`./quality.sh`) passes locally.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-1288 -->