### PR TITLE
Weight output bias-drift by class prior under OneHot/Simplex (#1316)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1316.md
+++ b/docs/archive/pr-summaries/pr-summary-1316.md
@@ -1,0 +1,65 @@
+## Summary
+
+Weight output bias-drift detection by class prior for `OneHot` / `Simplex`
+target topologies. Output neurons that never cross a saturating threshold
+on a class with positive support are flagged as **capacity-starved** and
+their estimated improvement is boosted, lifting them in the candidate
+ranking for growth. All other descriptors (`Independent`, `Margin`,
+`Unknown`, `OTHER`, absent) fall through to the existing detector
+verbatim — regression guard. Closes #1316.
+
+## Evidence
+
+Backend Rust crate — no UI surface to screenshot. Verified via TDD with
+nine targeted integration tests in
+`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`,
+all green:
+
+```
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured;
+```
+
+The full crate test suite (`cargo test --lib --tests --all-features
+-- --test-threads=2`) also passes; `cargo clippy --all-targets
+--all-features -- -D warnings` passes; `cargo fmt --all -- --check`
+clean; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` builds.
+
+### Dispatch wiring
+
+```mermaid
+flowchart LR
+    A[input.cost_name] --> B[TaskDescriptor::from_name]
+    B --> C[task_descriptor]
+    C --> D[prepare_and_detect_discovery_modules]
+    D --> E[append_scoring_specs]
+    E --> F[detect_output_bias_drift_with_descriptor]
+    F -- OneHot or Simplex --> G[flag + boost capacity-starved]
+    F -- other --> H[legacy detect_output_bias_drift]
+```
+
+## Test Plan
+
+Tests added in
+`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`:
+
+- `one_hot_descriptor_flags_capacity_starved_output_neuron` — positive
+  support + activation stuck below the saturating threshold under
+  `CATEGORICAL_ERROR` → `capacity_starved == true`.
+- `simplex_descriptor_flags_capacity_starved_output_neuron` — same under
+  `CROSS_ENTROPY` (Simplex topology).
+- `one_hot_does_not_flag_well_saturated_output` — activations cross
+  the saturating threshold → never flagged.
+- `neutral_descriptor_matches_legacy_detector` — regression guard for
+  `TaskDescriptor::neutral()`.
+- `other_cost_matches_legacy_detector` — regression guard for the
+  `OTHER` cost name.
+- `mse_descriptor_matches_legacy_detector` — regression guard for the
+  `Independent` topology.
+- `class_without_positive_support_is_not_flagged` — class prior
+  matters: no positive-support records ⇒ no capacity-starved flag.
+- `capacity_starved_candidate_is_weighted_up_vs_legacy` — verifies the
+  estimated improvement of a capacity-starved candidate is strictly
+  greater than the legacy detector's gain on the same input.
+- `hidden_neuron_is_not_flagged_capacity_starved` — output-only
+  detector continues to ignore hidden neurons under the role-aware
+  path.

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 use super::cost_function_hint::CostFunctionHint;
 use super::detection::topology_cache::CreatureTopologyCache;
+use super::task_descriptor::TaskDescriptor;
 use super::{
     cache, candidate_clustering, candidate_diversity, discovery_dispatch, ensemble_scoring,
     module_weights::{self, CandidateBudgetConfig, ModuleOutcomeTracker},
@@ -47,6 +48,7 @@ pub(crate) fn build_discovery_module_specs(
     shared_cache: &Arc<cache::RecordCache>,
     topo: &Arc<CreatureTopologyCache>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> Vec<discovery_dispatch::DiscoveryModuleSpec> {
     let mut modules: Vec<discovery_dispatch::DiscoveryModuleSpec> = Vec::with_capacity(32);
 
@@ -66,7 +68,13 @@ pub(crate) fn build_discovery_module_specs(
         shared_cache,
         topo,
     );
-    scoring_specs::append_scoring_specs(&mut modules, creature, shared_cache, cost_hint);
+    scoring_specs::append_scoring_specs(
+        &mut modules,
+        creature,
+        shared_cache,
+        cost_hint,
+        task_descriptor,
+    );
 
     modules
 }
@@ -85,6 +93,7 @@ pub(crate) fn build_discovery_module_specs(
 /// The `deadline` parameter is forwarded to [`discovery_dispatch::detect_discovery_modules_parallel`]
 /// so that modules are skipped when the analysis time budget is exhausted,
 /// preventing the detection phase from running indefinitely.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_and_detect_discovery_modules(
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
@@ -92,6 +101,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
     tracker: &ModuleOutcomeTracker,
     deadline: Option<std::time::SystemTime>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     prepare_and_detect_discovery_modules_with_starvation(
         creature,
@@ -102,6 +112,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
         None,
         0,
         cost_hint,
+        task_descriptor,
     )
 }
 
@@ -118,11 +129,18 @@ pub(crate) fn prepare_and_detect_discovery_modules_with_starvation(
     starvation_tracker: Option<&super::module_starvation_tracker::ModuleStarvationTracker>,
     current_epoch: u64,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
-    let mut modules =
-        build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo, cost_hint);
+    let mut modules = build_discovery_module_specs(
+        creature,
+        hidden_neurons,
+        shared_cache,
+        &topo,
+        cost_hint,
+        task_descriptor,
+    );
 
     // Issue #967: Allocate candidate budgets based on module success rates.
     let config = CandidateBudgetConfig::default();
@@ -427,6 +445,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
 
         // We expect 47 modules across all four spec groups (batch-successful
@@ -468,6 +487,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
         let mut phase_names: Vec<&str> = specs.iter().map(|s| s.phase_name).collect();
         let total = phase_names.len();
@@ -497,6 +517,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
 
         // With empty hidden neurons and no records, all modules should return None.

--- a/src/analysis/module_dispatch_specs/scoring_specs.rs
+++ b/src/analysis/module_dispatch_specs/scoring_specs.rs
@@ -15,6 +15,7 @@ use super::super::detection::{
 use super::super::recommendation::{
     batch_successful, gradient_discovery, output_bias_drift, sample_weighted,
 };
+use super::super::task_descriptor::TaskDescriptor;
 use super::super::{cache, discovery_dispatch};
 
 /// Append scoring and recommendation discovery module specs to the provided vector.
@@ -29,12 +30,20 @@ pub(crate) fn append_scoring_specs(
     creature: &Arc<crate::CreatureJson>,
     shared_cache: &Arc<cache::RecordCache>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) {
-    // Issue #361: Output bias drift detection
+    // Issue #361 / #1316: Output bias drift detection. Under OneHot / Simplex
+    // descriptors the role-aware path additionally weights up output neurons
+    // that never cross a saturating threshold for a class with positive
+    // support (capacity starvation); other descriptors are unchanged.
     discovery_spec!(modules, "output bias drift detection", "output_bias_drift_detection",
         cache = shared_cache, creature = creature =>
         records: cache.load_records_for_neuron_types(&creature, &["output"]),
-        detect: |records| output_bias_drift::detect_output_bias_drift(&creature, &records),
+        detect: |records| output_bias_drift::detect_output_bias_drift_with_descriptor(
+            &creature,
+            &records,
+            &task_descriptor,
+        ),
         convert: |detected| output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected),
     );
 

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -276,13 +276,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // dependent detectors run; for non-linear costs (MAPE / MSLE / HINGE /
     // CATEGORICAL_ERROR) they are skipped; absent / unrecognised / OTHER
     // collapses to `neutral()` which maps to a conservative skip.
-    let cost_hint: CostFunctionHint = input
+    // Issue #1316: also keep the full descriptor — the output_bias_drift
+    // module needs the topology (OneHot / Simplex) to weight up capacity-
+    // starved output neurons.
+    let task_descriptor: TaskDescriptor = input
         .cost_name
         .as_deref()
         .map_or_else(TaskDescriptor::neutral, |name| {
             TaskDescriptor::from_name(name, input.creature.output)
-        })
-        .cost_function_hint();
+        });
+    let cost_hint: CostFunctionHint = task_descriptor.cost_function_hint();
 
     // Issue #490: Compute current fingerprints and filter unchanged neurons.
     let current_fingerprints = neuron_fingerprint::compute_neuron_fingerprints(&input.creature);
@@ -761,6 +764,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                             &tracker,
                             discovery_deadline,
                             cost_hint,
+                            task_descriptor,
                         )
                     }))
                     .unwrap_or_else(|panic_payload| {

--- a/src/analysis/recommendation/output_bias_drift.rs
+++ b/src/analysis/recommendation/output_bias_drift.rs
@@ -29,6 +29,7 @@
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use std::collections::HashMap;
 
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
 
@@ -41,6 +42,29 @@ const MIN_MAJORITY_SIGN_FRACTION: f32 = 0.7;
 
 /// Minimum absolute mean error to distinguish from noise.
 const MIN_MEAN_ERROR_MAGNITUDE: f32 = 0.01;
+
+/// Capacity-starvation threshold (Issue #1316).
+///
+/// A class is considered "positively supported" when the recorded target
+/// value is above this threshold. For `OneHot` / `Simplex` topologies the
+/// targets sit on `[0, 1]` and the "on" class records as 1.0, so any
+/// threshold in the middle of the unit interval reliably separates "on"
+/// from "off" while tolerating soft labels.
+const POSITIVE_SUPPORT_TARGET_THRESHOLD: f32 = 0.5;
+
+/// Saturating activation threshold (Issue #1316).
+///
+/// Mirrors the bounded-unipolar saturation threshold used by the saturated
+/// neuron detector. An output neuron whose maximum activation on its
+/// positive-support class never reaches this value is treated as
+/// capacity-starved for that class.
+const SATURATING_ACTIVATION_THRESHOLD: f32 = 0.85;
+
+/// Multiplier applied to the estimated improvement of a candidate that is
+/// also flagged as capacity-starved under a `OneHot` / `Simplex` task
+/// (Issue #1316). Picked to lift the candidate above peers without
+/// overwhelming the rest of the ranking.
+const CAPACITY_STARVED_GAIN_BOOST: f32 = 2.0;
 
 /// Result of detecting output bias drift.
 #[derive(Debug, Clone)]
@@ -59,6 +83,12 @@ pub struct OutputBiasDriftCandidate {
     pub recommended_bias_delta: f32,
     /// Estimated creature score improvement from fixing the bias.
     pub estimated_improvement: f32,
+    /// Whether this candidate was flagged as capacity-starved under a
+    /// `OneHot` / `Simplex` task descriptor (Issue #1316). Always `false`
+    /// for the legacy `detect_output_bias_drift` entry point; only the
+    /// role-aware `detect_output_bias_drift_with_descriptor` path can
+    /// set this to `true`.
+    pub capacity_starved: bool,
 }
 
 /// Detect output neurons with bias drift from recorded activations.
@@ -145,6 +175,7 @@ pub fn detect_output_bias_drift(
             sample_count: error_values.len(),
             recommended_bias_delta,
             estimated_improvement,
+            capacity_starved: false,
         });
     }
 
@@ -187,4 +218,170 @@ pub fn output_bias_drift_to_coordinated_candidates(
     });
 
     results
+}
+
+// =============================================================================
+// Role-aware output bias drift (Issue #1316)
+// =============================================================================
+//
+// Under `OneHot` / `Simplex` topologies the recorded target marks exactly one
+// "on" class per sample. An output neuron whose maximum activation on the
+// samples that *belong to its class* never crosses the saturating threshold is
+// suffering capacity starvation — its parameters cannot push the prediction
+// high enough even when the class is well supported. The role-aware path runs
+// the legacy detector first (so unrelated callers are unaffected) and then,
+// when the descriptor topology is `OneHot` or `Simplex`, boosts the
+// estimated improvement of any matching candidate and synthesises a fresh
+// candidate for capacity-starved output neurons that the legacy detector
+// missed.
+
+/// Whether a descriptor's topology gates the role-aware bias-drift path.
+fn role_aware_topology(descriptor: &TaskDescriptor) -> bool {
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Diagnostics about an output neuron's positive-support class.
+struct PositiveSupportStats {
+    /// Count of records on the positive-support class (target above the
+    /// `POSITIVE_SUPPORT_TARGET_THRESHOLD`).
+    count: usize,
+    /// Maximum activation observed on the positive-support records.
+    max_activation: f32,
+    /// Mean activation observed on the positive-support records.
+    mean_activation: f32,
+    /// Mean error on the positive-support records (target − activation under
+    /// linear-residual costs).
+    mean_error: f32,
+}
+
+/// Summarise the positive-support behaviour of an output neuron given its
+/// records. Returns `None` when the recorded targets carry no positive
+/// support (no `value > POSITIVE_SUPPORT_TARGET_THRESHOLD`).
+fn summarise_positive_support(records: &[DiscoverRecord]) -> Option<PositiveSupportStats> {
+    let mut count = 0_usize;
+    let mut max_activation = f32::NEG_INFINITY;
+    let mut sum_activation = 0.0_f32;
+    let mut sum_error = 0.0_f32;
+
+    for r in records {
+        // Targets are recorded in `value` (Option<f32>). Records without a
+        // recorded target cannot contribute to positive-support reasoning.
+        let Some(target) = r.value else { continue };
+        if target <= POSITIVE_SUPPORT_TARGET_THRESHOLD {
+            continue;
+        }
+        count += 1;
+        sum_activation += r.activation;
+        if r.activation > max_activation {
+            max_activation = r.activation;
+        }
+        if let Some(&e) = r.errors.first() {
+            sum_error += e;
+        }
+    }
+
+    if count == 0 {
+        return None;
+    }
+
+    let n = count as f32;
+    Some(PositiveSupportStats {
+        count,
+        max_activation,
+        mean_activation: sum_activation / n,
+        mean_error: sum_error / n,
+    })
+}
+
+/// Determine whether the positive-support stats indicate capacity starvation:
+/// a well-supported class whose activations never cross the saturating
+/// threshold.
+fn is_capacity_starved(stats: &PositiveSupportStats) -> bool {
+    stats.count >= MIN_SAMPLES_FOR_BIAS_DRIFT
+        && stats.max_activation < SATURATING_ACTIVATION_THRESHOLD
+}
+
+/// Role-aware output bias drift detection (Issue #1316).
+///
+/// Behaves identically to [`detect_output_bias_drift`] when the descriptor
+/// reports a topology other than `OneHot` / `Simplex` — neutral, `OTHER`,
+/// `Independent`, `Margin`, and any future variant fall back to the legacy
+/// detector. For `OneHot` / `Simplex` descriptors, output neurons with
+/// positive class support whose activations never cross the saturating
+/// activation threshold are flagged as capacity-starved and their estimated
+/// improvement is boosted by a fixed gain multiplier. Capacity-starved
+/// neurons that the legacy detector missed receive a fresh candidate whose
+/// `recommended_bias_delta` matches the legacy convention (`−mean_error` on
+/// the positive-support records).
+pub fn detect_output_bias_drift_with_descriptor(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    descriptor: &TaskDescriptor,
+) -> Vec<OutputBiasDriftCandidate> {
+    let mut candidates = detect_output_bias_drift(creature, neuron_records);
+
+    if !role_aware_topology(descriptor) {
+        return candidates;
+    }
+
+    let output_neurons: HashMap<&str, f32> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| (n.uuid.as_str(), n.bias))
+        .collect();
+
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    for (&uuid, &current_bias) in &output_neurons {
+        let Some(records) = records_map.get(uuid) else {
+            continue;
+        };
+        let Some(stats) = summarise_positive_support(records) else {
+            continue;
+        };
+        if !is_capacity_starved(&stats) {
+            continue;
+        }
+
+        if let Some(existing) = candidates.iter_mut().find(|c| c.neuron_uuid == uuid) {
+            existing.capacity_starved = true;
+            existing.estimated_improvement *= CAPACITY_STARVED_GAIN_BOOST;
+            continue;
+        }
+
+        // No legacy candidate for this neuron — synthesise one. Picking the
+        // bias delta from the positive-support mean error matches the legacy
+        // convention (`recommended_bias_delta = −mean_error`) and falls back
+        // to closing the gap to saturation when the recorded errors are
+        // unusable.
+        let recommended_bias_delta = if stats.mean_error.is_finite() && stats.mean_error.abs() > 0.0
+        {
+            -stats.mean_error
+        } else {
+            SATURATING_ACTIVATION_THRESHOLD - stats.mean_activation
+        };
+        let gap = (SATURATING_ACTIVATION_THRESHOLD - stats.max_activation).max(0.0);
+        let estimated_improvement = gap * 0.1 * CAPACITY_STARVED_GAIN_BOOST;
+
+        candidates.push(OutputBiasDriftCandidate {
+            neuron_uuid: uuid.to_string(),
+            current_bias,
+            mean_error: stats.mean_error,
+            positive_error_fraction: 0.0,
+            sample_count: stats.count,
+            recommended_bias_delta,
+            estimated_improvement,
+            capacity_starved: true,
+        });
+    }
+
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
 }

--- a/tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs
+++ b/tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs
@@ -1,0 +1,374 @@
+//! Tests for Issue #1316: Weight output bias-drift detection by class prior.
+//!
+//! Under `OneHot` / `Simplex` target topologies, an output neuron whose class
+//! has positive support but whose activation never crosses a saturating
+//! threshold for that class is suffering capacity starvation. The role-aware
+//! detector flags / weights up those neurons for growth. For every other
+//! descriptor (`Independent`, `Margin`, `Unknown`, `OTHER`) the behaviour
+//! must be identical to the legacy detector — regression guard.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. Under a `OneHot` descriptor, an output neuron that stays unsaturated for
+//!    a well-supported class is flagged / weighted up for growth.
+//! 2. `OTHER` / `Unknown` / absent ⇒ current behaviour (regression guard).
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::recommendation::output_bias_drift::{
+    detect_output_bias_drift, detect_output_bias_drift_with_descriptor,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn creature_with_one_output() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-1", "output", 0.0),
+        ],
+        synapses: vec![synapse("input-1", "output-1", 0.5)],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// 60 records — 30 with target=1.0 (positive support) and 30 with target=0.0.
+/// On the positive-support samples the activation never crosses the
+/// saturating threshold (peaks at ~0.55), so the neuron is capacity-starved.
+fn capacity_starved_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                // Positive-support class: target=1, activation stuck near 0.5,
+                // error = target - activation ≈ +0.45 (positive bias drift).
+                make_record(uuid, i, 1.0, 0.55, 0.45)
+            } else {
+                make_record(uuid, i, 0.0, 0.05, -0.05)
+            }
+        })
+        .collect()
+}
+
+/// 60 records that are *both* a capacity-starvation case under `OneHot` AND a
+/// legacy bias-drift case (mean error positive, >70% same-sign errors). Used
+/// to verify the role-aware path boosts the existing candidate.
+fn capacity_starved_and_biased_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                make_record(uuid, i, 1.0, 0.55, 0.45)
+            } else {
+                // Off-class records still record a positive error (e.g. global
+                // upward shift) so the legacy detector sees a majority-positive
+                // error signal and emits a candidate.
+                make_record(uuid, i, 0.0, 0.05, 0.10)
+            }
+        })
+        .collect()
+}
+
+/// 60 records — output neuron *does* reach the saturating region on its
+/// positive-support class (activation peaks at ~0.95 for target=1).
+fn well_saturated_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                make_record(uuid, i, 1.0, 0.95, 0.05)
+            } else {
+                make_record(uuid, i, 0.0, 0.05, -0.05)
+            }
+        })
+        .collect()
+}
+
+// =============================================================================
+// 1. OneHot descriptor flags a capacity-starved output neuron
+// =============================================================================
+#[test]
+fn one_hot_descriptor_flags_capacity_starved_output_neuron() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "OneHot + capacity-starved output must produce a candidate",
+    );
+    let starved = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .expect("capacity-starved output-1 must be present");
+    assert!(
+        starved.capacity_starved,
+        "candidate must be marked capacity_starved under OneHot",
+    );
+}
+
+// =============================================================================
+// 2. Simplex descriptor (CROSS_ENTROPY) — same flag fires
+// =============================================================================
+#[test]
+fn simplex_descriptor_flags_capacity_starved_output_neuron() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 3);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    let starved = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .expect("Simplex + capacity-starved output must produce a candidate");
+    assert!(
+        starved.capacity_starved,
+        "candidate must be marked capacity_starved under Simplex",
+    );
+}
+
+// =============================================================================
+// 3. Saturated output under OneHot — capacity_starved is false
+// =============================================================================
+#[test]
+fn one_hot_does_not_flag_well_saturated_output() {
+    let creature = creature_with_one_output();
+    let records = well_saturated_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    // The neuron may or may not emit a bias-drift candidate from its
+    // residual errors; what must NOT happen is the capacity-starved flag.
+    for c in &candidates {
+        assert!(
+            !c.capacity_starved,
+            "well-saturated output must not be flagged capacity_starved (got {})",
+            c.neuron_uuid,
+        );
+    }
+}
+
+// =============================================================================
+// 4. Neutral descriptor ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn neutral_descriptor_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let neutral = TaskDescriptor::neutral();
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &neutral,
+    );
+
+    assert_eq!(
+        legacy.len(),
+        role_aware.len(),
+        "Neutral descriptor must return the same number of candidates as legacy detector",
+    );
+    for (a, b) in legacy.iter().zip(role_aware.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid);
+        assert!(
+            !b.capacity_starved,
+            "Neutral descriptor must never set capacity_starved",
+        );
+        assert!(
+            (a.estimated_improvement - b.estimated_improvement).abs() < 1e-6,
+            "Neutral descriptor must not boost estimated_improvement",
+        );
+    }
+}
+
+// =============================================================================
+// 5. OTHER cost ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn other_cost_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let other = TaskDescriptor::from_name("OTHER", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &other,
+    );
+
+    assert_eq!(legacy.len(), role_aware.len());
+    for c in &role_aware {
+        assert!(
+            !c.capacity_starved,
+            "OTHER descriptor must never set capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 6. Independent descriptor (MSE) ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn mse_descriptor_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let mse = TaskDescriptor::from_name("MSE", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &mse,
+    );
+
+    assert_eq!(legacy.len(), role_aware.len());
+    for c in &role_aware {
+        assert!(
+            !c.capacity_starved,
+            "MSE descriptor must never set capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 7. Class with no positive support is not flagged even when unsaturated.
+// =============================================================================
+#[test]
+fn class_without_positive_support_is_not_flagged() {
+    let creature = creature_with_one_output();
+    // All records have target=0.0 — no positive support for this class.
+    let records: Vec<DiscoverRecord> = (0..60)
+        .map(|i| make_record("output-1", i, 0.0, 0.05, -0.05))
+        .collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    for c in &candidates {
+        assert!(
+            !c.capacity_starved,
+            "Class with no positive support must not be flagged capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 8. Weight-up: starved candidate has higher estimated_improvement than the
+//    same neuron under the legacy detector.
+// =============================================================================
+#[test]
+fn capacity_starved_candidate_is_weighted_up_vs_legacy() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_and_biased_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    let legacy_gain = legacy
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .map(|c| c.estimated_improvement)
+        .expect("Legacy detector must emit a candidate for the biased output neuron");
+    let role_gain = role_aware
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .map(|c| c.estimated_improvement)
+        .expect("Role-aware detector must emit a candidate for the biased output neuron");
+
+    assert!(
+        role_gain > legacy_gain,
+        "capacity-starved candidate must be weighted up: role_gain={role_gain}, legacy_gain={legacy_gain}",
+    );
+}
+
+// =============================================================================
+// 9. Hidden neurons are excluded from capacity-starvation flagging.
+// =============================================================================
+#[test]
+fn hidden_neuron_is_not_flagged_capacity_starved() {
+    // A creature with a hidden neuron; output bias drift only looks at outputs
+    // anyway, so this is mostly a sanity check that the role-aware path
+    // doesn't accidentally pull hidden neurons into the candidate set.
+    let creature = CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("hidden-1", "hidden", 0.0),
+            neuron("output-1", "output", 0.0),
+        ],
+        synapses: vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+        input: 1,
+        output: 1,
+    };
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    // Hidden neuron records also have positive support and low activation,
+    // but the output detector must ignore them.
+    let hidden_records = capacity_starved_records("hidden-1");
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("hidden-1".to_string(), hidden_records)],
+        &descriptor,
+    );
+
+    assert!(
+        candidates.iter().all(|c| c.neuron_uuid != "hidden-1"),
+        "Hidden neurons must never appear in output_bias_drift candidates",
+    );
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -7,6 +7,7 @@ mod issue_1059_disable_batch_successful;
 mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
+mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;


### PR DESCRIPTION
## Summary

Weight output bias-drift detection by class prior for `OneHot` / `Simplex`
target topologies. Output neurons that never cross a saturating threshold
on a class with positive support are flagged as **capacity-starved** and
their estimated improvement is boosted, lifting them in the candidate
ranking for growth. All other descriptors (`Independent`, `Margin`,
`Unknown`, `OTHER`, absent) fall through to the existing detector
verbatim — regression guard. Closes #1316.

## Evidence

Backend Rust crate — no UI surface to screenshot. Verified via TDD with
nine targeted integration tests in
`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`,
all green:

```
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured;
```

The full crate test suite (`cargo test --lib --tests --all-features
-- --test-threads=2`) also passes; `cargo clippy --all-targets
--all-features -- -D warnings` passes; `cargo fmt --all -- --check`
clean; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` builds.

### Dispatch wiring

```mermaid
flowchart LR
    A[input.cost_name] --> B[TaskDescriptor::from_name]
    B --> C[task_descriptor]
    C --> D[prepare_and_detect_discovery_modules]
    D --> E[append_scoring_specs]
    E --> F[detect_output_bias_drift_with_descriptor]
    F -- OneHot or Simplex --> G[flag + boost capacity-starved]
    F -- other --> H[legacy detect_output_bias_drift]
```

## Test Plan

Tests added in
`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`:

- `one_hot_descriptor_flags_capacity_starved_output_neuron` — positive
  support + activation stuck below the saturating threshold under
  `CATEGORICAL_ERROR` → `capacity_starved == true`.
- `simplex_descriptor_flags_capacity_starved_output_neuron` — same under
  `CROSS_ENTROPY` (Simplex topology).
- `one_hot_does_not_flag_well_saturated_output` — activations cross
  the saturating threshold → never flagged.
- `neutral_descriptor_matches_legacy_detector` — regression guard for
  `TaskDescriptor::neutral()`.
- `other_cost_matches_legacy_detector` — regression guard for the
  `OTHER` cost name.
- `mse_descriptor_matches_legacy_detector` — regression guard for the
  `Independent` topology.
- `class_without_positive_support_is_not_flagged` — class prior
  matters: no positive-support records ⇒ no capacity-starved flag.
- `capacity_starved_candidate_is_weighted_up_vs_legacy` — verifies the
  estimated improvement of a capacity-starved candidate is strictly
  greater than the legacy detector's gain on the same input.
- `hidden_neuron_is_not_flagged_capacity_starved` — output-only
  detector continues to ignore hidden neurons under the role-aware
  path.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1316 -->