### PR TITLE
feat(recommendation): role-aware output-squash bias for OneHot/Simplex (Issue #1313)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1313.md
+++ b/docs/archive/pr-summaries/pr-summary-1313.md
@@ -1,0 +1,80 @@
+## Summary
+
+Add a role-aware activation recommendation entry point that biases
+**output-neuron** squash candidates toward the task descriptor's
+`output_squash_family` when the topology constrains the output to a
+specific manifold (OneHot, Simplex). Hidden-neuron behaviour and the
+neutral / `OTHER` / `Unknown` descriptor path are unchanged — they
+defer verbatim to the existing distribution-driven recommender. Closes
+#1313.
+
+This is the cold-start fix from the issue: output neurons with
+unbounded squashes (LINEAR / RELU / GELU / …) cannot settle on a
+one-hot `[0, 1]` manifold, so under a `CATEGORICAL_ERROR` or
+`CROSS_ENTROPY` descriptor the recommender now restricts candidates to
+the bounded unipolar family (LOGISTIC, STEP).
+
+## Scope
+
+Scoped to the recommendation **path** only (`src/analysis/recommendation/
+activation_recommendation.rs`). The activation scan set, bias-drift
+weighting, and output competition are intentionally **not** touched —
+they are tracked as separate issues. The new function exists alongside
+the legacy entry point; FFI ingest of the descriptor is #1314.
+
+## Evidence
+
+Backend-only change with no UI surface. Verified via:
+
+- New integration test file `tests/recommendation/
+  issue_1313_role_aware_output_squash.rs` (7 tests, all passing) — covers
+  the four acceptance criteria plus three regression guards.
+- New inline unit tests in `activation_recommendation.rs` — three
+  additional `#[cfg(test)]` cases exercise the bounded family pick,
+  hidden-neuron unchanged behaviour, and the neutral descriptor
+  fallback.
+- `./quality.sh` — full pipeline (fmt, clippy `-D warnings`, doc, lib +
+  integration tests, release build) passes cleanly.
+
+```mermaid
+flowchart LR
+    A[recommend_activation_function_for_role] --> B{is_output && topology in OneHot / Simplex?}
+    B -- no --> C[recommend_activation_function]
+    B -- yes --> D{output_squash_family}
+    D -- BoundedUnipolar --> E["LOGISTIC, STEP"]
+    D -- BoundedBipolar --> F["TANH, HARD_TANH, BIPOLAR_SIGMOID, BIPOLAR"]
+    D -- Positive --> G["RELU, RELU6, SOFTPLUS, ELU"]
+    D -- Unbounded --> H[IDENTITY]
+    D -- Any --> C
+    E --> I[Pick highest-scoring family member]
+    F --> I
+    G --> I
+    H --> I
+```
+
+## Test Plan
+
+Added to `tests/recommendation/issue_1313_role_aware_output_squash.rs`:
+
+- `one_hot_descriptor_recommends_bounded_unipolar_for_output_neuron` —
+  acceptance criterion 1 / 4 (CATEGORICAL_ERROR + IDENTITY output).
+- `simplex_descriptor_recommends_bounded_unipolar_for_output_neuron` —
+  acceptance criterion 1 (CROSS_ENTROPY + RELU output).
+- `neutral_descriptor_falls_back_to_existing_behaviour` — regression
+  guard against the `Unknown` / `Any` path.
+- `other_cost_descriptor_falls_back_to_existing_behaviour` —
+  regression guard for the `OTHER` cost name.
+- `one_hot_descriptor_does_not_bias_hidden_neuron_recommendation` —
+  acceptance criterion 2 (hidden-neuron path unchanged under OneHot).
+- `output_neuron_already_in_family_yields_no_recommendation` — no
+  spurious recommendation when the current squash is already
+  in-family.
+- `insufficient_samples_returns_none_for_output_role` — sample-count
+  regression guard.
+
+Added to `src/analysis/recommendation/activation_recommendation.rs`
+under `#[cfg(test)] mod tests`:
+
+- `test_role_aware_one_hot_picks_bounded_unipolar`
+- `test_role_aware_hidden_unchanged_under_one_hot`
+- `test_role_aware_neutral_descriptor_matches_legacy`

--- a/src/analysis/recommendation/activation_recommendation.rs
+++ b/src/analysis/recommendation/activation_recommendation.rs
@@ -32,6 +32,7 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )] // Intentional numeric casts for GPU/neural network computation (Issue #873)
+use crate::analysis::task_descriptor::{OutputSquashFamily, TargetTopology, TaskDescriptor};
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 use std::collections::HashMap;
@@ -558,6 +559,172 @@ pub fn recommend_activation_function(
     })
 }
 
+// =============================================================================
+// Role-aware Recommendation (Issue #1313)
+// =============================================================================
+//
+// For OneHot / Simplex tasks the output layer must sit on a `[0, 1]` manifold
+// (per-class scores). Unbounded squashes (IDENTITY / RELU / GELU / …) on the
+// output neuron cannot settle on that manifold at cold start. The role-aware
+// path restricts the candidate set for an **output** neuron to the descriptor's
+// `output_squash_family` whenever the topology constrains it (OneHot, Simplex).
+// Hidden-neuron behaviour and unconstrained descriptors (Unknown / Any /
+// `OTHER`) defer to the existing distribution-driven recommender.
+
+/// Bounded-unipolar output family — sigmoid-like squashes whose codomain is
+/// `[0, 1]`. Includes `STEP` for the binary/threshold case.
+const BOUNDED_UNIPOLAR_FAMILY: &[&str] = &["LOGISTIC", "STEP"];
+
+/// Bounded-bipolar output family — sigmoid-like squashes whose codomain is
+/// `[-1, 1]`. Used by hinge-style margin losses (descriptor: `Margin`).
+const BOUNDED_BIPOLAR_FAMILY: &[&str] = &["TANH", "HARD_TANH", "BIPOLAR_SIGMOID", "BIPOLAR"];
+
+/// Non-negative output family — `[0, +inf)`. Used by MAPE / MSLE-style losses.
+const POSITIVE_FAMILY: &[&str] = &["RELU", "RELU6", "SOFTPLUS", "ELU"];
+
+/// Unbounded output family — used by plain MSE / MAE.
+const UNBOUNDED_FAMILY: &[&str] = &["IDENTITY"];
+
+/// Squash candidates allowed for a given output-family constraint.
+fn family_candidates(family: OutputSquashFamily) -> &'static [&'static str] {
+    match family {
+        OutputSquashFamily::BoundedUnipolar => BOUNDED_UNIPOLAR_FAMILY,
+        OutputSquashFamily::BoundedBipolar => BOUNDED_BIPOLAR_FAMILY,
+        OutputSquashFamily::Positive => POSITIVE_FAMILY,
+        OutputSquashFamily::Unbounded => UNBOUNDED_FAMILY,
+        OutputSquashFamily::Any => &[],
+    }
+}
+
+/// Whether the role-aware path should bias an **output** neuron's candidate
+/// set toward the descriptor's `output_squash_family`. Issue #1313 scopes this
+/// to `OneHot` / `Simplex` topologies — the cases where an unbounded output squash
+/// cannot settle on the task's `[0, 1]` manifold. Other topologies (including
+/// `Unknown` / neutral / `OTHER`) defer to the legacy recommender.
+fn should_bias_to_family(descriptor: &TaskDescriptor, is_output: bool) -> bool {
+    if !is_output {
+        return false;
+    }
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Role-aware activation recommendation (Issue #1313).
+///
+/// If the neuron is an **output** neuron and the task descriptor reports a
+/// `OneHot` or `Simplex` topology, the candidate set is restricted to the
+/// descriptor's [`OutputSquashFamily`] (e.g. LOGISTIC / STEP for the bounded
+/// unipolar `[0, 1]` family). In every other case — hidden neurons, neutral
+/// descriptor, `OTHER` cost, or any unrecognised topology — this function
+/// defers verbatim to [`recommend_activation_function`].
+///
+/// # Arguments
+/// * `records` - Discovery records for the neuron.
+/// * `current_squash` - The current activation function name.
+/// * `is_output` - `true` if the neuron is in the output layer.
+/// * `descriptor` - Task descriptor derived from the cost function.
+#[must_use]
+pub fn recommend_activation_function_for_role(
+    records: &[DiscoverRecord],
+    current_squash: &str,
+    is_output: bool,
+    descriptor: &TaskDescriptor,
+) -> Option<ActivationRecommendation> {
+    if !should_bias_to_family(descriptor, is_output) {
+        return recommend_activation_function(records, current_squash);
+    }
+
+    let candidates = family_candidates(descriptor.output_squash_family);
+    if candidates.is_empty() {
+        // Family is unconstrained even though topology says OneHot/Simplex —
+        // defensively defer to the legacy recommender so we never silently
+        // drop a recommendation.
+        return recommend_activation_function(records, current_squash);
+    }
+
+    if records.len() < MIN_SAMPLES_FOR_ANALYSIS {
+        return None;
+    }
+
+    let neuron_uuid = records
+        .first()
+        .map(|r| r.neuron_uuid.clone())
+        .unwrap_or_default();
+
+    let distribution = analyse_input_distribution(records);
+    if distribution.class == InputDistributionClass::Unknown {
+        return None;
+    }
+
+    // Score every member of the family. Any family member not scored by the
+    // distribution-driven classifier (e.g. STEP under a Bounded distribution)
+    // receives a neutral default so the family is never empty.
+    let suitability = classify_activation_suitability(&distribution);
+    let mut family_scores: Vec<(&'static str, f32)> = candidates
+        .iter()
+        .map(|name| (*name, suitability.get(*name).copied().unwrap_or(0.6)))
+        .collect();
+    family_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+    let (best_squash, best_score) = *family_scores.first()?;
+
+    // Treat out-of-family current squashes as score-zero. The improvement
+    // delta then dominates the gating thresholds, and the rationale flags
+    // the family swap explicitly.
+    let current_in_family = candidates.contains(&current_squash);
+    let current_score = if current_in_family {
+        suitability.get(current_squash).copied().unwrap_or(0.6)
+    } else {
+        0.0
+    };
+
+    if best_squash == current_squash {
+        return None;
+    }
+
+    let improvement = best_score - current_score;
+    if improvement < MIN_IMPROVEMENT_THRESHOLD {
+        return None;
+    }
+
+    let sample_confidence = (records.len() as f32 / 100.0).min(1.0);
+    let improvement_confidence = (improvement * 5.0).min(1.0);
+    let confidence = (sample_confidence * 0.5 + improvement_confidence * 0.5).clamp(0.0, 1.0);
+
+    let topology_label = match descriptor.target_topology {
+        TargetTopology::OneHot => "one-hot",
+        TargetTopology::Simplex => "simplex",
+        _ => "constrained",
+    };
+    let family_label = match descriptor.output_squash_family {
+        OutputSquashFamily::BoundedUnipolar => "bounded unipolar [0,1]",
+        OutputSquashFamily::BoundedBipolar => "bounded bipolar [-1,1]",
+        OutputSquashFamily::Positive => "non-negative",
+        OutputSquashFamily::Unbounded => "unbounded",
+        OutputSquashFamily::Any => "any",
+    };
+    let reason = if current_in_family {
+        "better fit for the observed input distribution within the family"
+    } else {
+        "current squash is outside the family compatible with the loss"
+    };
+    let rationale = format!(
+        "Output neuron under {topology_label} task: restricting recommendation to the {family_label} \
+         family — replacing {current_squash} with {best_squash} ({reason})."
+    );
+
+    Some(ActivationRecommendation {
+        neuron_uuid,
+        current_squash: current_squash.to_string(),
+        recommended_squash: best_squash.to_string(),
+        confidence,
+        expected_improvement: improvement * 0.02,
+        rationale,
+        input_distribution: distribution.class,
+    })
+}
+
 /// Get the score for an activation function.
 ///
 /// Squash names are pre-normalised to uppercase at deserialisation (Issue #753),
@@ -688,6 +855,61 @@ mod tests {
 
         let scores = classify_activation_suitability(&dist);
         assert!(!scores.is_empty(), "Should have suitability scores");
+    }
+
+    #[test]
+    fn test_role_aware_one_hot_picks_bounded_unipolar() {
+        // Issue #1313: an unbounded output squash under a OneHot task must
+        // be replaced by something inside the bounded-unipolar family.
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("output-0", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+        let rec = recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor)
+            .expect("must recommend a bounded squash for a OneHot output neuron");
+
+        assert!(
+            BOUNDED_UNIPOLAR_FAMILY.contains(&rec.recommended_squash.as_str()),
+            "expected BOUNDED_UNIPOLAR_FAMILY recommendation, got {}",
+            rec.recommended_squash,
+        );
+    }
+
+    #[test]
+    fn test_role_aware_hidden_unchanged_under_one_hot() {
+        // Hidden-neuron recommendations must mirror the legacy path even
+        // when the descriptor constrains the output family.
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("hidden-1", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+        let hidden =
+            recommend_activation_function_for_role(&records, "IDENTITY", false, &descriptor);
+        let legacy = recommend_activation_function(&records, "IDENTITY");
+
+        assert_eq!(
+            hidden.map(|r| r.recommended_squash),
+            legacy.map(|r| r.recommended_squash),
+        );
+    }
+
+    #[test]
+    fn test_role_aware_neutral_descriptor_matches_legacy() {
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("output-0", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let neutral = TaskDescriptor::neutral();
+
+        let role_aware =
+            recommend_activation_function_for_role(&records, "IDENTITY", true, &neutral);
+        let legacy = recommend_activation_function(&records, "IDENTITY");
+
+        assert_eq!(
+            role_aware.map(|r| r.recommended_squash),
+            legacy.map(|r| r.recommended_squash),
+        );
     }
 
     #[test]

--- a/tests/recommendation/issue_1313_role_aware_output_squash.rs
+++ b/tests/recommendation/issue_1313_role_aware_output_squash.rs
@@ -1,0 +1,213 @@
+//! Tests for Issue #1313: Role-aware activation recommendation.
+//!
+//! When the [`TaskDescriptor`] reports a `OneHot` or `Simplex` target
+//! topology, **output-neuron** activation recommendations must be drawn
+//! from the descriptor's `output_squash_family` (a bounded family such
+//! as LOGISTIC / sigmoid). Hidden-neuron recommendations and the
+//! neutral / `OTHER` descriptor path are unchanged.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. With a `CATEGORICAL_ERROR` (or other OneHot/Simplex) descriptor,
+//!    output-neuron activation recommendations come from the bounded
+//!    family.
+//! 2. Hidden-neuron recommendations are unchanged.
+//! 3. `OTHER` / `Unknown` / absent descriptor ⇒ current behaviour
+//!    (regression guard).
+//! 4. Focused: small net with an unbounded output squash + one-hot
+//!    descriptor ⇒ recommends a bounded unipolar squash for the
+//!    output neuron.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::recommendation::activation_recommendation::{
+    recommend_activation_function, recommend_activation_function_for_role,
+};
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+fn record(uuid: &str, idx: u32, activation: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+/// 80 records spread across an unbounded range — the classifier sees
+/// these as a Uniform distribution, and the unconstrained recommender
+/// would prefer something like TANH / IDENTITY / RELU. Used as the raw
+/// material for "output neuron currently has an unbounded squash" tests.
+fn unbounded_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..80)
+        .map(|i| record(uuid, i, -8.0 + (i as f32) * 0.2))
+        .collect()
+}
+
+/// Set of squash names that constitute the bounded-unipolar output family.
+/// Recommendations under a OneHot/Simplex descriptor must land in this set.
+fn bounded_unipolar_family() -> &'static [&'static str] {
+    &["LOGISTIC", "STEP"]
+}
+
+// =============================================================================
+// 1. OneHot + unbounded output squash ⇒ recommends a bounded unipolar squash
+// =============================================================================
+
+#[test]
+fn one_hot_descriptor_recommends_bounded_unipolar_for_output_neuron() {
+    let records = unbounded_records("output-0");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::OneHot);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedUnipolar
+    );
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor)
+            .expect("OneHot + unbounded output squash must produce a recommendation");
+
+    assert_eq!(recommendation.current_squash, "IDENTITY");
+    assert!(
+        bounded_unipolar_family().contains(&recommendation.recommended_squash.as_str()),
+        "Expected recommendation in bounded-unipolar family, got {}",
+        recommendation.recommended_squash
+    );
+}
+
+// =============================================================================
+// 2. Simplex (CROSS_ENTROPY) + unbounded output squash ⇒ same bounded family
+// =============================================================================
+
+#[test]
+fn simplex_descriptor_recommends_bounded_unipolar_for_output_neuron() {
+    let records = unbounded_records("output-0");
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 5);
+    assert_eq!(descriptor.target_topology, TargetTopology::Simplex);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "RELU", true, &descriptor)
+            .expect("Simplex + RELU output must produce a recommendation");
+
+    assert!(
+        bounded_unipolar_family().contains(&recommendation.recommended_squash.as_str()),
+        "Expected bounded-unipolar recommendation under Simplex, got {}",
+        recommendation.recommended_squash
+    );
+}
+
+// =============================================================================
+// 3. Neutral / OTHER descriptor ⇒ falls back to existing recommender
+// =============================================================================
+
+#[test]
+fn neutral_descriptor_falls_back_to_existing_behaviour() {
+    let records = unbounded_records("output-0");
+    let neutral = TaskDescriptor::neutral();
+
+    let role_aware = recommend_activation_function_for_role(&records, "IDENTITY", true, &neutral);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    match (role_aware, legacy) {
+        (Some(a), Some(b)) => {
+            assert_eq!(
+                a.recommended_squash, b.recommended_squash,
+                "Neutral descriptor must mirror legacy recommendation"
+            );
+        }
+        (None, None) => {}
+        (a, b) => panic!(
+            "Neutral descriptor must mirror legacy recommender; got role_aware={:?} legacy={:?}",
+            a.map(|r| r.recommended_squash),
+            b.map(|r| r.recommended_squash),
+        ),
+    }
+}
+
+// =============================================================================
+// 4. OTHER cost name ⇒ neutral descriptor ⇒ existing behaviour
+// =============================================================================
+
+#[test]
+fn other_cost_descriptor_falls_back_to_existing_behaviour() {
+    let records = unbounded_records("output-0");
+    let other = TaskDescriptor::from_name("OTHER", 3);
+    assert_eq!(other, TaskDescriptor::neutral());
+
+    let role_aware = recommend_activation_function_for_role(&records, "IDENTITY", true, &other);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    assert_eq!(
+        role_aware.map(|r| r.recommended_squash),
+        legacy.map(|r| r.recommended_squash),
+        "OTHER cost must produce the legacy recommendation",
+    );
+}
+
+// =============================================================================
+// 5. Hidden neurons are NOT biased to the descriptor's family
+// =============================================================================
+
+#[test]
+fn one_hot_descriptor_does_not_bias_hidden_neuron_recommendation() {
+    let records = unbounded_records("hidden-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let hidden_rec =
+        recommend_activation_function_for_role(&records, "IDENTITY", false, &descriptor);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    assert_eq!(
+        hidden_rec.map(|r| r.recommended_squash),
+        legacy.map(|r| r.recommended_squash),
+        "Hidden-neuron path must mirror legacy recommender even under OneHot",
+    );
+}
+
+// =============================================================================
+// 6. Output neuron already in the bounded family ⇒ no recommendation
+// =============================================================================
+
+#[test]
+fn output_neuron_already_in_family_yields_no_recommendation() {
+    // Build records that are themselves already in [0, 1] — typical for a
+    // sigmoid output. The role-aware recommender should not propose a
+    // change when the current squash already matches the descriptor
+    // family and the data fits.
+    let records: Vec<DiscoverRecord> = (0..80)
+        .map(|i| record("output-0", i, (i as f32) / 80.0))
+        .collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "LOGISTIC", true, &descriptor);
+
+    assert!(
+        recommendation.is_none(),
+        "Output neuron already on LOGISTIC under OneHot should not be re-recommended (got {:?})",
+        recommendation.map(|r| r.recommended_squash),
+    );
+}
+
+// =============================================================================
+// 7. Insufficient samples ⇒ None (regression guard)
+// =============================================================================
+
+#[test]
+fn insufficient_samples_returns_none_for_output_role() {
+    let records: Vec<DiscoverRecord> = (0..5).map(|i| record("output-0", i, 0.5)).collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor);
+
+    assert!(
+        recommendation.is_none(),
+        "Should not recommend with insufficient samples"
+    );
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod issue_1059_disable_batch_successful;
 mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
+mod issue_1313_role_aware_output_squash;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;


### PR DESCRIPTION
## Summary

Add a role-aware activation recommendation entry point that biases
**output-neuron** squash candidates toward the task descriptor's
`output_squash_family` when the topology constrains the output to a
specific manifold (OneHot, Simplex). Hidden-neuron behaviour and the
neutral / `OTHER` / `Unknown` descriptor path are unchanged — they
defer verbatim to the existing distribution-driven recommender. Closes
#1313.

This is the cold-start fix from the issue: output neurons with
unbounded squashes (LINEAR / RELU / GELU / …) cannot settle on a
one-hot `[0, 1]` manifold, so under a `CATEGORICAL_ERROR` or
`CROSS_ENTROPY` descriptor the recommender now restricts candidates to
the bounded unipolar family (LOGISTIC, STEP).

## Scope

Scoped to the recommendation **path** only (`src/analysis/recommendation/
activation_recommendation.rs`). The activation scan set, bias-drift
weighting, and output competition are intentionally **not** touched —
they are tracked as separate issues. The new function exists alongside
the legacy entry point; FFI ingest of the descriptor is #1314.

## Evidence

Backend-only change with no UI surface. Verified via:

- New integration test file `tests/recommendation/
  issue_1313_role_aware_output_squash.rs` (7 tests, all passing) — covers
  the four acceptance criteria plus three regression guards.
- New inline unit tests in `activation_recommendation.rs` — three
  additional `#[cfg(test)]` cases exercise the bounded family pick,
  hidden-neuron unchanged behaviour, and the neutral descriptor
  fallback.
- `./quality.sh` — full pipeline (fmt, clippy `-D warnings`, doc, lib +
  integration tests, release build) passes cleanly.

```mermaid
flowchart LR
    A[recommend_activation_function_for_role] --> B{is_output && topology in OneHot / Simplex?}
    B -- no --> C[recommend_activation_function]
    B -- yes --> D{output_squash_family}
    D -- BoundedUnipolar --> E["LOGISTIC, STEP"]
    D -- BoundedBipolar --> F["TANH, HARD_TANH, BIPOLAR_SIGMOID, BIPOLAR"]
    D -- Positive --> G["RELU, RELU6, SOFTPLUS, ELU"]
    D -- Unbounded --> H[IDENTITY]
    D -- Any --> C
    E --> I[Pick highest-scoring family member]
    F --> I
    G --> I
    H --> I
```

## Test Plan

Added to `tests/recommendation/issue_1313_role_aware_output_squash.rs`:

- `one_hot_descriptor_recommends_bounded_unipolar_for_output_neuron` —
  acceptance criterion 1 / 4 (CATEGORICAL_ERROR + IDENTITY output).
- `simplex_descriptor_recommends_bounded_unipolar_for_output_neuron` —
  acceptance criterion 1 (CROSS_ENTROPY + RELU output).
- `neutral_descriptor_falls_back_to_existing_behaviour` — regression
  guard against the `Unknown` / `Any` path.
- `other_cost_descriptor_falls_back_to_existing_behaviour` —
  regression guard for the `OTHER` cost name.
- `one_hot_descriptor_does_not_bias_hidden_neuron_recommendation` —
  acceptance criterion 2 (hidden-neuron path unchanged under OneHot).
- `output_neuron_already_in_family_yields_no_recommendation` — no
  spurious recommendation when the current squash is already
  in-family.
- `insufficient_samples_returns_none_for_output_role` — sample-count
  regression guard.

Added to `src/analysis/recommendation/activation_recommendation.rs`
under `#[cfg(test)] mod tests`:

- `test_role_aware_one_hot_picks_bounded_unipolar`
- `test_role_aware_hidden_unchanged_under_one_hot`
- `test_role_aware_neutral_descriptor_matches_legacy`



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1313 -->