### PR TITLE
ci: add set -euo pipefail to bash blocks in ci.yml (Issue #1290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
       run: cargo install --locked --version 0.16.0 cargo-outdated
         
     - name: Check for source changes and increment version
+      shell: bash
       run: |
+        set -euo pipefail
         # Determine base branch name (try Develop first, then develop)
         BASE_BRANCH="Develop"
         if ! git show-ref --verify --quiet refs/remotes/origin/Develop; then
@@ -155,7 +157,9 @@ jobs:
         
     - name: Check if there are changes
       id: changes
+      shell: bash
       run: |
+        set -euo pipefail
         if ! git diff --quiet; then
           git add -A
           git commit -m "chore: auto-increment versions for changed projects"
@@ -196,7 +200,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Free up runner disk space
+      shell: bash
       run: |
+        set -euo pipefail
         # GitHub runners start with ~17GB free but Rust builds can exceed this.
         # Remove large pre-installed software we don't need to free 10-20GB.
         echo "Disk usage before cleanup:"
@@ -250,7 +256,9 @@ jobs:
       run: cargo build --lib
 
     - name: Clean intermediate artefacts before tests
+      shell: bash
       run: |
+        set -euo pipefail
         # Test compilation generates many large binaries. Remove incremental
         # compilation data and fingerprints to free space before this step.
         echo "Disk usage before cleanup:"
@@ -286,7 +294,9 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Check for required files
+      shell: bash
       run: |
+        set -euo pipefail
         echo "🔍 Checking for required project files..."
         
         required_files=(
@@ -311,7 +321,9 @@ jobs:
         fi
 
     - name: Validate Cargo.toml
+      shell: bash
       run: |
+        set -euo pipefail
         echo "🔍 Validating Cargo.toml..."
         
         if ! cargo check --manifest-path Cargo.toml --quiet; then
@@ -329,7 +341,9 @@ jobs:
         echo "✅ Cargo.toml validation passed"
 
     - name: Check documentation
+      shell: bash
       run: |
+        set -euo pipefail
         echo "🔍 Checking documentation..."
         
         readme_lines=$(wc -l < README.md)
@@ -369,7 +383,9 @@ jobs:
         token: ${{ secrets.ACTIONS_PUSH }}
 
     - name: Ensure bash scripts are executable
+      shell: bash
       run: |
+        set -euo pipefail
         echo "🔍 Ensuring all bash scripts are executable..."
         CHANGED=false
         while IFS= read -r script; do

--- a/docs/archive/pr-summaries/pr-summary-1290.md
+++ b/docs/archive/pr-summaries/pr-summary-1290.md
@@ -1,0 +1,52 @@
+## Summary
+
+Added `set -euo pipefail` (and an explicit `shell: bash`) to every
+multi-line `run: |` block in `.github/workflows/ci.yml` that was
+previously running unguarded. Without these guards a failed `sed` /
+`grep` / piped command silently swallows its exit code, which is
+especially dangerous in the `version-increment` step that rewrites
+`Cargo.toml` in place. Closes #1290.
+
+The eight steps now guarded:
+
+- `version-increment` → "Check for source changes and increment version"
+- `version-increment` → "Check if there are changes"
+- `quality` → "Free up runner disk space"
+- `quality` → "Clean intermediate artefacts before tests"
+- `validation` → "Check for required files"
+- `validation` → "Validate Cargo.toml"
+- `validation` → "Check documentation"
+- `auto-format` → "Ensure bash scripts are executable"
+
+Existing intentional-failure tolerances are preserved — e.g.
+`cargo outdated -R || true` continues to suppress that single command's
+exit code under `set -e`, and `find ... 2>/dev/null || true` and
+`grep -c "///" src/lib.rs || echo "0"` keep their fallbacks.
+
+## Evidence
+
+This is a CI workflow change with no UI or runtime behaviour to
+screenshot. Verification is via the new tests in
+`tests/issue_1290_workflow_set_euo_pipefail.rs`, which parse `ci.yml`
+and assert each named step contains `set -euo pipefail` and declares
+`shell: bash`. Both tests went from FAILED → ok after the edits, and
+the full `./quality.sh` gate passes (fmt, clippy, check, test, doc,
+release build).
+
+```mermaid
+flowchart LR
+    A[run: \|] -->|previously unguarded| B[silent failure of sed/grep/pipe]
+    A2[run: \|<br/>set -euo pipefail<br/>shell: bash] -->|after #1290| C[fail loudly on<br/>unset var, pipe error,<br/>intermediate non-zero]
+```
+
+## Test Plan
+
+- Added `tests/issue_1290_workflow_set_euo_pipefail.rs` with two tests:
+  - `ci_yml_guarded_steps_contain_set_euo_pipefail` — asserts each of
+    the eight steps contains `set -euo pipefail`.
+  - `ci_yml_guarded_steps_declare_shell_bash` — asserts each declares
+    `shell: bash`.
+- Existing workflow tests (`issue_1216_workflow_sha_pins`,
+  `issue_1286_workflow_permissions`, `issue_1287_workflow_timeouts`,
+  `issue_1288_workflow_concurrency`) continue to pass.
+- `./quality.sh` passes cleanly.

--- a/tests/issue_1290_workflow_set_euo_pipefail.rs
+++ b/tests/issue_1290_workflow_set_euo_pipefail.rs
@@ -1,0 +1,115 @@
+//! Issue #1290: every multi-line `run: |` block in `.github/workflows/ci.yml`
+//! that was previously running unguarded bash must now start with
+//! `set -euo pipefail` (and declare `shell: bash` to be explicit).
+//!
+//! Without `set -e` a failed intermediate command (e.g. a `sed` rewrite
+//! of `Cargo.toml`) can fall through and the step still exits 0. Without
+//! `-u` a typo in `${VAR}` silently expands to empty. Without
+//! `-o pipefail` failures in piped commands are hidden by the exit code
+//! of the last stage.
+//!
+//! This test parses `ci.yml` as plain text (no YAML parser is in the
+//! dependency tree), locates each named step listed in the issue, and
+//! asserts that the step's `run: |` block contains `set -euo pipefail`
+//! on a line of its own and that the step declares `shell: bash`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a step by its `- name: <step_name>` marker and return the
+/// block of the step up to the next sibling step or end of file. Steps
+/// are identified by a line of the form `    - name: <step_name>`
+/// (four-space indent typical of a job's `steps:` list).
+fn step_block<'a>(body: &'a str, step_name: &str) -> Option<&'a str> {
+    let header = format!("    - name: {step_name}\n");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    // Find next sibling step ("    - name:") or next job (two-space indent)
+    // by scanning subsequent lines.
+    let mut idx = header.len();
+    let bytes = after.as_bytes();
+    while idx < bytes.len() {
+        if let Some(nl) = after[idx..].find('\n') {
+            let line_start = idx + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling step at same indent, or a new job header.
+            if line.starts_with("    - name:")
+                || (line.starts_with("  ")
+                    && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                    && line.trim_end().ends_with(':'))
+            {
+                return Some(&after[..line_start]);
+            }
+            idx = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+fn has_set_euo_pipefail(block: &str) -> bool {
+    block.lines().any(|line| line.trim() == "set -euo pipefail")
+}
+
+fn declares_shell_bash(block: &str) -> bool {
+    block.lines().any(|line| line.trim() == "shell: bash")
+}
+
+/// The exact step names called out in Issue #1290 — every multi-line
+/// bash block in ci.yml that was running unguarded.
+const GUARDED_STEPS: &[&str] = &[
+    "Check for source changes and increment version",
+    "Check if there are changes",
+    "Free up runner disk space",
+    "Clean intermediate artefacts before tests",
+    "Check for required files",
+    "Validate Cargo.toml",
+    "Check documentation",
+    "Ensure bash scripts are executable",
+];
+
+#[test]
+fn ci_yml_guarded_steps_contain_set_euo_pipefail() {
+    let body = read_workflow("ci.yml");
+    for step_name in GUARDED_STEPS {
+        let block = step_block(&body, step_name)
+            .unwrap_or_else(|| panic!("step `{step_name}` not found in ci.yml"));
+        assert!(
+            has_set_euo_pipefail(block),
+            "step `{step_name}` in ci.yml must start its `run:` block with \
+             `set -euo pipefail` so unset variables and pipe failures are not \
+             silently swallowed (Issue #1290)",
+        );
+    }
+}
+
+#[test]
+fn ci_yml_guarded_steps_declare_shell_bash() {
+    let body = read_workflow("ci.yml");
+    for step_name in GUARDED_STEPS {
+        let block = step_block(&body, step_name)
+            .unwrap_or_else(|| panic!("step `{step_name}` not found in ci.yml"));
+        assert!(
+            declares_shell_bash(block),
+            "step `{step_name}` in ci.yml must declare `shell: bash` so the \
+             `set -euo pipefail` guard is honoured by the explicit interpreter \
+             (Issue #1290)",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Added `set -euo pipefail` (and an explicit `shell: bash`) to every
multi-line `run: |` block in `.github/workflows/ci.yml` that was
previously running unguarded. Without these guards a failed `sed` /
`grep` / piped command silently swallows its exit code, which is
especially dangerous in the `version-increment` step that rewrites
`Cargo.toml` in place. Closes #1290.

The eight steps now guarded:

- `version-increment` → "Check for source changes and increment version"
- `version-increment` → "Check if there are changes"
- `quality` → "Free up runner disk space"
- `quality` → "Clean intermediate artefacts before tests"
- `validation` → "Check for required files"
- `validation` → "Validate Cargo.toml"
- `validation` → "Check documentation"
- `auto-format` → "Ensure bash scripts are executable"

Existing intentional-failure tolerances are preserved — e.g.
`cargo outdated -R || true` continues to suppress that single command's
exit code under `set -e`, and `find ... 2>/dev/null || true` and
`grep -c "///" src/lib.rs || echo "0"` keep their fallbacks.

## Evidence

This is a CI workflow change with no UI or runtime behaviour to
screenshot. Verification is via the new tests in
`tests/issue_1290_workflow_set_euo_pipefail.rs`, which parse `ci.yml`
and assert each named step contains `set -euo pipefail` and declares
`shell: bash`. Both tests went from FAILED → ok after the edits, and
the full `./quality.sh` gate passes (fmt, clippy, check, test, doc,
release build).

```mermaid
flowchart LR
    A[run: \|] -->|previously unguarded| B[silent failure of sed/grep/pipe]
    A2[run: \|<br/>set -euo pipefail<br/>shell: bash] -->|after #1290| C[fail loudly on<br/>unset var, pipe error,<br/>intermediate non-zero]
```

## Test Plan

- Added `tests/issue_1290_workflow_set_euo_pipefail.rs` with two tests:
  - `ci_yml_guarded_steps_contain_set_euo_pipefail` — asserts each of
    the eight steps contains `set -euo pipefail`.
  - `ci_yml_guarded_steps_declare_shell_bash` — asserts each declares
    `shell: bash`.
- Existing workflow tests (`issue_1216_workflow_sha_pins`,
  `issue_1286_workflow_permissions`, `issue_1287_workflow_timeouts`,
  `issue_1288_workflow_concurrency`) continue to pass.
- `./quality.sh` passes cleanly.



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-1290 -->