### PR TITLE
feat(recommendation): output competition / lateral-inhibition under OneHot/Simplex (Issue #1321)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1321.md
+++ b/docs/archive/pr-summaries/pr-summary-1321.md
@@ -1,0 +1,65 @@
+## Summary
+
+Adds an output-competition / lateral-inhibition recommender gated by the
+task descriptor. Under `OneHot` / `Simplex` topologies it proposes
+inhibitory `AddSynapse(output_a → output_b)` operations when two output
+neurons co-fire strongly on the same samples; under every other topology
+(`Independent`, `Margin`, `Unknown` / `OTHER` / absent) it emits nothing,
+satisfying the regression guard in the acceptance criteria. Closes #1321.
+
+This is the stretch item in the cost-name milestone, landing after
+the bounded-squash (#1313) and bias-drift (#1316) work as required by
+the issue's ordering constraint.
+
+## Evidence
+
+Backend-only crate change with no UI surface. Verified via the unit and
+integration tests below; full `./quality.sh` passes (clippy, fmt,
+`cargo doc`, `cargo deny`, `cargo test --lib --tests --all-features`,
+release build).
+
+### Recommender flow
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor] -->|OneHot or Simplex| B[detect_output_competition]
+    A -->|Independent / Margin / Unknown / OTHER| Z[empty Vec — regression guard]
+    B --> C{>= 2 output neurons?}
+    C -->|no| Z
+    C -->|yes| D[For each output pair i<j]
+    D --> E{Existing synapse i→j?}
+    E -->|yes| D
+    E -->|no| F[Align records by obs_index<br/>both activations > 0.5]
+    F --> G{co-activated count<br/>>= MIN_DISCOVERY_SAMPLE_COUNT?}
+    G -->|no| D
+    G -->|yes| H[OutputCompetitionCandidate<br/>weight = -0.1]
+    H --> I[output_competition_to_<br/>coordinated_candidates]
+    I --> J[CoordinatedStructuralCandidateJson<br/>AddSynapse i→j, weight = -0.1]
+```
+
+## Test Plan
+
+Added `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs`
+with 11 integration tests covering both acceptance criteria:
+
+- `one_hot_descriptor_emits_inhibitory_recommendation` — OneHot + co-firing outputs ⇒ candidate emitted, weight < 0.
+- `simplex_descriptor_emits_inhibitory_recommendation` — `CROSS_ENTROPY` ⇒ candidate emitted.
+- `unknown_descriptor_emits_nothing` — neutral descriptor regression guard.
+- `other_descriptor_emits_nothing` — `OTHER` regression guard.
+- `independent_descriptor_emits_nothing` — `MSE` regression guard.
+- `margin_descriptor_emits_nothing` — `HINGE` regression guard.
+- `single_output_emits_nothing` — networks with only one output cannot compete.
+- `non_competing_outputs_emit_nothing` — disjoint firing patterns are not flagged.
+- `existing_synapse_is_not_duplicated` — pre-existing `output-a → output-b` skips the pair.
+- `coordinated_candidates_use_add_synapse_with_negative_weight` — converter emits `AddSynapse` with negative weight.
+- `forward_only_ordering_is_respected` — `from` precedes `to` in `creature.neurons[]`.
+
+Three additional in-module unit tests cover the `co_activation` helper
+and the gating shortcut.
+
+## Files Changed
+
+- `src/analysis/recommendation/output_competition.rs` — new recommender module.
+- `src/analysis/recommendation/mod.rs` — register the new module.
+- `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs` — integration tests.
+- `tests/recommendation/main.rs` — register the new test module.

--- a/src/analysis/recommendation/mod.rs
+++ b/src/analysis/recommendation/mod.rs
@@ -10,4 +10,5 @@ pub mod fan_in;
 pub mod gradient_discovery;
 pub mod multi_hop;
 pub mod output_bias_drift;
+pub mod output_competition;
 pub mod sample_weighted;

--- a/src/analysis/recommendation/output_competition.rs
+++ b/src/analysis/recommendation/output_competition.rs
@@ -1,0 +1,323 @@
+//! Output competition / lateral-inhibition recommender (Issue #1321).
+//!
+//! Under `OneHot` / `Simplex` target topologies, exactly one output class
+//! "wins" per sample. When two output neurons co-fire strongly on the same
+//! samples they are competing for the same evidence — a structural pattern
+//! lateral inhibition is designed to resolve. This recommender proposes
+//! mutual-exclusion structure between such output neurons by emitting
+//! inhibitory output→output `AddSynapse` operations (forward-only ordered
+//! so the resulting edge is valid).
+//!
+//! ## Gating
+//!
+//! - `target_topology = OneHot | Simplex` ⇒ run the detector.
+//! - Every other topology (`Independent`, `Margin`, `Unknown`, including
+//!   the neutral / `OTHER` fallbacks) ⇒ emit **nothing** (regression
+//!   guard, per the acceptance criteria of Issue #1321).
+//!
+//! ## Detection criteria
+//!
+//! 1. The creature has at least two output neurons.
+//! 2. For an ordered output pair `(a, b)` where `index_of(a) < index_of(b)`
+//!    in `creature.neurons[]` (so `AddSynapse(a → b)` respects forward-only
+//!    evaluation order):
+//!    a. Their records cover the same observation indices.
+//!    b. On at least `MIN_DISCOVERY_SAMPLE_COUNT` aligned samples both
+//!    activations exceed `CO_ACTIVATION_THRESHOLD` (they are "co-firing").
+//! 3. The pair has no existing synapse between them — we never duplicate.
+//!
+//! When all checks pass, an [`OutputCompetitionCandidate`] is emitted with
+//! a small negative `recommended_weight` (`LATERAL_INHIBITION_WEIGHT`).
+//! `output_competition_to_coordinated_candidates` packages each candidate
+//! as a single `AddSynapse` operation inside a coordinated structural
+//! candidate.
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts for neural-network statistics (Issue #873).
+
+use std::collections::{HashMap, HashSet};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Activation threshold above which an output neuron is considered to be
+/// firing strongly on a given sample. Chosen to sit comfortably inside the
+/// upper half of the unit interval so that genuine co-activation patterns
+/// (both outputs trying to "win" the same sample) are picked up while
+/// near-zero noise is excluded.
+const CO_ACTIVATION_THRESHOLD: f32 = 0.5;
+
+/// Initial inhibitory weight for proposed lateral connections. Small
+/// magnitude — the recommendation is structural; the optimiser is expected
+/// to tune it. Negative so the receiving neuron is *suppressed* when the
+/// sending neuron fires.
+const LATERAL_INHIBITION_WEIGHT: f32 = -0.1;
+
+/// Scale factor applied to the co-activation score when estimating the
+/// creature-level score gain. Kept small so output-competition candidates
+/// rank against the rest of the candidate set without dominating it.
+const COMPETITION_GAIN_SCALE: f32 = 0.01;
+
+/// A proposed inhibitory connection between two output neurons.
+#[derive(Debug, Clone)]
+pub struct OutputCompetitionCandidate {
+    /// Source output neuron (the inhibitor — fires first in evaluation order).
+    pub from_output_uuid: String,
+    /// Target output neuron (the suppressed neuron).
+    pub to_output_uuid: String,
+    /// Recommended initial weight for the inhibitory synapse. Always
+    /// negative; see the private `LATERAL_INHIBITION_WEIGHT` constant.
+    pub recommended_weight: f32,
+    /// Co-activation score in `[0, 1]` — the mean of `min(a, b)` over
+    /// samples where both outputs cross the co-activation threshold.
+    pub co_activation_score: f32,
+    /// Number of aligned co-activated samples that supported this candidate.
+    pub sample_count: usize,
+    /// Estimated creature-level score gain from applying the inhibition.
+    pub estimated_improvement: f32,
+}
+
+/// Whether a descriptor's topology gates the output-competition detector.
+fn role_aware_topology(descriptor: &TaskDescriptor) -> bool {
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Detect output competition under `OneHot` / `Simplex` topologies.
+///
+/// Returns an empty vector for any other descriptor (regression guard for
+/// `OTHER` / `Unknown` / `Independent` / `Margin`).
+///
+/// # Arguments
+/// * `creature` — the creature whose output neurons are inspected.
+/// * `neuron_records` — recorded `(uuid, records)` pairs. Only output-neuron
+///   entries are consulted; entries for non-outputs are ignored.
+/// * `descriptor` — the task descriptor; only `OneHot` / `Simplex`
+///   topologies activate detection.
+#[must_use]
+pub fn detect_output_competition(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    descriptor: &TaskDescriptor,
+) -> Vec<OutputCompetitionCandidate> {
+    if !role_aware_topology(descriptor) {
+        return Vec::new();
+    }
+
+    // Collect output neurons in their `creature.neurons[]` order so that
+    // any emitted `AddSynapse(a -> b)` respects forward-only evaluation.
+    let output_neurons: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if output_neurons.len() < 2 {
+        return Vec::new();
+    }
+
+    // Existing synapse set — we never propose a duplicate.
+    let existing: HashSet<(&str, &str)> = creature
+        .synapses
+        .iter()
+        .map(|s| (s.from_uuid.as_str(), s.to_uuid.as_str()))
+        .collect();
+
+    // Records lookup by uuid.
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for i in 0..output_neurons.len() {
+        for j in (i + 1)..output_neurons.len() {
+            let a = output_neurons[i];
+            let b = output_neurons[j];
+
+            if existing.contains(&(a, b)) {
+                continue;
+            }
+
+            let (Some(a_records), Some(b_records)) = (records_map.get(a), records_map.get(b))
+            else {
+                continue;
+            };
+
+            let Some((co_activation_score, sample_count)) = co_activation(a_records, b_records)
+            else {
+                continue;
+            };
+
+            if sample_count < MIN_DISCOVERY_SAMPLE_COUNT {
+                continue;
+            }
+
+            candidates.push(OutputCompetitionCandidate {
+                from_output_uuid: a.to_string(),
+                to_output_uuid: b.to_string(),
+                recommended_weight: LATERAL_INHIBITION_WEIGHT,
+                co_activation_score,
+                sample_count,
+                estimated_improvement: co_activation_score * COMPETITION_GAIN_SCALE,
+            });
+        }
+    }
+
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
+}
+
+/// Compute a co-activation score between two output neurons' records.
+///
+/// Returns `Some((score, count))` where:
+/// - `count` is the number of *aligned* samples (matched by `obs_index`) on
+///   which both neurons cross the co-activation threshold.
+/// - `score` is the mean of `min(a.activation, b.activation)` over those
+///   co-activated samples — bounded in `[threshold, 1]` for bounded-unipolar
+///   outputs.
+///
+/// Returns `None` when no aligned co-activated samples exist.
+fn co_activation(
+    a_records: &[DiscoverRecord],
+    b_records: &[DiscoverRecord],
+) -> Option<(f32, usize)> {
+    let b_by_idx: HashMap<u32, f32> = b_records
+        .iter()
+        .map(|r| (r.obs_index, r.activation))
+        .collect();
+
+    let mut count = 0_usize;
+    let mut sum_min = 0.0_f32;
+
+    for r in a_records {
+        let Some(&b_act) = b_by_idx.get(&r.obs_index) else {
+            continue;
+        };
+        if r.activation > CO_ACTIVATION_THRESHOLD && b_act > CO_ACTIVATION_THRESHOLD {
+            count += 1;
+            sum_min += r.activation.min(b_act);
+        }
+    }
+
+    if count == 0 {
+        return None;
+    }
+
+    Some((sum_min / count as f32, count))
+}
+
+/// Package output-competition candidates as coordinated structural
+/// candidates with a single `AddSynapse` operation each.
+#[must_use]
+pub fn output_competition_to_coordinated_candidates(
+    candidates: &[OutputCompetitionCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: c.from_output_uuid.clone(),
+                to_neuron_uuid: c.to_output_uuid.clone(),
+                weight: c.recommended_weight,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Output competition: {} ↔ {} co-fire on {} samples (score {:.3}) → propose inhibitory synapse (weight {:.3})",
+                c.from_output_uuid,
+                c.to_output_uuid,
+                c.sample_count,
+                c.co_activation_score,
+                c.recommended_weight,
+            )),
+        });
+    }
+
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NeuronJson, SynapseJson};
+
+    fn rec(uuid: &str, idx: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord {
+            obs_index: idx,
+            neuron_uuid: uuid.to_string(),
+            value: Some(0.0),
+            activation,
+            errors: vec![0.0],
+        }
+    }
+
+    fn neuron(uuid: &str, neuron_type: &str) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: neuron_type.to_string(),
+            squash: "LOGISTIC".to_string(),
+            bias: 0.0,
+        }
+    }
+
+    fn creature_with_two_outputs() -> CreatureJson {
+        CreatureJson {
+            neurons: vec![
+                neuron("input-1", "input"),
+                neuron("output-a", "output"),
+                neuron("output-b", "output"),
+            ],
+            synapses: vec![SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "output-a".to_string(),
+                weight: 0.1,
+                synapse_type: None,
+            }],
+            input: 1,
+            output: 2,
+        }
+    }
+
+    #[test]
+    fn co_activation_returns_none_for_disjoint_records() {
+        let a: Vec<_> = (0..30).map(|i| rec("a", i, 0.9)).collect();
+        let b: Vec<_> = (0..30).map(|i| rec("b", i, 0.1)).collect();
+        assert!(co_activation(&a, &b).is_none());
+    }
+
+    #[test]
+    fn co_activation_counts_only_aligned_pairs_above_threshold() {
+        let a: Vec<_> = (0..30).map(|i| rec("a", i, 0.8)).collect();
+        let b: Vec<_> = (0..30).map(|i| rec("b", i, 0.9)).collect();
+        let (score, count) = co_activation(&a, &b).expect("co-activated");
+        assert_eq!(count, 30);
+        assert!((score - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn neutral_descriptor_skips_detection() {
+        let creature = creature_with_two_outputs();
+        let records = vec![
+            (
+                "output-a".to_string(),
+                (0..30).map(|i| rec("output-a", i, 0.9)).collect(),
+            ),
+            (
+                "output-b".to_string(),
+                (0..30).map(|i| rec("output-b", i, 0.9)).collect(),
+            ),
+        ];
+        let candidates = detect_output_competition(&creature, &records, &TaskDescriptor::neutral());
+        assert!(candidates.is_empty());
+    }
+}

--- a/tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs
+++ b/tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs
@@ -1,0 +1,368 @@
+//! Tests for Issue #1321: Output competition / lateral-inhibition recommender
+//! under `OneHot` / `Simplex` target topologies.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. Under a `OneHot`/`Simplex` descriptor, the recommender proposes
+//!    inhibitory output↔output connections (or a normalisation hint) when
+//!    two output neurons co-fire on the same samples.
+//! 2. `OTHER` / `Unknown` / absent ⇒ nothing emitted (regression guard).
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::CoordinatedStructuralOpJson;
+use neat_ai_discovery::analysis::recommendation::output_competition::{
+    detect_output_competition, output_competition_to_coordinated_candidates,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Creature with one input feeding two output neurons (forward-only order
+/// preserves `output-a` before `output-b`).
+fn creature_with_two_outputs() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-a", "output", 0.0),
+            neuron("output-b", "output", 0.0),
+        ],
+        synapses: vec![
+            synapse("input-1", "output-a", 0.5),
+            synapse("input-1", "output-b", 0.5),
+        ],
+        input: 1,
+        output: 2,
+    }
+}
+
+fn creature_with_one_output() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-a", "output", 0.0),
+        ],
+        synapses: vec![synapse("input-1", "output-a", 0.5)],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// Records where two output neurons fire strongly on the same samples —
+/// classic "competition" pattern that lateral inhibition should resolve.
+fn co_firing_records() -> Vec<(String, Vec<DiscoverRecord>)> {
+    let mut a_records = Vec::new();
+    let mut b_records = Vec::new();
+    for i in 0..40 {
+        // On every sample both outputs fire strongly: this is the
+        // co-activation pattern we want to inhibit. Target alternates
+        // between the two classes so neither output is the dominant
+        // truth signal.
+        let (target_a, target_b) = if i % 2 == 0 { (1.0, 0.0) } else { (0.0, 1.0) };
+        a_records.push(make_record("output-a", i, target_a, 0.85, target_a - 0.85));
+        b_records.push(make_record("output-b", i, target_b, 0.80, target_b - 0.80));
+    }
+    vec![
+        ("output-a".to_string(), a_records),
+        ("output-b".to_string(), b_records),
+    ]
+}
+
+/// Records where two output neurons fire on disjoint sample sets — they
+/// are *not* competing. No lateral inhibition should be proposed.
+fn disjoint_firing_records() -> Vec<(String, Vec<DiscoverRecord>)> {
+    let mut a_records = Vec::new();
+    let mut b_records = Vec::new();
+    for i in 0..40 {
+        if i < 20 {
+            // a fires strongly, b stays low.
+            a_records.push(make_record("output-a", i, 1.0, 0.90, 0.10));
+            b_records.push(make_record("output-b", i, 0.0, 0.05, -0.05));
+        } else {
+            // b fires strongly, a stays low.
+            a_records.push(make_record("output-a", i, 0.0, 0.05, -0.05));
+            b_records.push(make_record("output-b", i, 1.0, 0.90, 0.10));
+        }
+    }
+    vec![
+        ("output-a".to_string(), a_records),
+        ("output-b".to_string(), b_records),
+    ]
+}
+
+// =============================================================================
+// 1. OneHot descriptor emits at least one inhibitory output↔output candidate.
+// =============================================================================
+#[test]
+fn one_hot_descriptor_emits_inhibitory_recommendation() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        !candidates.is_empty(),
+        "OneHot + co-firing outputs must produce at least one lateral-inhibition candidate",
+    );
+    for c in &candidates {
+        assert!(
+            c.recommended_weight < 0.0,
+            "lateral inhibition must use a negative weight (got {})",
+            c.recommended_weight,
+        );
+        assert_ne!(
+            c.from_output_uuid, c.to_output_uuid,
+            "self-loops must not be proposed",
+        );
+    }
+}
+
+// =============================================================================
+// 2. Simplex descriptor (CROSS_ENTROPY) — same behaviour.
+// =============================================================================
+#[test]
+fn simplex_descriptor_emits_inhibitory_recommendation() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        !candidates.is_empty(),
+        "Simplex + co-firing outputs must produce a candidate",
+    );
+    assert!(candidates.iter().all(|c| c.recommended_weight < 0.0));
+}
+
+// =============================================================================
+// 3. Neutral / Unknown descriptor — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn unknown_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let neutral = TaskDescriptor::neutral();
+
+    let candidates = detect_output_competition(&creature, &records, &neutral);
+
+    assert!(
+        candidates.is_empty(),
+        "Unknown descriptor must produce no candidates (got {})",
+        candidates.len(),
+    );
+}
+
+// =============================================================================
+// 4. OTHER descriptor — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn other_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let other = TaskDescriptor::from_name("OTHER", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &other);
+
+    assert!(candidates.is_empty(), "OTHER descriptor must emit nothing");
+}
+
+// =============================================================================
+// 5. Independent descriptor (MSE) — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn independent_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let mse = TaskDescriptor::from_name("MSE", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &mse);
+
+    assert!(
+        candidates.is_empty(),
+        "Independent (MSE) descriptor must emit nothing",
+    );
+}
+
+// =============================================================================
+// 6. Margin descriptor (HINGE) — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn margin_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let hinge = TaskDescriptor::from_name("HINGE", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &hinge);
+
+    assert!(
+        candidates.is_empty(),
+        "Margin (HINGE) descriptor must emit nothing",
+    );
+}
+
+// =============================================================================
+// 7. Single-output network — nothing to compete with.
+// =============================================================================
+#[test]
+fn single_output_emits_nothing() {
+    let creature = creature_with_one_output();
+    let records = vec![(
+        "output-a".to_string(),
+        (0..40)
+            .map(|i| make_record("output-a", i, 1.0, 0.85, 0.15))
+            .collect(),
+    )];
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        candidates.is_empty(),
+        "Single-output network cannot exhibit output competition",
+    );
+}
+
+// =============================================================================
+// 8. Non-competing outputs (disjoint firing) — nothing emitted.
+// =============================================================================
+#[test]
+fn non_competing_outputs_emit_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = disjoint_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        candidates.is_empty(),
+        "Outputs that fire on disjoint samples are not competing — none expected, got {}",
+        candidates.len(),
+    );
+}
+
+// =============================================================================
+// 9. Existing output→output synapse is not duplicated.
+// =============================================================================
+#[test]
+fn existing_synapse_is_not_duplicated() {
+    let mut creature = creature_with_two_outputs();
+    // Pre-existing inhibitory synapse output-a → output-b — the recommender
+    // must not propose another AddSynapse for the same pair.
+    creature
+        .synapses
+        .push(synapse("output-a", "output-b", -0.2));
+
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    for c in &candidates {
+        assert!(
+            !(c.from_output_uuid == "output-a" && c.to_output_uuid == "output-b"),
+            "must not propose an AddSynapse for an existing (output-a → output-b) pair",
+        );
+    }
+}
+
+// =============================================================================
+// 10. The coordinated-candidate converter emits AddSynapse operations with a
+//     negative weight (inhibitory connection).
+// =============================================================================
+#[test]
+fn coordinated_candidates_use_add_synapse_with_negative_weight() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+    assert!(!candidates.is_empty(), "test prerequisite");
+
+    let coordinated = output_competition_to_coordinated_candidates(&candidates);
+    assert_eq!(
+        coordinated.len(),
+        candidates.len(),
+        "each candidate maps to exactly one coordinated candidate",
+    );
+    for c in &coordinated {
+        assert_eq!(c.operations.len(), 1, "single AddSynapse op per candidate");
+        match &c.operations[0] {
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                weight,
+            } => {
+                assert_ne!(from_neuron_uuid, to_neuron_uuid);
+                assert!(
+                    *weight < 0.0,
+                    "lateral inhibition must use a negative weight (got {weight})",
+                );
+            }
+            other => panic!("expected AddSynapse, got {other:?}"),
+        }
+        assert!(
+            c.expected_creature_score_gain >= 0.0,
+            "expected gain must be non-negative",
+        );
+    }
+}
+
+// =============================================================================
+// 11. Forward-only ordering: only proposals where `from` precedes `to` in
+//     `creature.neurons[]` are emitted.
+// =============================================================================
+#[test]
+fn forward_only_ordering_is_respected() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    let index_of = |uuid: &str| {
+        creature
+            .neurons
+            .iter()
+            .position(|n| n.uuid == uuid)
+            .expect("uuid must exist in creature.neurons")
+    };
+
+    for c in &candidates {
+        assert!(
+            index_of(&c.from_output_uuid) < index_of(&c.to_output_uuid),
+            "candidate {} → {} violates forward-only ordering",
+            c.from_output_uuid,
+            c.to_output_uuid,
+        );
+    }
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -8,6 +8,7 @@ mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
 mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
+mod issue_1321_output_competition_lateral_inhibition;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;


### PR DESCRIPTION
## Summary

Adds an output-competition / lateral-inhibition recommender gated by the
task descriptor. Under `OneHot` / `Simplex` topologies it proposes
inhibitory `AddSynapse(output_a → output_b)` operations when two output
neurons co-fire strongly on the same samples; under every other topology
(`Independent`, `Margin`, `Unknown` / `OTHER` / absent) it emits nothing,
satisfying the regression guard in the acceptance criteria. Closes #1321.

This is the stretch item in the cost-name milestone, landing after
the bounded-squash (#1313) and bias-drift (#1316) work as required by
the issue's ordering constraint.

## Evidence

Backend-only crate change with no UI surface. Verified via the unit and
integration tests below; full `./quality.sh` passes (clippy, fmt,
`cargo doc`, `cargo deny`, `cargo test --lib --tests --all-features`,
release build).

### Recommender flow

```mermaid
flowchart LR
    A[TaskDescriptor] -->|OneHot or Simplex| B[detect_output_competition]
    A -->|Independent / Margin / Unknown / OTHER| Z[empty Vec — regression guard]
    B --> C{>= 2 output neurons?}
    C -->|no| Z
    C -->|yes| D[For each output pair i<j]
    D --> E{Existing synapse i→j?}
    E -->|yes| D
    E -->|no| F[Align records by obs_index<br/>both activations > 0.5]
    F --> G{co-activated count<br/>>= MIN_DISCOVERY_SAMPLE_COUNT?}
    G -->|no| D
    G -->|yes| H[OutputCompetitionCandidate<br/>weight = -0.1]
    H --> I[output_competition_to_<br/>coordinated_candidates]
    I --> J[CoordinatedStructuralCandidateJson<br/>AddSynapse i→j, weight = -0.1]
```

## Test Plan

Added `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs`
with 11 integration tests covering both acceptance criteria:

- `one_hot_descriptor_emits_inhibitory_recommendation` — OneHot + co-firing outputs ⇒ candidate emitted, weight < 0.
- `simplex_descriptor_emits_inhibitory_recommendation` — `CROSS_ENTROPY` ⇒ candidate emitted.
- `unknown_descriptor_emits_nothing` — neutral descriptor regression guard.
- `other_descriptor_emits_nothing` — `OTHER` regression guard.
- `independent_descriptor_emits_nothing` — `MSE` regression guard.
- `margin_descriptor_emits_nothing` — `HINGE` regression guard.
- `single_output_emits_nothing` — networks with only one output cannot compete.
- `non_competing_outputs_emit_nothing` — disjoint firing patterns are not flagged.
- `existing_synapse_is_not_duplicated` — pre-existing `output-a → output-b` skips the pair.
- `coordinated_candidates_use_add_synapse_with_negative_weight` — converter emits `AddSynapse` with negative weight.
- `forward_only_ordering_is_respected` — `from` precedes `to` in `creature.neurons[]`.

Three additional in-module unit tests cover the `co_activation` helper
and the gating shortcut.

## Files Changed

- `src/analysis/recommendation/output_competition.rs` — new recommender module.
- `src/analysis/recommendation/mod.rs` — register the new module.
- `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs` — integration tests.
- `tests/recommendation/main.rs` — register the new test module.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1321 -->