### PR TITLE
feat(allocation): per-class capacity allocation under OneHot (#1319)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.76"
+version = "0.74.77"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.76"
+version = "0.74.77"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1319.md
+++ b/docs/archive/pr-summaries/pr-summary-1319.md
@@ -1,0 +1,85 @@
+## Summary
+
+Under a `OneHot` task descriptor (e.g. `CATEGORICAL_ERROR`) the growth /
+candidate budget for add-neuron candidates now skews toward output neurons
+(classes) with the highest per-target failure counts, reusing the existing
+failure signal already supplied via `failure_cache` (Issue #1131, #1194)
+and documented on the per-target trackers in
+`src/analysis/within_batch_failures.rs` and
+`src/analysis/target_failure_tracker.rs`. The cost identity confirms the
+outputs are exchangeable classes, so per-class allocation is well-defined.
+For every other descriptor (`Independent`, `Margin`, `Simplex`, `Unknown`,
+`OTHER`, absent) the existing allocation runs verbatim — regression
+guard. Closes #1319.
+
+## Evidence
+
+Backend Rust crate — no UI surface to screenshot. Verified via TDD with a
+new pure module
+[`src/analysis/one_hot_class_allocation.rs`](../../../src/analysis/one_hot_class_allocation.rs)
+plus a dedicated integration test file
+[`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`](../../../tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs)
+and inline unit tests inside the neuron post-processing module. The full
+`./quality.sh` gate passes cleanly:
+
+```
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured (neuron::post_processing)
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured (one_hot_class_allocation)
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured (tests/recommendation/issue_1319)
+✅ All quality checks passed!
+```
+
+### Allocation dispatch
+
+```mermaid
+flowchart LR
+    A[AnalyzeAllInput.cost_name] --> B[TaskDescriptor::from_name]
+    B --> C[task_descriptor]
+    C --> D[AnalyzeNeuronsInput.task_descriptor]
+    D --> E[build_neuron_results]
+    E --> F[build_one_hot_class_priority]
+    F -- OneHot + failure_cache --> G[apply_class_priority_spread]
+    F -- OTHER/Unknown/absent --> H[apply_distinct_target_spread]
+    G --> I[apply_per_target_cap]
+    H --> I
+```
+
+## Test Plan
+
+Integration tests in
+`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`:
+
+- `one_hot_descriptor_computes_per_class_failure_counts` — under
+  `CATEGORICAL_ERROR`, aggregates per-output-neuron failures from the
+  failure cache; hidden / non-output targets are excluded; classes with
+  zero failures are omitted.
+- `neutral_descriptor_yields_no_class_failure_counts` — `neutral`,
+  `MSE`, `OTHER`, and `HINGE` descriptors all return `None`, opting out
+  of per-class allocation (regression guard).
+- `class_priority_spread_pulls_worst_classes_to_front` — the highest-
+  failure classes occupy the front of the reordered list before the
+  per-target cap is applied.
+- `empty_priority_map_is_a_noop` — an empty priority map preserves the
+  gain-sorted order verbatim.
+- `class_priority_spread_keeps_highest_gain_representative` — within
+  each priority slot, the highest-gain candidate is chosen.
+- `class_priority_spread_falls_through_when_pool_too_narrow` — when the
+  pool contains fewer distinct targets than the spread requires, the
+  list is left untouched.
+
+Inline unit tests in `src/analysis/one_hot_class_allocation.rs`:
+
+- `one_hot_aggregates_failures_per_output_class`
+- `non_one_hot_topologies_return_none` (covers MSE, MAE, MAPE, BCE, CE, HINGE)
+- `empty_failure_cache_under_one_hot_returns_empty_map`
+- `non_output_targets_are_skipped`
+
+Inline unit tests in `src/analysis/neuron/post_processing.rs`:
+
+- `per_target_cap_with_priority_pulls_high_priority_targets_to_front` —
+  end-to-end check that `apply_per_target_cap_with_priority` lets the
+  priority spread reach the emitted batch.
+- `per_target_cap_with_no_priority_matches_legacy_path` — regression
+  guard: `None` priority is byte-identical to the existing path.
+- `per_target_cap_with_empty_priority_uses_legacy_spread` — empty
+  priority map preserves the gain-sorted order.

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -73,6 +73,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let err =
@@ -780,6 +781,7 @@ fn analyze_neurons_reports_diagnostics_when_no_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result =
@@ -893,6 +895,7 @@ fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = pool

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -51,6 +51,7 @@ pub mod module_starvation_tracker;
 pub mod module_weights;
 pub mod neuron;
 pub mod neuron_fingerprint;
+pub mod one_hot_class_allocation;
 pub mod quantised_error;
 pub mod recent_failure_window;
 pub mod samples;

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -125,12 +125,24 @@ pub(crate) fn build_neuron_results(
     // remaining cap budget is spent on genuinely distinct proposals.
     let same_target_squash_drops = apply_same_target_squash_diversity(&mut helpful_results);
 
+    // Issue #1319: Under a OneHot task descriptor (e.g. CATEGORICAL_ERROR)
+    // bias the per-target cap's distinct-target spread toward output neurons
+    // (classes) with the highest cumulative per-target failure counts. The
+    // helper returns `None` for every non-OneHot descriptor (including OTHER /
+    // Unknown / absent) so the legacy allocation path is preserved verbatim.
+    let class_priority = build_one_hot_class_priority(
+        params.input.task_descriptor.as_ref(),
+        params.input.failure_cache.as_deref().unwrap_or(&[]),
+        params.neuron_type_map,
+    );
+
     // Issue #1140: Cap add-neuron candidates per target within a single
     // discovery batch. Without this cap, a single hopeless target can consume
     // most of the budget with minor variants (e.g. 17 of 19 failed add-neuron
     // candidates in GRQ-sampler commit 744ac60d targeted the same neuron).
     // The cross-batch cooldown (Issue #1130) does not help within a batch.
-    let per_target_cap_drops = apply_per_target_cap(&mut helpful_results);
+    let per_target_cap_drops =
+        apply_per_target_cap_with_priority(&mut helpful_results, class_priority.as_ref());
 
     // Deadline coverage (Jan 2026): diversify within the top-K
     if params.input.analysis_deadline_ms.is_some() {
@@ -391,7 +403,23 @@ pub(crate) fn apply_same_target_squash_diversity(
 /// gain-descending order) followed by the remaining candidates in gain-
 /// descending order. Returns the number of candidates dropped by the cap so
 /// callers can record it in the rejection breakdown.
+#[cfg(test)]
 pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) -> usize {
+    apply_per_target_cap_with_priority(candidates, None)
+}
+
+/// Issue #1319: Like [`apply_per_target_cap`] but accepts an optional
+/// per-target priority map. When `Some`, the cross-target spread step is
+/// replaced by
+/// [`crate::analysis::one_hot_class_allocation::apply_class_priority_spread`],
+/// which pulls the highest-priority targets (e.g. worst-performing output
+/// classes under a `OneHot` descriptor) to the front of the list before the
+/// per-target cap is applied. Passing `None` reproduces the legacy
+/// allocation verbatim — regression guard.
+pub(crate) fn apply_per_target_cap_with_priority(
+    candidates: &mut Vec<CandidateNeuronJson>,
+    class_priority: Option<&HashMap<String, u32>>,
+) -> usize {
     let cap = crate::analysis::constants::max_add_neuron_candidates_per_target();
     if candidates.is_empty() || cap == 0 {
         return 0;
@@ -405,11 +433,21 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
             .total_cmp(&a.expected_creature_score_gain)
     });
 
-    // Issue #1193: reorder so the top of the list covers at least
+    // Issue #1193 / #1319: reorder so the top of the list covers at least
     // `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets when the pool supports
-    // it. This stops a single problematic target from filling all three cap
-    // slots before any other target is considered.
-    apply_distinct_target_spread(candidates);
+    // it. Under a OneHot descriptor with class-failure priority the worst-
+    // performing classes are pulled to the front first.
+    let min_distinct = crate::analysis::constants::min_distinct_targets_per_batch();
+    match class_priority {
+        Some(priority) if !priority.is_empty() => {
+            crate::analysis::one_hot_class_allocation::apply_class_priority_spread(
+                candidates,
+                priority,
+                min_distinct,
+            );
+        }
+        _ => apply_distinct_target_spread(candidates),
+    }
 
     let original_len = candidates.len();
     let mut per_target: HashMap<String, usize> = HashMap::new();
@@ -425,6 +463,39 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
         }
     });
     original_len - candidates.len()
+}
+
+/// Issue #1319: Build the per-output-class priority map used by
+/// [`apply_per_target_cap_with_priority`].
+///
+/// Returns `None` when the supplied `task_descriptor` is not `OneHot` (or is
+/// absent / neutral / `OTHER`), preserving the legacy allocation path
+/// verbatim — regression guard. When `OneHot`, returns a map from each output
+/// neuron UUID to its cumulative within-batch / cross-batch failure count
+/// derived from `failure_cache` (Issue #1131, #1194). An empty map (no
+/// recorded class failures yet) is also returned as `None` so the legacy
+/// spread keeps the gain-order signal when there is no per-class evidence.
+fn build_one_hot_class_priority(
+    task_descriptor: Option<&crate::analysis::task_descriptor::TaskDescriptor>,
+    failure_cache: &[crate::analysis::scoring::calibration_correction::FailureCacheEntry],
+    neuron_type_map: &HashMap<super::preparation::SharedUuid, String>,
+) -> Option<HashMap<String, u32>> {
+    let descriptor = task_descriptor?;
+    let counts = crate::analysis::one_hot_class_allocation::compute_class_failure_counts(
+        descriptor,
+        failure_cache,
+        |uuid| {
+            neuron_type_map
+                .get(uuid)
+                .map(String::as_str)
+                .is_some_and(|t| t == "output")
+        },
+    )?;
+    if counts.is_empty() {
+        None
+    } else {
+        Some(counts)
+    }
 }
 
 /// Cross-target diversity spread (Issue #1193).
@@ -490,7 +561,8 @@ pub(crate) fn apply_distinct_target_spread(candidates: &mut Vec<CandidateNeuronJ
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_distinct_target_spread, apply_per_target_cap, apply_same_target_squash_diversity,
+        apply_distinct_target_spread, apply_per_target_cap, apply_per_target_cap_with_priority,
+        apply_same_target_squash_diversity,
     };
     use crate::CandidateNeuronJson;
     use serial_test::serial;
@@ -934,5 +1006,108 @@ mod tests {
         assert_eq!(candidates.len(), 1, "cap=1 should leave only one candidate");
         assert_eq!(dropped, 2);
         assert!((candidates[0].expected_creature_score_gain - 0.9).abs() < f32::EPSILON);
+    }
+
+    // =========================================================================
+    // Issue #1319 — per-class capacity allocation under OneHot
+    // =========================================================================
+
+    /// When the per-target cap is invoked with a non-empty priority map, the
+    /// spread step pulls the highest-priority targets to the front of the
+    /// list before the cap is applied. Mirrors the `OneHot` acceptance criterion
+    /// from issue #1319.
+    #[test]
+    #[serial]
+    fn per_target_cap_with_priority_pulls_high_priority_targets_to_front() {
+        let mut candidates = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+        let mut priority: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+        priority.insert("target-D".to_string(), 7);
+        priority.insert("target-C".to_string(), 5);
+
+        let _dropped = apply_per_target_cap_with_priority(&mut candidates, Some(&priority));
+
+        // Cap defaults to 3; the spread fronts target-D and target-C ahead of
+        // the cap, so they must be present in the emitted batch even though
+        // target-A had the gain-dominant candidates.
+        let distinct: HashSet<&str> = candidates
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert!(distinct.contains("target-D"));
+        assert!(distinct.contains("target-C"));
+
+        // Front of the emitted list must lead with the priority targets.
+        assert_eq!(candidates[0].target_neuron_uuid, "target-D");
+        assert_eq!(candidates[1].target_neuron_uuid, "target-C");
+    }
+
+    /// Regression guard: `None` priority preserves the existing distinct-
+    /// target spread behaviour byte-for-byte.
+    #[test]
+    #[serial]
+    fn per_target_cap_with_no_priority_matches_legacy_path() {
+        let mut legacy = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+        let mut with_none = legacy.clone();
+
+        let dropped_legacy = apply_per_target_cap(&mut legacy);
+        let dropped_with_none = apply_per_target_cap_with_priority(&mut with_none, None);
+        assert_eq!(dropped_legacy, dropped_with_none);
+        let legacy_view: Vec<(String, f32)> = legacy
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+        let new_view: Vec<(String, f32)> = with_none
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+        assert_eq!(legacy_view, new_view);
+    }
+
+    /// Acceptance: an empty priority map is treated as no signal, so the
+    /// legacy distinct-target spread runs (regression guard).
+    #[test]
+    #[serial]
+    fn per_target_cap_with_empty_priority_uses_legacy_spread() {
+        let empty: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+        let mut legacy = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+        ];
+        let mut with_empty = legacy.clone();
+
+        apply_per_target_cap(&mut legacy);
+        apply_per_target_cap_with_priority(&mut with_empty, Some(&empty));
+
+        let legacy_view: Vec<&str> = legacy
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        let new_view: Vec<&str> = with_empty
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert_eq!(legacy_view, new_view);
     }
 }

--- a/src/analysis/one_hot_class_allocation.rs
+++ b/src/analysis/one_hot_class_allocation.rs
@@ -1,0 +1,239 @@
+//! Per-class capacity allocation under a `OneHot` task descriptor
+//! (Issue #1319).
+//!
+//! When the producer reports a `OneHot` target topology (e.g.
+//! `CATEGORICAL_ERROR`), the output neurons are exchangeable class scores —
+//! the cost identity confirms per-class allocation is well-defined. This
+//! module skews the growth/candidate budget toward output neurons (classes)
+//! with the highest cumulative per-target failure counts, using the
+//! existing per-target failure signal already supplied via the
+//! `failure_cache` field on the discovery FFI inputs (Issue #1131) and the
+//! per-target trackers documented in
+//! [`crate::analysis::within_batch_failures`] and
+//! [`crate::analysis::target_failure_tracker`].
+//!
+//! The contract is intentionally narrow:
+//!
+//! - For non-`OneHot` descriptors (`Independent`, `Margin`, `Simplex`,
+//!   `Unknown`, `OTHER`, absent) [`compute_class_failure_counts`] returns
+//!   `None`, leaving the legacy allocation path untouched (regression
+//!   guard, per the issue acceptance criteria).
+//! - [`apply_class_priority_spread`] reorders a gain-sorted candidate list so
+//!   the front contains up to `max_distinct` distinct targets ordered by
+//!   descending priority (with ties broken by descending gain). The tail
+//!   preserves the remaining candidates in their original gain order. This
+//!   is a strict generalisation of the legacy `apply_distinct_target_spread`
+//!   helper in [`crate::analysis::neuron`] — passing an empty priority map
+//!   produces the same no-op behaviour as the legacy spread when there is
+//!   no per-class signal yet.
+//!
+//! Both functions are pure (no I/O, no global state) and operate on plain
+//! data, so they are exercised by integration tests in
+//! `tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::CandidateNeuronJson;
+use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
+
+/// Aggregate per-output-class failure counts from the supplied failure cache
+/// when, and only when, `descriptor.target_topology` is `OneHot`.
+///
+/// Returns `None` for every other topology — including `Unknown`,
+/// `Independent`, `Simplex`, `Margin`, and the neutral / OTHER descriptor —
+/// so callers can fall straight through to the legacy allocation path
+/// (acceptance criterion: "`OTHER` / `Unknown` / absent ⇒ existing
+/// allocation").
+///
+/// `is_output` is invoked to decide which `target_uuid`s in the cache are
+/// output neurons (i.e. classes). Hidden / input / constant targets are
+/// skipped — only output-neuron failures form the per-class budget signal.
+/// Entries that lack a `target_uuid` (legacy payloads, Issue #1194) are
+/// ignored.
+///
+/// The returned map omits classes with zero recorded failures so callers can
+/// cheaply detect "no signal yet" via `is_empty()`.
+#[must_use]
+pub fn compute_class_failure_counts(
+    descriptor: &TaskDescriptor,
+    failure_cache: &[FailureCacheEntry],
+    is_output: impl Fn(&str) -> bool,
+) -> Option<HashMap<String, u32>> {
+    if descriptor.target_topology != TargetTopology::OneHot {
+        return None;
+    }
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for entry in failure_cache {
+        let Some(target_uuid) = entry.target_uuid.as_deref() else {
+            continue;
+        };
+        if !is_output(target_uuid) {
+            continue;
+        }
+        *counts.entry(target_uuid.to_string()).or_insert(0) = counts
+            .get(target_uuid)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+    }
+    Some(counts)
+}
+
+/// Reorder a gain-sorted candidate list so the front contains the
+/// highest-gain candidate for each of up to `max_distinct` distinct targets,
+/// ordered by descending priority (with ties broken by descending gain).
+///
+/// Preconditions:
+///
+/// - `candidates` is sorted by `expected_creature_score_gain` descending
+///   (NaN-safe via `total_cmp`).
+/// - `priority` maps a `target_neuron_uuid` to its priority weight.
+///   Targets absent from the map are treated as priority `0`.
+///
+/// Postconditions:
+///
+/// - When the candidate pool contains at least `max_distinct` distinct
+///   targets, the front of the list contains the highest-gain representative
+///   of the `max_distinct` highest-priority targets. The tail preserves the
+///   remaining candidates in their original gain order (a stable partition).
+/// - When the pool has fewer distinct targets than `max_distinct` requires,
+///   the list is left untouched — same fall-through contract as the legacy
+///   `apply_distinct_target_spread` helper.
+/// - When `priority` is empty, the function behaves identically to the
+///   legacy spread (the first occurrence of each distinct target is chosen
+///   in gain order, since priority ties break by best-index ascending).
+/// - No candidates are added or removed; only the order changes.
+pub fn apply_class_priority_spread(
+    candidates: &mut Vec<CandidateNeuronJson>,
+    priority: &HashMap<String, u32>,
+    max_distinct: usize,
+) {
+    if candidates.len() <= 1 || max_distinct <= 1 {
+        return;
+    }
+
+    // First occurrence (smallest index) of each distinct target in the
+    // gain-sorted list — that is, the highest-gain representative for that
+    // target.
+    let mut first_index_per_target: HashMap<String, usize> = HashMap::new();
+    for (i, c) in candidates.iter().enumerate() {
+        first_index_per_target
+            .entry(c.target_neuron_uuid.clone())
+            .or_insert(i);
+    }
+
+    // Fall through when the pool cannot support the requested spread.
+    if first_index_per_target.len() < max_distinct {
+        return;
+    }
+
+    // Order distinct targets by descending priority; ties broken by
+    // ascending first-index (i.e. descending gain). This makes the
+    // empty-priority case identical to the legacy spread.
+    let mut ordered: Vec<(usize, u32)> = first_index_per_target
+        .iter()
+        .map(|(target, &idx)| (idx, priority.get(target).copied().unwrap_or(0)))
+        .collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    let head_indices: Vec<usize> = ordered.iter().take(max_distinct).map(|(i, _)| *i).collect();
+    let head_index_set: HashSet<usize> = head_indices.iter().copied().collect();
+
+    // Stable partition: drain candidates into Option slots so we can pull
+    // out the head in priority order without disturbing the relative order
+    // of the tail.
+    let mut slots: Vec<Option<CandidateNeuronJson>> = candidates.drain(..).map(Some).collect();
+    let mut head: Vec<CandidateNeuronJson> = Vec::with_capacity(head_indices.len());
+    for idx in &head_indices {
+        head.push(
+            slots[*idx]
+                .take()
+                .expect("head indices are unique by construction"),
+        );
+    }
+    let mut tail: Vec<CandidateNeuronJson> = Vec::with_capacity(slots.len());
+    for (idx, slot) in slots.into_iter().enumerate() {
+        if head_index_set.contains(&idx) {
+            // Already moved to head.
+            debug_assert!(slot.is_none());
+            continue;
+        }
+        if let Some(c) = slot {
+            tail.push(c);
+        }
+    }
+    candidates.extend(head);
+    candidates.extend(tail);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
+
+    fn fc(target_uuid: &str) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: "add-neurons".to_string(),
+            expected_error_reduction: 0.1,
+            actual_error_reduction: -0.01,
+            target_squash: None,
+            variant_key: None,
+            target_uuid: Some(target_uuid.to_string()),
+            improved_count: None,
+            total_count: None,
+        }
+    }
+
+    #[test]
+    fn one_hot_aggregates_failures_per_output_class() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let cache = vec![fc("o-A"), fc("o-A"), fc("o-B")];
+        let outputs: HashSet<&str> = ["o-A", "o-B"].into_iter().collect();
+        let counts = compute_class_failure_counts(&descriptor, &cache, |u| outputs.contains(u))
+            .expect("OneHot must produce a map");
+        assert_eq!(counts.get("o-A").copied(), Some(2));
+        assert_eq!(counts.get("o-B").copied(), Some(1));
+    }
+
+    #[test]
+    fn non_one_hot_topologies_return_none() {
+        let cache = vec![fc("o-A")];
+        for name in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "BINARY_CROSS_ENTROPY",
+            "CROSS_ENTROPY",
+            "HINGE",
+        ] {
+            let descriptor = TaskDescriptor::from_name(name, 4);
+            assert!(
+                compute_class_failure_counts(&descriptor, &cache, |_| true).is_none(),
+                "{name} must opt out of per-class allocation",
+            );
+        }
+        assert!(
+            compute_class_failure_counts(&TaskDescriptor::neutral(), &cache, |_| true).is_none()
+        );
+    }
+
+    #[test]
+    fn empty_failure_cache_under_one_hot_returns_empty_map() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let counts = compute_class_failure_counts(&descriptor, &[], |_| true)
+            .expect("OneHot must still produce a (possibly empty) map");
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn non_output_targets_are_skipped() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let cache = vec![fc("o-A"), fc("h-1")];
+        let outputs: HashSet<&str> = ["o-A"].into_iter().collect();
+        let counts = compute_class_failure_counts(&descriptor, &cache, |u| outputs.contains(u))
+            .expect("OneHot must produce a map");
+        assert_eq!(counts.get("o-A").copied(), Some(1));
+        assert!(!counts.contains_key("h-1"));
+    }
+}

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -531,6 +531,9 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             temperature: input.temperature,
             failure_cache: input.failure_cache.clone(),
             discovery_outcome_log: input.discovery_outcome_log.clone(),
+            // Issue #1319: thread the task descriptor down so the neuron
+            // post-processing can bias per-class allocation under OneHot.
+            task_descriptor: Some(task_descriptor),
         })
     } else {
         None

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -208,6 +208,13 @@ pub struct AnalyzeNeuronsInput {
     /// When absent or empty, cooldown uses the static configured thresholds.
     #[serde(default)]
     pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
+    /// Task-shape descriptor derived from `AnalyzeAllInput::cost_name`
+    /// (Issue #1319). Threaded down so the neuron post-processing path can
+    /// bias per-class allocation under a `OneHot` descriptor. `None` (or a
+    /// non-`OneHot` topology) preserves the existing allocation verbatim —
+    /// regression guard.
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// Internal input structure for combined analysis (used by `analyze_parallel`)

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -127,6 +127,7 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/leaky_relu_filtered.rs
+++ b/tests/activation/leaky_relu_filtered.rs
@@ -74,6 +74,7 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/relu_adjacent_filtered.rs
+++ b/tests/activation/relu_adjacent_filtered.rs
@@ -78,6 +78,7 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/step_hidden_neuron_prediction.rs
+++ b/tests/activation/step_hidden_neuron_prediction.rs
@@ -173,6 +173,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -266,6 +267,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -373,6 +375,7 @@ fn test_step_output_neuron_no_identity_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -203,6 +203,7 @@ fn neuron_analysis_respects_deadline() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let start = Instant::now();
@@ -289,6 +290,7 @@ fn focus_neurons_are_randomised_across_runs() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).expect("Analysis should complete successfully");

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -156,6 +156,7 @@ fn test_optimised_params_vary_by_sample() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -236,6 +237,7 @@ fn test_conservative_params_more_stable_across_samples() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let subset_result = analyze_neurons(&subset_input).unwrap();
@@ -371,6 +373,7 @@ fn test_relu_fixed_params_consistent_across_samples() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).unwrap();

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -106,6 +106,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -163,6 +164,7 @@ fn input_neuron_reported_as_filtered_in_neuron_diagnostics() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/analysis/split_error_all_activations.rs
+++ b/tests/analysis/split_error_all_activations.rs
@@ -152,6 +152,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -286,6 +287,7 @@ fn test_skewed_errors_return_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/split_error_fallback_candidates.rs
+++ b/tests/analysis/split_error_fallback_candidates.rs
@@ -169,6 +169,7 @@ fn regression_split_error_must_return_fallback_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -352,6 +353,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
@@ -127,6 +127,7 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -134,6 +134,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -266,6 +267,7 @@ fn test_all_new_activations_produce_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -157,6 +157,7 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     // Run analysis - this uses the GPU work queue internally

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -92,6 +92,7 @@ fn neuron_analysis_with_deadline_completes() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis with deadline should succeed");
@@ -177,6 +178,7 @@ fn analysis_with_expired_deadline_returns_promptly() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let start = std::time::Instant::now();

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -334,6 +334,7 @@ fn neuron_analysis_timing_collected() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -511,6 +511,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -609,6 +610,7 @@ fn test_bias_values_are_activation_specific() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -881,6 +883,7 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -992,6 +995,7 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1093,6 +1097,7 @@ fn test_bias_improves_neuron_performance() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1225,6 +1230,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1390,6 +1396,7 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/neuron/issue_834_lock_free_error_collection.rs
+++ b/tests/neuron/issue_834_lock_free_error_collection.rs
@@ -162,6 +162,7 @@ fn test_lock_free_error_collection_many_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -245,6 +245,7 @@ fn test_add_neuron_between_hidden_neurons() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -357,6 +358,7 @@ fn test_hidden_neuron_candidate_properties() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs
+++ b/tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs
@@ -1,0 +1,272 @@
+//! Tests for Issue #1319: Per-class capacity allocation under `one_hot` using
+//! the existing per-target failure counters.
+//!
+//! Under a `OneHot` task descriptor the growth/candidate budget must skew
+//! toward output neurons (classes) with the highest per-target failure
+//! counts. For every other descriptor (`Independent`, `Margin`, `Unknown`,
+//! `OTHER`, absent) the existing allocation must hold verbatim — regression
+//! guard.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::collections::HashMap;
+
+use neat_ai_discovery::CandidateNeuronJson;
+use neat_ai_discovery::analysis::one_hot_class_allocation::{
+    apply_class_priority_spread, compute_class_failure_counts,
+};
+use neat_ai_discovery::analysis::scoring::calibration_correction::FailureCacheEntry;
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+fn fc_entry(target_uuid: &str) -> FailureCacheEntry {
+    FailureCacheEntry {
+        change_type: "add-neurons".to_string(),
+        expected_error_reduction: 0.1,
+        actual_error_reduction: -0.01,
+        target_squash: None,
+        variant_key: None,
+        target_uuid: Some(target_uuid.to_string()),
+        improved_count: None,
+        total_count: None,
+    }
+}
+
+fn candidate(target_uuid: &str, gain: f32) -> CandidateNeuronJson {
+    CandidateNeuronJson {
+        source_neuron_uuid: format!("source-{target_uuid}-{gain}"),
+        target_neuron_uuid: target_uuid.to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.0,
+        outgoing_weight: 1.0,
+        squash: format!("SQUASH-{gain}"),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: gain,
+        expected_creature_score_gain: gain,
+        improved_count: 10,
+        total_count: 10,
+        improvement_magnitude_ratio: None,
+        target_neuron_stats: None,
+        prediction_confidence: 0.5,
+        expected_score_gain_confidence_interval: [gain, gain],
+        target_saturation_factor: None,
+        variant_key: None,
+    }
+}
+
+/// Acceptance #1: under `OneHot`, per-class failure counts derived from
+/// `failure_cache` map output neurons to their cumulative failure count.
+#[test]
+fn one_hot_descriptor_computes_per_class_failure_counts() {
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+    let cache = vec![
+        fc_entry("output-A"),
+        fc_entry("output-A"),
+        fc_entry("output-A"),
+        fc_entry("output-B"),
+        fc_entry("hidden-X"), // hidden, must not be counted as a class
+    ];
+
+    let outputs: std::collections::HashSet<String> = ["output-A", "output-B", "output-C"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    let counts = compute_class_failure_counts(&descriptor, &cache, |uuid| outputs.contains(uuid))
+        .expect("OneHot descriptor must produce a failure-count map");
+
+    assert_eq!(counts.get("output-A").copied(), Some(3));
+    assert_eq!(counts.get("output-B").copied(), Some(1));
+    // Output-C never failed — must be absent (not present with 0).
+    assert!(!counts.contains_key("output-C"));
+    // Hidden neurons must never appear in the class-failure map.
+    assert!(!counts.contains_key("hidden-X"));
+}
+
+/// Acceptance #2: non-OneHot descriptors yield `None`, locking the caller
+/// into the existing allocation path (regression guard).
+#[test]
+fn neutral_descriptor_yields_no_class_failure_counts() {
+    let cache = vec![fc_entry("output-A")];
+    let outputs: std::collections::HashSet<String> =
+        ["output-A"].into_iter().map(String::from).collect();
+
+    assert!(
+        compute_class_failure_counts(&TaskDescriptor::neutral(), &cache, |u| outputs.contains(u))
+            .is_none(),
+        "neutral descriptor must opt out of per-class allocation",
+    );
+
+    let mse = TaskDescriptor::from_name("MSE", 3);
+    assert!(
+        compute_class_failure_counts(&mse, &cache, |u| outputs.contains(u)).is_none(),
+        "Independent descriptor must opt out of per-class allocation",
+    );
+
+    let other = TaskDescriptor::from_name("OTHER", 3);
+    assert!(
+        compute_class_failure_counts(&other, &cache, |u| outputs.contains(u)).is_none(),
+        "OTHER descriptor must opt out of per-class allocation",
+    );
+
+    let hinge = TaskDescriptor::from_name("HINGE", 1);
+    assert!(
+        compute_class_failure_counts(&hinge, &cache, |u| outputs.contains(u)).is_none(),
+        "Margin descriptor must opt out of per-class allocation",
+    );
+}
+
+/// Acceptance #3: under `OneHot` priority, the highest-failure-count classes
+/// occupy the front of the reordered candidate list — pulling growth budget
+/// toward the worst-performing classes ahead of the per-target cap.
+#[test]
+fn class_priority_spread_pulls_worst_classes_to_front() {
+    // target-A: 6 candidates, gain dominant.
+    // target-B: 1 candidate, mid gain.
+    // target-C: 1 candidate, low gain.
+    // target-D: 1 candidate, even lower gain.
+    let mut candidates = vec![
+        candidate("target-A", 0.99),
+        candidate("target-A", 0.95),
+        candidate("target-A", 0.92),
+        candidate("target-A", 0.90),
+        candidate("target-A", 0.87),
+        candidate("target-A", 0.85),
+        candidate("target-B", 0.50),
+        candidate("target-C", 0.40),
+        candidate("target-D", 0.30),
+    ];
+    // Pre-sort by gain to mirror the documented precondition.
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    // Priority: D worst, then C, then B; A unseen (priority 0).
+    let mut priority: HashMap<String, u32> = HashMap::new();
+    priority.insert("target-D".to_string(), 9);
+    priority.insert("target-C".to_string(), 6);
+    priority.insert("target-B".to_string(), 3);
+
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    let front: Vec<&str> = candidates[0..3]
+        .iter()
+        .map(|c| c.target_neuron_uuid.as_str())
+        .collect();
+    assert_eq!(
+        front,
+        vec!["target-D", "target-C", "target-B"],
+        "front of the list must lead with the worst-performing classes",
+    );
+    // No candidate dropped.
+    assert_eq!(candidates.len(), 9);
+    // Tail retains the remaining target-A candidates in gain order.
+    let tail_a_gains: Vec<f32> = candidates[3..]
+        .iter()
+        .filter(|c| c.target_neuron_uuid == "target-A")
+        .map(|c| c.expected_creature_score_gain)
+        .collect();
+    let mut sorted_a = tail_a_gains.clone();
+    sorted_a.sort_by(|a, b| b.total_cmp(a));
+    assert_eq!(
+        tail_a_gains, sorted_a,
+        "target-A tail must remain in gain-descending order",
+    );
+}
+
+/// Acceptance #4 (regression guard): an empty priority map is a no-op — the
+/// gain-sorted order is preserved verbatim. Equivalent to running on a
+/// neutral / OTHER descriptor.
+#[test]
+fn empty_priority_map_is_a_noop() {
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-B", 0.5),
+        candidate("target-C", 0.4),
+        candidate("target-D", 0.3),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let before: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+
+    apply_class_priority_spread(&mut candidates, &HashMap::new(), 3);
+
+    let after: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+    assert_eq!(
+        before, after,
+        "empty priority map must not reorder candidates",
+    );
+}
+
+/// Acceptance #5: priority spread keeps the highest-gain representative for
+/// each priority target — within a class, gain order still decides which
+/// candidate occupies the spread slot.
+#[test]
+fn class_priority_spread_keeps_highest_gain_representative() {
+    // target-B has two candidates with very different gains.
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-B", 0.05),
+        candidate("target-B", 0.6),
+        candidate("target-C", 0.4),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let mut priority = HashMap::new();
+    priority.insert("target-B".to_string(), 7);
+    priority.insert("target-C".to_string(), 5);
+
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    // Front: target-B (priority 7, gain 0.6), target-C (priority 5, gain 0.4),
+    // target-A (priority 0, gain 0.9).
+    assert_eq!(candidates[0].target_neuron_uuid, "target-B");
+    assert!((candidates[0].expected_creature_score_gain - 0.6).abs() < f32::EPSILON);
+    assert_eq!(candidates[1].target_neuron_uuid, "target-C");
+    assert_eq!(candidates[2].target_neuron_uuid, "target-A");
+}
+
+/// Acceptance #6: if the pool has fewer distinct targets than the spread
+/// requires, the function falls through and preserves gain-order — same
+/// contract as the legacy `apply_distinct_target_spread`.
+#[test]
+fn class_priority_spread_falls_through_when_pool_too_narrow() {
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-A", 0.8),
+        candidate("target-B", 0.6),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let before: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+
+    let mut priority = HashMap::new();
+    priority.insert("target-A".to_string(), 5);
+
+    // min_distinct=3 but only 2 distinct targets — must no-op.
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    let after: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+    assert_eq!(before, after);
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -8,6 +8,7 @@ mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
 mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
+mod issue_1319_one_hot_per_class_capacity_allocation;
 mod issue_1321_output_competition_lateral_inhibition;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;

--- a/tests/regression/regression_v0_1_123.rs
+++ b/tests/regression/regression_v0_1_123.rs
@@ -140,6 +140,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -274,6 +275,7 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -543,6 +545,7 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -732,6 +735,7 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_486_neuron_error_distribution.rs
+++ b/tests/scoring/issue_486_neuron_error_distribution.rs
@@ -100,6 +100,7 @@ fn test_neuron_analysis_populates_error_distribution() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -201,6 +202,7 @@ fn test_neuron_analysis_no_errors_returns_none() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -308,6 +310,7 @@ fn test_neuron_analysis_error_distribution_multiple_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/synapse/source_variance_discounting.rs
+++ b/tests/synapse/source_variance_discounting.rs
@@ -133,6 +133,7 @@ fn test_constant_source_gives_zero_improvement() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -236,6 +237,7 @@ fn test_low_variance_source_discounts_prediction() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -339,6 +341,7 @@ fn test_high_variance_source_not_discounted() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -449,6 +452,7 @@ fn test_constant_vs_varying_source_comparison() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");


### PR DESCRIPTION
## Summary

Under a `OneHot` task descriptor (e.g. `CATEGORICAL_ERROR`) the growth /
candidate budget for add-neuron candidates now skews toward output neurons
(classes) with the highest per-target failure counts, reusing the existing
failure signal already supplied via `failure_cache` (Issue #1131, #1194)
and documented on the per-target trackers in
`src/analysis/within_batch_failures.rs` and
`src/analysis/target_failure_tracker.rs`. The cost identity confirms the
outputs are exchangeable classes, so per-class allocation is well-defined.
For every other descriptor (`Independent`, `Margin`, `Simplex`, `Unknown`,
`OTHER`, absent) the existing allocation runs verbatim — regression
guard. Closes #1319.

## Evidence

Backend Rust crate — no UI surface to screenshot. Verified via TDD with a
new pure module
[`src/analysis/one_hot_class_allocation.rs`](../../../src/analysis/one_hot_class_allocation.rs)
plus a dedicated integration test file
[`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`](../../../tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs)
and inline unit tests inside the neuron post-processing module. The full
`./quality.sh` gate passes cleanly:

```
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured (neuron::post_processing)
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured (one_hot_class_allocation)
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured (tests/recommendation/issue_1319)
✅ All quality checks passed!
```

### Allocation dispatch

```mermaid
flowchart LR
    A[AnalyzeAllInput.cost_name] --> B[TaskDescriptor::from_name]
    B --> C[task_descriptor]
    C --> D[AnalyzeNeuronsInput.task_descriptor]
    D --> E[build_neuron_results]
    E --> F[build_one_hot_class_priority]
    F -- OneHot + failure_cache --> G[apply_class_priority_spread]
    F -- OTHER/Unknown/absent --> H[apply_distinct_target_spread]
    G --> I[apply_per_target_cap]
    H --> I
```

## Test Plan

Integration tests in
`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`:

- `one_hot_descriptor_computes_per_class_failure_counts` — under
  `CATEGORICAL_ERROR`, aggregates per-output-neuron failures from the
  failure cache; hidden / non-output targets are excluded; classes with
  zero failures are omitted.
- `neutral_descriptor_yields_no_class_failure_counts` — `neutral`,
  `MSE`, `OTHER`, and `HINGE` descriptors all return `None`, opting out
  of per-class allocation (regression guard).
- `class_priority_spread_pulls_worst_classes_to_front` — the highest-
  failure classes occupy the front of the reordered list before the
  per-target cap is applied.
- `empty_priority_map_is_a_noop` — an empty priority map preserves the
  gain-sorted order verbatim.
- `class_priority_spread_keeps_highest_gain_representative` — within
  each priority slot, the highest-gain candidate is chosen.
- `class_priority_spread_falls_through_when_pool_too_narrow` — when the
  pool contains fewer distinct targets than the spread requires, the
  list is left untouched.

Inline unit tests in `src/analysis/one_hot_class_allocation.rs`:

- `one_hot_aggregates_failures_per_output_class`
- `non_one_hot_topologies_return_none` (covers MSE, MAE, MAPE, BCE, CE, HINGE)
- `empty_failure_cache_under_one_hot_returns_empty_map`
- `non_output_targets_are_skipped`

Inline unit tests in `src/analysis/neuron/post_processing.rs`:

- `per_target_cap_with_priority_pulls_high_priority_targets_to_front` —
  end-to-end check that `apply_per_target_cap_with_priority` lets the
  priority spread reach the emitted batch.
- `per_target_cap_with_no_priority_matches_legacy_path` — regression
  guard: `None` priority is byte-identical to the existing path.
- `per_target_cap_with_empty_priority_uses_legacy_spread` — empty
  priority map preserves the gain-sorted order.



## Milestone
This PR is part of the **Cost Name** milestone and targets the `milestone/cost-name` feature branch.

---

🤖 Processed by: VibeCoderST<!-- vibe-worker-issue-1319 -->