### PR TITLE
Add TaskDescriptor type + cost-name mapping (Issue #1312)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -2854,18 +2854,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/archive/pr-summaries/pr-summary-1312.md
+++ b/docs/archive/pr-summaries/pr-summary-1312.md
@@ -1,0 +1,60 @@
+## Summary
+
+Introduce the pure `TaskDescriptor` type and its `from_name` cost-name mapping
+in a new `src/analysis/task_descriptor.rs` module. The descriptor summarises
+the supervised-learning task shape — target topology, target range, and
+output squash family — derived purely from the cost name and the network's
+output count. No FFI plumbing, no consumer detector changes, and no I/O are
+introduced; those land via the follow-up issues (notably #1314) that
+reference this one. Closes #1312.
+
+## Evidence
+
+CLI / library change only — no UI to screenshot. Verified via the new unit
+tests (15 cases, all passing) and the full `./quality.sh` gate (clippy with
+`-D warnings`, `cargo check --all-targets --all-features`, full test suite,
+docs build with `RUSTDOCFLAGS="-D warnings"`, release build).
+
+Mapping (matches the issue table verbatim):
+
+| costName              | topology    | range       | output squash family |
+| --------------------- | ----------- | ----------- | -------------------- |
+| MSE, MAE              | Independent | Unbounded   | Unbounded            |
+| MAPE, MSLE            | Independent | Positive    | Positive             |
+| BINARY_CROSS_ENTROPY  | Independent | Unit        | BoundedUnipolar      |
+| CROSS_ENTROPY         | Simplex     | Unit        | BoundedUnipolar      |
+| HINGE                 | Margin      | SignedUnit  | BoundedBipolar       |
+| CATEGORICAL_ERROR     | OneHot      | Unit        | BoundedUnipolar      |
+| OTHER / unrecognised  | Unknown     | Unbounded   | Any (= neutral)      |
+
+```mermaid
+flowchart LR
+    A["cost name (str)"] --> B["TaskDescriptor::from_name(name, num_outputs)"]
+    B -->|recognised| C["topology / range / squash family / num_outputs"]
+    B -->|OTHER / unknown / absent| D["TaskDescriptor::neutral()"]
+    D --> E["Unknown / Unbounded / Any / num_outputs = 0"]
+```
+
+## Test Plan
+
+Added `src/analysis/task_descriptor.rs::tests` covering:
+
+- `neutral_is_unknown_unbounded_any` — neutral descriptor fields.
+- `default_descriptor_equals_neutral` — `Default` matches `neutral()`.
+- `mse_maps_to_independent_unbounded_unbounded`
+- `mae_maps_to_independent_unbounded_unbounded`
+- `mape_maps_to_independent_positive_positive`
+- `msle_maps_to_independent_positive_positive`
+- `binary_cross_entropy_maps_to_independent_unit_bounded_unipolar`
+- `cross_entropy_maps_to_simplex_unit_bounded_unipolar`
+- `hinge_maps_to_margin_signed_unit_bounded_bipolar`
+- `categorical_error_maps_to_onehot_unit_bounded_unipolar`
+- `other_collapses_to_neutral`
+- `unrecognised_name_collapses_to_neutral`
+- `empty_name_collapses_to_neutral`
+- `lookup_is_case_insensitive`
+- `num_outputs_is_preserved_verbatim` — including zero, large counts, and
+  the unrecognised-name branch (always 0 via neutral).
+
+Quality gate (`./quality.sh`) passes cleanly with all 15 new tests added to
+the lib test suite.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -60,6 +60,7 @@ pub mod streaming;
 pub mod synapse;
 pub mod system;
 pub mod target_failure_tracker;
+pub mod task_descriptor;
 pub mod utils;
 pub mod within_batch_failures;
 

--- a/src/analysis/task_descriptor.rs
+++ b/src/analysis/task_descriptor.rs
@@ -1,0 +1,310 @@
+//! Task descriptor for discovery consumers (Issue #1312).
+//!
+//! A [`TaskDescriptor`] is a small, FFI-free summary of the **shape of the
+//! supervised-learning task** a recorded creature was trained against. It is
+//! derived purely from the cost-function name (and the network's output
+//! count) and carries no per-record data.
+//!
+//! Detectors and recommenders consult the descriptor to gate behaviour that
+//! depends on the structural assumptions of the loss:
+//!
+//! - **Target topology** — are the outputs independent scalars, a one-hot
+//!   class label, a soft-max simplex, or a signed margin?
+//! - **Target range** — what numeric range can the recorded target take?
+//! - **Output squash family** — what activation shape is compatible with the
+//!   loss on the final layer?
+//!
+//! The mapping is exhaustive for the seven built-in NEAT-AI costs listed in
+//! the issue. Any other name — including `OTHER` and any unrecognised /
+//! absent string — falls back to [`TaskDescriptor::neutral`], which encodes
+//! "we know nothing; don't gate on this".
+//!
+//! This module is intentionally pure: it has no FFI surface, no I/O, and no
+//! dependency on other discovery modules. Wiring the descriptor through the
+//! FFI ingest path and consumer detectors is tracked separately (see
+//! issue #1314 and the per-consumer issues that reference #1312).
+
+/// Topology of the recorded targets vector for a single training sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TargetTopology {
+    /// Each output is an independent scalar target (e.g. regression, BCE).
+    Independent,
+    /// Targets form a one-hot class label (exactly one output is `1`, the
+    /// rest are `0`) and the model produces per-class scores.
+    OneHot,
+    /// Targets sit on the probability simplex; the output layer is expected
+    /// to be a soft-max producing values summing to one.
+    Simplex,
+    /// Margin-based target — used by hinge-style losses where the recorded
+    /// target is a signed margin label rather than a probability.
+    Margin,
+    /// Topology is unknown or not constrained by the cost. Detectors should
+    /// fall back to their generic, pre-Issue-#1312 behaviour.
+    #[default]
+    Unknown,
+}
+
+/// Numeric range the recorded targets can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TargetRange {
+    /// Targets are unbounded reals.
+    #[default]
+    Unbounded,
+    /// Targets are in `[0, 1]`.
+    Unit,
+    /// Targets are non-negative reals (`>= 0`).
+    Positive,
+    /// Targets are in `[-1, 1]`.
+    SignedUnit,
+}
+
+/// Family of activation functions that is compatible with the loss on the
+/// final layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputSquashFamily {
+    /// Bounded, unipolar squash (range `[0, 1]`): LOGISTIC, `BIPOLAR_SIGMOID`
+    /// rescaled to unipolar, etc.
+    BoundedUnipolar,
+    /// Bounded, bipolar squash (range `[-1, 1]`): TANH, `BIPOLAR_SIGMOID`.
+    BoundedBipolar,
+    /// Non-negative output (range `[0, +inf)`): RELU, SOFTPLUS, ABSOLUTE.
+    Positive,
+    /// Unbounded real output: IDENTITY, SELU on large inputs.
+    Unbounded,
+    /// No constraint imposed by the loss. Detectors should not gate on the
+    /// output activation family.
+    #[default]
+    Any,
+}
+
+/// Cost-function-derived description of the supervised-learning task.
+///
+/// Constructed via [`TaskDescriptor::from_name`] or
+/// [`TaskDescriptor::neutral`]. The struct is `Copy` and trivially cheap to
+/// pass by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskDescriptor {
+    /// Topology of the targets vector.
+    pub target_topology: TargetTopology,
+    /// Numeric range of recorded targets.
+    pub target_range: TargetRange,
+    /// Output squash family compatible with the loss.
+    pub output_squash_family: OutputSquashFamily,
+    /// Number of output neurons in the network. Captured so that consumers
+    /// can sanity-check topology assumptions (e.g. `OneHot` requires more
+    /// than one output to be meaningful).
+    pub num_outputs: usize,
+}
+
+impl TaskDescriptor {
+    /// Neutral descriptor — used when the cost name is absent, unrecognised,
+    /// or explicitly `OTHER`. Encodes "we know nothing; don't gate on this".
+    ///
+    /// `num_outputs` is set to `0` because the neutral descriptor carries
+    /// no information about the network's shape. Call
+    /// [`TaskDescriptor::from_name`] when the output count matters.
+    #[must_use]
+    pub const fn neutral() -> Self {
+        Self {
+            target_topology: TargetTopology::Unknown,
+            target_range: TargetRange::Unbounded,
+            output_squash_family: OutputSquashFamily::Any,
+            num_outputs: 0,
+        }
+    }
+
+    /// Map a NEAT-AI cost name (case-insensitive) and the network's output
+    /// count onto a [`TaskDescriptor`].
+    ///
+    /// Recognised names: `MSE`, `MAE`, `MAPE`, `MSLE`,
+    /// `BINARY_CROSS_ENTROPY`, `CROSS_ENTROPY`, `HINGE`, `CATEGORICAL_ERROR`.
+    /// Any other input — including `OTHER`, empty strings, and arbitrary
+    /// unknown names — returns [`TaskDescriptor::neutral`].
+    #[must_use]
+    pub fn from_name(name: &str, num_outputs: usize) -> Self {
+        match name.to_ascii_uppercase().as_str() {
+            "MSE" | "MAE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Unbounded,
+                output_squash_family: OutputSquashFamily::Unbounded,
+                num_outputs,
+            },
+            "MAPE" | "MSLE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Positive,
+                output_squash_family: OutputSquashFamily::Positive,
+                num_outputs,
+            },
+            "BINARY_CROSS_ENTROPY" | "BINARYCROSSENTROPY" | "BCE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            "CROSS_ENTROPY" | "CROSSENTROPY" | "CE" => Self {
+                target_topology: TargetTopology::Simplex,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            "HINGE" => Self {
+                target_topology: TargetTopology::Margin,
+                target_range: TargetRange::SignedUnit,
+                output_squash_family: OutputSquashFamily::BoundedBipolar,
+                num_outputs,
+            },
+            "CATEGORICAL_ERROR" | "CATEGORICALERROR" => Self {
+                target_topology: TargetTopology::OneHot,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            // OTHER and every unrecognised / absent name collapse to neutral.
+            _ => Self::neutral(),
+        }
+    }
+}
+
+impl Default for TaskDescriptor {
+    fn default() -> Self {
+        Self::neutral()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neutral_is_unknown_unbounded_any() {
+        let d = TaskDescriptor::neutral();
+        assert_eq!(d.target_topology, TargetTopology::Unknown);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Any);
+        assert_eq!(d.num_outputs, 0);
+    }
+
+    #[test]
+    fn default_descriptor_equals_neutral() {
+        assert_eq!(TaskDescriptor::default(), TaskDescriptor::neutral());
+    }
+
+    #[test]
+    fn mse_maps_to_independent_unbounded_unbounded() {
+        let d = TaskDescriptor::from_name("MSE", 3);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        assert_eq!(d.num_outputs, 3);
+    }
+
+    #[test]
+    fn mae_maps_to_independent_unbounded_unbounded() {
+        let d = TaskDescriptor::from_name("MAE", 5);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        assert_eq!(d.num_outputs, 5);
+    }
+
+    #[test]
+    fn mape_maps_to_independent_positive_positive() {
+        let d = TaskDescriptor::from_name("MAPE", 2);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Positive);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Positive);
+        assert_eq!(d.num_outputs, 2);
+    }
+
+    #[test]
+    fn msle_maps_to_independent_positive_positive() {
+        let d = TaskDescriptor::from_name("MSLE", 4);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Positive);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Positive);
+        assert_eq!(d.num_outputs, 4);
+    }
+
+    #[test]
+    fn binary_cross_entropy_maps_to_independent_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("BINARY_CROSS_ENTROPY", 1);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 1);
+    }
+
+    #[test]
+    fn cross_entropy_maps_to_simplex_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        assert_eq!(d.target_topology, TargetTopology::Simplex);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 10);
+    }
+
+    #[test]
+    fn hinge_maps_to_margin_signed_unit_bounded_bipolar() {
+        let d = TaskDescriptor::from_name("HINGE", 1);
+        assert_eq!(d.target_topology, TargetTopology::Margin);
+        assert_eq!(d.target_range, TargetRange::SignedUnit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedBipolar);
+        assert_eq!(d.num_outputs, 1);
+    }
+
+    #[test]
+    fn categorical_error_maps_to_onehot_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        assert_eq!(d.target_topology, TargetTopology::OneHot);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 7);
+    }
+
+    #[test]
+    fn other_collapses_to_neutral() {
+        assert_eq!(
+            TaskDescriptor::from_name("OTHER", 4),
+            TaskDescriptor::neutral(),
+        );
+    }
+
+    #[test]
+    fn unrecognised_name_collapses_to_neutral() {
+        assert_eq!(
+            TaskDescriptor::from_name("EXOTIC_LOSS", 8),
+            TaskDescriptor::neutral(),
+        );
+    }
+
+    #[test]
+    fn empty_name_collapses_to_neutral() {
+        assert_eq!(TaskDescriptor::from_name("", 2), TaskDescriptor::neutral(),);
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive() {
+        for name in ["mse", "Mse", "mSe", "MSE"] {
+            let d = TaskDescriptor::from_name(name, 1);
+            assert_eq!(d.target_topology, TargetTopology::Independent);
+            assert_eq!(d.target_range, TargetRange::Unbounded);
+            assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        }
+        for name in ["hinge", "Hinge", "HINGE"] {
+            let d = TaskDescriptor::from_name(name, 1);
+            assert_eq!(d.target_topology, TargetTopology::Margin);
+        }
+    }
+
+    #[test]
+    fn num_outputs_is_preserved_verbatim() {
+        for n in [0_usize, 1, 7, 1024] {
+            assert_eq!(TaskDescriptor::from_name("MSE", n).num_outputs, n);
+            assert_eq!(TaskDescriptor::from_name("CROSS_ENTROPY", n).num_outputs, n);
+            // Unrecognised names go through neutral(), which always has 0
+            // outputs by design — the caller should not be relying on the
+            // value when the cost is unknown.
+            assert_eq!(TaskDescriptor::from_name("OTHER", n).num_outputs, 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the pure `TaskDescriptor` type and its `from_name` cost-name mapping
in a new `src/analysis/task_descriptor.rs` module. The descriptor summarises
the supervised-learning task shape — target topology, target range, and
output squash family — derived purely from the cost name and the network's
output count. No FFI plumbing, no consumer detector changes, and no I/O are
introduced; those land via the follow-up issues (notably #1314) that
reference this one. Closes #1312.

## Evidence

CLI / library change only — no UI to screenshot. Verified via the new unit
tests (15 cases, all passing) and the full `./quality.sh` gate (clippy with
`-D warnings`, `cargo check --all-targets --all-features`, full test suite,
docs build with `RUSTDOCFLAGS="-D warnings"`, release build).

Mapping (matches the issue table verbatim):

| costName              | topology    | range       | output squash family |
| --------------------- | ----------- | ----------- | -------------------- |
| MSE, MAE              | Independent | Unbounded   | Unbounded            |
| MAPE, MSLE            | Independent | Positive    | Positive             |
| BINARY_CROSS_ENTROPY  | Independent | Unit        | BoundedUnipolar      |
| CROSS_ENTROPY         | Simplex     | Unit        | BoundedUnipolar      |
| HINGE                 | Margin      | SignedUnit  | BoundedBipolar       |
| CATEGORICAL_ERROR     | OneHot      | Unit        | BoundedUnipolar      |
| OTHER / unrecognised  | Unknown     | Unbounded   | Any (= neutral)      |

```mermaid
flowchart LR
    A["cost name (str)"] --> B["TaskDescriptor::from_name(name, num_outputs)"]
    B -->|recognised| C["topology / range / squash family / num_outputs"]
    B -->|OTHER / unknown / absent| D["TaskDescriptor::neutral()"]
    D --> E["Unknown / Unbounded / Any / num_outputs = 0"]
```

## Test Plan

Added `src/analysis/task_descriptor.rs::tests` covering:

- `neutral_is_unknown_unbounded_any` — neutral descriptor fields.
- `default_descriptor_equals_neutral` — `Default` matches `neutral()`.
- `mse_maps_to_independent_unbounded_unbounded`
- `mae_maps_to_independent_unbounded_unbounded`
- `mape_maps_to_independent_positive_positive`
- `msle_maps_to_independent_positive_positive`
- `binary_cross_entropy_maps_to_independent_unit_bounded_unipolar`
- `cross_entropy_maps_to_simplex_unit_bounded_unipolar`
- `hinge_maps_to_margin_signed_unit_bounded_bipolar`
- `categorical_error_maps_to_onehot_unit_bounded_unipolar`
- `other_collapses_to_neutral`
- `unrecognised_name_collapses_to_neutral`
- `empty_name_collapses_to_neutral`
- `lookup_is_case_insensitive`
- `num_outputs_is_preserved_verbatim` — including zero, large counts, and
  the unrecognised-name branch (always 0 via neutral).

Quality gate (`./quality.sh`) passes cleanly with all 15 new tests added to
the lib test suite.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1312 -->