### PR TITLE
test(constants): replace circular magic-value asserts with compile-time + behavioural checks (#1295)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1295.md
+++ b/docs/archive/pr-summaries/pr-summary-1295.md
@@ -1,0 +1,81 @@
+## Summary
+
+Rewrites two test files that consisted almost entirely of circular
+magic-value `assert_eq!(constants::FOO, <literal>)` assertions — the
+canonical anti-pattern flagged by the test audit. Each assertion passed
+if and only if the literal in the test matched the literal in
+`src/analysis/constants/*.rs`, obstructed legitimate retuning of every
+discovery constant, and caught no real defect.
+
+The new files split the original intent into two stronger guarantees:
+
+- **Compile-time re-export and invariant checks** — `const _: T =
+  constants::FOO;` confirms each constant is still reachable via the
+  central module (a stronger guarantee than the runtime assertion, since
+  any missing re-export breaks the build). `const _: () = assert!(...)`
+  declarations encode pure-constant invariants (logistic curve
+  positivity, hold-out fraction inside `(0, 1)`, monotonic op-count
+  discounts, compression bounds, pessimism floors inside `[0, 1]`,
+  etc.). These execute at compile time, cost zero runtime, and never
+  need updating when a value is tuned within its declared envelope.
+- **Behavioural tests** — runtime tests for helper functions
+  (`activation_neuron_boost`, `cmp_f32_*`, `coordinated_empirical_discount`)
+  and for the consolidated-constants behaviour exercised through real
+  detection modules (saturation, dead-neuron). These survive value
+  tuning because they assert on observable behaviour, not on magic
+  numbers.
+
+Closes #1295.
+
+## Evidence
+
+CLI-only refactor of two test files — no UI surface to screenshot. The
+behavioural change is captured by the test outcomes themselves:
+
+```
+test result: ok. 14 passed; 0 failed; 0 ignored
+```
+
+`./quality.sh` passes end-to-end (fmt, clippy `-D warnings`, check,
+full test suite of 171 analysis integration tests, doc build, release
+build).
+
+### Before / after at a glance
+
+```mermaid
+flowchart LR
+    A[assert_eq! constants::FOO == 64] -->|edit constant| B[Test fails]
+    B -->|mechanical edit| C[Update literal in test]
+    C -.->|catches nothing| D[No real defect found]
+
+    E[const _: usize = constants::FOO] -->|re-export removed| F[Build fails<br/>compile-time]
+    G[const _: assert! FOO_MIN <= FOO_MAX] -->|envelope violated| F
+    H[Behavioural test:<br/>activation_neuron_boost lookup] -->|contract violated| I[Test fails<br/>with real diagnostic]
+```
+
+## Test Plan
+
+Modified test files:
+- `tests/analysis/issue_938_constants_submodule_organisation.rs`
+- `tests/analysis/issue_424_consolidate_discovery_constants.rs`
+
+Coverage retained / strengthened:
+- Every constant previously asserted via `assert_eq!` is still
+  reachable through a `const _:` re-export check — removing any
+  re-export breaks the build.
+- Pure-constant invariants (logistic curve positivity, hold-out
+  fraction in `(0, 1)`, sample-threshold consistency, monotonic
+  coordinated discounts, compression bounds, pessimism floor / curve
+  envelopes, sentinel tolerance vs gap) are now compile-time
+  `const _: () = assert!(...)` declarations.
+- Behavioural tests retained: `activation_neuron_boost` contract,
+  NaN-safe comparator ordering, `coordinated_empirical_discount`
+  monotonicity / saturation, `CANDIDATE_SENTINELS` low/zero/high
+  coverage and pairwise separation, saturation / dead-neuron detection
+  through the consolidated constants.
+
+Verification:
+- `cargo test --test analysis` → 14 of the new constants-tests pass,
+  full suite 171/171.
+- `./quality.sh` → all gates green (fmt, clippy `-D warnings`,
+  cargo check, doc build, release build).

--- a/tests/analysis/issue_424_consolidate_discovery_constants.rs
+++ b/tests/analysis/issue_424_consolidate_discovery_constants.rs
@@ -1,50 +1,88 @@
 //! Tests for Issue #424: Consolidate discovery constants into central module.
 //!
-//! Verifies that the central `constants` module provides a single source of truth
-//! for discovery thresholds, and that all analysis modules use these constants
-//! consistently.
+//! Verifies that the central `constants` module provides a single source of
+//! truth for discovery thresholds, and that analysis modules consume those
+//! constants consistently.
 //!
-//! ## TDD Plan
-//! 1. Test that constants are accessible from the central module
-//! 2. Test that constant values match expected defaults
-//! 3. Test that detection modules still function correctly using centralised constants
-//! 4. Test that sentinel-related constants are consistent across observation, bounded-range,
-//!    and sentinel-gating modules
+//! Issue #1295: the original file asserted `assert_eq!(constants::FOO, <literal>)`
+//! for each consolidated constant. Those assertions were circular magic-value
+//! tests (the literal in the test matched the literal in the source by
+//! construction) and have been replaced with:
+//!
+//! - **Compile-only re-export and invariant checks** (`const _: T = constants::FOO;`
+//!   and `const _: () = assert!(...)`) that confirm each consolidated constant
+//!   is still reachable via the central module and that its declared envelope
+//!   is preserved.
+//! - **Behavioural tests** that exercise detection modules through the
+//!   consolidated constants — these are the tests that genuinely guard the
+//!   "single source of truth" contract.
 
 use neat_ai_discovery::analysis::constants;
 
-/// Verify `MIN_NEURON_SAMPLE_COUNT` is accessible from the central constants module.
-#[test]
-fn test_min_neuron_sample_count_accessible() {
-    assert_eq!(constants::MIN_NEURON_SAMPLE_COUNT, 10);
-}
+// =============================================================================
+// Compile-time re-export checks — confirm every consolidated constant is
+// still reachable via the central `constants` module.
+// =============================================================================
 
-/// Verify `MIN_DISCOVERY_SAMPLE_COUNT` is accessible from the central constants module.
-#[test]
-fn test_min_discovery_sample_count_accessible() {
-    assert_eq!(constants::MIN_DISCOVERY_SAMPLE_COUNT, 20);
-}
+const _: usize = constants::MIN_NEURON_SAMPLE_COUNT;
+const _: usize = constants::MIN_DISCOVERY_SAMPLE_COUNT;
+const _: [f32; 3] = constants::CANDIDATE_SENTINELS;
+const _: f32 = constants::MIN_SENTINEL_FRACTION;
+const _: f32 = constants::SENTINEL_TOLERANCE;
+const _: f32 = constants::MIN_SENTINEL_GAP;
+const _: f32 = constants::MIN_SOURCE_STD_DEV;
+const _: usize = constants::DIVERSIFY_TOP_K;
 
-/// Verify sentinel detection constants are accessible from the central module.
-#[test]
-fn test_sentinel_constants_accessible() {
-    assert_eq!(constants::CANDIDATE_SENTINELS, [-1.0_f32, 0.0, 1.0]);
-    assert!((constants::MIN_SENTINEL_FRACTION - 0.15).abs() < f32::EPSILON);
-    assert!((constants::SENTINEL_TOLERANCE - 0.02).abs() < f32::EPSILON);
-    assert!((constants::MIN_SENTINEL_GAP - 0.05).abs() < f32::EPSILON);
-}
+// =============================================================================
+// Compile-time invariant checks — pure-constant relationships that guard
+// the consolidated module against accidental tuning past a safe envelope.
+// =============================================================================
 
-/// Verify `MIN_SOURCE_STD_DEV` is accessible from the central module.
-#[test]
-fn test_min_source_std_dev_accessible() {
-    assert!((constants::MIN_SOURCE_STD_DEV - 0.05).abs() < f32::EPSILON);
-}
+// Sample thresholds — pattern detection needs at least as many samples as
+// the per-neuron statistical floor, and that floor must support a meaningful
+// statistical calculation.
+const _: () = assert!(
+    constants::MIN_DISCOVERY_SAMPLE_COUNT >= constants::MIN_NEURON_SAMPLE_COUNT,
+    "discovery sample minimum must be >= neuron sample minimum"
+);
+const _: () = assert!(
+    constants::MIN_NEURON_SAMPLE_COUNT >= 2,
+    "neuron sample minimum must be >= 2 for any statistical calculation"
+);
 
-/// Verify `DIVERSIFY_TOP_K` is accessible from the central module.
-#[test]
-fn test_diversify_top_k_accessible() {
-    assert_eq!(constants::DIVERSIFY_TOP_K, 64);
-}
+// Diversification — a zero or negative top-k would disable diversification.
+const _: () = assert!(
+    constants::DIVERSIFY_TOP_K > 0,
+    "DIVERSIFY_TOP_K must be positive to enable diversification"
+);
+
+// Source variance — a zero floor would admit constant sources, defeating
+// variance filtering.
+const _: () = assert!(
+    constants::MIN_SOURCE_STD_DEV > 0.0,
+    "MIN_SOURCE_STD_DEV must be strictly positive — a zero floor would \
+     admit constant sources"
+);
+
+// Sentinel contract — tolerance must be smaller than the inter-sentinel gap
+// (otherwise tolerance windows overlap and a value could match two
+// sentinels at once), and the minimum fraction must lie strictly inside
+// (0, 1).
+const _: () = assert!(
+    constants::SENTINEL_TOLERANCE < constants::MIN_SENTINEL_GAP,
+    "SENTINEL_TOLERANCE must be smaller than MIN_SENTINEL_GAP to avoid \
+     overlapping tolerance windows"
+);
+const _: () = assert!(
+    constants::MIN_SENTINEL_FRACTION > 0.0 && constants::MIN_SENTINEL_FRACTION < 1.0,
+    "MIN_SENTINEL_FRACTION must lie strictly inside (0, 1)"
+);
+
+// =============================================================================
+// Behavioural tests — exercise the consolidated constants through real
+// detection modules. These survive value tuning because they assert on
+// observable behaviour, not on magic numbers.
+// =============================================================================
 
 /// Verify that saturated neuron detection still works (uses `MIN_NEURON_SAMPLE_COUNT`
 /// indirectly via sample count filtering).
@@ -141,4 +179,22 @@ fn test_dead_neuron_detection_uses_centralised_constants() {
         detected.is_empty(),
         "Should not detect dead neurons with fewer than MIN_DISCOVERY_SAMPLE_COUNT samples"
     );
+}
+
+/// Every pair of `CANDIDATE_SENTINELS` is separated by at least
+/// `MIN_SENTINEL_GAP`. This is a runtime check because iterating sentinel
+/// pairs is not const-eval-able on stable Rust.
+#[test]
+fn test_candidate_sentinels_are_well_separated() {
+    let sentinels = constants::CANDIDATE_SENTINELS;
+    for (i, a) in sentinels.iter().enumerate() {
+        for b in sentinels.iter().skip(i + 1) {
+            assert!(
+                (a - b).abs() >= constants::MIN_SENTINEL_GAP,
+                "sentinels {a} and {b} must differ by at least \
+                 MIN_SENTINEL_GAP={}",
+                constants::MIN_SENTINEL_GAP
+            );
+        }
+    }
 }

--- a/tests/analysis/issue_938_constants_submodule_organisation.rs
+++ b/tests/analysis/issue_938_constants_submodule_organisation.rs
@@ -1,175 +1,291 @@
 //! Tests for Issue #938: Split constants.rs into thematic sub-modules.
 //!
-//! Verifies that all constants remain accessible via the same
-//! `crate::analysis::constants::CONSTANT_NAME` paths after the split,
-//! ensuring backward compatibility. Also validates that no constants
-//! are duplicated and that each sub-module category is correctly populated.
+//! The stated intent of these tests is to verify that all constants remain
+//! accessible via the same `crate::analysis::constants::CONSTANT_NAME` paths
+//! after the sub-module split — i.e. that the re-export contract is intact.
+//!
+//! Issue #1295: this file previously asserted `assert_eq!(constants::FOO, <literal>)`
+//! for every constant. Those assertions were circular magic-value tests: they
+//! pass if and only if the literal in the test matches the literal in the
+//! source, and they obstruct legitimate retuning of any constant without
+//! catching any real defect. They have been replaced with:
+//!
+//! - **Compile-only re-export and invariant checks** (`const _: T = constants::FOO;`
+//!   and `const _: () = assert!(...)`) for the symbol-accessibility intent and
+//!   pure-constant invariants. If the re-export breaks or a value tuned past
+//!   its declared envelope, the file fails to compile — a stronger guarantee
+//!   than the runtime assertion ever provided, at zero runtime cost.
+//! - **Behavioural tests** for the small number of helper functions exposed by
+//!   the constants module (NaN-safe comparators, activation boost lookup,
+//!   empirical discount lookup).
 
 use neat_ai_discovery::analysis::constants;
 
 // =============================================================================
-// Sample Thresholds Sub-module
+// Compile-time re-export checks — verifies every constant tested by the
+// original file is still reachable via `constants::*`. If any re-export is
+// removed the file will fail to compile.
 // =============================================================================
 
-/// Verify sample count thresholds are accessible via the re-export.
-#[test]
-fn test_sample_thresholds_accessible() {
-    assert_eq!(constants::MIN_NEURON_SAMPLE_COUNT, 10);
-    assert_eq!(constants::MIN_DISCOVERY_SAMPLE_COUNT, 20);
-    assert_eq!(constants::HOLDOUT_MIN_SAMPLE_COUNT, 20);
-    assert!((constants::HOLDOUT_VALIDATION_FRACTION - 0.3).abs() < f32::EPSILON);
-}
+// Sample thresholds
+const _: usize = constants::MIN_NEURON_SAMPLE_COUNT;
+const _: usize = constants::MIN_DISCOVERY_SAMPLE_COUNT;
+const _: usize = constants::HOLDOUT_MIN_SAMPLE_COUNT;
+const _: f32 = constants::HOLDOUT_VALIDATION_FRACTION;
+
+// Sentinel detection
+const _: [f32; 3] = constants::CANDIDATE_SENTINELS;
+const _: f32 = constants::MIN_SENTINEL_FRACTION;
+const _: f32 = constants::SENTINEL_TOLERANCE;
+const _: f32 = constants::MIN_SENTINEL_GAP;
+
+// Source variance
+const _: f32 = constants::MIN_SOURCE_STD_DEV;
+
+// Candidate scoring — diversification
+const _: usize = constants::DIVERSIFY_TOP_K;
+
+// Candidate scoring — source / target type boosts
+const _: f64 = constants::INPUT_SOURCE_BOOST;
+const _: f64 = constants::HIDDEN_SOURCE_BOOST;
+const _: usize = constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL;
+const _: usize = constants::MIN_BOOST_SAMPLES;
+const _: f64 = constants::EXISTING_HIDDEN_TARGET_BOOST;
+
+// Candidate scoring — activation boosts
+const _: f64 = constants::ACTIVATION_BOOST_GELU;
+const _: f64 = constants::ACTIVATION_BOOST_IDENTITY;
+const _: f64 = constants::ACTIVATION_BOOST_TANH;
+const _: f64 = constants::ACTIVATION_BOOST_HARD_TANH;
+const _: f64 = constants::ACTIVATION_BOOST_MIN;
+const _: f64 = constants::ACTIVATION_BOOST_MAX;
+
+// Candidate scoring — pessimism discounting
+const _: f32 = constants::PESSIMISM_DISCOUNT_FLOOR;
+const _: f32 = constants::PESSIMISM_CURVE_EXPONENT;
+const _: f32 = constants::NEURON_PESSIMISM_DISCOUNT_FLOOR;
+const _: f32 = constants::NEURON_PESSIMISM_CURVE_EXPONENT;
+const _: f32 = constants::SYNAPSE_PESSIMISM_DISCOUNT_FLOOR;
+const _: f32 = constants::SYNAPSE_PESSIMISM_CURVE_EXPONENT;
+
+// Candidate scoring — coordinated-structural
+const _: f32 = constants::COORDINATED_EMPIRICAL_DISCOUNT_2OPS;
+const _: f32 = constants::COORDINATED_EMPIRICAL_DISCOUNT_3OPS;
+const _: f32 = constants::COORDINATED_EMPIRICAL_DISCOUNT_4PLUS_OPS;
+const _: f32 = constants::MIN_COORDINATED_MULTI_OP_GAIN;
+const _: f32 = constants::COORDINATED_ESTIMATION_WEIGHT_SCALE;
+
+// Candidate scoring — prediction calibration
+const _: f32 = constants::SYNAPSE_PREDICTION_CALIBRATION;
+const _: f32 = constants::NEURON_PREDICTION_CALIBRATION;
+const _: f32 = constants::COORDINATED_PREDICTION_CALIBRATION;
+const _: f32 = constants::LOGISTIC_CALIBRATION_FLOOR;
+const _: f32 = constants::LOGISTIC_CALIBRATION_STEEPNESS;
+const _: f32 = constants::LOGISTIC_CALIBRATION_MIDPOINT;
+
+// Candidate scoring — scoring boost multipliers
+const _: f32 = constants::MICRO_NUDGE_VARIANT_BOOST;
+const _: f32 = constants::REMOVAL_CANDIDATE_BOOST;
+
+// Detection thresholds
+const _: f32 = constants::MIN_IMPROVED_RATIO;
+const _: f32 = constants::NEURON_MIN_IMPROVED_RATIO;
+const _: f32 = constants::REMOVAL_MEAN_ACTIVATION_THRESHOLD;
+const _: f32 = constants::REMOVAL_IMPACT_THRESHOLD;
+const _: f32 = constants::MAX_INCOMING_WEIGHT;
+const _: f32 = constants::MAX_BIAS_MAGNITUDE;
+const _: f32 = constants::MAX_INDIVIDUAL_HARM_FOR_PAIRING;
+
+// Compression
+const _: usize = constants::MIN_COMPRESSED_SOURCES;
+const _: usize = constants::MAX_COMPRESSION_INPUTS;
+const _: f32 = constants::COMPRESSION_SATURATION_THRESHOLD;
+const _: f32 = constants::COMPRESSION_MIN_BENEFIT_RATIO;
 
 // =============================================================================
-// Sentinel Detection Sub-module
+// Compile-time invariant checks — pure-constant relationships that would
+// be `#[test]` assertions if the values were not const-eval-able. Using
+// `const _: () = assert!(...)` evaluates them at compile time and avoids
+// the `clippy::assertions_on_constants` lint.
 // =============================================================================
 
-/// Verify sentinel detection constants are accessible via the re-export.
-#[test]
-fn test_sentinel_detection_accessible() {
-    assert_eq!(constants::CANDIDATE_SENTINELS, [-1.0_f32, 0.0, 1.0]);
-    assert!((constants::MIN_SENTINEL_FRACTION - 0.15).abs() < f32::EPSILON);
-    assert!((constants::SENTINEL_TOLERANCE - 0.02).abs() < f32::EPSILON);
-    assert!((constants::MIN_SENTINEL_GAP - 0.05).abs() < f32::EPSILON);
-}
+// Logistic calibration parameters describe a usable curve.
+const _: () = assert!(
+    constants::LOGISTIC_CALIBRATION_FLOOR > 0.0,
+    "logistic floor must be strictly positive — a zero floor would collapse \
+     the calibration onto the asymptote"
+);
+const _: () = assert!(
+    constants::LOGISTIC_CALIBRATION_STEEPNESS > 0.0,
+    "logistic steepness must be strictly positive — a non-positive value \
+     would flip the curve"
+);
+const _: () = assert!(
+    constants::LOGISTIC_CALIBRATION_MIDPOINT > 0.0
+        && constants::LOGISTIC_CALIBRATION_MIDPOINT < 1.0,
+    "logistic midpoint must lie inside (0, 1)"
+);
+
+// Hold-out validation parameters describe a usable train/validate split.
+const _: () = assert!(
+    constants::HOLDOUT_VALIDATION_FRACTION > 0.0 && constants::HOLDOUT_VALIDATION_FRACTION < 1.0,
+    "validation fraction must lie strictly inside (0, 1) — otherwise one \
+     partition would be empty"
+);
+const _: () = assert!(
+    constants::HOLDOUT_MIN_SAMPLE_COUNT >= constants::MIN_DISCOVERY_SAMPLE_COUNT,
+    "hold-out minimum must be at least as large as the generic discovery minimum"
+);
+
+// Pessimism discount floors stay inside the unit interval.
+const _: () = assert!(
+    constants::PESSIMISM_DISCOUNT_FLOOR >= 0.0 && constants::PESSIMISM_DISCOUNT_FLOOR <= 1.0,
+    "PESSIMISM_DISCOUNT_FLOOR must lie within [0, 1]"
+);
+const _: () = assert!(
+    constants::NEURON_PESSIMISM_DISCOUNT_FLOOR >= 0.0
+        && constants::NEURON_PESSIMISM_DISCOUNT_FLOOR <= 1.0,
+    "NEURON_PESSIMISM_DISCOUNT_FLOOR must lie within [0, 1]"
+);
+const _: () = assert!(
+    constants::SYNAPSE_PESSIMISM_DISCOUNT_FLOOR >= 0.0
+        && constants::SYNAPSE_PESSIMISM_DISCOUNT_FLOOR <= 1.0,
+    "SYNAPSE_PESSIMISM_DISCOUNT_FLOOR must lie within [0, 1]"
+);
+const _: () = assert!(
+    constants::PESSIMISM_CURVE_EXPONENT > 0.0,
+    "PESSIMISM_CURVE_EXPONENT must be strictly positive"
+);
+const _: () = assert!(
+    constants::NEURON_PESSIMISM_CURVE_EXPONENT > 0.0,
+    "NEURON_PESSIMISM_CURVE_EXPONENT must be strictly positive"
+);
+const _: () = assert!(
+    constants::SYNAPSE_PESSIMISM_CURVE_EXPONENT > 0.0,
+    "SYNAPSE_PESSIMISM_CURVE_EXPONENT must be strictly positive"
+);
+
+// Coordinated-structural empirical discounts shrink monotonically with op count
+// (more ops = more pessimism), and the 4-plus bucket is the smallest.
+const _: () = assert!(
+    constants::COORDINATED_EMPIRICAL_DISCOUNT_2OPS > constants::COORDINATED_EMPIRICAL_DISCOUNT_3OPS,
+    "two-op discount must exceed three-op discount"
+);
+const _: () = assert!(
+    constants::COORDINATED_EMPIRICAL_DISCOUNT_3OPS
+        > constants::COORDINATED_EMPIRICAL_DISCOUNT_4PLUS_OPS,
+    "three-op discount must exceed four-plus discount"
+);
+
+// Compression bounds form a valid range.
+const _: () = assert!(
+    constants::MIN_COMPRESSED_SOURCES >= 2,
+    "compressing fewer than 2 sources is a no-op"
+);
+const _: () = assert!(
+    constants::MIN_COMPRESSED_SOURCES <= constants::MAX_COMPRESSION_INPUTS,
+    "minimum compressed sources must not exceed the maximum"
+);
+const _: () = assert!(
+    constants::COMPRESSION_MIN_BENEFIT_RATIO > 1.0,
+    "compression must require at least a 1.0x benefit to be worthwhile"
+);
+const _: () = assert!(
+    constants::COMPRESSION_SATURATION_THRESHOLD > 0.0
+        && constants::COMPRESSION_SATURATION_THRESHOLD < 1.0,
+    "compression saturation threshold must lie strictly inside (0, 1)"
+);
 
 // =============================================================================
-// Source Variance Sub-module
+// Behavioural tests — these exercise function behaviour, not magic values.
+// They survive value tuning because they assert on relationships and contracts.
 // =============================================================================
 
-/// Verify source variance threshold is accessible via the re-export.
+/// `activation_neuron_boost` returns the per-squash boost for known squashes
+/// and a neutral 1.0 for unknown squashes.
 #[test]
-fn test_source_variance_accessible() {
-    assert!((constants::MIN_SOURCE_STD_DEV - 0.05).abs() < f32::EPSILON);
+fn test_activation_neuron_boost_contract() {
+    // Known squash returns its registered boost.
+    assert!(
+        (constants::activation_neuron_boost("GELU") - constants::ACTIVATION_BOOST_GELU).abs()
+            < f64::EPSILON,
+        "GELU boost must match the registered constant"
+    );
+    assert!(
+        (constants::activation_neuron_boost("IDENTITY") - constants::ACTIVATION_BOOST_IDENTITY)
+            .abs()
+            < f64::EPSILON,
+        "IDENTITY boost must match the registered constant"
+    );
+    // Unknown squash falls back to the neutral 1.0 multiplier (no boost, no penalty).
+    assert!(
+        (constants::activation_neuron_boost("unknown") - 1.0).abs() < f64::EPSILON,
+        "unknown squash must fall back to a neutral 1.0 multiplier"
+    );
+    // Every returned boost stays inside the declared [MIN, MAX] envelope.
+    for squash in ["GELU", "IDENTITY", "TANH", "HARD_TANH"] {
+        let boost = constants::activation_neuron_boost(squash);
+        assert!(
+            (constants::ACTIVATION_BOOST_MIN..=constants::ACTIVATION_BOOST_MAX).contains(&boost),
+            "{squash} boost {boost} must lie within \
+             [ACTIVATION_BOOST_MIN, ACTIVATION_BOOST_MAX]"
+        );
+    }
 }
 
-// =============================================================================
-// Candidate Scoring Sub-module
-// =============================================================================
-
-/// Verify diversification constant is accessible.
+/// NaN-safe comparators sort in the documented direction.
 #[test]
-fn test_diversify_top_k_accessible() {
-    assert_eq!(constants::DIVERSIFY_TOP_K, 64);
-}
-
-/// Verify source-type scoring constants are accessible.
-#[test]
-fn test_source_type_scoring_accessible() {
-    assert!((constants::INPUT_SOURCE_BOOST - 1.5).abs() < f64::EPSILON);
-    assert!((constants::HIDDEN_SOURCE_BOOST - 1.2).abs() < f64::EPSILON);
-    assert_eq!(constants::HIDDEN_SOURCE_INTERLEAVE_INTERVAL, 3);
-    assert_eq!(constants::MIN_BOOST_SAMPLES, 10);
-}
-
-/// Verify target-type scoring constant is accessible.
-#[test]
-fn test_target_type_scoring_accessible() {
-    assert!((constants::EXISTING_HIDDEN_TARGET_BOOST - 1.5).abs() < f64::EPSILON);
-}
-
-/// Verify activation boost function and constants are accessible.
-#[test]
-fn test_activation_boosts_accessible() {
-    assert!((constants::ACTIVATION_BOOST_GELU - 2.0).abs() < f64::EPSILON);
-    assert!((constants::ACTIVATION_BOOST_IDENTITY - 0.85).abs() < f64::EPSILON);
-    assert!((constants::ACTIVATION_BOOST_TANH - 1.0).abs() < f64::EPSILON);
-    assert!((constants::ACTIVATION_BOOST_HARD_TANH - 0.80).abs() < f64::EPSILON);
-    assert!((constants::ACTIVATION_BOOST_MIN - 0.5).abs() < f64::EPSILON);
-    assert!((constants::ACTIVATION_BOOST_MAX - 2.0).abs() < f64::EPSILON);
-
-    // Verify the lookup function is accessible and returns correct values.
-    assert!((constants::activation_neuron_boost("GELU") - 2.0).abs() < f64::EPSILON);
-    assert!((constants::activation_neuron_boost("IDENTITY") - 0.85).abs() < f64::EPSILON);
-    assert!((constants::activation_neuron_boost("unknown") - 1.0).abs() < f64::EPSILON);
-}
-
-/// Verify pessimism discount constants are accessible.
-///
-/// Issue #1056: Updated values to match production success rates from GRQ-sampler.
-#[test]
-fn test_pessimism_discounts_accessible() {
-    assert!((constants::PESSIMISM_DISCOUNT_FLOOR - 0.15).abs() < f32::EPSILON);
-    assert!((constants::PESSIMISM_CURVE_EXPONENT - 0.6).abs() < f32::EPSILON);
-    assert!((constants::NEURON_PESSIMISM_DISCOUNT_FLOOR - 0.08).abs() < f32::EPSILON);
-    assert!((constants::NEURON_PESSIMISM_CURVE_EXPONENT - 0.80).abs() < f32::EPSILON);
-    assert!((constants::SYNAPSE_PESSIMISM_DISCOUNT_FLOOR - 0.03).abs() < f32::EPSILON);
-    assert!((constants::SYNAPSE_PESSIMISM_CURVE_EXPONENT - 0.90).abs() < f32::EPSILON);
-}
-
-/// Verify NaN-safe comparison functions are accessible and correct.
-#[test]
-fn test_nan_safe_comparison_accessible() {
+fn test_nan_safe_comparators_ordering() {
     use std::cmp::Ordering;
+
+    // Descending: a larger value sorts before a smaller one.
     assert_eq!(constants::cmp_f32_desc(&2.0, &1.0), Ordering::Less);
+    assert_eq!(constants::cmp_f32_desc(&1.0, &2.0), Ordering::Greater);
+    assert_eq!(constants::cmp_f32_desc(&1.0, &1.0), Ordering::Equal);
+
+    // Ascending: a smaller value sorts first.
     assert_eq!(constants::cmp_f32_asc(&1.0, &2.0), Ordering::Less);
+    assert_eq!(constants::cmp_f32_asc(&2.0, &1.0), Ordering::Greater);
+
+    // f64 descending mirrors the f32 contract.
     assert_eq!(constants::cmp_f64_desc(&2.0, &1.0), Ordering::Less);
+    assert_eq!(constants::cmp_f64_desc(&1.0, &2.0), Ordering::Greater);
 }
 
-/// Verify coordinated-structural constants are accessible (Issue #1058: updated).
+/// `coordinated_empirical_discount` returns the per-op-count discount factor
+/// and saturates at the 4-plus-ops bucket for higher op counts.
 #[test]
-fn test_coordinated_structural_accessible() {
-    // Issue #1058: Empirical per-op-count factors replace compound discount.
-    assert!((constants::COORDINATED_EMPIRICAL_DISCOUNT_2OPS - 0.5).abs() < f32::EPSILON);
-    assert!((constants::COORDINATED_EMPIRICAL_DISCOUNT_3OPS - 0.2).abs() < f32::EPSILON);
-    assert!((constants::COORDINATED_EMPIRICAL_DISCOUNT_4PLUS_OPS - 0.1).abs() < f32::EPSILON);
-    // Issue #1058: Lowered from 1e-3 to 1e-5.
-    assert!((constants::MIN_COORDINATED_MULTI_OP_GAIN - 1e-5).abs() < f32::EPSILON);
-    assert!((constants::COORDINATED_ESTIMATION_WEIGHT_SCALE - 0.2).abs() < f32::EPSILON);
-    // Issue #1058: Verify empirical discount function is accessible.
-    let d = constants::coordinated_empirical_discount(2);
-    assert!((d - 0.5).abs() < f32::EPSILON);
+fn test_coordinated_empirical_discount_contract() {
+    let d2 = constants::coordinated_empirical_discount(2);
+    let d3 = constants::coordinated_empirical_discount(3);
+    let d4 = constants::coordinated_empirical_discount(4);
+    let d5 = constants::coordinated_empirical_discount(5);
+
+    // Each op-count bucket returns its registered discount.
+    assert!((d2 - constants::COORDINATED_EMPIRICAL_DISCOUNT_2OPS).abs() < f32::EPSILON);
+    assert!((d3 - constants::COORDINATED_EMPIRICAL_DISCOUNT_3OPS).abs() < f32::EPSILON);
+    assert!((d4 - constants::COORDINATED_EMPIRICAL_DISCOUNT_4PLUS_OPS).abs() < f32::EPSILON);
+
+    // The 4-plus bucket saturates — five-op candidates use the same factor
+    // as four-op candidates.
+    assert!(
+        (d5 - d4).abs() < f32::EPSILON,
+        "4-plus bucket must saturate"
+    );
 }
 
-/// Verify prediction calibration constants are accessible.
-///
-/// Issue #1056: Updated values to match production success rates from GRQ-sampler.
+/// `CANDIDATE_SENTINELS` covers the canonical low / zero / high sentinel
+/// values used for sentinel-gating detection.
 #[test]
-fn test_prediction_calibration_accessible() {
-    assert!((constants::SYNAPSE_PREDICTION_CALIBRATION - 0.0003).abs() < f32::EPSILON);
-    assert!((constants::NEURON_PREDICTION_CALIBRATION - 0.003).abs() < f32::EPSILON);
-    assert!((constants::COORDINATED_PREDICTION_CALIBRATION - 0.00005).abs() < f32::EPSILON);
-    // Issue #1056: Verify logistic calibration constants are also accessible.
-    let floor = constants::LOGISTIC_CALIBRATION_FLOOR;
-    let steepness = constants::LOGISTIC_CALIBRATION_STEEPNESS;
-    let midpoint = constants::LOGISTIC_CALIBRATION_MIDPOINT;
-    assert!(floor > 0.0, "floor should be positive");
-    assert!(steepness > 0.0, "steepness should be positive");
-    assert!(midpoint > 0.0, "midpoint should be positive");
-}
-
-/// Verify scoring boost multipliers are accessible.
-#[test]
-fn test_scoring_boosts_accessible() {
-    assert!((constants::MICRO_NUDGE_VARIANT_BOOST - 1.5).abs() < f32::EPSILON);
-    assert!((constants::REMOVAL_CANDIDATE_BOOST - 1.5).abs() < f32::EPSILON);
-}
-
-// =============================================================================
-// Detection Thresholds Sub-module
-// =============================================================================
-
-/// Verify detection threshold constants are accessible.
-#[test]
-fn test_detection_thresholds_accessible() {
-    assert!((constants::MIN_IMPROVED_RATIO - 0.6).abs() < f32::EPSILON);
-    assert!((constants::NEURON_MIN_IMPROVED_RATIO - 0.55).abs() < f32::EPSILON);
-    assert!((constants::REMOVAL_MEAN_ACTIVATION_THRESHOLD - 0.04).abs() < f32::EPSILON);
-    assert!((constants::REMOVAL_IMPACT_THRESHOLD - 6e-5).abs() < f32::EPSILON);
-    assert!((constants::MAX_INCOMING_WEIGHT - 5.0).abs() < f32::EPSILON);
-    assert!((constants::MAX_BIAS_MAGNITUDE - 2.0).abs() < f32::EPSILON);
-    assert!((constants::MAX_INDIVIDUAL_HARM_FOR_PAIRING - 0.0).abs() < f32::EPSILON);
-}
-
-// =============================================================================
-// Compression Sub-module
-// =============================================================================
-
-/// Verify compression constants are accessible.
-#[test]
-fn test_compression_accessible() {
-    assert_eq!(constants::MIN_COMPRESSED_SOURCES, 2);
-    assert_eq!(constants::MAX_COMPRESSION_INPUTS, 5);
-    assert!((constants::COMPRESSION_SATURATION_THRESHOLD - 0.9).abs() < f32::EPSILON);
-    assert!((constants::COMPRESSION_MIN_BENEFIT_RATIO - 1.05).abs() < f32::EPSILON);
+fn test_candidate_sentinels_cover_low_zero_high() {
+    let sentinels = constants::CANDIDATE_SENTINELS;
+    assert!(
+        sentinels.iter().any(|s| *s < 0.0),
+        "expected a negative sentinel"
+    );
+    assert!(sentinels.contains(&0.0), "expected a zero sentinel");
+    assert!(
+        sentinels.iter().any(|s| *s > 0.0),
+        "expected a positive sentinel"
+    );
 }


### PR DESCRIPTION
## Summary

Rewrites two test files that consisted almost entirely of circular
magic-value `assert_eq!(constants::FOO, <literal>)` assertions — the
canonical anti-pattern flagged by the test audit. Each assertion passed
if and only if the literal in the test matched the literal in
`src/analysis/constants/*.rs`, obstructed legitimate retuning of every
discovery constant, and caught no real defect.

The new files split the original intent into two stronger guarantees:

- **Compile-time re-export and invariant checks** — `const _: T =
  constants::FOO;` confirms each constant is still reachable via the
  central module (a stronger guarantee than the runtime assertion, since
  any missing re-export breaks the build). `const _: () = assert!(...)`
  declarations encode pure-constant invariants (logistic curve
  positivity, hold-out fraction inside `(0, 1)`, monotonic op-count
  discounts, compression bounds, pessimism floors inside `[0, 1]`,
  etc.). These execute at compile time, cost zero runtime, and never
  need updating when a value is tuned within its declared envelope.
- **Behavioural tests** — runtime tests for helper functions
  (`activation_neuron_boost`, `cmp_f32_*`, `coordinated_empirical_discount`)
  and for the consolidated-constants behaviour exercised through real
  detection modules (saturation, dead-neuron). These survive value
  tuning because they assert on observable behaviour, not on magic
  numbers.

Closes #1295.

## Evidence

CLI-only refactor of two test files — no UI surface to screenshot. The
behavioural change is captured by the test outcomes themselves:

```
test result: ok. 14 passed; 0 failed; 0 ignored
```

`./quality.sh` passes end-to-end (fmt, clippy `-D warnings`, check,
full test suite of 171 analysis integration tests, doc build, release
build).

### Before / after at a glance

```mermaid
flowchart LR
    A[assert_eq! constants::FOO == 64] -->|edit constant| B[Test fails]
    B -->|mechanical edit| C[Update literal in test]
    C -.->|catches nothing| D[No real defect found]

    E[const _: usize = constants::FOO] -->|re-export removed| F[Build fails<br/>compile-time]
    G[const _: assert! FOO_MIN <= FOO_MAX] -->|envelope violated| F
    H[Behavioural test:<br/>activation_neuron_boost lookup] -->|contract violated| I[Test fails<br/>with real diagnostic]
```

## Test Plan

Modified test files:
- `tests/analysis/issue_938_constants_submodule_organisation.rs`
- `tests/analysis/issue_424_consolidate_discovery_constants.rs`

Coverage retained / strengthened:
- Every constant previously asserted via `assert_eq!` is still
  reachable through a `const _:` re-export check — removing any
  re-export breaks the build.
- Pure-constant invariants (logistic curve positivity, hold-out
  fraction in `(0, 1)`, sample-threshold consistency, monotonic
  coordinated discounts, compression bounds, pessimism floor / curve
  envelopes, sentinel tolerance vs gap) are now compile-time
  `const _: () = assert!(...)` declarations.
- Behavioural tests retained: `activation_neuron_boost` contract,
  NaN-safe comparator ordering, `coordinated_empirical_discount`
  monotonicity / saturation, `CANDIDATE_SENTINELS` low/zero/high
  coverage and pairwise separation, saturation / dead-neuron detection
  through the consolidated constants.

Verification:
- `cargo test --test analysis` → 14 of the new constants-tests pass,
  full suite 171/171.
- `./quality.sh` → all gates green (fmt, clippy `-D warnings`,
  cargo check, doc build, release build).



## Milestone
This PR is part of the **Audit issues** milestone and targets the `milestone/audit-issues` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-1295 -->