### PR TITLE
Role- and task-aware activation scan candidate set (Issue #1315)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1315.md
+++ b/docs/archive/pr-summaries/pr-summary-1315.md
@@ -1,0 +1,45 @@
+## Summary
+
+Made the activation/squash **scan** candidate set role- and task-aware. Closes #1315.
+
+A new helper `scan_specs_for_role(role, descriptor)` in
+`src/analysis/activation/specs.rs` returns the activation candidate specs to
+scan for a given neuron role (`Output` / `Hidden`) and `TaskDescriptor`:
+
+- **Output neuron** under `target_topology ∈ {OneHot, Simplex}` → bounded
+  subset only (`LOGISTIC`, `STEP`, `BIPOLAR` — the names in
+  `BOUNDED_OUTPUT_SCAN_NAMES`; `STEP` is listed for forward compatibility,
+  the effective set is currently `LOGISTIC` + `BIPOLAR` since `STEP` is
+  not yet in `ACTIVATION_SPECS`).
+- **Hidden neuron**, *any* descriptor → full `ACTIVATION_SPECS`.
+- **Output neuron** under `Independent` / `Margin` / `Unknown` topology →
+  full `ACTIVATION_SPECS` (regression guard for `OTHER` / unrecognised /
+  absent cost names, which collapse to `TaskDescriptor::neutral()`).
+
+The helper is pure: it consumes the `TaskDescriptor` from #1312 but does
+not depend on the #1314 FFI plumbing. No existing call site is touched —
+the scan path keeps its current behaviour until a consumer migration
+opts in.
+
+## Evidence
+
+CLI/library change, no UI to screenshot. Verified via tests below.
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor + NeuronRole] --> B{Output & OneHot/Simplex?}
+    B -- yes --> C[Bounded subset<br/>LOGISTIC, BIPOLAR, STEP*]
+    B -- no  --> D[Full ACTIVATION_SPECS<br/>regression-safe]
+```
+
+`*` — `STEP` is listed for forward compatibility; it is silently skipped
+while it is absent from `ACTIVATION_SPECS`.
+
+## Test Plan
+
+- `src/analysis/activation/specs.rs::scan_specs_tests` — 9 inline unit
+  tests covering OneHot/Simplex × Output/Hidden, `OTHER`, neutral,
+  unrecognised, Independent costs, and bounded-subset name validation.
+- `tests/activation/issue_1315_role_task_aware_scan.rs` — 7 integration
+  tests asserting the public API behaviour and the regression guards.
+- `./quality.sh` passes cleanly.

--- a/src/analysis/activation/specs.rs
+++ b/src/analysis/activation/specs.rs
@@ -4,6 +4,7 @@
 //! neuron candidates, along with GPU shader ID mappings and bias range helpers.
 
 use super::functions::*;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 
 // ============================================================================
 // Activation Candidate Specification
@@ -246,4 +247,210 @@ pub fn get_bias_values(squash: &str) -> Vec<f32> {
     values.extend_from_slice(base_positive);
     values.sort_by(f32::total_cmp);
     values
+}
+
+// ============================================================================
+// Role- and Task-aware Scan Candidate Set (Issue #1315)
+// ============================================================================
+
+/// Role of the neuron being scanned for an activation candidate.
+///
+/// The activation/squash scan offers different candidate sets depending on
+/// whether we are searching for a replacement squash on an **output** neuron
+/// — whose activation shape is constrained by the loss — or on a **hidden**
+/// neuron — where any squash is fair game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NeuronRole {
+    /// Output (final-layer) neuron. The activation family is constrained by
+    /// the cost function via the [`TaskDescriptor`].
+    Output,
+    /// Hidden (non-output) neuron. The full unbounded scan set applies.
+    Hidden,
+}
+
+/// Names of the bounded-squash candidates offered when scanning an **output**
+/// neuron under a `OneHot` or `Simplex` target topology.
+///
+/// These activations all produce outputs in `[0, 1]` (or a step-function
+/// surrogate), which is the family compatible with `CROSS_ENTROPY` /
+/// `CATEGORICAL_ERROR` losses (see [`TaskDescriptor::from_name`]). Names not
+/// present in [`ACTIVATION_SPECS`] are silently skipped — at the time of
+/// writing `STEP` is recognised by NEAT-AI as a valid squash but does not
+/// yet appear in the scan specs, so the effective set is `LOGISTIC` and
+/// `BIPOLAR`. If `STEP` is added to [`ACTIVATION_SPECS`] in future it will
+/// be picked up automatically.
+pub const BOUNDED_OUTPUT_SCAN_NAMES: &[&str] = &["LOGISTIC", "STEP", "BIPOLAR"];
+
+/// Select the activation candidate specs to scan for the given neuron role
+/// and task descriptor.
+///
+/// Behaviour (Issue #1315):
+///
+/// - **Output neuron** under `OneHot` or `Simplex` topology — returns the
+///   bounded squash subset (`LOGISTIC`, `STEP`, `BIPOLAR`; see
+///   [`BOUNDED_OUTPUT_SCAN_NAMES`]).
+/// - **All other cases** — output neurons under `Independent` / `Margin` /
+///   `Unknown` topology, and *every* hidden neuron — return the full
+///   [`ACTIVATION_SPECS`]. This includes the `OTHER` / unknown / absent
+///   descriptor (which collapses to [`TaskDescriptor::neutral`]) so callers
+///   not yet plumbed for task-shape awareness keep their existing scan.
+#[must_use]
+pub fn scan_specs_for_role(
+    role: NeuronRole,
+    descriptor: &TaskDescriptor,
+) -> Vec<&'static ActivationCandidateSpec> {
+    let use_bounded_subset = matches!(role, NeuronRole::Output)
+        && matches!(
+            descriptor.target_topology,
+            TargetTopology::OneHot | TargetTopology::Simplex
+        );
+
+    if use_bounded_subset {
+        ACTIVATION_SPECS
+            .iter()
+            .filter(|spec| BOUNDED_OUTPUT_SCAN_NAMES.contains(&spec.name))
+            .collect()
+    } else {
+        ACTIVATION_SPECS.iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod scan_specs_tests {
+    use super::*;
+    use crate::analysis::task_descriptor::TaskDescriptor;
+
+    fn names(specs: &[&'static ActivationCandidateSpec]) -> Vec<&'static str> {
+        specs.iter().map(|s| s.name).collect()
+    }
+
+    #[test]
+    fn onehot_output_returns_only_bounded_subset() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        let names = names(&specs);
+
+        assert!(
+            names.contains(&"LOGISTIC"),
+            "OneHot output scan must include LOGISTIC, got {names:?}",
+        );
+        assert!(
+            names.contains(&"BIPOLAR"),
+            "OneHot output scan must include BIPOLAR, got {names:?}",
+        );
+        // Unbounded scans must be excluded for OneHot/Simplex output.
+        for unbounded in ["GELU", "ELU", "IDENTITY", "Mish", "Softplus"] {
+            assert!(
+                !names.contains(&unbounded),
+                "OneHot output scan must exclude {unbounded}, got {names:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn simplex_output_returns_only_bounded_subset() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        let names = names(&specs);
+
+        assert!(names.contains(&"LOGISTIC"));
+        assert!(names.contains(&"BIPOLAR"));
+        for unbounded in ["GELU", "ELU", "IDENTITY"] {
+            assert!(!names.contains(&unbounded));
+        }
+    }
+
+    #[test]
+    fn onehot_hidden_uses_full_scan_set() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "Hidden neurons always see the full scan set",
+        );
+    }
+
+    #[test]
+    fn simplex_hidden_uses_full_scan_set() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+
+    #[test]
+    fn unknown_descriptor_returns_full_scan_for_both_roles() {
+        // Regression guard: absent / unrecognised cost name collapses to
+        // neutral, which must preserve the pre-Issue-#1315 scan set.
+        let d = TaskDescriptor::neutral();
+        for role in [NeuronRole::Output, NeuronRole::Hidden] {
+            let specs = scan_specs_for_role(role, &d);
+            assert_eq!(
+                specs.len(),
+                ACTIVATION_SPECS.len(),
+                "Neutral descriptor must yield the full scan set for {role:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn other_cost_name_returns_full_scan_for_both_roles() {
+        // OTHER is the explicit "I don't know" cost name. Must behave
+        // identically to neutral().
+        let d = TaskDescriptor::from_name("OTHER", 4);
+        for role in [NeuronRole::Output, NeuronRole::Hidden] {
+            let specs = scan_specs_for_role(role, &d);
+            assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+        }
+    }
+
+    #[test]
+    fn unrecognised_cost_name_returns_full_scan() {
+        let d = TaskDescriptor::from_name("EXOTIC_LOSS", 2);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+
+    #[test]
+    fn independent_output_uses_full_scan() {
+        // MSE / MAE / MAPE / MSLE / BCE / HINGE — none of these gate the
+        // scan to bounded only (only OneHot and Simplex do).
+        for cost in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "MSLE",
+            "BINARY_CROSS_ENTROPY",
+            "HINGE",
+        ] {
+            let d = TaskDescriptor::from_name(cost, 3);
+            let specs = scan_specs_for_role(NeuronRole::Output, &d);
+            assert_eq!(
+                specs.len(),
+                ACTIVATION_SPECS.len(),
+                "Cost {cost} must not gate the output scan to bounded only",
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_subset_only_contains_known_spec_names() {
+        // Defensive: every name we report in the bounded subset must
+        // actually exist in ACTIVATION_SPECS so callers don't get a stale
+        // / mis-spelled label. STEP is intentionally allowed to be missing
+        // from ACTIVATION_SPECS (it is listed for forward compatibility).
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        for spec in &specs {
+            assert!(
+                BOUNDED_OUTPUT_SCAN_NAMES.contains(&spec.name),
+                "Spec {} returned from bounded scan must be in BOUNDED_OUTPUT_SCAN_NAMES",
+                spec.name,
+            );
+        }
+        // Sanity: at least LOGISTIC and BIPOLAR must be present.
+        let names = names(&specs);
+        assert!(names.contains(&"LOGISTIC"));
+        assert!(names.contains(&"BIPOLAR"));
+    }
 }

--- a/tests/activation/issue_1315_role_task_aware_scan.rs
+++ b/tests/activation/issue_1315_role_task_aware_scan.rs
@@ -1,0 +1,113 @@
+//! Issue #1315 — the activation/squash scan candidate set is role- and
+//! task-aware.
+//!
+//! Acceptance criteria:
+//! - Under a OneHot/Simplex descriptor, the scan offers bounded squashes
+//!   for **output** neurons and the existing set for **hidden** neurons.
+//! - `OTHER` / `Unknown` / absent ⇒ current scan set (regression guard).
+
+use neat_ai_discovery::analysis::activation::{
+    ACTIVATION_SPECS, BOUNDED_OUTPUT_SCAN_NAMES, NeuronRole, scan_specs_for_role,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+fn spec_names(
+    specs: &[&'static neat_ai_discovery::analysis::activation::ActivationCandidateSpec],
+) -> Vec<&'static str> {
+    specs.iter().map(|s| s.name).collect()
+}
+
+#[test]
+fn onehot_output_scan_is_bounded_only() {
+    let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 5);
+    let names = spec_names(&scan_specs_for_role(NeuronRole::Output, &d));
+
+    // Bounded set members that exist in ACTIVATION_SPECS must be present.
+    assert!(names.contains(&"LOGISTIC"));
+    assert!(names.contains(&"BIPOLAR"));
+
+    // Unbounded hidden-layer favourites must NOT appear.
+    for unbounded in ["GELU", "ELU", "Mish", "Softplus", "IDENTITY", "ReLU6"] {
+        assert!(
+            !names.contains(&unbounded),
+            "{unbounded} must be excluded from the OneHot output scan",
+        );
+    }
+
+    // Every reported name belongs to the documented bounded-subset.
+    for name in &names {
+        assert!(BOUNDED_OUTPUT_SCAN_NAMES.contains(name));
+    }
+}
+
+#[test]
+fn simplex_output_scan_is_bounded_only() {
+    let d = TaskDescriptor::from_name("CROSS_ENTROPY", 4);
+    let names = spec_names(&scan_specs_for_role(NeuronRole::Output, &d));
+
+    assert!(names.contains(&"LOGISTIC"));
+    assert!(names.contains(&"BIPOLAR"));
+    for unbounded in ["GELU", "ELU", "Mish"] {
+        assert!(!names.contains(&unbounded));
+    }
+}
+
+#[test]
+fn onehot_hidden_scan_is_full_set() {
+    let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 5);
+    let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+    assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+}
+
+#[test]
+fn simplex_hidden_scan_is_full_set() {
+    let d = TaskDescriptor::from_name("CROSS_ENTROPY", 4);
+    let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+    assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+}
+
+#[test]
+fn other_cost_is_regression_safe_for_both_roles() {
+    let d = TaskDescriptor::from_name("OTHER", 3);
+    for role in [NeuronRole::Output, NeuronRole::Hidden] {
+        let specs = scan_specs_for_role(role, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "OTHER must preserve the full scan set for {role:?}",
+        );
+    }
+}
+
+#[test]
+fn absent_descriptor_is_regression_safe_for_both_roles() {
+    // Absent ≡ neutral().
+    let d = TaskDescriptor::neutral();
+    for role in [NeuronRole::Output, NeuronRole::Hidden] {
+        let specs = scan_specs_for_role(role, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+}
+
+#[test]
+fn independent_output_keeps_full_scan() {
+    // MSE / MAE / MAPE / MSLE / BCE / HINGE all have target_topology that
+    // is *not* OneHot or Simplex, so the scan must keep its full set
+    // (Issue #1315 only narrows OneHot / Simplex output scans).
+    for cost in [
+        "MSE",
+        "MAE",
+        "MAPE",
+        "MSLE",
+        "BINARY_CROSS_ENTROPY",
+        "HINGE",
+    ] {
+        let d = TaskDescriptor::from_name(cost, 3);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "Cost {cost} must keep the full output scan",
+        );
+    }
+}

--- a/tests/activation/main.rs
+++ b/tests/activation/main.rs
@@ -8,6 +8,7 @@ mod activation_coverage_neat_ai_registry;
 mod activation_overflow_protection_f32;
 mod complement_via_identity;
 mod discrete_activation_filtering;
+mod issue_1315_role_task_aware_scan;
 mod issue_417_increase_change_squash_rate;
 mod issue_768_activation_properties;
 mod leaky_relu_filtered;


### PR DESCRIPTION
## Summary

Made the activation/squash **scan** candidate set role- and task-aware. Closes #1315.

A new helper `scan_specs_for_role(role, descriptor)` in
`src/analysis/activation/specs.rs` returns the activation candidate specs to
scan for a given neuron role (`Output` / `Hidden`) and `TaskDescriptor`:

- **Output neuron** under `target_topology ∈ {OneHot, Simplex}` → bounded
  subset only (`LOGISTIC`, `STEP`, `BIPOLAR` — names in
  `BOUNDED_OUTPUT_SCAN_NAMES`; `STEP` is listed for forward compatibility,
  the effective set is currently `LOGISTIC` + `BIPOLAR` since `STEP` is
  not yet in `ACTIVATION_SPECS`).
- **Hidden neuron**, *any* descriptor → full `ACTIVATION_SPECS`.
- **Output neuron** under `Independent` / `Margin` / `Unknown` topology →
  full `ACTIVATION_SPECS` (regression guard for `OTHER` / unrecognised /
  absent cost names, which collapse to `TaskDescriptor::neutral()`).

The helper is pure: it consumes the `TaskDescriptor` from #1312 but does
not depend on the #1314 FFI plumbing. No existing call site is touched —
the scan path keeps its current behaviour until a consumer migration
opts in.

## Test plan

- [x] Unit: `src/analysis/activation/specs.rs::scan_specs_tests` (9 tests)
- [x] Integration: `tests/activation/issue_1315_role_task_aware_scan.rs` (7 tests)
- [x] `./quality.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)