### PR TITLE
Cost-aware early-termination / drought thresholds from TaskDescriptor

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1320.md
+++ b/docs/archive/pr-summaries/pr-summary-1320.md
@@ -1,0 +1,66 @@
+## Summary
+
+Calibrated the SPRT early-termination config and the drought-diagnostic
+threshold by the `TaskDescriptor` so classification runs are not stopped
+prematurely or falsely flagged as in drought. Absolute error scale is
+cost-dependent — a `0.1` categorical error already implies ~90% accuracy
+(excellent), while a `0.1` MSE is mediocre — so per-sample improvement
+signal is sparser on classification tasks and the thresholds must move
+accordingly. Closes #1320.
+
+Regression guard: `OTHER` / `Unknown` / neutral descriptors and any
+`Independent` (regression) topology return the existing defaults
+unchanged.
+
+## Changes
+
+- `src/analysis/early_termination.rs`
+  - New `EarlyTerminationConfig::for_task(&TaskDescriptor)`. Classification
+    topologies (`OneHot`, `Simplex`, `Margin`) double `min_samples` and lift
+    the SPRT `threshold` by `0.1` above the 50% baseline. Everything else
+    returns `Self::default()`.
+- `src/analysis/drought_diagnostic.rs`
+  - New `drought_threshold_for_task(base, &TaskDescriptor)`. Classification
+    topologies multiply the base by `CLASSIFICATION_DROUGHT_MULTIPLIER` (2,
+    saturating) so the warn / `droughtDiagnostic` fire point sits later.
+    Other topologies return `base` unchanged.
+- `src/analysis/orchestration.rs`
+  - Wired `drought_threshold_for_task` into the drought-emission path, using
+    the `task_descriptor` already computed earlier in `analyze_all`.
+
+```mermaid
+flowchart LR
+    TD[TaskDescriptor<br/>from_name] --> ETC[EarlyTerminationConfig::for_task]
+    TD --> DT[drought_threshold_for_task]
+    ETC -->|classification:<br/>min_samples x2,<br/>threshold + 0.1| SPRT[SPRT evaluator]
+    ETC -->|regression / Unknown| Defaults1[Self::default unchanged]
+    DT -->|classification:<br/>base x2 saturating| Orch[orchestration drought check]
+    DT -->|regression / Unknown| Defaults2[base unchanged]
+```
+
+## Evidence
+
+Backend-only change (no UI). Verified by the test suite:
+
+- `tests/issue_1320_task_calibrated_thresholds.rs` — 15 new tests covering:
+  - Neutral / `OTHER` / unrecognised / MSE descriptors return unchanged
+    config + drought threshold (regression guard).
+  - `CATEGORICAL_ERROR`, `CROSS_ENTROPY`, `HINGE` descriptors require
+    strictly more samples and a stricter SPRT threshold than default.
+  - `CROSS_ENTROPY` and `HINGE` share the classification profile with
+    `CATEGORICAL_ERROR`.
+  - Evaluator built from a calibrated config inherits the larger
+    `min_samples` and does not short-circuit `is_strongly_beneficial` until
+    the calibrated minimum is reached.
+  - Drought threshold is larger for all three classification costs.
+  - Drought threshold saturates safely at `u32::MAX`.
+- `./quality.sh` ran clean (fmt, clippy `-D warnings`, full test suite,
+  rustdoc, release build).
+
+## Test Plan
+
+- [x] New tests added in `tests/issue_1320_task_calibrated_thresholds.rs`
+      (15 cases — regression-guard, classification-stricter, evaluator
+      wiring, drought saturation).
+- [x] No existing tests modified.
+- [x] `./quality.sh` passes locally.

--- a/src/analysis/drought_diagnostic.rs
+++ b/src/analysis/drought_diagnostic.rs
@@ -27,6 +27,36 @@ use super::diagnostics::RejectionBreakdown;
 use super::discovery_mode::DiscoveryMode;
 use super::module_starvation_tracker::ModuleStarvationTracker;
 use super::target_failure_tracker::TargetFailureTracker;
+use super::task_descriptor::{TargetTopology, TaskDescriptor};
+
+/// Multiplier applied to the base drought threshold for classification
+/// topologies (Issue #1320). Classification per-sample signal is sparse — a
+/// trailing streak of empty passes is normal early in training — so we lift
+/// the warn / `droughtDiagnostic` fire point above the regression default.
+const CLASSIFICATION_DROUGHT_MULTIPLIER: u32 = 2;
+
+/// Calibrate the drought-diagnostic threshold to the supervised-learning task
+/// (Issue #1320).
+///
+/// Classification topologies (one-hot, simplex, margin) generate sparser
+/// per-sample improvement signal than regression — a `0.1` categorical error
+/// is excellent (~90% accuracy) while a `0.1` MSE is mediocre. Treating a
+/// short trailing-failure streak as a "drought" on a classification run fires
+/// the diagnostic prematurely and, when the operator escape hatch is enabled,
+/// can trigger an unnecessary cache / cooldown reset. This helper scales the
+/// threshold up so the warn fires later.
+///
+/// Regression guard: `OTHER` / `Unknown` / neutral descriptors and
+/// `Independent` (regression) topologies return `base` unchanged.
+#[must_use]
+pub fn drought_threshold_for_task(base: u32, descriptor: &TaskDescriptor) -> u32 {
+    match descriptor.target_topology {
+        TargetTopology::OneHot | TargetTopology::Simplex | TargetTopology::Margin => {
+            base.saturating_mul(CLASSIFICATION_DROUGHT_MULTIPLIER)
+        }
+        TargetTopology::Independent | TargetTopology::Unknown => base,
+    }
+}
 
 /// Structured payload describing the current drought state (Issue #1202).
 ///

--- a/src/analysis/early_termination.rs
+++ b/src/analysis/early_termination.rs
@@ -364,6 +364,39 @@ impl EarlyTerminationConfig {
         }
     }
 
+    /// Calibrate the early-termination config to the supervised-learning task
+    /// (Issue #1320).
+    ///
+    /// Absolute error scale is cost-dependent: a `0.1` categorical error
+    /// already implies ~90% accuracy, while a `0.1` MSE is mediocre. The
+    /// per-sample improvement signal is therefore much sparser for
+    /// classification topologies (one-hot / simplex / margin), and the SPRT
+    /// must collect more samples and require a stricter threshold before
+    /// committing to an Accept / Reject decision — otherwise a clearly
+    /// beneficial classification candidate is rejected on noise.
+    ///
+    /// Regression guard: `OTHER` / `Unknown` / neutral descriptors and any
+    /// `Independent` (regression) topology return [`Self::default`]
+    /// unchanged.
+    #[must_use]
+    pub fn for_task(descriptor: &super::task_descriptor::TaskDescriptor) -> Self {
+        use super::task_descriptor::TargetTopology;
+
+        let base = Self::default();
+        match descriptor.target_topology {
+            TargetTopology::OneHot | TargetTopology::Simplex | TargetTopology::Margin => Self {
+                // Classification: roughly double the sample budget and lift
+                // the SPRT threshold off the 50% baseline so a sparse signal
+                // is not mistaken for evidence.
+                min_samples: base.min_samples.saturating_mul(2),
+                threshold: base.threshold + 0.1,
+                ..base
+            },
+            // Independent (regression) / Unknown ⇒ current thresholds.
+            TargetTopology::Independent | TargetTopology::Unknown => base,
+        }
+    }
+
     /// Create an evaluator from this config.
     #[must_use]
     pub fn create_evaluator(&self) -> SequentialEvaluator {

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -944,7 +944,15 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // surfaces. The orchestrator owns the only call site, so the warn fires
     // at most once per `analyze_all` invocation.
     let consecutive_failures = outcome_log.consecutive_trailing_failures();
-    let drought_threshold = crate::config::drought_log_threshold();
+    // Issue #1320: calibrate the drought threshold to the task descriptor.
+    // Classification topologies generate sparse per-sample improvement signal,
+    // so the base threshold is scaled up to avoid premature drought fires.
+    // OTHER / Unknown / Independent descriptors keep the base threshold (the
+    // regression guard).
+    let drought_threshold = super::drought_diagnostic::drought_threshold_for_task(
+        crate::config::drought_log_threshold(),
+        &task_descriptor,
+    );
     if consecutive_failures >= drought_threshold {
         // Snapshot the global target-cooldown tracker. Lock failures fall back
         // to "no tracker" so the diagnostic still fires.

--- a/tests/issue_1320_task_calibrated_thresholds.rs
+++ b/tests/issue_1320_task_calibrated_thresholds.rs
@@ -1,0 +1,189 @@
+//! Tests for cost-aware early-termination / drought thresholds (Issue #1320).
+//!
+//! Verifies that the SPRT early-termination config and the drought-diagnostic
+//! threshold can be calibrated from a [`TaskDescriptor`]. Classification tasks
+//! (one-hot, simplex, margin) get more lenient (later-firing) thresholds so
+//! per-sample sparse improvements are not misread as "drought" / "no
+//! improvement", while regression and unknown / OTHER descriptors retain the
+//! current defaults (regression guard).
+
+use neat_ai_discovery::analysis::drought_diagnostic::drought_threshold_for_task;
+use neat_ai_discovery::analysis::early_termination::EarlyTerminationConfig;
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+// =============================================================================
+// EarlyTerminationConfig::for_task
+// =============================================================================
+
+#[test]
+fn early_termination_for_neutral_descriptor_matches_default() {
+    // Regression guard: OTHER / Unknown / absent should preserve the current
+    // pre-Issue-#1320 defaults exactly.
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::neutral());
+
+    assert_eq!(calibrated.enabled, default.enabled);
+    assert_eq!(calibrated.alpha, default.alpha);
+    assert_eq!(calibrated.beta, default.beta);
+    assert_eq!(calibrated.threshold, default.threshold);
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.check_interval, default.check_interval);
+}
+
+#[test]
+fn early_termination_for_other_cost_matches_default() {
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("OTHER", 4));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_unrecognised_cost_matches_default() {
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("EXOTIC_LOSS", 3));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_mse_matches_default_regression_guard() {
+    // MSE is the canonical unbounded regression cost — current thresholds are
+    // already calibrated to it, so for_task should not move them.
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("MSE", 1));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_categorical_error_requires_more_evidence() {
+    // CATEGORICAL_ERROR is binary-ish per sample — a 0.1 error already implies
+    // ~90% accuracy. Per-sample improvement signal is sparse, so we must
+    // require more samples and tighter SPRT before deciding.
+    let default = EarlyTerminationConfig::default();
+    let calibrated =
+        EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 10));
+    assert!(
+        calibrated.min_samples > default.min_samples,
+        "classification should require more samples (got {}, default {})",
+        calibrated.min_samples,
+        default.min_samples,
+    );
+    assert!(
+        calibrated.threshold > default.threshold,
+        "classification should require a stricter SPRT threshold (got {}, default {})",
+        calibrated.threshold,
+        default.threshold,
+    );
+}
+
+#[test]
+fn early_termination_for_cross_entropy_matches_classification_profile() {
+    // CROSS_ENTROPY → Simplex topology → classification profile.
+    let cross = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CROSS_ENTROPY", 5));
+    let cat = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    assert_eq!(cross.min_samples, cat.min_samples);
+    assert_eq!(cross.threshold, cat.threshold);
+}
+
+#[test]
+fn early_termination_for_hinge_matches_classification_profile() {
+    let hinge = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("HINGE", 1));
+    let cat = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    assert_eq!(hinge.min_samples, cat.min_samples);
+    assert_eq!(hinge.threshold, cat.threshold);
+}
+
+#[test]
+fn early_termination_evaluator_inherits_calibrated_min_samples() {
+    // The evaluator built from a calibrated config should pick up the larger
+    // min_samples count; verify the wiring from the field to the evaluator.
+    let calibrated =
+        EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    let evaluator = calibrated.create_evaluator();
+    // The evaluator exposes its decision; with 30 strongly-positive samples it
+    // would normally trip is_strongly_beneficial at 30, but classification
+    // needs more — the calibrated config bumps min_samples past 30 so the
+    // heuristic short-circuit must wait.
+    let mut e = evaluator;
+    e.add_batch(28, 2);
+    assert!(
+        !e.is_strongly_beneficial(),
+        "calibrated min_samples must gate is_strongly_beneficial above 30",
+    );
+}
+
+// =============================================================================
+// drought_threshold_for_task
+// =============================================================================
+
+#[test]
+fn drought_threshold_for_neutral_is_unchanged() {
+    // Regression guard: OTHER / Unknown / absent ⇒ base threshold.
+    assert_eq!(drought_threshold_for_task(5, &TaskDescriptor::neutral()), 5);
+    assert_eq!(drought_threshold_for_task(7, &TaskDescriptor::default()), 7);
+}
+
+#[test]
+fn drought_threshold_for_other_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("OTHER", 4)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_unrecognised_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("EXOTIC_LOSS", 4)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_mse_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("MSE", 1)),
+        5,
+    );
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("MAE", 1)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_classification_is_larger() {
+    // Classification: sparse per-sample signal → longer trailing streak is
+    // expected, so the drought threshold should fire later.
+    for name in ["CATEGORICAL_ERROR", "CROSS_ENTROPY", "HINGE"] {
+        let descriptor = TaskDescriptor::from_name(name, 10);
+        let calibrated = drought_threshold_for_task(5, &descriptor);
+        assert!(
+            calibrated > 5,
+            "{name}: drought threshold must scale up for classification (got {calibrated})",
+        );
+    }
+}
+
+#[test]
+fn drought_threshold_for_classification_scales_with_base() {
+    // The calibration is multiplicative-ish — a higher base should still come
+    // out higher after calibration.
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 10);
+    let low = drought_threshold_for_task(5, &descriptor);
+    let high = drought_threshold_for_task(20, &descriptor);
+    assert!(
+        high > low,
+        "calibrated threshold should respect base ordering"
+    );
+}
+
+#[test]
+fn drought_threshold_saturates_safely() {
+    // u32::MAX as base must not overflow.
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 10);
+    let out = drought_threshold_for_task(u32::MAX, &descriptor);
+    assert_eq!(out, u32::MAX);
+}


### PR DESCRIPTION
## Summary

Calibrated the SPRT early-termination config and the drought-diagnostic
threshold by the `TaskDescriptor` so classification runs are not stopped
prematurely or falsely flagged as in drought. Absolute error scale is
cost-dependent — a `0.1` categorical error already implies ~90% accuracy
(excellent), while a `0.1` MSE is mediocre — so per-sample improvement
signal is sparser on classification tasks and the thresholds must move
accordingly. Closes #1320.

Regression guard: `OTHER` / `Unknown` / neutral descriptors and any
`Independent` (regression) topology return the existing defaults
unchanged.

## Changes

- `src/analysis/early_termination.rs`
  - New `EarlyTerminationConfig::for_task(&TaskDescriptor)`. Classification
    topologies (`OneHot`, `Simplex`, `Margin`) double `min_samples` and lift
    the SPRT `threshold` by `0.1` above the 50% baseline. Everything else
    returns `Self::default()`.
- `src/analysis/drought_diagnostic.rs`
  - New `drought_threshold_for_task(base, &TaskDescriptor)`. Classification
    topologies multiply the base by `CLASSIFICATION_DROUGHT_MULTIPLIER` (2,
    saturating) so the warn / `droughtDiagnostic` fire point sits later.
    Other topologies return `base` unchanged.
- `src/analysis/orchestration.rs`
  - Wired `drought_threshold_for_task` into the drought-emission path, using
    the `task_descriptor` already computed earlier in `analyze_all`.

```mermaid
flowchart LR
    TD[TaskDescriptor<br/>from_name] --> ETC[EarlyTerminationConfig::for_task]
    TD --> DT[drought_threshold_for_task]
    ETC -->|classification:<br/>min_samples x2,<br/>threshold + 0.1| SPRT[SPRT evaluator]
    ETC -->|regression / Unknown| Defaults1[Self::default unchanged]
    DT -->|classification:<br/>base x2 saturating| Orch[orchestration drought check]
    DT -->|regression / Unknown| Defaults2[base unchanged]
```

## Evidence

Backend-only change (no UI). Verified by the test suite:

- `tests/issue_1320_task_calibrated_thresholds.rs` — 15 new tests covering:
  - Neutral / `OTHER` / unrecognised / MSE descriptors return unchanged
    config + drought threshold (regression guard).
  - `CATEGORICAL_ERROR`, `CROSS_ENTROPY`, `HINGE` descriptors require
    strictly more samples and a stricter SPRT threshold than default.
  - `CROSS_ENTROPY` and `HINGE` share the classification profile with
    `CATEGORICAL_ERROR`.
  - Evaluator built from a calibrated config inherits the larger
    `min_samples` and does not short-circuit `is_strongly_beneficial` until
    the calibrated minimum is reached.
  - Drought threshold is larger for all three classification costs.
  - Drought threshold saturates safely at `u32::MAX`.
- `./quality.sh` ran clean (fmt, clippy `-D warnings`, full test suite,
  rustdoc, release build).

## Test Plan

- [x] New tests added in `tests/issue_1320_task_calibrated_thresholds.rs`
      (15 cases — regression-guard, classification-stricter, evaluator
      wiring, drought saturation).
- [x] No existing tests modified.
- [x] `./quality.sh` passes locally.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: stservice<!-- vibe-worker-issue-1320 -->