### PR TITLE
Accept optional task_descriptor on discovery FFI inputs (Issue #1314)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1314.md
+++ b/docs/archive/pr-summaries/pr-summary-1314.md
@@ -1,0 +1,53 @@
+## Summary
+
+Plumbing-only change that lets producers pass an optional `task_descriptor`
+through the discovery FFI. The three request structs in
+`src/ffi_types/requests.rs` — `RecordDiscoveryInput`, `AnalyzeParallelInput`,
+`RankFocusNeuronsInput` — now carry an `Option<TaskDescriptor>` field marked
+with `#[serde(default)]`. A payload that omits the field deserialises to
+`None`, which consumers treat as `TaskDescriptor::neutral()`. No
+recommendation generator reads the field yet, so behaviour is unchanged.
+
+`TaskDescriptor`, `TargetTopology`, `TargetRange`, and `OutputSquashFamily`
+gained `serde::Deserialize` derives; `TaskDescriptor` uses
+`#[serde(rename_all = "camelCase")]` so producers send the field names in the
+same camelCase convention as the rest of the FFI payloads.
+
+Closes #1314.
+
+## Evidence
+
+Backend / FFI-only change; no UI surface to screenshot. The serde round-trip
+is verified by the new test module
+`tests/ffi/issue_1314_task_descriptor_plumbing.rs`, which covers:
+
+- An omitted `task_descriptor` deserialising to `None` for all three structs
+  and `None.unwrap_or_default() == TaskDescriptor::neutral()`.
+- A supplied descriptor round-tripping verbatim through serde.
+- A payload that supplies every other previously-supported `AnalyzeParallel`
+  field still parses cleanly (regression guard).
+
+```mermaid
+flowchart LR
+    Producer["NEAT-AI host"] -->|JSON payload| FFI["FFI request structs"]
+    FFI -->|"Option&lt;TaskDescriptor&gt;"| Consumer["Discovery pipeline (no-op today)"]
+    Consumer -.->|"None ⇒ neutral()"| Neutral["TaskDescriptor::neutral()"]
+```
+
+`./quality.sh` passes locally (fmt, clippy, check, doc, all tests, release
+build).
+
+## Test Plan
+
+- New tests in `tests/ffi/issue_1314_task_descriptor_plumbing.rs`:
+  - `record_discovery_input_omits_task_descriptor_to_none`
+  - `record_discovery_input_supplied_task_descriptor_round_trips`
+  - `analyze_parallel_input_omits_task_descriptor_to_none`
+  - `analyze_parallel_input_supplied_task_descriptor_round_trips`
+  - `analyze_parallel_input_accepts_neutral_descriptor`
+  - `rank_focus_neurons_input_omits_task_descriptor_to_none`
+  - `rank_focus_neurons_input_supplied_task_descriptor_round_trips`
+  - `payload_without_task_descriptor_still_parses_all_existing_fields`
+- Existing tests under `src/record/tests.rs` updated to initialise the new
+  field with `task_descriptor: None`.
+- Full `./quality.sh` run passes.

--- a/src/analysis/task_descriptor.rs
+++ b/src/analysis/task_descriptor.rs
@@ -22,15 +22,18 @@
 //! The descriptor itself is intentionally pure (no FFI surface, no I/O) but
 //! it exposes a small projection — [`TaskDescriptor::cost_function_hint`] —
 //! that maps the task shape onto the [`crate::analysis::cost_function_hint::CostFunctionHint`]
-//! used by the implied-target reconstruction guard (issue #1317). Wiring the
-//! descriptor through the FFI ingest path and the remaining per-consumer
-//! sites is tracked separately (see issue #1314 and the per-consumer issues
-//! that reference #1312).
+//! used by the implied-target reconstruction guard (issue #1317). The FFI
+//! ingest path now also carries an optional `task_descriptor` field on the
+//! discovery FFI inputs (Issue #1314) — pure plumbing, no consumer reads it
+//! yet. The remaining per-consumer wiring is tracked separately (see the
+//! consumer issues that reference #1312).
+
+use serde::Deserialize;
 
 use crate::analysis::cost_function_hint::CostFunctionHint;
 
 /// Topology of the recorded targets vector for a single training sample.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum TargetTopology {
     /// Each output is an independent scalar target (e.g. regression, BCE).
     Independent,
@@ -50,7 +53,7 @@ pub enum TargetTopology {
 }
 
 /// Numeric range the recorded targets can take.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum TargetRange {
     /// Targets are unbounded reals.
     #[default]
@@ -65,7 +68,7 @@ pub enum TargetRange {
 
 /// Family of activation functions that is compatible with the loss on the
 /// final layer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum OutputSquashFamily {
     /// Bounded, unipolar squash (range `[0, 1]`): LOGISTIC, `BIPOLAR_SIGMOID`
     /// rescaled to unipolar, etc.
@@ -87,7 +90,8 @@ pub enum OutputSquashFamily {
 /// Constructed via [`TaskDescriptor::from_name`] or
 /// [`TaskDescriptor::neutral`]. The struct is `Copy` and trivially cheap to
 /// pass by value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TaskDescriptor {
     /// Topology of the targets vector.
     pub target_topology: TargetTopology,

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -5,6 +5,7 @@
 use serde::Deserialize;
 
 use crate::analysis;
+use crate::analysis::task_descriptor::TaskDescriptor;
 
 use super::{CreatureJson, TrainingRecord};
 
@@ -20,6 +21,13 @@ pub struct RecordDiscoveryInput {
     pub record_indices: Option<Vec<usize>>,
     #[serde(default)]
     pub timeout_seconds: Option<u64>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// FFI request payload for
@@ -119,6 +127,13 @@ pub struct AnalyzeParallelInput {
     /// underlying defect.
     #[serde(default)]
     pub cost_name: Option<String>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -277,6 +292,13 @@ pub struct RankFocusNeuronsInput {
     /// Issue #132: Pass this from NEAT-AI's configured costOfGrowth for consistency.
     #[serde(default)]
     pub cost_of_growth: Option<f32>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/record/tests.rs
+++ b/src/record/tests.rs
@@ -66,6 +66,7 @@ fn create_test_input() -> RecordDiscoveryInput {
         binary_file_path: None,
         record_indices: None,
         timeout_seconds: None,
+        task_descriptor: None,
     }
 }
 

--- a/tests/ffi/issue_1314_task_descriptor_plumbing.rs
+++ b/tests/ffi/issue_1314_task_descriptor_plumbing.rs
@@ -1,0 +1,213 @@
+//! Tests for Issue #1314: optional `task_descriptor` plumbing on the
+//! discovery FFI inputs.
+//!
+//! The three FFI request structs — [`RecordDiscoveryInput`],
+//! [`AnalyzeParallelInput`], and [`RankFocusNeuronsInput`] — accept an
+//! optional `task_descriptor` field. The field is pure plumbing in this
+//! issue: no recommendation generator reads it yet.
+//!
+//! Acceptance criteria checked here:
+//!
+//! - A payload that omits `task_descriptor` deserialises cleanly and the
+//!   resulting `Option<TaskDescriptor>` is `None` — consumers treat that
+//!   as [`TaskDescriptor::neutral`].
+//! - A payload that supplies a structured `task_descriptor` round-trips
+//!   the value verbatim.
+//! - Adding the field does not break any existing payload shape (the
+//!   regression guard).
+
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetRange, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::{AnalyzeParallelInput, RankFocusNeuronsInput, RecordDiscoveryInput};
+
+// =============================================================================
+// RecordDiscoveryInput
+// =============================================================================
+
+#[test]
+fn record_discovery_input_omits_task_descriptor_to_none() {
+    // RecordDiscoveryInput uses snake_case at the top level.
+    let payload = r#"{
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "training_data": [],
+        "temp_dir": "/tmp/x"
+    }"#;
+    let parsed: RecordDiscoveryInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    // None must collapse to neutral() at the consumer site.
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn record_discovery_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "training_data": [],
+        "temp_dir": "/tmp/x",
+        "task_descriptor": {
+            "targetTopology": "OneHot",
+            "targetRange": "Unit",
+            "outputSquashFamily": "BoundedUnipolar",
+            "numOutputs": 5
+        }
+    }"#;
+    let parsed: RecordDiscoveryInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::OneHot);
+    assert_eq!(descriptor.target_range, TargetRange::Unit);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedUnipolar
+    );
+    assert_eq!(descriptor.num_outputs, 5);
+}
+
+// =============================================================================
+// AnalyzeParallelInput
+// =============================================================================
+
+#[test]
+fn analyze_parallel_input_omits_task_descriptor_to_none() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": []
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn analyze_parallel_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "taskDescriptor": {
+            "targetTopology": "Margin",
+            "targetRange": "SignedUnit",
+            "outputSquashFamily": "BoundedBipolar",
+            "numOutputs": 1
+        }
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::Margin);
+    assert_eq!(descriptor.target_range, TargetRange::SignedUnit);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedBipolar
+    );
+    assert_eq!(descriptor.num_outputs, 1);
+}
+
+#[test]
+fn analyze_parallel_input_accepts_neutral_descriptor() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "taskDescriptor": {
+            "targetTopology": "Unknown",
+            "targetRange": "Unbounded",
+            "outputSquashFamily": "Any",
+            "numOutputs": 0
+        }
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor, TaskDescriptor::neutral());
+}
+
+// =============================================================================
+// RankFocusNeuronsInput
+// =============================================================================
+
+#[test]
+fn rank_focus_neurons_input_omits_task_descriptor_to_none() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0}
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn rank_focus_neurons_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "taskDescriptor": {
+            "targetTopology": "Independent",
+            "targetRange": "Unbounded",
+            "outputSquashFamily": "Unbounded",
+            "numOutputs": 3
+        }
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::Independent);
+    assert_eq!(descriptor.target_range, TargetRange::Unbounded);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::Unbounded
+    );
+    assert_eq!(descriptor.num_outputs, 3);
+}
+
+// =============================================================================
+// Back-compat / regression guard
+// =============================================================================
+
+#[test]
+fn payload_without_task_descriptor_still_parses_all_existing_fields() {
+    // Verify that adding the optional field has not perturbed how an
+    // existing payload (carrying every other previously-supported field)
+    // is parsed. This is the "no behaviour change" guard from the issue.
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": ["a", "b"],
+        "maxSynapseCandidates": 16,
+        "maxNeuronCandidates": 8,
+        "analysisDeadlineMs": 1000,
+        "randomSeed": 42,
+        "temperature": 1.25,
+        "maxAnalysisMemoryMb": 512,
+        "maxDiscoveryWallClockMinutes": 5,
+        "costName": "MSE"
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    assert_eq!(parsed.focus_neurons, vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(parsed.max_synapse_candidates, Some(16));
+    assert_eq!(parsed.max_neuron_candidates, Some(8));
+    assert_eq!(parsed.analysis_deadline_ms, Some(1000));
+    assert_eq!(parsed.random_seed, Some(42));
+    assert!((parsed.temperature - 1.25).abs() < 1e-6);
+    assert_eq!(parsed.max_analysis_memory_mb, Some(512));
+    assert_eq!(parsed.max_discovery_wall_clock_minutes, Some(5));
+    assert_eq!(parsed.cost_name.as_deref(), Some("MSE"));
+    assert!(parsed.task_descriptor.is_none());
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -7,6 +7,7 @@ mod issue_1027_memory_usage_ffi;
 mod issue_1028_memory_budget;
 mod issue_1184_recurrent_synapse_rejection;
 mod issue_1188_grq3_strip_pattern_rejection;
+mod issue_1314_task_descriptor_plumbing;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
## Summary

Plumbing-only change that lets producers pass an optional `task_descriptor`
through the discovery FFI. The three request structs in
`src/ffi_types/requests.rs` — `RecordDiscoveryInput`, `AnalyzeParallelInput`,
`RankFocusNeuronsInput` — now carry an `Option<TaskDescriptor>` field marked
with `#[serde(default)]`. A payload that omits the field deserialises to
`None`, which consumers treat as `TaskDescriptor::neutral()`. No
recommendation generator reads the field yet, so behaviour is unchanged.

`TaskDescriptor`, `TargetTopology`, `TargetRange`, and `OutputSquashFamily`
gained `serde::Deserialize` derives; `TaskDescriptor` uses
`#[serde(rename_all = "camelCase")]` so producers send the field names in the
same camelCase convention as the rest of the FFI payloads.

Closes #1314.

## Evidence

Backend / FFI-only change; no UI surface to screenshot. The serde round-trip
is verified by the new test module
`tests/ffi/issue_1314_task_descriptor_plumbing.rs`, which covers:

- An omitted `task_descriptor` deserialising to `None` for all three structs
  and `None.unwrap_or_default() == TaskDescriptor::neutral()`.
- A supplied descriptor round-tripping verbatim through serde.
- A payload that supplies every other previously-supported `AnalyzeParallel`
  field still parses cleanly (regression guard).

```mermaid
flowchart LR
    Producer["NEAT-AI host"] -->|JSON payload| FFI["FFI request structs"]
    FFI -->|"Option&lt;TaskDescriptor&gt;"| Consumer["Discovery pipeline (no-op today)"]
    Consumer -.->|"None ⇒ neutral()"| Neutral["TaskDescriptor::neutral()"]
```

`./quality.sh` passes locally (fmt, clippy, check, doc, all tests, release
build).

## Test Plan

- New tests in `tests/ffi/issue_1314_task_descriptor_plumbing.rs`:
  - `record_discovery_input_omits_task_descriptor_to_none`
  - `record_discovery_input_supplied_task_descriptor_round_trips`
  - `analyze_parallel_input_omits_task_descriptor_to_none`
  - `analyze_parallel_input_supplied_task_descriptor_round_trips`
  - `analyze_parallel_input_accepts_neutral_descriptor`
  - `rank_focus_neurons_input_omits_task_descriptor_to_none`
  - `rank_focus_neurons_input_supplied_task_descriptor_round_trips`
  - `payload_without_task_descriptor_still_parses_all_existing_fields`
- Existing tests under `src/record/tests.rs` updated to initialise the new
  field with `task_descriptor: None`.
- Full `./quality.sh` run passes.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-1314 -->