### PR TITLE
feat(focus): margin-aware ranking for OneHot/Margin costs (Issue #1318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.75"
+version = "0.74.76"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.75"
+version = "0.74.76"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1318.md
+++ b/docs/archive/pr-summaries/pr-summary-1318.md
@@ -1,0 +1,78 @@
+# Margin-aware focus ranking for OneHot / Margin costs
+
+## Summary
+
+Focus ranking now reweights per-neuron error by the **per-observation
+decision margin** when the task descriptor reports a `OneHot` or `Margin`
+topology. Observations where the network's top-1 vs top-2 output activation
+gap is small contribute more weight; observations where the gap is wide
+contribute less. This targets the plateau where margin-improving changes
+that don't yet flip an argmax otherwise look worthless.
+
+For every other topology (`Independent`, `Simplex`, `Unknown`, `OTHER`) and
+for `None`, the legacy unweighted ranking is preserved — regression guard.
+
+Closes #1318.
+
+## Design
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor] -->|OneHot/Margin| B[compute_per_obs_margins]
+    A -->|other/None| Z[legacy unweighted ranking]
+    B --> C[margin_weights_from_margins<br/>w = 1 / (margin + 0.05)]
+    C --> D[weighted_average_absolute_error_from_records]
+    D --> E[RankedNeuron.total_error]
+    D --> F[max_output_error clamp]
+```
+
+Touch points (as scoped in the issue):
+
+- `src/focus/impact.rs` — `compute_per_obs_margins` (top-1 minus top-2 per
+  obs from recorded output activations) and `margin_weights_from_margins`
+  (`w = 1 / (margin + MARGIN_WEIGHT_EPS)`).
+- `src/focus/ranking/score_calculation.rs` —
+  `weighted_average_absolute_error_from_records` (falls back to the
+  unweighted mean when no weights are supplied).
+- `src/focus/ranking/mod.rs` —
+  `rank_focus_neurons_with_descriptor` and
+  `rank_focus_neurons_with_history_and_descriptor`. Existing
+  `rank_focus_neurons` / `rank_focus_neurons_with_history` delegate with
+  `None` so external callers see no change.
+- `src/ffi_internal/analysis.rs` — forwards `input.task_descriptor` (already
+  plumbed by #1314) into the new function.
+
+## Evidence
+
+CLI / library change with no UI. Verified via the new test module
+`tests/focus/issue_1318_margin_aware_ranking.rs` (9 tests, all green).
+Full `./quality.sh` passes — `cargo fmt`, `cargo clippy -D warnings`,
+`cargo test`, doc build, release build.
+
+## Test Plan
+
+New tests in `tests/focus/issue_1318_margin_aware_ranking.rs`:
+
+- `margins_reflect_top1_minus_top2_per_observation` — `compute_per_obs_margins`
+  returns the correct top-1 minus top-2 gap.
+- `margin_weights_upweight_small_margins` — `margin_weights_from_margins`
+  obeys the `1 / (margin + eps)` formula.
+- `one_hot_descriptor_promotes_close_margin_error_neuron` — under
+  `TargetTopology::OneHot`, the hidden neuron whose error sits on the
+  close-margin observation ranks above the mirror neuron whose error sits
+  on the wide-margin observation, despite identical unweighted means.
+- `margin_descriptor_promotes_close_margin_error_neuron` — same for
+  `TargetTopology::Margin` (HINGE).
+- `one_hot_descriptor_changes_total_error_for_close_margin_neuron` — direct
+  numeric guard that the reweighted `total_error` is strictly larger for the
+  close-margin neuron under `OneHot`.
+- `no_descriptor_matches_legacy_ranking` — passing `None` matches the legacy
+  `rank_focus_neurons` exactly.
+- `unknown_descriptor_matches_legacy_ranking` — `TaskDescriptor::neutral()`
+  matches legacy (covers `OTHER` and unrecognised cost names).
+- `independent_descriptor_matches_legacy_ranking` — `MSE` matches legacy.
+- `simplex_descriptor_matches_legacy_ranking` — `CROSS_ENTROPY` matches
+  legacy.
+
+The four regression-guard tests provide the acceptance criterion
+"`OTHER` / `Unknown` / absent ⇒ existing ranking".

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -328,11 +328,16 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
     // Uses an RAII guard so the counter is decremented even on panic.
     let _active_guard = crate::cancellation::AnalysisActiveGuard::new();
 
-    let rank_result = focus::rank_focus_neurons(
+    // Issue #1318: forward the optional task descriptor so OneHot / Margin
+    // topologies activate margin-aware focus ranking. Other topologies
+    // (Independent / Simplex / Unknown / OTHER) and `None` get the existing
+    // unweighted ranking.
+    let rank_result = focus::rank_focus_neurons_with_descriptor(
         &input.parquet_file,
         &input.creature,
         input.max_results,
         input.cost_of_growth,
+        input.task_descriptor.as_ref(),
     );
 
     match rank_result {

--- a/src/focus/impact.rs
+++ b/src/focus/impact.rs
@@ -894,6 +894,101 @@ pub fn compute_impacts_with_contract(
     compute_impacts_internal_with_stats_and_contract(creature, grouped_records, contract)
 }
 
+/// Smoothing constant for converting per-observation margin into a weight
+/// (Issue #1318). Prevents weight explosion when margin is zero and bounds
+/// the maximum weight to `1.0 / MARGIN_WEIGHT_EPS`.
+pub const MARGIN_WEIGHT_EPS: f32 = 0.05;
+
+/// Compute per-observation decision margin from recorded output activations
+/// (Issue #1318).
+///
+/// For `OneHot` / `Margin` classification topologies, the network's decision is the
+/// argmax over output activations. The **decision margin** for an observation is
+/// the gap between the top-1 and top-2 output activation: small margin ⇒ the
+/// decision is fragile, and a change that nudges the margin matters even when
+/// it does not yet flip the argmax. Large margin ⇒ the decision is dominant,
+/// and a change of similar magnitude is comparatively worthless.
+///
+/// Observations with fewer than two finite output activations are skipped.
+/// The returned map keys are `obs_index` values; observations absent from the
+/// map should be treated by callers as having an unknown / neutral margin.
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider fails to load any output
+/// neuron's records.
+pub fn compute_per_obs_margins(
+    creature: &CreatureJson,
+    grouped_records: &dyn RecordProvider,
+) -> Result<HashMap<u32, f32>> {
+    let output_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if output_uuids.len() < 2 {
+        // Margin is undefined when there are fewer than two outputs.
+        return Ok(HashMap::new());
+    }
+
+    // Collect per-observation output activations.
+    let mut obs_to_acts: HashMap<u32, Vec<f32>> = HashMap::new();
+    for uuid in &output_uuids {
+        match grouped_records.get(uuid)? {
+            None => continue,
+            Some(records) => {
+                for record in records.iter() {
+                    if record.activation.is_finite() {
+                        obs_to_acts
+                            .entry(record.obs_index)
+                            .or_default()
+                            .push(record.activation);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut margins: HashMap<u32, f32> = HashMap::with_capacity(obs_to_acts.len());
+    for (obs, acts) in obs_to_acts {
+        if acts.len() < 2 {
+            continue;
+        }
+        // Find top-1 and top-2 in a single pass.
+        let mut top1 = f32::NEG_INFINITY;
+        let mut top2 = f32::NEG_INFINITY;
+        for &v in &acts {
+            if v > top1 {
+                top2 = top1;
+                top1 = v;
+            } else if v > top2 {
+                top2 = v;
+            }
+        }
+        if top2.is_finite() {
+            margins.insert(obs, (top1 - top2).max(0.0));
+        }
+    }
+    Ok(margins)
+}
+
+/// Convert per-observation margins into per-observation weights for
+/// margin-aware error aggregation (Issue #1318).
+///
+/// Weight = `1.0 / (margin + MARGIN_WEIGHT_EPS)`. Small-margin observations
+/// (decision near a flip) get high weight; wide-margin observations (decision
+/// dominant) get low weight. This is the per-observation reweighting used by
+/// the `OneHot` / `Margin` focus ranking path.
+#[must_use]
+pub fn margin_weights_from_margins(margins: &HashMap<u32, f32>) -> HashMap<u32, f32> {
+    margins
+        .iter()
+        .map(|(&obs, &m)| (obs, 1.0 / (m.max(0.0) + MARGIN_WEIGHT_EPS)))
+        .collect()
+}
+
 /// Public version that computes impacts with activation-based selection statistics.
 ///
 /// When activation records are provided, this function computes actual win probabilities

--- a/src/focus/mod.rs
+++ b/src/focus/mod.rs
@@ -40,13 +40,15 @@ pub use gradient::{GradientFlowStats, compute_gradient_flow_stats};
 
 // From impact
 pub use impact::{
-    ConsumerContract, OutputGate, compute_impacts_public, compute_impacts_with_activations,
-    compute_impacts_with_contract, compute_selection_stats, derive_regime_threshold_from_records,
+    ConsumerContract, MARGIN_WEIGHT_EPS, OutputGate, compute_impacts_public,
+    compute_impacts_with_activations, compute_impacts_with_contract, compute_per_obs_margins,
+    compute_selection_stats, derive_regime_threshold_from_records, margin_weights_from_margins,
 };
 
 // From ranking
 pub use ranking::{
     FocusLazyReason, FocusLoadingMode, RankFocusStats, RankedNeuron, RecordProvider,
     RemovalCandidate, SelectionStats, SynapseCounts, calculate_removal_savings,
-    decide_loading_mode_for_budget, rank_focus_neurons, rank_focus_neurons_with_history,
+    decide_loading_mode_for_budget, rank_focus_neurons, rank_focus_neurons_with_descriptor,
+    rank_focus_neurons_with_history, rank_focus_neurons_with_history_and_descriptor,
 };

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -31,12 +31,16 @@ use removal_candidates::{detect_constant_neuron_removals, identify_removal_candi
 use score_calculation::{
     activation_frequency_from_records, average_absolute_error_from_records,
     compute_frequency_factor, mean_absolute_activation_from_records,
+    weighted_average_absolute_error_from_records,
 };
 
 use super::gradient::{
     build_squash_map, compute_gradient_flow_factor, compute_gradient_flow_for_neuron,
 };
-use super::impact::compute_impacts_with_activations;
+use super::impact::{
+    compute_impacts_with_activations, compute_per_obs_margins, margin_weights_from_margins,
+};
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::analysis::utils::{
     bytes_to_mb_ceil, check_memory_for_parquet, estimate_parquet_in_memory_bytes, verbose_enabled,
 };
@@ -305,9 +309,14 @@ fn log_focus_ranking_summary(
 }
 
 /// Compute max output error across all output neurons.
+///
+/// When `obs_weights` is provided (`OneHot` / `Margin` descriptors), the per-output
+/// error is reweighted by the per-observation margin weight so the clamp scale
+/// stays consistent with the margin-weighted per-neuron error (Issue #1318).
 fn compute_max_output_error(
     creature: &CreatureJson,
     records_provider: &dyn RecordProvider,
+    obs_weights: Option<&std::collections::HashMap<u32, f32>>,
 ) -> Result<f32> {
     let output_neurons: Vec<&NeuronJson> = creature
         .neurons
@@ -323,7 +332,10 @@ fn compute_max_output_error(
         .iter()
         .map(|neuron| {
             let records = get_records_or_error(records_provider, &neuron.uuid)?;
-            Ok(average_absolute_error_from_records(&records))
+            Ok(weighted_average_absolute_error_from_records(
+                &records,
+                obs_weights,
+            ))
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -331,18 +343,27 @@ fn compute_max_output_error(
 }
 
 /// Build ranked neurons from selectable neurons with their metrics.
+///
+/// When `obs_weights` is provided (`OneHot` / `Margin` descriptors), per-neuron
+/// errors are aggregated using the per-observation margin weight rather than
+/// the unweighted mean. Issue #1318.
 fn build_ranked_neurons(
     selectable: &[&NeuronJson],
     records_provider: &dyn RecordProvider,
     impact_map: &std::collections::HashMap<String, f32>,
     squash_map: &std::collections::HashMap<String, String>,
     max_output_error: f32,
+    obs_weights: Option<&std::collections::HashMap<u32, f32>>,
 ) -> Result<Vec<RankedNeuron>> {
     selectable
         .par_iter()
         .map(|neuron| -> Result<RankedNeuron> {
             let records = get_records_or_error(records_provider, &neuron.uuid)?;
-            let raw_error = average_absolute_error_from_records(&records);
+            let raw_error = if obs_weights.is_some() {
+                weighted_average_absolute_error_from_records(&records, obs_weights)
+            } else {
+                average_absolute_error_from_records(&records)
+            };
             let structural_impact = *impact_map.get(&neuron.uuid).unwrap_or(&0.0);
             let mean_activation = mean_absolute_activation_from_records(&records);
 
@@ -386,6 +407,44 @@ pub fn rank_focus_neurons(
     creature: &CreatureJson,
     max_results: Option<usize>,
     cost_of_growth: Option<f32>,
+) -> Result<RankFocusStats> {
+    rank_focus_neurons_with_descriptor(parquet_file, creature, max_results, cost_of_growth, None)
+}
+
+/// Returns `true` when the descriptor's target topology should activate
+/// margin-aware focus ranking (Issue #1318). Currently `OneHot` and `Margin`.
+fn descriptor_activates_margin_ranking(descriptor: Option<&TaskDescriptor>) -> bool {
+    descriptor.is_some_and(|d| {
+        matches!(
+            d.target_topology,
+            TargetTopology::OneHot | TargetTopology::Margin
+        )
+    })
+}
+
+/// Rank focus neurons with an optional [`TaskDescriptor`] (Issue #1318).
+///
+/// When the descriptor reports a `OneHot` or `Margin` topology, the per-neuron
+/// error component of the ranking score is replaced with a **margin-weighted**
+/// average — observations where the network's decision margin (top-1 vs top-2
+/// output activation) is small contribute more, observations where the margin
+/// is wide contribute less. This targets the plateau where margin-improving
+/// changes that don't yet flip an argmax otherwise look worthless.
+///
+/// For `OTHER` / `Unknown` / `Independent` / `Simplex` topologies and for
+/// `None`, the ranking falls back to the existing arithmetic-mean error path
+/// (regression guard).
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider or impact computation
+/// fails.
+pub fn rank_focus_neurons_with_descriptor(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
+    descriptor: Option<&TaskDescriptor>,
 ) -> Result<RankFocusStats> {
     let start = Instant::now();
     let selectable: Vec<&NeuronJson> = creature
@@ -434,7 +493,25 @@ pub fn rank_focus_neurons(
             .context("Failed to read discovery records for all selectable neurons")?;
     }
 
-    let max_output_error = compute_max_output_error(creature, records_provider.as_ref())?;
+    // Issue #1318: Under OneHot / Margin descriptors, compute per-observation
+    // margin weights from output activations. These reweight per-neuron error
+    // aggregation so candidates whose error mass lands on close-margin
+    // observations rank above those whose error mass lands on already-dominant
+    // decisions. Other topologies (Independent / Simplex / Unknown / None) fall
+    // back to the unweighted mean (regression guard).
+    let obs_weights = if descriptor_activates_margin_ranking(descriptor) {
+        let margins = compute_per_obs_margins(creature, records_provider.as_ref())?;
+        if margins.is_empty() {
+            None
+        } else {
+            Some(margin_weights_from_margins(&margins))
+        }
+    } else {
+        None
+    };
+
+    let max_output_error =
+        compute_max_output_error(creature, records_provider.as_ref(), obs_weights.as_ref())?;
 
     // Use activation-based impact calculation for more accurate MIN/MAX/IF statistics
     let impact_map = compute_impacts_with_activations(creature, records_provider.as_ref())?;
@@ -451,6 +528,7 @@ pub fn rank_focus_neurons(
         &impact_map,
         &squash_map,
         max_output_error,
+        obs_weights.as_ref(),
     )?;
 
     // Sort by weighted score (error × impact × gradient_factor × frequency_factor) to prioritise neurons that:
@@ -643,6 +721,34 @@ pub fn rank_focus_neurons_with_history(
     cost_of_growth: Option<f32>,
     history: Option<&DiscoveryHistory>,
 ) -> Result<RankFocusStats> {
+    rank_focus_neurons_with_history_and_descriptor(
+        parquet_file,
+        creature,
+        max_results,
+        cost_of_growth,
+        history,
+        None,
+    )
+}
+
+/// History-aware variant of [`rank_focus_neurons_with_descriptor`] (Issue #1318).
+///
+/// Combines the historical success multiplier with the margin-aware error
+/// reweighting under `OneHot` / `Margin` topologies. Behaviour is identical to
+/// [`rank_focus_neurons_with_history`] for other topologies and for `None`.
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider or impact computation
+/// fails.
+pub fn rank_focus_neurons_with_history_and_descriptor(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
+    history: Option<&DiscoveryHistory>,
+    descriptor: Option<&TaskDescriptor>,
+) -> Result<RankFocusStats> {
     let start = Instant::now();
     let selectable: Vec<&NeuronJson> = creature
         .neurons
@@ -690,7 +796,20 @@ pub fn rank_focus_neurons_with_history(
             .context("Failed to read discovery records for all selectable neurons")?;
     }
 
-    let max_output_error = compute_max_output_error(creature, records_provider.as_ref())?;
+    // Issue #1318: Same margin-aware reweighting as `rank_focus_neurons_with_descriptor`.
+    let obs_weights = if descriptor_activates_margin_ranking(descriptor) {
+        let margins = compute_per_obs_margins(creature, records_provider.as_ref())?;
+        if margins.is_empty() {
+            None
+        } else {
+            Some(margin_weights_from_margins(&margins))
+        }
+    } else {
+        None
+    };
+
+    let max_output_error =
+        compute_max_output_error(creature, records_provider.as_ref(), obs_weights.as_ref())?;
 
     // Use activation-based impact calculation for more accurate MIN/MAX/IF statistics
     let impact_map = compute_impacts_with_activations(creature, records_provider.as_ref())?;
@@ -708,6 +827,7 @@ pub fn rank_focus_neurons_with_history(
         &impact_map,
         &squash_map,
         max_output_error,
+        obs_weights.as_ref(),
     )?;
 
     // Sort by weighted score with optional history factor, gradient flow factor, and frequency factor

--- a/src/focus/ranking/score_calculation.rs
+++ b/src/focus/ranking/score_calculation.rs
@@ -67,6 +67,46 @@ pub(super) fn average_absolute_error_from_records(records: &[DiscoverRecord]) ->
     if count == 0 { 0.0 } else { sum / count as f32 }
 }
 
+/// Margin-weighted average absolute error (Issue #1318).
+///
+/// When `obs_weights` is provided, each record's contribution is multiplied by
+/// the per-observation weight before averaging. Observations absent from the
+/// map default to weight `1.0` (i.e. they contribute as in the unweighted mean).
+///
+/// When `obs_weights` is `None`, this is identical to
+/// [`average_absolute_error_from_records`] — used by the regression guard so
+/// callers without an `OneHot` / `Margin` descriptor get the legacy ranking.
+pub(super) fn weighted_average_absolute_error_from_records(
+    records: &[DiscoverRecord],
+    obs_weights: Option<&HashMap<u32, f32>>,
+) -> f32 {
+    let Some(weights) = obs_weights else {
+        return average_absolute_error_from_records(records);
+    };
+
+    let mut weighted_sum = 0.0f32;
+    let mut weight_total = 0.0f32;
+
+    for record in records {
+        let w = weights.get(&record.obs_index).copied().unwrap_or(1.0);
+        if !w.is_finite() || w <= 0.0 {
+            continue;
+        }
+        for err in &record.errors {
+            if err.is_finite() {
+                weighted_sum += w * err.abs();
+                weight_total += w;
+            }
+        }
+    }
+
+    if weight_total <= 0.0 {
+        0.0
+    } else {
+        weighted_sum / weight_total
+    }
+}
+
 /// Compute mean absolute activation from discovery records.
 /// Sum of |activation| divided by number of finite records.
 ///

--- a/tests/focus/issue_1318_margin_aware_ranking.rs
+++ b/tests/focus/issue_1318_margin_aware_ranking.rs
@@ -1,0 +1,492 @@
+//! Issue #1318: Margin-aware candidate ranking for argmax/margin costs.
+//!
+//! Under a `OneHot` / `Margin` task descriptor, focus ranking should reflect
+//! the **decision margin** (top-1 vs top-2 output activation) rather than the
+//! raw residual. Observations whose decision is on the edge — where the margin
+//! is small — contribute more weight to a candidate's score than observations
+//! whose decision is already dominant.
+//!
+//! These tests verify:
+//! 1. With a `OneHot` / `Margin` descriptor, the hidden neuron whose error
+//!    lands on close-margin observations ranks above one whose error lands on
+//!    wide-margin observations even when their unweighted mean errors match.
+//! 2. With `Independent` / `Simplex` / `Unknown` / `OTHER` / absent descriptors
+//!    the legacy unweighted ranking is preserved (regression guard).
+//! 3. [`compute_per_obs_margins`] correctly extracts the top-1 minus top-2 gap
+//!    from recorded output activations.
+
+#![allow(clippy::cast_precision_loss)] // Test arithmetic only.
+use std::sync::Arc;
+
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetRange, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::focus::{
+    MARGIN_WEIGHT_EPS, compute_per_obs_margins, margin_weights_from_margins, rank_focus_neurons,
+    rank_focus_neurons_with_descriptor,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Build a creature with three outputs and two hidden neurons. Each hidden
+/// neuron feeds all three outputs so structural impacts are roughly balanced.
+fn make_three_class_creature() -> CreatureJson {
+    let neurons = vec![
+        NeuronJson {
+            uuid: "h1".into(),
+            neuron_type: "hidden".into(),
+            squash: "IDENTITY".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "h2".into(),
+            neuron_type: "hidden".into(),
+            squash: "IDENTITY".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-0".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-1".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-2".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+    ];
+    let synapses = vec![
+        SynapseJson {
+            from_uuid: "input-0".into(),
+            to_uuid: "h1".into(),
+            weight: 1.0,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "input-0".into(),
+            to_uuid: "h2".into(),
+            weight: 1.0,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-0".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-1".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-2".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-0".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-1".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-2".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+    ];
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 1,
+        output: 3,
+    }
+}
+
+fn record(obs_index: u32, uuid: &str, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.into(),
+        value: Some(activation),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn write_temp_parquet(records: &[DiscoverRecord]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().expect("create temp file");
+    write_records_to_parquet(tmp.path().to_str().unwrap(), records).expect("write parquet");
+    tmp
+}
+
+/// Build the standard fixture used by the ranking tests: two observations,
+/// one with a close margin and one with a wide margin. h1 has its error
+/// concentrated on the close-margin observation, h2 on the wide-margin one.
+fn build_margin_fixture() -> (CreatureJson, NamedTempFile) {
+    let creature = make_three_class_creature();
+
+    // Observation 0 — close margin: top1=0.51 (out-0), top2=0.50 (out-1).
+    // Observation 1 — wide margin:  top1=0.95 (out-0), top2=0.10 (out-1).
+    let records = vec![
+        // out-0
+        record(0, "out-0", 0.51, 0.0),
+        record(1, "out-0", 0.95, 0.0),
+        // out-1
+        record(0, "out-1", 0.50, 0.0),
+        record(1, "out-1", 0.10, 0.0),
+        // out-2
+        record(0, "out-2", 0.05, 0.0),
+        record(1, "out-2", 0.05, 0.0),
+        // h1 has high error on close-margin obs, low error on wide obs.
+        record(0, "h1", 0.5, 0.9),
+        record(1, "h1", 0.5, 0.1),
+        // h2 has the mirror: low error on close-margin obs, high error on wide.
+        record(0, "h2", 0.5, 0.1),
+        record(1, "h2", 0.5, 0.9),
+    ];
+
+    let tmp = write_temp_parquet(&records);
+    (creature, tmp)
+}
+
+// =============================================================================
+// compute_per_obs_margins
+// =============================================================================
+
+#[test]
+fn margins_reflect_top1_minus_top2_per_observation() {
+    let (creature, tmp) = build_margin_fixture();
+
+    // Re-load the parquet via an eager provider through the public ranking API
+    // — we go through the public path so we know we are exercising the same
+    // record-provider used in production.
+    use neat_ai_discovery::parquet_format::read_all_records_grouped_by_neuron;
+    let grouped =
+        read_all_records_grouped_by_neuron(tmp.path().to_str().unwrap()).expect("read records");
+
+    struct InMemoryProvider {
+        records: std::collections::HashMap<String, Arc<Vec<DiscoverRecord>>>,
+    }
+
+    impl neat_ai_discovery::focus::RecordProvider for InMemoryProvider {
+        fn get(&self, neuron_uuid: &str) -> anyhow::Result<Option<Arc<Vec<DiscoverRecord>>>> {
+            Ok(self.records.get(neuron_uuid).cloned())
+        }
+        fn len(&self) -> usize {
+            self.records.len()
+        }
+    }
+
+    let provider = InMemoryProvider {
+        records: grouped.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
+    };
+
+    let margins = compute_per_obs_margins(&creature, &provider).expect("margins");
+    assert!(
+        (margins[&0] - 0.01).abs() < 1e-4,
+        "obs 0 margin: {}",
+        margins[&0]
+    );
+    assert!(
+        (margins[&1] - 0.85).abs() < 1e-4,
+        "obs 1 margin: {}",
+        margins[&1]
+    );
+}
+
+#[test]
+fn margin_weights_upweight_small_margins() {
+    let mut margins = std::collections::HashMap::new();
+    margins.insert(0u32, 0.01_f32);
+    margins.insert(1u32, 0.85_f32);
+
+    let weights = margin_weights_from_margins(&margins);
+
+    let w_close = weights[&0];
+    let w_wide = weights[&1];
+
+    assert!(
+        w_close > w_wide,
+        "close-margin weight {w_close} must exceed wide-margin weight {w_wide}"
+    );
+    // Sanity check the exact formula: w = 1 / (margin + eps).
+    assert!(
+        (w_close - 1.0 / (0.01 + MARGIN_WEIGHT_EPS)).abs() < 1e-4,
+        "close weight does not match formula: {w_close}"
+    );
+}
+
+// =============================================================================
+// Ranking under OneHot / Margin descriptors
+// =============================================================================
+
+fn one_hot_descriptor() -> TaskDescriptor {
+    TaskDescriptor {
+        target_topology: TargetTopology::OneHot,
+        target_range: TargetRange::Unit,
+        output_squash_family: OutputSquashFamily::BoundedUnipolar,
+        num_outputs: 3,
+    }
+}
+
+fn margin_descriptor() -> TaskDescriptor {
+    TaskDescriptor {
+        target_topology: TargetTopology::Margin,
+        target_range: TargetRange::SignedUnit,
+        output_squash_family: OutputSquashFamily::BoundedBipolar,
+        num_outputs: 3,
+    }
+}
+
+#[test]
+fn one_hot_descriptor_promotes_close_margin_error_neuron() {
+    let (creature, tmp) = build_margin_fixture();
+    let descriptor = one_hot_descriptor();
+
+    let result = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("rank focus neurons");
+
+    let h1_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h1")
+        .expect("h1 ranked");
+    let h2_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h2")
+        .expect("h2 ranked");
+
+    assert!(
+        h1_pos < h2_pos,
+        "Under OneHot, h1 (error on close margin) at {h1_pos} must rank above h2 \
+         (error on wide margin) at {h2_pos}"
+    );
+}
+
+#[test]
+fn margin_descriptor_promotes_close_margin_error_neuron() {
+    let (creature, tmp) = build_margin_fixture();
+    let descriptor = margin_descriptor();
+
+    let result = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("rank focus neurons");
+
+    let h1_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h1")
+        .expect("h1 ranked");
+    let h2_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h2")
+        .expect("h2 ranked");
+
+    assert!(
+        h1_pos < h2_pos,
+        "Under Margin, h1 (error on close margin) at {h1_pos} must rank above h2 \
+         (error on wide margin) at {h2_pos}"
+    );
+}
+
+#[test]
+fn one_hot_descriptor_changes_total_error_for_close_margin_neuron() {
+    // Direct numeric guard: under OneHot, h1's reweighted total_error must be
+    // strictly larger than h2's. Under no descriptor the two are equal.
+    let (creature, tmp) = build_margin_fixture();
+
+    let baseline =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("baseline");
+    let h1_baseline = baseline
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h1")
+        .expect("h1");
+    let h2_baseline = baseline
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h2")
+        .expect("h2");
+    assert!(
+        (h1_baseline.total_error - h2_baseline.total_error).abs() < 1e-6,
+        "baseline: equal mean errors expected, got h1={} h2={}",
+        h1_baseline.total_error,
+        h2_baseline.total_error
+    );
+
+    let descriptor = one_hot_descriptor();
+    let onehot = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("onehot");
+    let h1_onehot = onehot
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h1")
+        .expect("h1");
+    let h2_onehot = onehot
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h2")
+        .expect("h2");
+    assert!(
+        h1_onehot.total_error > h2_onehot.total_error,
+        "under OneHot: h1 total_error {} must exceed h2 {}",
+        h1_onehot.total_error,
+        h2_onehot.total_error,
+    );
+}
+
+// =============================================================================
+// Regression guard — non-margin topologies preserve legacy behaviour
+// =============================================================================
+
+#[test]
+fn no_descriptor_matches_legacy_ranking() {
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+    let with_none = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        None,
+    )
+    .expect("with_none");
+
+    assert_eq!(legacy.neurons.len(), with_none.neurons.len());
+    for (a, b) in legacy.neurons.iter().zip(with_none.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn unknown_descriptor_matches_legacy_ranking() {
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::neutral(); // Unknown / OTHER / absent.
+    let with_neutral = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with neutral descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_neutral.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn independent_descriptor_matches_legacy_ranking() {
+    // MSE / MAE / BCE produce Independent topology; the margin path must NOT
+    // engage here.
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::from_name("MSE", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::Independent);
+    let with_indep = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with independent descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_indep.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn simplex_descriptor_matches_legacy_ranking() {
+    // CROSS_ENTROPY yields Simplex topology — also not in the margin-aware
+    // set (top-1 vs top-2 attribution does not match the softmax structure).
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::Simplex);
+    let with_simplex = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with simplex descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_simplex.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}

--- a/tests/focus/main.rs
+++ b/tests/focus/main.rs
@@ -9,6 +9,7 @@ mod focus_gradient;
 mod focus_layers;
 mod focus_ranking;
 mod issue_1172_focus_ranking_memory_budget;
+mod issue_1318_margin_aware_ranking;
 mod issue_156_hidden_focus_neurons_filtered;
 mod issue_182_focus_unused_observations;
 mod issue_222_hierarchical_focus;


### PR DESCRIPTION
# Margin-aware focus ranking for OneHot / Margin costs

## Summary

Focus ranking now reweights per-neuron error by the **per-observation
decision margin** when the task descriptor reports a `OneHot` or `Margin`
topology. Observations where the network's top-1 vs top-2 output activation
gap is small contribute more weight; observations where the gap is wide
contribute less. This targets the plateau where margin-improving changes
that don't yet flip an argmax otherwise look worthless.

For every other topology (`Independent`, `Simplex`, `Unknown`, `OTHER`) and
for `None`, the legacy unweighted ranking is preserved — regression guard.

Closes #1318.

## Design

```mermaid
flowchart LR
    A[TaskDescriptor] -->|OneHot/Margin| B[compute_per_obs_margins]
    A -->|other/None| Z[legacy unweighted ranking]
    B --> C[margin_weights_from_margins<br/>w = 1 / (margin + 0.05)]
    C --> D[weighted_average_absolute_error_from_records]
    D --> E[RankedNeuron.total_error]
    D --> F[max_output_error clamp]
```

Touch points (as scoped in the issue):

- `src/focus/impact.rs` — `compute_per_obs_margins` (top-1 minus top-2 per
  obs from recorded output activations) and `margin_weights_from_margins`
  (`w = 1 / (margin + MARGIN_WEIGHT_EPS)`).
- `src/focus/ranking/score_calculation.rs` —
  `weighted_average_absolute_error_from_records` (falls back to the
  unweighted mean when no weights are supplied).
- `src/focus/ranking/mod.rs` —
  `rank_focus_neurons_with_descriptor` and
  `rank_focus_neurons_with_history_and_descriptor`. Existing
  `rank_focus_neurons` / `rank_focus_neurons_with_history` delegate with
  `None` so external callers see no change.
- `src/ffi_internal/analysis.rs` — forwards `input.task_descriptor` (already
  plumbed by #1314) into the new function.

## Evidence

CLI / library change with no UI. Verified via the new test module
`tests/focus/issue_1318_margin_aware_ranking.rs` (9 tests, all green).
Full `./quality.sh` passes — `cargo fmt`, `cargo clippy -D warnings`,
`cargo test`, doc build, release build.

## Test Plan

New tests in `tests/focus/issue_1318_margin_aware_ranking.rs`:

- `margins_reflect_top1_minus_top2_per_observation` — `compute_per_obs_margins`
  returns the correct top-1 minus top-2 gap.
- `margin_weights_upweight_small_margins` — `margin_weights_from_margins`
  obeys the `1 / (margin + eps)` formula.
- `one_hot_descriptor_promotes_close_margin_error_neuron` — under
  `TargetTopology::OneHot`, the hidden neuron whose error sits on the
  close-margin observation ranks above the mirror neuron whose error sits
  on the wide-margin observation, despite identical unweighted means.
- `margin_descriptor_promotes_close_margin_error_neuron` — same for
  `TargetTopology::Margin` (HINGE).
- `one_hot_descriptor_changes_total_error_for_close_margin_neuron` — direct
  numeric guard that the reweighted `total_error` is strictly larger for the
  close-margin neuron under `OneHot`.
- `no_descriptor_matches_legacy_ranking` — passing `None` matches the legacy
  `rank_focus_neurons` exactly.
- `unknown_descriptor_matches_legacy_ranking` — `TaskDescriptor::neutral()`
  matches legacy (covers `OTHER` and unrecognised cost names).
- `independent_descriptor_matches_legacy_ranking` — `MSE` matches legacy.
- `simplex_descriptor_matches_legacy_ranking` — `CROSS_ENTROPY` matches
  legacy.

The four regression-guard tests provide the acceptance criterion
"`OTHER` / `Unknown` / absent ⇒ existing ranking".



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1318 -->