### PR TITLE
Milestone: Cost Name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.76"
+version = "0.74.77"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -2854,18 +2854,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.75"
+version = "0.74.76"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.75"
+version = "0.74.76"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.76"
+version = "0.74.77"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/benches/async_pipeline.rs
+++ b/benches/async_pipeline.rs
@@ -178,6 +178,7 @@ fn bench_async_pipeline(c: &mut Criterion) {
                         temperature: 1.0,
                         failure_cache: None,
                         discovery_outcome_log: None,
+                        cost_name: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/parallel_discovery.rs
+++ b/benches/parallel_discovery.rs
@@ -185,6 +185,7 @@ fn bench_parallel_discovery(c: &mut Criterion) {
                         temperature: 1.0,
                         failure_cache: None,
                         discovery_outcome_log: None,
+                        cost_name: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });

--- a/benches/pipeline_utilisation.rs
+++ b/benches/pipeline_utilisation.rs
@@ -333,6 +333,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         temperature: 1.0,
                         failure_cache: None,
                         discovery_outcome_log: None,
+                        cost_name: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -362,6 +363,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         temperature: 1.0,
                         failure_cache: None,
                         discovery_outcome_log: None,
+                        cost_name: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -391,6 +393,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
                         temperature: 1.0,
                         failure_cache: None,
                         discovery_outcome_log: None,
+                        cost_name: None,
                     };
                     black_box(analyze_all(&input).expect("analyze_all failed"))
                 });
@@ -416,6 +419,7 @@ fn bench_pipeline_utilisation(c: &mut Criterion) {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            cost_name: None,
         };
 
         let mut profile = ProfileData::new();

--- a/docs/archive/pr-summaries/pr-summary-1312.md
+++ b/docs/archive/pr-summaries/pr-summary-1312.md
@@ -1,0 +1,60 @@
+## Summary
+
+Introduce the pure `TaskDescriptor` type and its `from_name` cost-name mapping
+in a new `src/analysis/task_descriptor.rs` module. The descriptor summarises
+the supervised-learning task shape — target topology, target range, and
+output squash family — derived purely from the cost name and the network's
+output count. No FFI plumbing, no consumer detector changes, and no I/O are
+introduced; those land via the follow-up issues (notably #1314) that
+reference this one. Closes #1312.
+
+## Evidence
+
+CLI / library change only — no UI to screenshot. Verified via the new unit
+tests (15 cases, all passing) and the full `./quality.sh` gate (clippy with
+`-D warnings`, `cargo check --all-targets --all-features`, full test suite,
+docs build with `RUSTDOCFLAGS="-D warnings"`, release build).
+
+Mapping (matches the issue table verbatim):
+
+| costName              | topology    | range       | output squash family |
+| --------------------- | ----------- | ----------- | -------------------- |
+| MSE, MAE              | Independent | Unbounded   | Unbounded            |
+| MAPE, MSLE            | Independent | Positive    | Positive             |
+| BINARY_CROSS_ENTROPY  | Independent | Unit        | BoundedUnipolar      |
+| CROSS_ENTROPY         | Simplex     | Unit        | BoundedUnipolar      |
+| HINGE                 | Margin      | SignedUnit  | BoundedBipolar       |
+| CATEGORICAL_ERROR     | OneHot      | Unit        | BoundedUnipolar      |
+| OTHER / unrecognised  | Unknown     | Unbounded   | Any (= neutral)      |
+
+```mermaid
+flowchart LR
+    A["cost name (str)"] --> B["TaskDescriptor::from_name(name, num_outputs)"]
+    B -->|recognised| C["topology / range / squash family / num_outputs"]
+    B -->|OTHER / unknown / absent| D["TaskDescriptor::neutral()"]
+    D --> E["Unknown / Unbounded / Any / num_outputs = 0"]
+```
+
+## Test Plan
+
+Added `src/analysis/task_descriptor.rs::tests` covering:
+
+- `neutral_is_unknown_unbounded_any` — neutral descriptor fields.
+- `default_descriptor_equals_neutral` — `Default` matches `neutral()`.
+- `mse_maps_to_independent_unbounded_unbounded`
+- `mae_maps_to_independent_unbounded_unbounded`
+- `mape_maps_to_independent_positive_positive`
+- `msle_maps_to_independent_positive_positive`
+- `binary_cross_entropy_maps_to_independent_unit_bounded_unipolar`
+- `cross_entropy_maps_to_simplex_unit_bounded_unipolar`
+- `hinge_maps_to_margin_signed_unit_bounded_bipolar`
+- `categorical_error_maps_to_onehot_unit_bounded_unipolar`
+- `other_collapses_to_neutral`
+- `unrecognised_name_collapses_to_neutral`
+- `empty_name_collapses_to_neutral`
+- `lookup_is_case_insensitive`
+- `num_outputs_is_preserved_verbatim` — including zero, large counts, and
+  the unrecognised-name branch (always 0 via neutral).
+
+Quality gate (`./quality.sh`) passes cleanly with all 15 new tests added to
+the lib test suite.

--- a/docs/archive/pr-summaries/pr-summary-1313.md
+++ b/docs/archive/pr-summaries/pr-summary-1313.md
@@ -1,0 +1,80 @@
+## Summary
+
+Add a role-aware activation recommendation entry point that biases
+**output-neuron** squash candidates toward the task descriptor's
+`output_squash_family` when the topology constrains the output to a
+specific manifold (OneHot, Simplex). Hidden-neuron behaviour and the
+neutral / `OTHER` / `Unknown` descriptor path are unchanged — they
+defer verbatim to the existing distribution-driven recommender. Closes
+#1313.
+
+This is the cold-start fix from the issue: output neurons with
+unbounded squashes (LINEAR / RELU / GELU / …) cannot settle on a
+one-hot `[0, 1]` manifold, so under a `CATEGORICAL_ERROR` or
+`CROSS_ENTROPY` descriptor the recommender now restricts candidates to
+the bounded unipolar family (LOGISTIC, STEP).
+
+## Scope
+
+Scoped to the recommendation **path** only (`src/analysis/recommendation/
+activation_recommendation.rs`). The activation scan set, bias-drift
+weighting, and output competition are intentionally **not** touched —
+they are tracked as separate issues. The new function exists alongside
+the legacy entry point; FFI ingest of the descriptor is #1314.
+
+## Evidence
+
+Backend-only change with no UI surface. Verified via:
+
+- New integration test file `tests/recommendation/
+  issue_1313_role_aware_output_squash.rs` (7 tests, all passing) — covers
+  the four acceptance criteria plus three regression guards.
+- New inline unit tests in `activation_recommendation.rs` — three
+  additional `#[cfg(test)]` cases exercise the bounded family pick,
+  hidden-neuron unchanged behaviour, and the neutral descriptor
+  fallback.
+- `./quality.sh` — full pipeline (fmt, clippy `-D warnings`, doc, lib +
+  integration tests, release build) passes cleanly.
+
+```mermaid
+flowchart LR
+    A[recommend_activation_function_for_role] --> B{is_output && topology in OneHot / Simplex?}
+    B -- no --> C[recommend_activation_function]
+    B -- yes --> D{output_squash_family}
+    D -- BoundedUnipolar --> E["LOGISTIC, STEP"]
+    D -- BoundedBipolar --> F["TANH, HARD_TANH, BIPOLAR_SIGMOID, BIPOLAR"]
+    D -- Positive --> G["RELU, RELU6, SOFTPLUS, ELU"]
+    D -- Unbounded --> H[IDENTITY]
+    D -- Any --> C
+    E --> I[Pick highest-scoring family member]
+    F --> I
+    G --> I
+    H --> I
+```
+
+## Test Plan
+
+Added to `tests/recommendation/issue_1313_role_aware_output_squash.rs`:
+
+- `one_hot_descriptor_recommends_bounded_unipolar_for_output_neuron` —
+  acceptance criterion 1 / 4 (CATEGORICAL_ERROR + IDENTITY output).
+- `simplex_descriptor_recommends_bounded_unipolar_for_output_neuron` —
+  acceptance criterion 1 (CROSS_ENTROPY + RELU output).
+- `neutral_descriptor_falls_back_to_existing_behaviour` — regression
+  guard against the `Unknown` / `Any` path.
+- `other_cost_descriptor_falls_back_to_existing_behaviour` —
+  regression guard for the `OTHER` cost name.
+- `one_hot_descriptor_does_not_bias_hidden_neuron_recommendation` —
+  acceptance criterion 2 (hidden-neuron path unchanged under OneHot).
+- `output_neuron_already_in_family_yields_no_recommendation` — no
+  spurious recommendation when the current squash is already
+  in-family.
+- `insufficient_samples_returns_none_for_output_role` — sample-count
+  regression guard.
+
+Added to `src/analysis/recommendation/activation_recommendation.rs`
+under `#[cfg(test)] mod tests`:
+
+- `test_role_aware_one_hot_picks_bounded_unipolar`
+- `test_role_aware_hidden_unchanged_under_one_hot`
+- `test_role_aware_neutral_descriptor_matches_legacy`

--- a/docs/archive/pr-summaries/pr-summary-1314.md
+++ b/docs/archive/pr-summaries/pr-summary-1314.md
@@ -1,0 +1,53 @@
+## Summary
+
+Plumbing-only change that lets producers pass an optional `task_descriptor`
+through the discovery FFI. The three request structs in
+`src/ffi_types/requests.rs` — `RecordDiscoveryInput`, `AnalyzeParallelInput`,
+`RankFocusNeuronsInput` — now carry an `Option<TaskDescriptor>` field marked
+with `#[serde(default)]`. A payload that omits the field deserialises to
+`None`, which consumers treat as `TaskDescriptor::neutral()`. No
+recommendation generator reads the field yet, so behaviour is unchanged.
+
+`TaskDescriptor`, `TargetTopology`, `TargetRange`, and `OutputSquashFamily`
+gained `serde::Deserialize` derives; `TaskDescriptor` uses
+`#[serde(rename_all = "camelCase")]` so producers send the field names in the
+same camelCase convention as the rest of the FFI payloads.
+
+Closes #1314.
+
+## Evidence
+
+Backend / FFI-only change; no UI surface to screenshot. The serde round-trip
+is verified by the new test module
+`tests/ffi/issue_1314_task_descriptor_plumbing.rs`, which covers:
+
+- An omitted `task_descriptor` deserialising to `None` for all three structs
+  and `None.unwrap_or_default() == TaskDescriptor::neutral()`.
+- A supplied descriptor round-tripping verbatim through serde.
+- A payload that supplies every other previously-supported `AnalyzeParallel`
+  field still parses cleanly (regression guard).
+
+```mermaid
+flowchart LR
+    Producer["NEAT-AI host"] -->|JSON payload| FFI["FFI request structs"]
+    FFI -->|"Option&lt;TaskDescriptor&gt;"| Consumer["Discovery pipeline (no-op today)"]
+    Consumer -.->|"None ⇒ neutral()"| Neutral["TaskDescriptor::neutral()"]
+```
+
+`./quality.sh` passes locally (fmt, clippy, check, doc, all tests, release
+build).
+
+## Test Plan
+
+- New tests in `tests/ffi/issue_1314_task_descriptor_plumbing.rs`:
+  - `record_discovery_input_omits_task_descriptor_to_none`
+  - `record_discovery_input_supplied_task_descriptor_round_trips`
+  - `analyze_parallel_input_omits_task_descriptor_to_none`
+  - `analyze_parallel_input_supplied_task_descriptor_round_trips`
+  - `analyze_parallel_input_accepts_neutral_descriptor`
+  - `rank_focus_neurons_input_omits_task_descriptor_to_none`
+  - `rank_focus_neurons_input_supplied_task_descriptor_round_trips`
+  - `payload_without_task_descriptor_still_parses_all_existing_fields`
+- Existing tests under `src/record/tests.rs` updated to initialise the new
+  field with `task_descriptor: None`.
+- Full `./quality.sh` run passes.

--- a/docs/archive/pr-summaries/pr-summary-1315.md
+++ b/docs/archive/pr-summaries/pr-summary-1315.md
@@ -1,0 +1,45 @@
+## Summary
+
+Made the activation/squash **scan** candidate set role- and task-aware. Closes #1315.
+
+A new helper `scan_specs_for_role(role, descriptor)` in
+`src/analysis/activation/specs.rs` returns the activation candidate specs to
+scan for a given neuron role (`Output` / `Hidden`) and `TaskDescriptor`:
+
+- **Output neuron** under `target_topology ∈ {OneHot, Simplex}` → bounded
+  subset only (`LOGISTIC`, `STEP`, `BIPOLAR` — the names in
+  `BOUNDED_OUTPUT_SCAN_NAMES`; `STEP` is listed for forward compatibility,
+  the effective set is currently `LOGISTIC` + `BIPOLAR` since `STEP` is
+  not yet in `ACTIVATION_SPECS`).
+- **Hidden neuron**, *any* descriptor → full `ACTIVATION_SPECS`.
+- **Output neuron** under `Independent` / `Margin` / `Unknown` topology →
+  full `ACTIVATION_SPECS` (regression guard for `OTHER` / unrecognised /
+  absent cost names, which collapse to `TaskDescriptor::neutral()`).
+
+The helper is pure: it consumes the `TaskDescriptor` from #1312 but does
+not depend on the #1314 FFI plumbing. No existing call site is touched —
+the scan path keeps its current behaviour until a consumer migration
+opts in.
+
+## Evidence
+
+CLI/library change, no UI to screenshot. Verified via tests below.
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor + NeuronRole] --> B{Output & OneHot/Simplex?}
+    B -- yes --> C[Bounded subset<br/>LOGISTIC, BIPOLAR, STEP*]
+    B -- no  --> D[Full ACTIVATION_SPECS<br/>regression-safe]
+```
+
+`*` — `STEP` is listed for forward compatibility; it is silently skipped
+while it is absent from `ACTIVATION_SPECS`.
+
+## Test Plan
+
+- `src/analysis/activation/specs.rs::scan_specs_tests` — 9 inline unit
+  tests covering OneHot/Simplex × Output/Hidden, `OTHER`, neutral,
+  unrecognised, Independent costs, and bounded-subset name validation.
+- `tests/activation/issue_1315_role_task_aware_scan.rs` — 7 integration
+  tests asserting the public API behaviour and the regression guards.
+- `./quality.sh` passes cleanly.

--- a/docs/archive/pr-summaries/pr-summary-1316.md
+++ b/docs/archive/pr-summaries/pr-summary-1316.md
@@ -1,0 +1,65 @@
+## Summary
+
+Weight output bias-drift detection by class prior for `OneHot` / `Simplex`
+target topologies. Output neurons that never cross a saturating threshold
+on a class with positive support are flagged as **capacity-starved** and
+their estimated improvement is boosted, lifting them in the candidate
+ranking for growth. All other descriptors (`Independent`, `Margin`,
+`Unknown`, `OTHER`, absent) fall through to the existing detector
+verbatim — regression guard. Closes #1316.
+
+## Evidence
+
+Backend Rust crate — no UI surface to screenshot. Verified via TDD with
+nine targeted integration tests in
+`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`,
+all green:
+
+```
+test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured;
+```
+
+The full crate test suite (`cargo test --lib --tests --all-features
+-- --test-threads=2`) also passes; `cargo clippy --all-targets
+--all-features -- -D warnings` passes; `cargo fmt --all -- --check`
+clean; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` builds.
+
+### Dispatch wiring
+
+```mermaid
+flowchart LR
+    A[input.cost_name] --> B[TaskDescriptor::from_name]
+    B --> C[task_descriptor]
+    C --> D[prepare_and_detect_discovery_modules]
+    D --> E[append_scoring_specs]
+    E --> F[detect_output_bias_drift_with_descriptor]
+    F -- OneHot or Simplex --> G[flag + boost capacity-starved]
+    F -- other --> H[legacy detect_output_bias_drift]
+```
+
+## Test Plan
+
+Tests added in
+`tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs`:
+
+- `one_hot_descriptor_flags_capacity_starved_output_neuron` — positive
+  support + activation stuck below the saturating threshold under
+  `CATEGORICAL_ERROR` → `capacity_starved == true`.
+- `simplex_descriptor_flags_capacity_starved_output_neuron` — same under
+  `CROSS_ENTROPY` (Simplex topology).
+- `one_hot_does_not_flag_well_saturated_output` — activations cross
+  the saturating threshold → never flagged.
+- `neutral_descriptor_matches_legacy_detector` — regression guard for
+  `TaskDescriptor::neutral()`.
+- `other_cost_matches_legacy_detector` — regression guard for the
+  `OTHER` cost name.
+- `mse_descriptor_matches_legacy_detector` — regression guard for the
+  `Independent` topology.
+- `class_without_positive_support_is_not_flagged` — class prior
+  matters: no positive-support records ⇒ no capacity-starved flag.
+- `capacity_starved_candidate_is_weighted_up_vs_legacy` — verifies the
+  estimated improvement of a capacity-starved candidate is strictly
+  greater than the legacy detector's gain on the same input.
+- `hidden_neuron_is_not_flagged_capacity_starved` — output-only
+  detector continues to ignore hidden neurons under the role-aware
+  path.

--- a/docs/archive/pr-summaries/pr-summary-1317.md
+++ b/docs/archive/pr-summaries/pr-summary-1317.md
@@ -1,0 +1,110 @@
+# Wire the cost identity into the target-reconstruction guard (Issue #1317)
+
+## Summary
+
+Feeds the real cost-function identity into the implied-target reconstruction
+guard introduced for Issue #1250 so the two reconstruction-dependent
+detectors run only when the recorded error is provably a linear residual.
+Closes #1317.
+
+Two detectors reconstruct an "implied target" as `activation ± error`:
+
+- `detection::output_squash_mismatch` Strategy 4 (pre-activation squash
+  comparison).
+- `detection::high_error_squash_exploration`.
+
+Both were already cost-aware at the API level (the `_with_cost_hint`
+variants from Issue #1250) but the dispatch path always invoked the
+legacy entry point and so always evaluated as if the cost were
+`CostFunctionHint::Unknown`. This change threads the actual cost name
+through to the dispatch layer and converts it into a `CostFunctionHint`
+via `TaskDescriptor`.
+
+### Behaviour matrix
+
+| Cost name | `TaskDescriptor` | `CostFunctionHint` | Detectors |
+|-----------|------------------|--------------------|-----------|
+| `MSE`, `MAE`, `BINARY_CROSS_ENTROPY`, `CROSS_ENTROPY` | linear-residual shape | `LinearResidual` | run |
+| `MAPE`, `MSLE`, `HINGE`, `CATEGORICAL_ERROR` | non-linear-residual shape | `NonLinearResidual` | skipped |
+| `OTHER` / unrecognised / absent | `neutral()` | `NonLinearResidual` (conservative skip) | skipped |
+
+### Changes
+
+- `src/analysis/task_descriptor.rs`: new `TaskDescriptor::cost_function_hint()`
+  projection. Neutral / unknown descriptors map to `NonLinearResidual` so
+  the dispatch boundary conservatively skips the reconstruction-dependent
+  detectors when the cost shape is unknown.
+- `src/ffi_types/requests.rs`: `AnalyzeParallelInput` and `AnalyzeAllInput`
+  gain an optional `cost_name: Option<String>` (camelCase JSON `costName`).
+  Absent / `null` deserialises to `None`. Existing payloads continue to
+  parse unchanged.
+- `src/ffi_internal/analysis.rs`: forwards `cost_name` from
+  `AnalyzeParallelInput` into `AnalyzeAllInput`.
+- `src/analysis/orchestration.rs`: derives a `CostFunctionHint` from
+  `input.cost_name` + `input.creature.output` at the top of `analyze_all`
+  and forwards it into the discovery dispatch path.
+- `src/analysis/module_dispatch_specs/{mod.rs,neuron_specs.rs,scoring_specs.rs}`:
+  `build_discovery_module_specs`, `prepare_and_detect_discovery_modules*`,
+  `append_neuron_specs`, and `append_scoring_specs` all take a
+  `CostFunctionHint` parameter. The high-error squash exploration and
+  output-squash-mismatch dispatch specs now call the `_with_cost_hint`
+  detector variants.
+
+### Data-flow
+
+```mermaid
+flowchart LR
+    A[FFI input<br/>costName] --> B[AnalyzeParallelInput.cost_name]
+    B --> C[AnalyzeAllInput.cost_name]
+    C --> D[TaskDescriptor::from_name]
+    D --> E[TaskDescriptor::cost_function_hint]
+    E --> F[CostFunctionHint]
+    F --> G[prepare_and_detect_discovery_modules]
+    G --> H1[high_error_squash<br/>_with_cost_hint]
+    G --> H2[output_squash_mismatch<br/>_with_cost_hint]
+```
+
+## Evidence
+
+This is a backend wiring change with no UI surface. Verified by:
+
+- New tests in
+  `tests/analysis/issue_1317_cost_identity_wiring.rs` covering:
+  - `TaskDescriptor::cost_function_hint()` mapping for every recognised
+    cost name plus `OTHER`, unrecognised, empty, and neutral.
+  - Both reconstruction-dependent detectors gated correctly under
+    `LinearResidual`, `NonLinearResidual`, and `neutral` hints.
+  - FFI round-trip of the new optional `costName` field on
+    `AnalyzeParallelInput` (with and without the field present).
+- New unit tests inside `src/analysis/task_descriptor.rs` cover the new
+  projection for the seven built-in costs plus neutral / `OTHER`.
+- Existing Issue #1250 detector tests
+  (`tests/detection/issue_1250_implied_target_cost_hint.rs`) continue to
+  pass unchanged — the underlying `CostFunctionHint::Unknown` semantics
+  are preserved so legacy detector callers see no behaviour change.
+
+## Test Plan
+
+- [x] `cargo test --lib --all-features -- --test-threads=2` (1068 passed).
+- [x] `cargo test --test analysis --all-features -- --test-threads=2` (590 passed).
+- [x] `cargo test --test detection issue_1250 …` (7 passed, unchanged).
+- [x] `cargo test --test analysis issue_1317 …` (7 new passed).
+- [x] `cargo test --test analysis issue_930 …` (3 passed — confirms the
+      conservative-skip default does not regress the change-squash
+      discovery test, which relies on other detectors).
+- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
+- [x] `cargo fmt --all -- --check` clean.
+- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
+      clean.
+
+## Notes for reviewers
+
+- Issue #1314 (FFI plumbing for `task_descriptor: Option<TaskDescriptor>`)
+  is still open. This change introduces a narrower equivalent
+  (`cost_name: Option<String>`) needed by Issue #1317; the broader
+  descriptor field from #1314 can replace it when that issue lands.
+- Existing `AnalyzeAllInput` construction sites in tests and benches have
+  been updated to supply the new field as `cost_name: None`, preserving
+  their original behaviour (conservative skip — same as the pre-#1250
+  detector emit-but-don't-recommend behaviour would now be unsafe to
+  assume by default).

--- a/docs/archive/pr-summaries/pr-summary-1318.md
+++ b/docs/archive/pr-summaries/pr-summary-1318.md
@@ -1,0 +1,78 @@
+# Margin-aware focus ranking for OneHot / Margin costs
+
+## Summary
+
+Focus ranking now reweights per-neuron error by the **per-observation
+decision margin** when the task descriptor reports a `OneHot` or `Margin`
+topology. Observations where the network's top-1 vs top-2 output activation
+gap is small contribute more weight; observations where the gap is wide
+contribute less. This targets the plateau where margin-improving changes
+that don't yet flip an argmax otherwise look worthless.
+
+For every other topology (`Independent`, `Simplex`, `Unknown`, `OTHER`) and
+for `None`, the legacy unweighted ranking is preserved — regression guard.
+
+Closes #1318.
+
+## Design
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor] -->|OneHot/Margin| B[compute_per_obs_margins]
+    A -->|other/None| Z[legacy unweighted ranking]
+    B --> C[margin_weights_from_margins<br/>w = 1 / (margin + 0.05)]
+    C --> D[weighted_average_absolute_error_from_records]
+    D --> E[RankedNeuron.total_error]
+    D --> F[max_output_error clamp]
+```
+
+Touch points (as scoped in the issue):
+
+- `src/focus/impact.rs` — `compute_per_obs_margins` (top-1 minus top-2 per
+  obs from recorded output activations) and `margin_weights_from_margins`
+  (`w = 1 / (margin + MARGIN_WEIGHT_EPS)`).
+- `src/focus/ranking/score_calculation.rs` —
+  `weighted_average_absolute_error_from_records` (falls back to the
+  unweighted mean when no weights are supplied).
+- `src/focus/ranking/mod.rs` —
+  `rank_focus_neurons_with_descriptor` and
+  `rank_focus_neurons_with_history_and_descriptor`. Existing
+  `rank_focus_neurons` / `rank_focus_neurons_with_history` delegate with
+  `None` so external callers see no change.
+- `src/ffi_internal/analysis.rs` — forwards `input.task_descriptor` (already
+  plumbed by #1314) into the new function.
+
+## Evidence
+
+CLI / library change with no UI. Verified via the new test module
+`tests/focus/issue_1318_margin_aware_ranking.rs` (9 tests, all green).
+Full `./quality.sh` passes — `cargo fmt`, `cargo clippy -D warnings`,
+`cargo test`, doc build, release build.
+
+## Test Plan
+
+New tests in `tests/focus/issue_1318_margin_aware_ranking.rs`:
+
+- `margins_reflect_top1_minus_top2_per_observation` — `compute_per_obs_margins`
+  returns the correct top-1 minus top-2 gap.
+- `margin_weights_upweight_small_margins` — `margin_weights_from_margins`
+  obeys the `1 / (margin + eps)` formula.
+- `one_hot_descriptor_promotes_close_margin_error_neuron` — under
+  `TargetTopology::OneHot`, the hidden neuron whose error sits on the
+  close-margin observation ranks above the mirror neuron whose error sits
+  on the wide-margin observation, despite identical unweighted means.
+- `margin_descriptor_promotes_close_margin_error_neuron` — same for
+  `TargetTopology::Margin` (HINGE).
+- `one_hot_descriptor_changes_total_error_for_close_margin_neuron` — direct
+  numeric guard that the reweighted `total_error` is strictly larger for the
+  close-margin neuron under `OneHot`.
+- `no_descriptor_matches_legacy_ranking` — passing `None` matches the legacy
+  `rank_focus_neurons` exactly.
+- `unknown_descriptor_matches_legacy_ranking` — `TaskDescriptor::neutral()`
+  matches legacy (covers `OTHER` and unrecognised cost names).
+- `independent_descriptor_matches_legacy_ranking` — `MSE` matches legacy.
+- `simplex_descriptor_matches_legacy_ranking` — `CROSS_ENTROPY` matches
+  legacy.
+
+The four regression-guard tests provide the acceptance criterion
+"`OTHER` / `Unknown` / absent ⇒ existing ranking".

--- a/docs/archive/pr-summaries/pr-summary-1319.md
+++ b/docs/archive/pr-summaries/pr-summary-1319.md
@@ -1,0 +1,85 @@
+## Summary
+
+Under a `OneHot` task descriptor (e.g. `CATEGORICAL_ERROR`) the growth /
+candidate budget for add-neuron candidates now skews toward output neurons
+(classes) with the highest per-target failure counts, reusing the existing
+failure signal already supplied via `failure_cache` (Issue #1131, #1194)
+and documented on the per-target trackers in
+`src/analysis/within_batch_failures.rs` and
+`src/analysis/target_failure_tracker.rs`. The cost identity confirms the
+outputs are exchangeable classes, so per-class allocation is well-defined.
+For every other descriptor (`Independent`, `Margin`, `Simplex`, `Unknown`,
+`OTHER`, absent) the existing allocation runs verbatim — regression
+guard. Closes #1319.
+
+## Evidence
+
+Backend Rust crate — no UI surface to screenshot. Verified via TDD with a
+new pure module
+[`src/analysis/one_hot_class_allocation.rs`](../../../src/analysis/one_hot_class_allocation.rs)
+plus a dedicated integration test file
+[`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`](../../../tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs)
+and inline unit tests inside the neuron post-processing module. The full
+`./quality.sh` gate passes cleanly:
+
+```
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured (neuron::post_processing)
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured (one_hot_class_allocation)
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured (tests/recommendation/issue_1319)
+✅ All quality checks passed!
+```
+
+### Allocation dispatch
+
+```mermaid
+flowchart LR
+    A[AnalyzeAllInput.cost_name] --> B[TaskDescriptor::from_name]
+    B --> C[task_descriptor]
+    C --> D[AnalyzeNeuronsInput.task_descriptor]
+    D --> E[build_neuron_results]
+    E --> F[build_one_hot_class_priority]
+    F -- OneHot + failure_cache --> G[apply_class_priority_spread]
+    F -- OTHER/Unknown/absent --> H[apply_distinct_target_spread]
+    G --> I[apply_per_target_cap]
+    H --> I
+```
+
+## Test Plan
+
+Integration tests in
+`tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`:
+
+- `one_hot_descriptor_computes_per_class_failure_counts` — under
+  `CATEGORICAL_ERROR`, aggregates per-output-neuron failures from the
+  failure cache; hidden / non-output targets are excluded; classes with
+  zero failures are omitted.
+- `neutral_descriptor_yields_no_class_failure_counts` — `neutral`,
+  `MSE`, `OTHER`, and `HINGE` descriptors all return `None`, opting out
+  of per-class allocation (regression guard).
+- `class_priority_spread_pulls_worst_classes_to_front` — the highest-
+  failure classes occupy the front of the reordered list before the
+  per-target cap is applied.
+- `empty_priority_map_is_a_noop` — an empty priority map preserves the
+  gain-sorted order verbatim.
+- `class_priority_spread_keeps_highest_gain_representative` — within
+  each priority slot, the highest-gain candidate is chosen.
+- `class_priority_spread_falls_through_when_pool_too_narrow` — when the
+  pool contains fewer distinct targets than the spread requires, the
+  list is left untouched.
+
+Inline unit tests in `src/analysis/one_hot_class_allocation.rs`:
+
+- `one_hot_aggregates_failures_per_output_class`
+- `non_one_hot_topologies_return_none` (covers MSE, MAE, MAPE, BCE, CE, HINGE)
+- `empty_failure_cache_under_one_hot_returns_empty_map`
+- `non_output_targets_are_skipped`
+
+Inline unit tests in `src/analysis/neuron/post_processing.rs`:
+
+- `per_target_cap_with_priority_pulls_high_priority_targets_to_front` —
+  end-to-end check that `apply_per_target_cap_with_priority` lets the
+  priority spread reach the emitted batch.
+- `per_target_cap_with_no_priority_matches_legacy_path` — regression
+  guard: `None` priority is byte-identical to the existing path.
+- `per_target_cap_with_empty_priority_uses_legacy_spread` — empty
+  priority map preserves the gain-sorted order.

--- a/docs/archive/pr-summaries/pr-summary-1320.md
+++ b/docs/archive/pr-summaries/pr-summary-1320.md
@@ -1,0 +1,66 @@
+## Summary
+
+Calibrated the SPRT early-termination config and the drought-diagnostic
+threshold by the `TaskDescriptor` so classification runs are not stopped
+prematurely or falsely flagged as in drought. Absolute error scale is
+cost-dependent — a `0.1` categorical error already implies ~90% accuracy
+(excellent), while a `0.1` MSE is mediocre — so per-sample improvement
+signal is sparser on classification tasks and the thresholds must move
+accordingly. Closes #1320.
+
+Regression guard: `OTHER` / `Unknown` / neutral descriptors and any
+`Independent` (regression) topology return the existing defaults
+unchanged.
+
+## Changes
+
+- `src/analysis/early_termination.rs`
+  - New `EarlyTerminationConfig::for_task(&TaskDescriptor)`. Classification
+    topologies (`OneHot`, `Simplex`, `Margin`) double `min_samples` and lift
+    the SPRT `threshold` by `0.1` above the 50% baseline. Everything else
+    returns `Self::default()`.
+- `src/analysis/drought_diagnostic.rs`
+  - New `drought_threshold_for_task(base, &TaskDescriptor)`. Classification
+    topologies multiply the base by `CLASSIFICATION_DROUGHT_MULTIPLIER` (2,
+    saturating) so the warn / `droughtDiagnostic` fire point sits later.
+    Other topologies return `base` unchanged.
+- `src/analysis/orchestration.rs`
+  - Wired `drought_threshold_for_task` into the drought-emission path, using
+    the `task_descriptor` already computed earlier in `analyze_all`.
+
+```mermaid
+flowchart LR
+    TD[TaskDescriptor<br/>from_name] --> ETC[EarlyTerminationConfig::for_task]
+    TD --> DT[drought_threshold_for_task]
+    ETC -->|classification:<br/>min_samples x2,<br/>threshold + 0.1| SPRT[SPRT evaluator]
+    ETC -->|regression / Unknown| Defaults1[Self::default unchanged]
+    DT -->|classification:<br/>base x2 saturating| Orch[orchestration drought check]
+    DT -->|regression / Unknown| Defaults2[base unchanged]
+```
+
+## Evidence
+
+Backend-only change (no UI). Verified by the test suite:
+
+- `tests/issue_1320_task_calibrated_thresholds.rs` — 15 new tests covering:
+  - Neutral / `OTHER` / unrecognised / MSE descriptors return unchanged
+    config + drought threshold (regression guard).
+  - `CATEGORICAL_ERROR`, `CROSS_ENTROPY`, `HINGE` descriptors require
+    strictly more samples and a stricter SPRT threshold than default.
+  - `CROSS_ENTROPY` and `HINGE` share the classification profile with
+    `CATEGORICAL_ERROR`.
+  - Evaluator built from a calibrated config inherits the larger
+    `min_samples` and does not short-circuit `is_strongly_beneficial` until
+    the calibrated minimum is reached.
+  - Drought threshold is larger for all three classification costs.
+  - Drought threshold saturates safely at `u32::MAX`.
+- `./quality.sh` ran clean (fmt, clippy `-D warnings`, full test suite,
+  rustdoc, release build).
+
+## Test Plan
+
+- [x] New tests added in `tests/issue_1320_task_calibrated_thresholds.rs`
+      (15 cases — regression-guard, classification-stricter, evaluator
+      wiring, drought saturation).
+- [x] No existing tests modified.
+- [x] `./quality.sh` passes locally.

--- a/docs/archive/pr-summaries/pr-summary-1321.md
+++ b/docs/archive/pr-summaries/pr-summary-1321.md
@@ -1,0 +1,65 @@
+## Summary
+
+Adds an output-competition / lateral-inhibition recommender gated by the
+task descriptor. Under `OneHot` / `Simplex` topologies it proposes
+inhibitory `AddSynapse(output_a → output_b)` operations when two output
+neurons co-fire strongly on the same samples; under every other topology
+(`Independent`, `Margin`, `Unknown` / `OTHER` / absent) it emits nothing,
+satisfying the regression guard in the acceptance criteria. Closes #1321.
+
+This is the stretch item in the cost-name milestone, landing after
+the bounded-squash (#1313) and bias-drift (#1316) work as required by
+the issue's ordering constraint.
+
+## Evidence
+
+Backend-only crate change with no UI surface. Verified via the unit and
+integration tests below; full `./quality.sh` passes (clippy, fmt,
+`cargo doc`, `cargo deny`, `cargo test --lib --tests --all-features`,
+release build).
+
+### Recommender flow
+
+```mermaid
+flowchart LR
+    A[TaskDescriptor] -->|OneHot or Simplex| B[detect_output_competition]
+    A -->|Independent / Margin / Unknown / OTHER| Z[empty Vec — regression guard]
+    B --> C{>= 2 output neurons?}
+    C -->|no| Z
+    C -->|yes| D[For each output pair i<j]
+    D --> E{Existing synapse i→j?}
+    E -->|yes| D
+    E -->|no| F[Align records by obs_index<br/>both activations > 0.5]
+    F --> G{co-activated count<br/>>= MIN_DISCOVERY_SAMPLE_COUNT?}
+    G -->|no| D
+    G -->|yes| H[OutputCompetitionCandidate<br/>weight = -0.1]
+    H --> I[output_competition_to_<br/>coordinated_candidates]
+    I --> J[CoordinatedStructuralCandidateJson<br/>AddSynapse i→j, weight = -0.1]
+```
+
+## Test Plan
+
+Added `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs`
+with 11 integration tests covering both acceptance criteria:
+
+- `one_hot_descriptor_emits_inhibitory_recommendation` — OneHot + co-firing outputs ⇒ candidate emitted, weight < 0.
+- `simplex_descriptor_emits_inhibitory_recommendation` — `CROSS_ENTROPY` ⇒ candidate emitted.
+- `unknown_descriptor_emits_nothing` — neutral descriptor regression guard.
+- `other_descriptor_emits_nothing` — `OTHER` regression guard.
+- `independent_descriptor_emits_nothing` — `MSE` regression guard.
+- `margin_descriptor_emits_nothing` — `HINGE` regression guard.
+- `single_output_emits_nothing` — networks with only one output cannot compete.
+- `non_competing_outputs_emit_nothing` — disjoint firing patterns are not flagged.
+- `existing_synapse_is_not_duplicated` — pre-existing `output-a → output-b` skips the pair.
+- `coordinated_candidates_use_add_synapse_with_negative_weight` — converter emits `AddSynapse` with negative weight.
+- `forward_only_ordering_is_respected` — `from` precedes `to` in `creature.neurons[]`.
+
+Three additional in-module unit tests cover the `co_activation` helper
+and the gating shortcut.
+
+## Files Changed
+
+- `src/analysis/recommendation/output_competition.rs` — new recommender module.
+- `src/analysis/recommendation/mod.rs` — register the new module.
+- `tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs` — integration tests.
+- `tests/recommendation/main.rs` — register the new test module.

--- a/src/analysis/activation/specs.rs
+++ b/src/analysis/activation/specs.rs
@@ -4,6 +4,7 @@
 //! neuron candidates, along with GPU shader ID mappings and bias range helpers.
 
 use super::functions::*;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 
 // ============================================================================
 // Activation Candidate Specification
@@ -246,4 +247,210 @@ pub fn get_bias_values(squash: &str) -> Vec<f32> {
     values.extend_from_slice(base_positive);
     values.sort_by(f32::total_cmp);
     values
+}
+
+// ============================================================================
+// Role- and Task-aware Scan Candidate Set (Issue #1315)
+// ============================================================================
+
+/// Role of the neuron being scanned for an activation candidate.
+///
+/// The activation/squash scan offers different candidate sets depending on
+/// whether we are searching for a replacement squash on an **output** neuron
+/// — whose activation shape is constrained by the loss — or on a **hidden**
+/// neuron — where any squash is fair game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NeuronRole {
+    /// Output (final-layer) neuron. The activation family is constrained by
+    /// the cost function via the [`TaskDescriptor`].
+    Output,
+    /// Hidden (non-output) neuron. The full unbounded scan set applies.
+    Hidden,
+}
+
+/// Names of the bounded-squash candidates offered when scanning an **output**
+/// neuron under a `OneHot` or `Simplex` target topology.
+///
+/// These activations all produce outputs in `[0, 1]` (or a step-function
+/// surrogate), which is the family compatible with `CROSS_ENTROPY` /
+/// `CATEGORICAL_ERROR` losses (see [`TaskDescriptor::from_name`]). Names not
+/// present in [`ACTIVATION_SPECS`] are silently skipped — at the time of
+/// writing `STEP` is recognised by NEAT-AI as a valid squash but does not
+/// yet appear in the scan specs, so the effective set is `LOGISTIC` and
+/// `BIPOLAR`. If `STEP` is added to [`ACTIVATION_SPECS`] in future it will
+/// be picked up automatically.
+pub const BOUNDED_OUTPUT_SCAN_NAMES: &[&str] = &["LOGISTIC", "STEP", "BIPOLAR"];
+
+/// Select the activation candidate specs to scan for the given neuron role
+/// and task descriptor.
+///
+/// Behaviour (Issue #1315):
+///
+/// - **Output neuron** under `OneHot` or `Simplex` topology — returns the
+///   bounded squash subset (`LOGISTIC`, `STEP`, `BIPOLAR`; see
+///   [`BOUNDED_OUTPUT_SCAN_NAMES`]).
+/// - **All other cases** — output neurons under `Independent` / `Margin` /
+///   `Unknown` topology, and *every* hidden neuron — return the full
+///   [`ACTIVATION_SPECS`]. This includes the `OTHER` / unknown / absent
+///   descriptor (which collapses to [`TaskDescriptor::neutral`]) so callers
+///   not yet plumbed for task-shape awareness keep their existing scan.
+#[must_use]
+pub fn scan_specs_for_role(
+    role: NeuronRole,
+    descriptor: &TaskDescriptor,
+) -> Vec<&'static ActivationCandidateSpec> {
+    let use_bounded_subset = matches!(role, NeuronRole::Output)
+        && matches!(
+            descriptor.target_topology,
+            TargetTopology::OneHot | TargetTopology::Simplex
+        );
+
+    if use_bounded_subset {
+        ACTIVATION_SPECS
+            .iter()
+            .filter(|spec| BOUNDED_OUTPUT_SCAN_NAMES.contains(&spec.name))
+            .collect()
+    } else {
+        ACTIVATION_SPECS.iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod scan_specs_tests {
+    use super::*;
+    use crate::analysis::task_descriptor::TaskDescriptor;
+
+    fn names(specs: &[&'static ActivationCandidateSpec]) -> Vec<&'static str> {
+        specs.iter().map(|s| s.name).collect()
+    }
+
+    #[test]
+    fn onehot_output_returns_only_bounded_subset() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        let names = names(&specs);
+
+        assert!(
+            names.contains(&"LOGISTIC"),
+            "OneHot output scan must include LOGISTIC, got {names:?}",
+        );
+        assert!(
+            names.contains(&"BIPOLAR"),
+            "OneHot output scan must include BIPOLAR, got {names:?}",
+        );
+        // Unbounded scans must be excluded for OneHot/Simplex output.
+        for unbounded in ["GELU", "ELU", "IDENTITY", "Mish", "Softplus"] {
+            assert!(
+                !names.contains(&unbounded),
+                "OneHot output scan must exclude {unbounded}, got {names:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn simplex_output_returns_only_bounded_subset() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        let names = names(&specs);
+
+        assert!(names.contains(&"LOGISTIC"));
+        assert!(names.contains(&"BIPOLAR"));
+        for unbounded in ["GELU", "ELU", "IDENTITY"] {
+            assert!(!names.contains(&unbounded));
+        }
+    }
+
+    #[test]
+    fn onehot_hidden_uses_full_scan_set() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "Hidden neurons always see the full scan set",
+        );
+    }
+
+    #[test]
+    fn simplex_hidden_uses_full_scan_set() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+
+    #[test]
+    fn unknown_descriptor_returns_full_scan_for_both_roles() {
+        // Regression guard: absent / unrecognised cost name collapses to
+        // neutral, which must preserve the pre-Issue-#1315 scan set.
+        let d = TaskDescriptor::neutral();
+        for role in [NeuronRole::Output, NeuronRole::Hidden] {
+            let specs = scan_specs_for_role(role, &d);
+            assert_eq!(
+                specs.len(),
+                ACTIVATION_SPECS.len(),
+                "Neutral descriptor must yield the full scan set for {role:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn other_cost_name_returns_full_scan_for_both_roles() {
+        // OTHER is the explicit "I don't know" cost name. Must behave
+        // identically to neutral().
+        let d = TaskDescriptor::from_name("OTHER", 4);
+        for role in [NeuronRole::Output, NeuronRole::Hidden] {
+            let specs = scan_specs_for_role(role, &d);
+            assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+        }
+    }
+
+    #[test]
+    fn unrecognised_cost_name_returns_full_scan() {
+        let d = TaskDescriptor::from_name("EXOTIC_LOSS", 2);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+
+    #[test]
+    fn independent_output_uses_full_scan() {
+        // MSE / MAE / MAPE / MSLE / BCE / HINGE — none of these gate the
+        // scan to bounded only (only OneHot and Simplex do).
+        for cost in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "MSLE",
+            "BINARY_CROSS_ENTROPY",
+            "HINGE",
+        ] {
+            let d = TaskDescriptor::from_name(cost, 3);
+            let specs = scan_specs_for_role(NeuronRole::Output, &d);
+            assert_eq!(
+                specs.len(),
+                ACTIVATION_SPECS.len(),
+                "Cost {cost} must not gate the output scan to bounded only",
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_subset_only_contains_known_spec_names() {
+        // Defensive: every name we report in the bounded subset must
+        // actually exist in ACTIVATION_SPECS so callers don't get a stale
+        // / mis-spelled label. STEP is intentionally allowed to be missing
+        // from ACTIVATION_SPECS (it is listed for forward compatibility).
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        for spec in &specs {
+            assert!(
+                BOUNDED_OUTPUT_SCAN_NAMES.contains(&spec.name),
+                "Spec {} returned from bounded scan must be in BOUNDED_OUTPUT_SCAN_NAMES",
+                spec.name,
+            );
+        }
+        // Sanity: at least LOGISTIC and BIPOLAR must be present.
+        let names = names(&specs);
+        assert!(names.contains(&"LOGISTIC"));
+        assert!(names.contains(&"BIPOLAR"));
+    }
 }

--- a/src/analysis/drought_diagnostic.rs
+++ b/src/analysis/drought_diagnostic.rs
@@ -27,6 +27,36 @@ use super::diagnostics::RejectionBreakdown;
 use super::discovery_mode::DiscoveryMode;
 use super::module_starvation_tracker::ModuleStarvationTracker;
 use super::target_failure_tracker::TargetFailureTracker;
+use super::task_descriptor::{TargetTopology, TaskDescriptor};
+
+/// Multiplier applied to the base drought threshold for classification
+/// topologies (Issue #1320). Classification per-sample signal is sparse — a
+/// trailing streak of empty passes is normal early in training — so we lift
+/// the warn / `droughtDiagnostic` fire point above the regression default.
+const CLASSIFICATION_DROUGHT_MULTIPLIER: u32 = 2;
+
+/// Calibrate the drought-diagnostic threshold to the supervised-learning task
+/// (Issue #1320).
+///
+/// Classification topologies (one-hot, simplex, margin) generate sparser
+/// per-sample improvement signal than regression — a `0.1` categorical error
+/// is excellent (~90% accuracy) while a `0.1` MSE is mediocre. Treating a
+/// short trailing-failure streak as a "drought" on a classification run fires
+/// the diagnostic prematurely and, when the operator escape hatch is enabled,
+/// can trigger an unnecessary cache / cooldown reset. This helper scales the
+/// threshold up so the warn fires later.
+///
+/// Regression guard: `OTHER` / `Unknown` / neutral descriptors and
+/// `Independent` (regression) topologies return `base` unchanged.
+#[must_use]
+pub fn drought_threshold_for_task(base: u32, descriptor: &TaskDescriptor) -> u32 {
+    match descriptor.target_topology {
+        TargetTopology::OneHot | TargetTopology::Simplex | TargetTopology::Margin => {
+            base.saturating_mul(CLASSIFICATION_DROUGHT_MULTIPLIER)
+        }
+        TargetTopology::Independent | TargetTopology::Unknown => base,
+    }
+}
 
 /// Structured payload describing the current drought state (Issue #1202).
 ///

--- a/src/analysis/early_termination.rs
+++ b/src/analysis/early_termination.rs
@@ -364,6 +364,39 @@ impl EarlyTerminationConfig {
         }
     }
 
+    /// Calibrate the early-termination config to the supervised-learning task
+    /// (Issue #1320).
+    ///
+    /// Absolute error scale is cost-dependent: a `0.1` categorical error
+    /// already implies ~90% accuracy, while a `0.1` MSE is mediocre. The
+    /// per-sample improvement signal is therefore much sparser for
+    /// classification topologies (one-hot / simplex / margin), and the SPRT
+    /// must collect more samples and require a stricter threshold before
+    /// committing to an Accept / Reject decision — otherwise a clearly
+    /// beneficial classification candidate is rejected on noise.
+    ///
+    /// Regression guard: `OTHER` / `Unknown` / neutral descriptors and any
+    /// `Independent` (regression) topology return [`Self::default`]
+    /// unchanged.
+    #[must_use]
+    pub fn for_task(descriptor: &super::task_descriptor::TaskDescriptor) -> Self {
+        use super::task_descriptor::TargetTopology;
+
+        let base = Self::default();
+        match descriptor.target_topology {
+            TargetTopology::OneHot | TargetTopology::Simplex | TargetTopology::Margin => Self {
+                // Classification: roughly double the sample budget and lift
+                // the SPRT threshold off the 50% baseline so a sparse signal
+                // is not mistaken for evidence.
+                min_samples: base.min_samples.saturating_mul(2),
+                threshold: base.threshold + 0.1,
+                ..base
+            },
+            // Independent (regression) / Unknown ⇒ current thresholds.
+            TargetTopology::Independent | TargetTopology::Unknown => base,
+        }
+    }
+
     /// Create an evaluator from this config.
     #[must_use]
     pub fn create_evaluator(&self) -> SequentialEvaluator {

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -73,6 +73,7 @@ fn analyze_neurons_rejects_duplicate_focus_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let err =
@@ -780,6 +781,7 @@ fn analyze_neurons_reports_diagnostics_when_no_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result =
@@ -893,6 +895,7 @@ fn analyze_neurons_uses_vertical_timeout_with_randomized_order() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = pool

--- a/src/analysis/implementation_tests/synapse_analysis_tests.rs
+++ b/src/analysis/implementation_tests/synapse_analysis_tests.rs
@@ -720,6 +720,7 @@ fn analyze_all_runs_synapse_and_neuron_phases() {
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Combined analysis should succeed");

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -51,6 +51,7 @@ pub mod module_starvation_tracker;
 pub mod module_weights;
 pub mod neuron;
 pub mod neuron_fingerprint;
+pub mod one_hot_class_allocation;
 pub mod quantised_error;
 pub mod recent_failure_window;
 pub mod samples;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -60,6 +60,7 @@ pub mod streaming;
 pub mod synapse;
 pub mod system;
 pub mod target_failure_tracker;
+pub mod task_descriptor;
 pub mod utils;
 pub mod within_batch_failures;
 

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -24,6 +24,7 @@ mod synapse_specs;
 
 use std::sync::Arc;
 
+use super::cost_function_hint::CostFunctionHint;
 use super::detection::topology_cache::CreatureTopologyCache;
 use super::{
     cache, candidate_clustering, candidate_diversity, discovery_dispatch, ensemble_scoring,
@@ -45,10 +46,18 @@ pub(crate) fn build_discovery_module_specs(
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
     shared_cache: &Arc<cache::RecordCache>,
     topo: &Arc<CreatureTopologyCache>,
+    cost_hint: CostFunctionHint,
 ) -> Vec<discovery_dispatch::DiscoveryModuleSpec> {
     let mut modules: Vec<discovery_dispatch::DiscoveryModuleSpec> = Vec::with_capacity(32);
 
-    neuron_specs::append_neuron_specs(&mut modules, creature, hidden_neurons, shared_cache, topo);
+    neuron_specs::append_neuron_specs(
+        &mut modules,
+        creature,
+        hidden_neurons,
+        shared_cache,
+        topo,
+        cost_hint,
+    );
     synapse_specs::append_synapse_specs(&mut modules, creature, hidden_neurons, shared_cache, topo);
     structural_specs::append_structural_specs(
         &mut modules,
@@ -57,7 +66,7 @@ pub(crate) fn build_discovery_module_specs(
         shared_cache,
         topo,
     );
-    scoring_specs::append_scoring_specs(&mut modules, creature, shared_cache);
+    scoring_specs::append_scoring_specs(&mut modules, creature, shared_cache, cost_hint);
 
     modules
 }
@@ -82,6 +91,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
     shared_cache: &Arc<cache::RecordCache>,
     tracker: &ModuleOutcomeTracker,
     deadline: Option<std::time::SystemTime>,
+    cost_hint: CostFunctionHint,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     prepare_and_detect_discovery_modules_with_starvation(
         creature,
@@ -91,12 +101,14 @@ pub(crate) fn prepare_and_detect_discovery_modules(
         deadline,
         None,
         0,
+        cost_hint,
     )
 }
 
 /// Same contract as [`prepare_and_detect_discovery_modules`] but also forwards
 /// the per-creature [`ModuleStarvationTracker`] so modules in active
 /// starvation cooldown are skipped at detection time (Issue #1273).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_and_detect_discovery_modules_with_starvation(
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
@@ -105,10 +117,12 @@ pub(crate) fn prepare_and_detect_discovery_modules_with_starvation(
     deadline: Option<std::time::SystemTime>,
     starvation_tracker: Option<&super::module_starvation_tracker::ModuleStarvationTracker>,
     current_epoch: u64,
+    cost_hint: CostFunctionHint,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
-    let mut modules = build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo);
+    let mut modules =
+        build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo, cost_hint);
 
     // Issue #967: Allocate candidate budgets based on module success rates.
     let config = CandidateBudgetConfig::default();
@@ -407,7 +421,13 @@ mod tests {
             super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
         );
 
-        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+        let specs = build_discovery_module_specs(
+            &creature,
+            &hidden,
+            &cache,
+            &topo,
+            CostFunctionHint::Unknown,
+        );
 
         // We expect 47 modules across all four spec groups (batch-successful
         // is disabled by default, Issue #1059).
@@ -442,7 +462,13 @@ mod tests {
             super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
         );
 
-        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+        let specs = build_discovery_module_specs(
+            &creature,
+            &hidden,
+            &cache,
+            &topo,
+            CostFunctionHint::Unknown,
+        );
         let mut phase_names: Vec<&str> = specs.iter().map(|s| s.phase_name).collect();
         let total = phase_names.len();
         phase_names.sort();
@@ -465,7 +491,13 @@ mod tests {
             super::super::detection::topology_cache::CreatureTopologyCache::new(&creature),
         );
 
-        let specs = build_discovery_module_specs(&creature, &hidden, &cache, &topo);
+        let specs = build_discovery_module_specs(
+            &creature,
+            &hidden,
+            &cache,
+            &topo,
+            CostFunctionHint::Unknown,
+        );
 
         // With empty hidden neurons and no records, all modules should return None.
         for spec in specs {

--- a/src/analysis/module_dispatch_specs/mod.rs
+++ b/src/analysis/module_dispatch_specs/mod.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 
 use super::cost_function_hint::CostFunctionHint;
 use super::detection::topology_cache::CreatureTopologyCache;
+use super::task_descriptor::TaskDescriptor;
 use super::{
     cache, candidate_clustering, candidate_diversity, discovery_dispatch, ensemble_scoring,
     module_weights::{self, CandidateBudgetConfig, ModuleOutcomeTracker},
@@ -47,6 +48,7 @@ pub(crate) fn build_discovery_module_specs(
     shared_cache: &Arc<cache::RecordCache>,
     topo: &Arc<CreatureTopologyCache>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> Vec<discovery_dispatch::DiscoveryModuleSpec> {
     let mut modules: Vec<discovery_dispatch::DiscoveryModuleSpec> = Vec::with_capacity(32);
 
@@ -66,7 +68,13 @@ pub(crate) fn build_discovery_module_specs(
         shared_cache,
         topo,
     );
-    scoring_specs::append_scoring_specs(&mut modules, creature, shared_cache, cost_hint);
+    scoring_specs::append_scoring_specs(
+        &mut modules,
+        creature,
+        shared_cache,
+        cost_hint,
+        task_descriptor,
+    );
 
     modules
 }
@@ -85,6 +93,7 @@ pub(crate) fn build_discovery_module_specs(
 /// The `deadline` parameter is forwarded to [`discovery_dispatch::detect_discovery_modules_parallel`]
 /// so that modules are skipped when the analysis time budget is exhausted,
 /// preventing the detection phase from running indefinitely.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn prepare_and_detect_discovery_modules(
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
@@ -92,6 +101,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
     tracker: &ModuleOutcomeTracker,
     deadline: Option<std::time::SystemTime>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     prepare_and_detect_discovery_modules_with_starvation(
         creature,
@@ -102,6 +112,7 @@ pub(crate) fn prepare_and_detect_discovery_modules(
         None,
         0,
         cost_hint,
+        task_descriptor,
     )
 }
 
@@ -118,11 +129,18 @@ pub(crate) fn prepare_and_detect_discovery_modules_with_starvation(
     starvation_tracker: Option<&super::module_starvation_tracker::ModuleStarvationTracker>,
     current_epoch: u64,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) -> discovery_dispatch::DiscoveryModuleDetectionResults {
     // Issue #754: Pre-compute topology cache once for all detection modules.
     let topo = Arc::new(CreatureTopologyCache::new(creature));
-    let mut modules =
-        build_discovery_module_specs(creature, hidden_neurons, shared_cache, &topo, cost_hint);
+    let mut modules = build_discovery_module_specs(
+        creature,
+        hidden_neurons,
+        shared_cache,
+        &topo,
+        cost_hint,
+        task_descriptor,
+    );
 
     // Issue #967: Allocate candidate budgets based on module success rates.
     let config = CandidateBudgetConfig::default();
@@ -427,6 +445,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
 
         // We expect 47 modules across all four spec groups (batch-successful
@@ -468,6 +487,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
         let mut phase_names: Vec<&str> = specs.iter().map(|s| s.phase_name).collect();
         let total = phase_names.len();
@@ -497,6 +517,7 @@ mod tests {
             &cache,
             &topo,
             CostFunctionHint::Unknown,
+            TaskDescriptor::neutral(),
         );
 
         // With empty hidden neurons and no records, all modules should return None.

--- a/src/analysis/module_dispatch_specs/neuron_specs.rs
+++ b/src/analysis/module_dispatch_specs/neuron_specs.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use super::super::cost_function_hint::CostFunctionHint;
 use super::super::detection::{
     activation_mismatch, bias_perturbation, bimodal_neuron, bottleneck, co_adaptation, dead_neuron,
     high_error_squash_exploration, low_impact_neuron, monotonicity, noise_signal, operating_point,
@@ -17,12 +18,17 @@ use super::super::recommendation::activation_recommendation;
 use super::super::{cache, discovery_dispatch};
 
 /// Append neuron-focused discovery module specs to the provided vector.
+///
+/// `cost_hint` (Issue #1317) governs the implied-target reconstruction
+/// guard: linear-residual costs enable the high-error squash exploration
+/// detector, non-linear-residual costs (and neutral / absent) gate it off.
 pub(crate) fn append_neuron_specs(
     modules: &mut Vec<discovery_dispatch::DiscoveryModuleSpec>,
     creature: &Arc<crate::CreatureJson>,
     hidden_neurons: &Arc<Vec<(String, String, f32)>>,
     shared_cache: &Arc<cache::RecordCache>,
     topo: &Arc<CreatureTopologyCache>,
+    cost_hint: CostFunctionHint,
 ) {
     // Issue #342: Saturated neuron detection
     discovery_spec!(modules, "saturation detection", "saturation_detection",
@@ -154,11 +160,13 @@ pub(crate) fn append_neuron_specs(
     );
 
     // Issue #788: High-error squash exploration (proactive change-squash volume)
+    // Issue #1317: forward the cost-function hint so the detector skips when
+    // the recorded error is not a linear residual (or is unknown).
     discovery_spec!(modules, "high error squash exploration", "high_error_squash_exploration",
         cache = shared_cache, hidden = hidden_neurons =>
         guard: hidden,
         records: cache.load_records_for_hidden(&hidden),
-        detect: |records| high_error_squash_exploration::detect_high_error_squash_candidates(&hidden, &records),
+        detect: |records| high_error_squash_exploration::detect_high_error_squash_candidates_with_cost_hint(&hidden, &records, cost_hint),
         convert: |detected| high_error_squash_exploration::high_error_squash_to_coordinated_candidates(&detected),
     );
 

--- a/src/analysis/module_dispatch_specs/scoring_specs.rs
+++ b/src/analysis/module_dispatch_specs/scoring_specs.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use super::super::cost_function_hint::CostFunctionHint;
 use super::super::detection::{
     bounded_range, error_plateau, input_sensitivity, observation_utilisation,
     output_range_compression, output_squash_mismatch, sentinel_gating,
@@ -17,10 +18,17 @@ use super::super::recommendation::{
 use super::super::{cache, discovery_dispatch};
 
 /// Append scoring and recommendation discovery module specs to the provided vector.
+///
+/// `cost_hint` (Issue #1317) is forwarded into the
+/// `output_squash_mismatch` detector so Strategy 4 (the pre-activation
+/// squash comparison that reconstructs the implied target via
+/// `activation − error`) is skipped when the recorded error is not a
+/// linear residual (or is unknown).
 pub(crate) fn append_scoring_specs(
     modules: &mut Vec<discovery_dispatch::DiscoveryModuleSpec>,
     creature: &Arc<crate::CreatureJson>,
     shared_cache: &Arc<cache::RecordCache>,
+    cost_hint: CostFunctionHint,
 ) {
     // Issue #361: Output bias drift detection
     discovery_spec!(modules, "output bias drift detection", "output_bias_drift_detection",
@@ -127,9 +135,13 @@ pub(crate) fn append_scoring_specs(
                 return None;
             }
             let records = cache.load_records_for_neuron_types(&creature, &["output"]);
-            let detected = output_squash_mismatch::detect_output_squash_mismatches(
+            // Issue #1317: forward the cost-function hint so Strategy 4's
+            // implied-target reconstruction is skipped for non-linear /
+            // unknown costs.
+            let detected = output_squash_mismatch::detect_output_squash_mismatches_with_cost_hint(
                 &output_neurons,
                 &records,
+                cost_hint,
             );
             if detected.is_empty() {
                 return None;

--- a/src/analysis/module_dispatch_specs/scoring_specs.rs
+++ b/src/analysis/module_dispatch_specs/scoring_specs.rs
@@ -15,6 +15,7 @@ use super::super::detection::{
 use super::super::recommendation::{
     batch_successful, gradient_discovery, output_bias_drift, sample_weighted,
 };
+use super::super::task_descriptor::TaskDescriptor;
 use super::super::{cache, discovery_dispatch};
 
 /// Append scoring and recommendation discovery module specs to the provided vector.
@@ -29,12 +30,20 @@ pub(crate) fn append_scoring_specs(
     creature: &Arc<crate::CreatureJson>,
     shared_cache: &Arc<cache::RecordCache>,
     cost_hint: CostFunctionHint,
+    task_descriptor: TaskDescriptor,
 ) {
-    // Issue #361: Output bias drift detection
+    // Issue #361 / #1316: Output bias drift detection. Under OneHot / Simplex
+    // descriptors the role-aware path additionally weights up output neurons
+    // that never cross a saturating threshold for a class with positive
+    // support (capacity starvation); other descriptors are unchanged.
     discovery_spec!(modules, "output bias drift detection", "output_bias_drift_detection",
         cache = shared_cache, creature = creature =>
         records: cache.load_records_for_neuron_types(&creature, &["output"]),
-        detect: |records| output_bias_drift::detect_output_bias_drift(&creature, &records),
+        detect: |records| output_bias_drift::detect_output_bias_drift_with_descriptor(
+            &creature,
+            &records,
+            &task_descriptor,
+        ),
         convert: |detected| output_bias_drift::output_bias_drift_to_coordinated_candidates(&detected),
     );
 

--- a/src/analysis/neuron/post_processing.rs
+++ b/src/analysis/neuron/post_processing.rs
@@ -125,12 +125,24 @@ pub(crate) fn build_neuron_results(
     // remaining cap budget is spent on genuinely distinct proposals.
     let same_target_squash_drops = apply_same_target_squash_diversity(&mut helpful_results);
 
+    // Issue #1319: Under a OneHot task descriptor (e.g. CATEGORICAL_ERROR)
+    // bias the per-target cap's distinct-target spread toward output neurons
+    // (classes) with the highest cumulative per-target failure counts. The
+    // helper returns `None` for every non-OneHot descriptor (including OTHER /
+    // Unknown / absent) so the legacy allocation path is preserved verbatim.
+    let class_priority = build_one_hot_class_priority(
+        params.input.task_descriptor.as_ref(),
+        params.input.failure_cache.as_deref().unwrap_or(&[]),
+        params.neuron_type_map,
+    );
+
     // Issue #1140: Cap add-neuron candidates per target within a single
     // discovery batch. Without this cap, a single hopeless target can consume
     // most of the budget with minor variants (e.g. 17 of 19 failed add-neuron
     // candidates in GRQ-sampler commit 744ac60d targeted the same neuron).
     // The cross-batch cooldown (Issue #1130) does not help within a batch.
-    let per_target_cap_drops = apply_per_target_cap(&mut helpful_results);
+    let per_target_cap_drops =
+        apply_per_target_cap_with_priority(&mut helpful_results, class_priority.as_ref());
 
     // Deadline coverage (Jan 2026): diversify within the top-K
     if params.input.analysis_deadline_ms.is_some() {
@@ -391,7 +403,23 @@ pub(crate) fn apply_same_target_squash_diversity(
 /// gain-descending order) followed by the remaining candidates in gain-
 /// descending order. Returns the number of candidates dropped by the cap so
 /// callers can record it in the rejection breakdown.
+#[cfg(test)]
 pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) -> usize {
+    apply_per_target_cap_with_priority(candidates, None)
+}
+
+/// Issue #1319: Like [`apply_per_target_cap`] but accepts an optional
+/// per-target priority map. When `Some`, the cross-target spread step is
+/// replaced by
+/// [`crate::analysis::one_hot_class_allocation::apply_class_priority_spread`],
+/// which pulls the highest-priority targets (e.g. worst-performing output
+/// classes under a `OneHot` descriptor) to the front of the list before the
+/// per-target cap is applied. Passing `None` reproduces the legacy
+/// allocation verbatim — regression guard.
+pub(crate) fn apply_per_target_cap_with_priority(
+    candidates: &mut Vec<CandidateNeuronJson>,
+    class_priority: Option<&HashMap<String, u32>>,
+) -> usize {
     let cap = crate::analysis::constants::max_add_neuron_candidates_per_target();
     if candidates.is_empty() || cap == 0 {
         return 0;
@@ -405,11 +433,21 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
             .total_cmp(&a.expected_creature_score_gain)
     });
 
-    // Issue #1193: reorder so the top of the list covers at least
+    // Issue #1193 / #1319: reorder so the top of the list covers at least
     // `MIN_DISTINCT_TARGETS_PER_BATCH` distinct targets when the pool supports
-    // it. This stops a single problematic target from filling all three cap
-    // slots before any other target is considered.
-    apply_distinct_target_spread(candidates);
+    // it. Under a OneHot descriptor with class-failure priority the worst-
+    // performing classes are pulled to the front first.
+    let min_distinct = crate::analysis::constants::min_distinct_targets_per_batch();
+    match class_priority {
+        Some(priority) if !priority.is_empty() => {
+            crate::analysis::one_hot_class_allocation::apply_class_priority_spread(
+                candidates,
+                priority,
+                min_distinct,
+            );
+        }
+        _ => apply_distinct_target_spread(candidates),
+    }
 
     let original_len = candidates.len();
     let mut per_target: HashMap<String, usize> = HashMap::new();
@@ -425,6 +463,39 @@ pub(crate) fn apply_per_target_cap(candidates: &mut Vec<CandidateNeuronJson>) ->
         }
     });
     original_len - candidates.len()
+}
+
+/// Issue #1319: Build the per-output-class priority map used by
+/// [`apply_per_target_cap_with_priority`].
+///
+/// Returns `None` when the supplied `task_descriptor` is not `OneHot` (or is
+/// absent / neutral / `OTHER`), preserving the legacy allocation path
+/// verbatim — regression guard. When `OneHot`, returns a map from each output
+/// neuron UUID to its cumulative within-batch / cross-batch failure count
+/// derived from `failure_cache` (Issue #1131, #1194). An empty map (no
+/// recorded class failures yet) is also returned as `None` so the legacy
+/// spread keeps the gain-order signal when there is no per-class evidence.
+fn build_one_hot_class_priority(
+    task_descriptor: Option<&crate::analysis::task_descriptor::TaskDescriptor>,
+    failure_cache: &[crate::analysis::scoring::calibration_correction::FailureCacheEntry],
+    neuron_type_map: &HashMap<super::preparation::SharedUuid, String>,
+) -> Option<HashMap<String, u32>> {
+    let descriptor = task_descriptor?;
+    let counts = crate::analysis::one_hot_class_allocation::compute_class_failure_counts(
+        descriptor,
+        failure_cache,
+        |uuid| {
+            neuron_type_map
+                .get(uuid)
+                .map(String::as_str)
+                .is_some_and(|t| t == "output")
+        },
+    )?;
+    if counts.is_empty() {
+        None
+    } else {
+        Some(counts)
+    }
 }
 
 /// Cross-target diversity spread (Issue #1193).
@@ -490,7 +561,8 @@ pub(crate) fn apply_distinct_target_spread(candidates: &mut Vec<CandidateNeuronJ
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_distinct_target_spread, apply_per_target_cap, apply_same_target_squash_diversity,
+        apply_distinct_target_spread, apply_per_target_cap, apply_per_target_cap_with_priority,
+        apply_same_target_squash_diversity,
     };
     use crate::CandidateNeuronJson;
     use serial_test::serial;
@@ -934,5 +1006,108 @@ mod tests {
         assert_eq!(candidates.len(), 1, "cap=1 should leave only one candidate");
         assert_eq!(dropped, 2);
         assert!((candidates[0].expected_creature_score_gain - 0.9).abs() < f32::EPSILON);
+    }
+
+    // =========================================================================
+    // Issue #1319 — per-class capacity allocation under OneHot
+    // =========================================================================
+
+    /// When the per-target cap is invoked with a non-empty priority map, the
+    /// spread step pulls the highest-priority targets to the front of the
+    /// list before the cap is applied. Mirrors the `OneHot` acceptance criterion
+    /// from issue #1319.
+    #[test]
+    #[serial]
+    fn per_target_cap_with_priority_pulls_high_priority_targets_to_front() {
+        let mut candidates = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+        let mut priority: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+        priority.insert("target-D".to_string(), 7);
+        priority.insert("target-C".to_string(), 5);
+
+        let _dropped = apply_per_target_cap_with_priority(&mut candidates, Some(&priority));
+
+        // Cap defaults to 3; the spread fronts target-D and target-C ahead of
+        // the cap, so they must be present in the emitted batch even though
+        // target-A had the gain-dominant candidates.
+        let distinct: HashSet<&str> = candidates
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert!(distinct.contains("target-D"));
+        assert!(distinct.contains("target-C"));
+
+        // Front of the emitted list must lead with the priority targets.
+        assert_eq!(candidates[0].target_neuron_uuid, "target-D");
+        assert_eq!(candidates[1].target_neuron_uuid, "target-C");
+    }
+
+    /// Regression guard: `None` priority preserves the existing distinct-
+    /// target spread behaviour byte-for-byte.
+    #[test]
+    #[serial]
+    fn per_target_cap_with_no_priority_matches_legacy_path() {
+        let mut legacy = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-A", 0.92),
+            test_candidate("target-A", 0.90),
+            test_candidate("target-A", 0.87),
+            test_candidate("target-A", 0.85),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+            test_candidate("target-D", 0.30),
+        ];
+        let mut with_none = legacy.clone();
+
+        let dropped_legacy = apply_per_target_cap(&mut legacy);
+        let dropped_with_none = apply_per_target_cap_with_priority(&mut with_none, None);
+        assert_eq!(dropped_legacy, dropped_with_none);
+        let legacy_view: Vec<(String, f32)> = legacy
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+        let new_view: Vec<(String, f32)> = with_none
+            .iter()
+            .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+            .collect();
+        assert_eq!(legacy_view, new_view);
+    }
+
+    /// Acceptance: an empty priority map is treated as no signal, so the
+    /// legacy distinct-target spread runs (regression guard).
+    #[test]
+    #[serial]
+    fn per_target_cap_with_empty_priority_uses_legacy_spread() {
+        let empty: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+        let mut legacy = vec![
+            test_candidate("target-A", 0.99),
+            test_candidate("target-A", 0.95),
+            test_candidate("target-B", 0.50),
+            test_candidate("target-C", 0.40),
+        ];
+        let mut with_empty = legacy.clone();
+
+        apply_per_target_cap(&mut legacy);
+        apply_per_target_cap_with_priority(&mut with_empty, Some(&empty));
+
+        let legacy_view: Vec<&str> = legacy
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        let new_view: Vec<&str> = with_empty
+            .iter()
+            .map(|c| c.target_neuron_uuid.as_str())
+            .collect();
+        assert_eq!(legacy_view, new_view);
     }
 }

--- a/src/analysis/one_hot_class_allocation.rs
+++ b/src/analysis/one_hot_class_allocation.rs
@@ -1,0 +1,239 @@
+//! Per-class capacity allocation under a `OneHot` task descriptor
+//! (Issue #1319).
+//!
+//! When the producer reports a `OneHot` target topology (e.g.
+//! `CATEGORICAL_ERROR`), the output neurons are exchangeable class scores —
+//! the cost identity confirms per-class allocation is well-defined. This
+//! module skews the growth/candidate budget toward output neurons (classes)
+//! with the highest cumulative per-target failure counts, using the
+//! existing per-target failure signal already supplied via the
+//! `failure_cache` field on the discovery FFI inputs (Issue #1131) and the
+//! per-target trackers documented in
+//! [`crate::analysis::within_batch_failures`] and
+//! [`crate::analysis::target_failure_tracker`].
+//!
+//! The contract is intentionally narrow:
+//!
+//! - For non-`OneHot` descriptors (`Independent`, `Margin`, `Simplex`,
+//!   `Unknown`, `OTHER`, absent) [`compute_class_failure_counts`] returns
+//!   `None`, leaving the legacy allocation path untouched (regression
+//!   guard, per the issue acceptance criteria).
+//! - [`apply_class_priority_spread`] reorders a gain-sorted candidate list so
+//!   the front contains up to `max_distinct` distinct targets ordered by
+//!   descending priority (with ties broken by descending gain). The tail
+//!   preserves the remaining candidates in their original gain order. This
+//!   is a strict generalisation of the legacy `apply_distinct_target_spread`
+//!   helper in [`crate::analysis::neuron`] — passing an empty priority map
+//!   produces the same no-op behaviour as the legacy spread when there is
+//!   no per-class signal yet.
+//!
+//! Both functions are pure (no I/O, no global state) and operate on plain
+//! data, so they are exercised by integration tests in
+//! `tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::CandidateNeuronJson;
+use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
+
+/// Aggregate per-output-class failure counts from the supplied failure cache
+/// when, and only when, `descriptor.target_topology` is `OneHot`.
+///
+/// Returns `None` for every other topology — including `Unknown`,
+/// `Independent`, `Simplex`, `Margin`, and the neutral / OTHER descriptor —
+/// so callers can fall straight through to the legacy allocation path
+/// (acceptance criterion: "`OTHER` / `Unknown` / absent ⇒ existing
+/// allocation").
+///
+/// `is_output` is invoked to decide which `target_uuid`s in the cache are
+/// output neurons (i.e. classes). Hidden / input / constant targets are
+/// skipped — only output-neuron failures form the per-class budget signal.
+/// Entries that lack a `target_uuid` (legacy payloads, Issue #1194) are
+/// ignored.
+///
+/// The returned map omits classes with zero recorded failures so callers can
+/// cheaply detect "no signal yet" via `is_empty()`.
+#[must_use]
+pub fn compute_class_failure_counts(
+    descriptor: &TaskDescriptor,
+    failure_cache: &[FailureCacheEntry],
+    is_output: impl Fn(&str) -> bool,
+) -> Option<HashMap<String, u32>> {
+    if descriptor.target_topology != TargetTopology::OneHot {
+        return None;
+    }
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for entry in failure_cache {
+        let Some(target_uuid) = entry.target_uuid.as_deref() else {
+            continue;
+        };
+        if !is_output(target_uuid) {
+            continue;
+        }
+        *counts.entry(target_uuid.to_string()).or_insert(0) = counts
+            .get(target_uuid)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+    }
+    Some(counts)
+}
+
+/// Reorder a gain-sorted candidate list so the front contains the
+/// highest-gain candidate for each of up to `max_distinct` distinct targets,
+/// ordered by descending priority (with ties broken by descending gain).
+///
+/// Preconditions:
+///
+/// - `candidates` is sorted by `expected_creature_score_gain` descending
+///   (NaN-safe via `total_cmp`).
+/// - `priority` maps a `target_neuron_uuid` to its priority weight.
+///   Targets absent from the map are treated as priority `0`.
+///
+/// Postconditions:
+///
+/// - When the candidate pool contains at least `max_distinct` distinct
+///   targets, the front of the list contains the highest-gain representative
+///   of the `max_distinct` highest-priority targets. The tail preserves the
+///   remaining candidates in their original gain order (a stable partition).
+/// - When the pool has fewer distinct targets than `max_distinct` requires,
+///   the list is left untouched — same fall-through contract as the legacy
+///   `apply_distinct_target_spread` helper.
+/// - When `priority` is empty, the function behaves identically to the
+///   legacy spread (the first occurrence of each distinct target is chosen
+///   in gain order, since priority ties break by best-index ascending).
+/// - No candidates are added or removed; only the order changes.
+pub fn apply_class_priority_spread(
+    candidates: &mut Vec<CandidateNeuronJson>,
+    priority: &HashMap<String, u32>,
+    max_distinct: usize,
+) {
+    if candidates.len() <= 1 || max_distinct <= 1 {
+        return;
+    }
+
+    // First occurrence (smallest index) of each distinct target in the
+    // gain-sorted list — that is, the highest-gain representative for that
+    // target.
+    let mut first_index_per_target: HashMap<String, usize> = HashMap::new();
+    for (i, c) in candidates.iter().enumerate() {
+        first_index_per_target
+            .entry(c.target_neuron_uuid.clone())
+            .or_insert(i);
+    }
+
+    // Fall through when the pool cannot support the requested spread.
+    if first_index_per_target.len() < max_distinct {
+        return;
+    }
+
+    // Order distinct targets by descending priority; ties broken by
+    // ascending first-index (i.e. descending gain). This makes the
+    // empty-priority case identical to the legacy spread.
+    let mut ordered: Vec<(usize, u32)> = first_index_per_target
+        .iter()
+        .map(|(target, &idx)| (idx, priority.get(target).copied().unwrap_or(0)))
+        .collect();
+    ordered.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    let head_indices: Vec<usize> = ordered.iter().take(max_distinct).map(|(i, _)| *i).collect();
+    let head_index_set: HashSet<usize> = head_indices.iter().copied().collect();
+
+    // Stable partition: drain candidates into Option slots so we can pull
+    // out the head in priority order without disturbing the relative order
+    // of the tail.
+    let mut slots: Vec<Option<CandidateNeuronJson>> = candidates.drain(..).map(Some).collect();
+    let mut head: Vec<CandidateNeuronJson> = Vec::with_capacity(head_indices.len());
+    for idx in &head_indices {
+        head.push(
+            slots[*idx]
+                .take()
+                .expect("head indices are unique by construction"),
+        );
+    }
+    let mut tail: Vec<CandidateNeuronJson> = Vec::with_capacity(slots.len());
+    for (idx, slot) in slots.into_iter().enumerate() {
+        if head_index_set.contains(&idx) {
+            // Already moved to head.
+            debug_assert!(slot.is_none());
+            continue;
+        }
+        if let Some(c) = slot {
+            tail.push(c);
+        }
+    }
+    candidates.extend(head);
+    candidates.extend(tail);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::scoring::calibration_correction::FailureCacheEntry;
+
+    fn fc(target_uuid: &str) -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: "add-neurons".to_string(),
+            expected_error_reduction: 0.1,
+            actual_error_reduction: -0.01,
+            target_squash: None,
+            variant_key: None,
+            target_uuid: Some(target_uuid.to_string()),
+            improved_count: None,
+            total_count: None,
+        }
+    }
+
+    #[test]
+    fn one_hot_aggregates_failures_per_output_class() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let cache = vec![fc("o-A"), fc("o-A"), fc("o-B")];
+        let outputs: HashSet<&str> = ["o-A", "o-B"].into_iter().collect();
+        let counts = compute_class_failure_counts(&descriptor, &cache, |u| outputs.contains(u))
+            .expect("OneHot must produce a map");
+        assert_eq!(counts.get("o-A").copied(), Some(2));
+        assert_eq!(counts.get("o-B").copied(), Some(1));
+    }
+
+    #[test]
+    fn non_one_hot_topologies_return_none() {
+        let cache = vec![fc("o-A")];
+        for name in [
+            "MSE",
+            "MAE",
+            "MAPE",
+            "BINARY_CROSS_ENTROPY",
+            "CROSS_ENTROPY",
+            "HINGE",
+        ] {
+            let descriptor = TaskDescriptor::from_name(name, 4);
+            assert!(
+                compute_class_failure_counts(&descriptor, &cache, |_| true).is_none(),
+                "{name} must opt out of per-class allocation",
+            );
+        }
+        assert!(
+            compute_class_failure_counts(&TaskDescriptor::neutral(), &cache, |_| true).is_none()
+        );
+    }
+
+    #[test]
+    fn empty_failure_cache_under_one_hot_returns_empty_map() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let counts = compute_class_failure_counts(&descriptor, &[], |_| true)
+            .expect("OneHot must still produce a (possibly empty) map");
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn non_output_targets_are_skipped() {
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+        let cache = vec![fc("o-A"), fc("h-1")];
+        let outputs: HashSet<&str> = ["o-A"].into_iter().collect();
+        let counts = compute_class_failure_counts(&descriptor, &cache, |u| outputs.contains(u))
+            .expect("OneHot must produce a map");
+        assert_eq!(counts.get("o-A").copied(), Some(1));
+        assert!(!counts.contains_key("h-1"));
+    }
+}

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -531,6 +531,9 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             temperature: input.temperature,
             failure_cache: input.failure_cache.clone(),
             discovery_outcome_log: input.discovery_outcome_log.clone(),
+            // Issue #1319: thread the task descriptor down so the neuron
+            // post-processing can bias per-class allocation under OneHot.
+            task_descriptor: Some(task_descriptor),
         })
     } else {
         None

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -16,7 +16,9 @@ use crate::observability::{
 };
 use crate::{AnalyzeAllInput, AnalyzeNeuronsInput, AnalyzeSynapsesInput};
 
+use super::cost_function_hint::CostFunctionHint;
 use super::shared::{AnalyzeAllResult, AnalyzeNeuronsResult, AnalyzeSynapsesResult};
+use super::task_descriptor::TaskDescriptor;
 use super::{
     cache, candidate_aggregation, candidate_compression, discovery_dispatch, module_dispatch_specs,
     module_weights, neuron, neuron_fingerprint, synapse, utils,
@@ -267,6 +269,20 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
 
     let include_synapse = input.include_synapse_analysis.unwrap_or(true);
     let include_neuron = input.include_neuron_analysis.unwrap_or(true);
+
+    // Issue #1317: Derive the cost-function hint that gates the
+    // implied-target reconstruction guard. When the caller supplies a known
+    // linear-residual cost name (MSE / MAE / CE / BCE) the reconstruction-
+    // dependent detectors run; for non-linear costs (MAPE / MSLE / HINGE /
+    // CATEGORICAL_ERROR) they are skipped; absent / unrecognised / OTHER
+    // collapses to `neutral()` which maps to a conservative skip.
+    let cost_hint: CostFunctionHint = input
+        .cost_name
+        .as_deref()
+        .map_or_else(TaskDescriptor::neutral, |name| {
+            TaskDescriptor::from_name(name, input.creature.output)
+        })
+        .cost_function_hint();
 
     // Issue #490: Compute current fingerprints and filter unchanged neurons.
     let current_fingerprints = neuron_fingerprint::compute_neuron_fingerprints(&input.creature);
@@ -744,6 +760,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                             &shared_cache,
                             &tracker,
                             discovery_deadline,
+                            cost_hint,
                         )
                     }))
                     .unwrap_or_else(|panic_payload| {

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -276,13 +276,16 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // dependent detectors run; for non-linear costs (MAPE / MSLE / HINGE /
     // CATEGORICAL_ERROR) they are skipped; absent / unrecognised / OTHER
     // collapses to `neutral()` which maps to a conservative skip.
-    let cost_hint: CostFunctionHint = input
+    // Issue #1316: also keep the full descriptor — the output_bias_drift
+    // module needs the topology (OneHot / Simplex) to weight up capacity-
+    // starved output neurons.
+    let task_descriptor: TaskDescriptor = input
         .cost_name
         .as_deref()
         .map_or_else(TaskDescriptor::neutral, |name| {
             TaskDescriptor::from_name(name, input.creature.output)
-        })
-        .cost_function_hint();
+        });
+    let cost_hint: CostFunctionHint = task_descriptor.cost_function_hint();
 
     // Issue #490: Compute current fingerprints and filter unchanged neurons.
     let current_fingerprints = neuron_fingerprint::compute_neuron_fingerprints(&input.creature);
@@ -761,6 +764,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
                             &tracker,
                             discovery_deadline,
                             cost_hint,
+                            task_descriptor,
                         )
                     }))
                     .unwrap_or_else(|panic_payload| {

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -944,7 +944,15 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // surfaces. The orchestrator owns the only call site, so the warn fires
     // at most once per `analyze_all` invocation.
     let consecutive_failures = outcome_log.consecutive_trailing_failures();
-    let drought_threshold = crate::config::drought_log_threshold();
+    // Issue #1320: calibrate the drought threshold to the task descriptor.
+    // Classification topologies generate sparse per-sample improvement signal,
+    // so the base threshold is scaled up to avoid premature drought fires.
+    // OTHER / Unknown / Independent descriptors keep the base threshold (the
+    // regression guard).
+    let drought_threshold = super::drought_diagnostic::drought_threshold_for_task(
+        crate::config::drought_log_threshold(),
+        &task_descriptor,
+    );
     if consecutive_failures >= drought_threshold {
         // Snapshot the global target-cooldown tracker. Lock failures fall back
         // to "no tracker" so the diagnostic still fires.

--- a/src/analysis/recommendation/activation_recommendation.rs
+++ b/src/analysis/recommendation/activation_recommendation.rs
@@ -32,6 +32,7 @@
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )] // Intentional numeric casts for GPU/neural network computation (Issue #873)
+use crate::analysis::task_descriptor::{OutputSquashFamily, TargetTopology, TaskDescriptor};
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
 use std::collections::HashMap;
@@ -558,6 +559,172 @@ pub fn recommend_activation_function(
     })
 }
 
+// =============================================================================
+// Role-aware Recommendation (Issue #1313)
+// =============================================================================
+//
+// For OneHot / Simplex tasks the output layer must sit on a `[0, 1]` manifold
+// (per-class scores). Unbounded squashes (IDENTITY / RELU / GELU / …) on the
+// output neuron cannot settle on that manifold at cold start. The role-aware
+// path restricts the candidate set for an **output** neuron to the descriptor's
+// `output_squash_family` whenever the topology constrains it (OneHot, Simplex).
+// Hidden-neuron behaviour and unconstrained descriptors (Unknown / Any /
+// `OTHER`) defer to the existing distribution-driven recommender.
+
+/// Bounded-unipolar output family — sigmoid-like squashes whose codomain is
+/// `[0, 1]`. Includes `STEP` for the binary/threshold case.
+const BOUNDED_UNIPOLAR_FAMILY: &[&str] = &["LOGISTIC", "STEP"];
+
+/// Bounded-bipolar output family — sigmoid-like squashes whose codomain is
+/// `[-1, 1]`. Used by hinge-style margin losses (descriptor: `Margin`).
+const BOUNDED_BIPOLAR_FAMILY: &[&str] = &["TANH", "HARD_TANH", "BIPOLAR_SIGMOID", "BIPOLAR"];
+
+/// Non-negative output family — `[0, +inf)`. Used by MAPE / MSLE-style losses.
+const POSITIVE_FAMILY: &[&str] = &["RELU", "RELU6", "SOFTPLUS", "ELU"];
+
+/// Unbounded output family — used by plain MSE / MAE.
+const UNBOUNDED_FAMILY: &[&str] = &["IDENTITY"];
+
+/// Squash candidates allowed for a given output-family constraint.
+fn family_candidates(family: OutputSquashFamily) -> &'static [&'static str] {
+    match family {
+        OutputSquashFamily::BoundedUnipolar => BOUNDED_UNIPOLAR_FAMILY,
+        OutputSquashFamily::BoundedBipolar => BOUNDED_BIPOLAR_FAMILY,
+        OutputSquashFamily::Positive => POSITIVE_FAMILY,
+        OutputSquashFamily::Unbounded => UNBOUNDED_FAMILY,
+        OutputSquashFamily::Any => &[],
+    }
+}
+
+/// Whether the role-aware path should bias an **output** neuron's candidate
+/// set toward the descriptor's `output_squash_family`. Issue #1313 scopes this
+/// to `OneHot` / `Simplex` topologies — the cases where an unbounded output squash
+/// cannot settle on the task's `[0, 1]` manifold. Other topologies (including
+/// `Unknown` / neutral / `OTHER`) defer to the legacy recommender.
+fn should_bias_to_family(descriptor: &TaskDescriptor, is_output: bool) -> bool {
+    if !is_output {
+        return false;
+    }
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Role-aware activation recommendation (Issue #1313).
+///
+/// If the neuron is an **output** neuron and the task descriptor reports a
+/// `OneHot` or `Simplex` topology, the candidate set is restricted to the
+/// descriptor's [`OutputSquashFamily`] (e.g. LOGISTIC / STEP for the bounded
+/// unipolar `[0, 1]` family). In every other case — hidden neurons, neutral
+/// descriptor, `OTHER` cost, or any unrecognised topology — this function
+/// defers verbatim to [`recommend_activation_function`].
+///
+/// # Arguments
+/// * `records` - Discovery records for the neuron.
+/// * `current_squash` - The current activation function name.
+/// * `is_output` - `true` if the neuron is in the output layer.
+/// * `descriptor` - Task descriptor derived from the cost function.
+#[must_use]
+pub fn recommend_activation_function_for_role(
+    records: &[DiscoverRecord],
+    current_squash: &str,
+    is_output: bool,
+    descriptor: &TaskDescriptor,
+) -> Option<ActivationRecommendation> {
+    if !should_bias_to_family(descriptor, is_output) {
+        return recommend_activation_function(records, current_squash);
+    }
+
+    let candidates = family_candidates(descriptor.output_squash_family);
+    if candidates.is_empty() {
+        // Family is unconstrained even though topology says OneHot/Simplex —
+        // defensively defer to the legacy recommender so we never silently
+        // drop a recommendation.
+        return recommend_activation_function(records, current_squash);
+    }
+
+    if records.len() < MIN_SAMPLES_FOR_ANALYSIS {
+        return None;
+    }
+
+    let neuron_uuid = records
+        .first()
+        .map(|r| r.neuron_uuid.clone())
+        .unwrap_or_default();
+
+    let distribution = analyse_input_distribution(records);
+    if distribution.class == InputDistributionClass::Unknown {
+        return None;
+    }
+
+    // Score every member of the family. Any family member not scored by the
+    // distribution-driven classifier (e.g. STEP under a Bounded distribution)
+    // receives a neutral default so the family is never empty.
+    let suitability = classify_activation_suitability(&distribution);
+    let mut family_scores: Vec<(&'static str, f32)> = candidates
+        .iter()
+        .map(|name| (*name, suitability.get(*name).copied().unwrap_or(0.6)))
+        .collect();
+    family_scores.sort_by(|a, b| b.1.total_cmp(&a.1));
+    let (best_squash, best_score) = *family_scores.first()?;
+
+    // Treat out-of-family current squashes as score-zero. The improvement
+    // delta then dominates the gating thresholds, and the rationale flags
+    // the family swap explicitly.
+    let current_in_family = candidates.contains(&current_squash);
+    let current_score = if current_in_family {
+        suitability.get(current_squash).copied().unwrap_or(0.6)
+    } else {
+        0.0
+    };
+
+    if best_squash == current_squash {
+        return None;
+    }
+
+    let improvement = best_score - current_score;
+    if improvement < MIN_IMPROVEMENT_THRESHOLD {
+        return None;
+    }
+
+    let sample_confidence = (records.len() as f32 / 100.0).min(1.0);
+    let improvement_confidence = (improvement * 5.0).min(1.0);
+    let confidence = (sample_confidence * 0.5 + improvement_confidence * 0.5).clamp(0.0, 1.0);
+
+    let topology_label = match descriptor.target_topology {
+        TargetTopology::OneHot => "one-hot",
+        TargetTopology::Simplex => "simplex",
+        _ => "constrained",
+    };
+    let family_label = match descriptor.output_squash_family {
+        OutputSquashFamily::BoundedUnipolar => "bounded unipolar [0,1]",
+        OutputSquashFamily::BoundedBipolar => "bounded bipolar [-1,1]",
+        OutputSquashFamily::Positive => "non-negative",
+        OutputSquashFamily::Unbounded => "unbounded",
+        OutputSquashFamily::Any => "any",
+    };
+    let reason = if current_in_family {
+        "better fit for the observed input distribution within the family"
+    } else {
+        "current squash is outside the family compatible with the loss"
+    };
+    let rationale = format!(
+        "Output neuron under {topology_label} task: restricting recommendation to the {family_label} \
+         family — replacing {current_squash} with {best_squash} ({reason})."
+    );
+
+    Some(ActivationRecommendation {
+        neuron_uuid,
+        current_squash: current_squash.to_string(),
+        recommended_squash: best_squash.to_string(),
+        confidence,
+        expected_improvement: improvement * 0.02,
+        rationale,
+        input_distribution: distribution.class,
+    })
+}
+
 /// Get the score for an activation function.
 ///
 /// Squash names are pre-normalised to uppercase at deserialisation (Issue #753),
@@ -688,6 +855,61 @@ mod tests {
 
         let scores = classify_activation_suitability(&dist);
         assert!(!scores.is_empty(), "Should have suitability scores");
+    }
+
+    #[test]
+    fn test_role_aware_one_hot_picks_bounded_unipolar() {
+        // Issue #1313: an unbounded output squash under a OneHot task must
+        // be replaced by something inside the bounded-unipolar family.
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("output-0", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+        let rec = recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor)
+            .expect("must recommend a bounded squash for a OneHot output neuron");
+
+        assert!(
+            BOUNDED_UNIPOLAR_FAMILY.contains(&rec.recommended_squash.as_str()),
+            "expected BOUNDED_UNIPOLAR_FAMILY recommendation, got {}",
+            rec.recommended_squash,
+        );
+    }
+
+    #[test]
+    fn test_role_aware_hidden_unchanged_under_one_hot() {
+        // Hidden-neuron recommendations must mirror the legacy path even
+        // when the descriptor constrains the output family.
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("hidden-1", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+        let hidden =
+            recommend_activation_function_for_role(&records, "IDENTITY", false, &descriptor);
+        let legacy = recommend_activation_function(&records, "IDENTITY");
+
+        assert_eq!(
+            hidden.map(|r| r.recommended_squash),
+            legacy.map(|r| r.recommended_squash),
+        );
+    }
+
+    #[test]
+    fn test_role_aware_neutral_descriptor_matches_legacy() {
+        let records: Vec<DiscoverRecord> = (0..80)
+            .map(|i| make_record("output-0", i, -8.0 + (i as f32) * 0.2))
+            .collect();
+        let neutral = TaskDescriptor::neutral();
+
+        let role_aware =
+            recommend_activation_function_for_role(&records, "IDENTITY", true, &neutral);
+        let legacy = recommend_activation_function(&records, "IDENTITY");
+
+        assert_eq!(
+            role_aware.map(|r| r.recommended_squash),
+            legacy.map(|r| r.recommended_squash),
+        );
     }
 
     #[test]

--- a/src/analysis/recommendation/mod.rs
+++ b/src/analysis/recommendation/mod.rs
@@ -10,4 +10,5 @@ pub mod fan_in;
 pub mod gradient_discovery;
 pub mod multi_hop;
 pub mod output_bias_drift;
+pub mod output_competition;
 pub mod sample_weighted;

--- a/src/analysis/recommendation/output_bias_drift.rs
+++ b/src/analysis/recommendation/output_bias_drift.rs
@@ -29,6 +29,7 @@
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use std::collections::HashMap;
 
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::types::DiscoverRecord;
 use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
 
@@ -41,6 +42,29 @@ const MIN_MAJORITY_SIGN_FRACTION: f32 = 0.7;
 
 /// Minimum absolute mean error to distinguish from noise.
 const MIN_MEAN_ERROR_MAGNITUDE: f32 = 0.01;
+
+/// Capacity-starvation threshold (Issue #1316).
+///
+/// A class is considered "positively supported" when the recorded target
+/// value is above this threshold. For `OneHot` / `Simplex` topologies the
+/// targets sit on `[0, 1]` and the "on" class records as 1.0, so any
+/// threshold in the middle of the unit interval reliably separates "on"
+/// from "off" while tolerating soft labels.
+const POSITIVE_SUPPORT_TARGET_THRESHOLD: f32 = 0.5;
+
+/// Saturating activation threshold (Issue #1316).
+///
+/// Mirrors the bounded-unipolar saturation threshold used by the saturated
+/// neuron detector. An output neuron whose maximum activation on its
+/// positive-support class never reaches this value is treated as
+/// capacity-starved for that class.
+const SATURATING_ACTIVATION_THRESHOLD: f32 = 0.85;
+
+/// Multiplier applied to the estimated improvement of a candidate that is
+/// also flagged as capacity-starved under a `OneHot` / `Simplex` task
+/// (Issue #1316). Picked to lift the candidate above peers without
+/// overwhelming the rest of the ranking.
+const CAPACITY_STARVED_GAIN_BOOST: f32 = 2.0;
 
 /// Result of detecting output bias drift.
 #[derive(Debug, Clone)]
@@ -59,6 +83,12 @@ pub struct OutputBiasDriftCandidate {
     pub recommended_bias_delta: f32,
     /// Estimated creature score improvement from fixing the bias.
     pub estimated_improvement: f32,
+    /// Whether this candidate was flagged as capacity-starved under a
+    /// `OneHot` / `Simplex` task descriptor (Issue #1316). Always `false`
+    /// for the legacy `detect_output_bias_drift` entry point; only the
+    /// role-aware `detect_output_bias_drift_with_descriptor` path can
+    /// set this to `true`.
+    pub capacity_starved: bool,
 }
 
 /// Detect output neurons with bias drift from recorded activations.
@@ -145,6 +175,7 @@ pub fn detect_output_bias_drift(
             sample_count: error_values.len(),
             recommended_bias_delta,
             estimated_improvement,
+            capacity_starved: false,
         });
     }
 
@@ -187,4 +218,170 @@ pub fn output_bias_drift_to_coordinated_candidates(
     });
 
     results
+}
+
+// =============================================================================
+// Role-aware output bias drift (Issue #1316)
+// =============================================================================
+//
+// Under `OneHot` / `Simplex` topologies the recorded target marks exactly one
+// "on" class per sample. An output neuron whose maximum activation on the
+// samples that *belong to its class* never crosses the saturating threshold is
+// suffering capacity starvation — its parameters cannot push the prediction
+// high enough even when the class is well supported. The role-aware path runs
+// the legacy detector first (so unrelated callers are unaffected) and then,
+// when the descriptor topology is `OneHot` or `Simplex`, boosts the
+// estimated improvement of any matching candidate and synthesises a fresh
+// candidate for capacity-starved output neurons that the legacy detector
+// missed.
+
+/// Whether a descriptor's topology gates the role-aware bias-drift path.
+fn role_aware_topology(descriptor: &TaskDescriptor) -> bool {
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Diagnostics about an output neuron's positive-support class.
+struct PositiveSupportStats {
+    /// Count of records on the positive-support class (target above the
+    /// `POSITIVE_SUPPORT_TARGET_THRESHOLD`).
+    count: usize,
+    /// Maximum activation observed on the positive-support records.
+    max_activation: f32,
+    /// Mean activation observed on the positive-support records.
+    mean_activation: f32,
+    /// Mean error on the positive-support records (target − activation under
+    /// linear-residual costs).
+    mean_error: f32,
+}
+
+/// Summarise the positive-support behaviour of an output neuron given its
+/// records. Returns `None` when the recorded targets carry no positive
+/// support (no `value > POSITIVE_SUPPORT_TARGET_THRESHOLD`).
+fn summarise_positive_support(records: &[DiscoverRecord]) -> Option<PositiveSupportStats> {
+    let mut count = 0_usize;
+    let mut max_activation = f32::NEG_INFINITY;
+    let mut sum_activation = 0.0_f32;
+    let mut sum_error = 0.0_f32;
+
+    for r in records {
+        // Targets are recorded in `value` (Option<f32>). Records without a
+        // recorded target cannot contribute to positive-support reasoning.
+        let Some(target) = r.value else { continue };
+        if target <= POSITIVE_SUPPORT_TARGET_THRESHOLD {
+            continue;
+        }
+        count += 1;
+        sum_activation += r.activation;
+        if r.activation > max_activation {
+            max_activation = r.activation;
+        }
+        if let Some(&e) = r.errors.first() {
+            sum_error += e;
+        }
+    }
+
+    if count == 0 {
+        return None;
+    }
+
+    let n = count as f32;
+    Some(PositiveSupportStats {
+        count,
+        max_activation,
+        mean_activation: sum_activation / n,
+        mean_error: sum_error / n,
+    })
+}
+
+/// Determine whether the positive-support stats indicate capacity starvation:
+/// a well-supported class whose activations never cross the saturating
+/// threshold.
+fn is_capacity_starved(stats: &PositiveSupportStats) -> bool {
+    stats.count >= MIN_SAMPLES_FOR_BIAS_DRIFT
+        && stats.max_activation < SATURATING_ACTIVATION_THRESHOLD
+}
+
+/// Role-aware output bias drift detection (Issue #1316).
+///
+/// Behaves identically to [`detect_output_bias_drift`] when the descriptor
+/// reports a topology other than `OneHot` / `Simplex` — neutral, `OTHER`,
+/// `Independent`, `Margin`, and any future variant fall back to the legacy
+/// detector. For `OneHot` / `Simplex` descriptors, output neurons with
+/// positive class support whose activations never cross the saturating
+/// activation threshold are flagged as capacity-starved and their estimated
+/// improvement is boosted by a fixed gain multiplier. Capacity-starved
+/// neurons that the legacy detector missed receive a fresh candidate whose
+/// `recommended_bias_delta` matches the legacy convention (`−mean_error` on
+/// the positive-support records).
+pub fn detect_output_bias_drift_with_descriptor(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    descriptor: &TaskDescriptor,
+) -> Vec<OutputBiasDriftCandidate> {
+    let mut candidates = detect_output_bias_drift(creature, neuron_records);
+
+    if !role_aware_topology(descriptor) {
+        return candidates;
+    }
+
+    let output_neurons: HashMap<&str, f32> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| (n.uuid.as_str(), n.bias))
+        .collect();
+
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    for (&uuid, &current_bias) in &output_neurons {
+        let Some(records) = records_map.get(uuid) else {
+            continue;
+        };
+        let Some(stats) = summarise_positive_support(records) else {
+            continue;
+        };
+        if !is_capacity_starved(&stats) {
+            continue;
+        }
+
+        if let Some(existing) = candidates.iter_mut().find(|c| c.neuron_uuid == uuid) {
+            existing.capacity_starved = true;
+            existing.estimated_improvement *= CAPACITY_STARVED_GAIN_BOOST;
+            continue;
+        }
+
+        // No legacy candidate for this neuron — synthesise one. Picking the
+        // bias delta from the positive-support mean error matches the legacy
+        // convention (`recommended_bias_delta = −mean_error`) and falls back
+        // to closing the gap to saturation when the recorded errors are
+        // unusable.
+        let recommended_bias_delta = if stats.mean_error.is_finite() && stats.mean_error.abs() > 0.0
+        {
+            -stats.mean_error
+        } else {
+            SATURATING_ACTIVATION_THRESHOLD - stats.mean_activation
+        };
+        let gap = (SATURATING_ACTIVATION_THRESHOLD - stats.max_activation).max(0.0);
+        let estimated_improvement = gap * 0.1 * CAPACITY_STARVED_GAIN_BOOST;
+
+        candidates.push(OutputBiasDriftCandidate {
+            neuron_uuid: uuid.to_string(),
+            current_bias,
+            mean_error: stats.mean_error,
+            positive_error_fraction: 0.0,
+            sample_count: stats.count,
+            recommended_bias_delta,
+            estimated_improvement,
+            capacity_starved: true,
+        });
+    }
+
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
 }

--- a/src/analysis/recommendation/output_competition.rs
+++ b/src/analysis/recommendation/output_competition.rs
@@ -1,0 +1,323 @@
+//! Output competition / lateral-inhibition recommender (Issue #1321).
+//!
+//! Under `OneHot` / `Simplex` target topologies, exactly one output class
+//! "wins" per sample. When two output neurons co-fire strongly on the same
+//! samples they are competing for the same evidence — a structural pattern
+//! lateral inhibition is designed to resolve. This recommender proposes
+//! mutual-exclusion structure between such output neurons by emitting
+//! inhibitory output→output `AddSynapse` operations (forward-only ordered
+//! so the resulting edge is valid).
+//!
+//! ## Gating
+//!
+//! - `target_topology = OneHot | Simplex` ⇒ run the detector.
+//! - Every other topology (`Independent`, `Margin`, `Unknown`, including
+//!   the neutral / `OTHER` fallbacks) ⇒ emit **nothing** (regression
+//!   guard, per the acceptance criteria of Issue #1321).
+//!
+//! ## Detection criteria
+//!
+//! 1. The creature has at least two output neurons.
+//! 2. For an ordered output pair `(a, b)` where `index_of(a) < index_of(b)`
+//!    in `creature.neurons[]` (so `AddSynapse(a → b)` respects forward-only
+//!    evaluation order):
+//!    a. Their records cover the same observation indices.
+//!    b. On at least `MIN_DISCOVERY_SAMPLE_COUNT` aligned samples both
+//!    activations exceed `CO_ACTIVATION_THRESHOLD` (they are "co-firing").
+//! 3. The pair has no existing synapse between them — we never duplicate.
+//!
+//! When all checks pass, an [`OutputCompetitionCandidate`] is emitted with
+//! a small negative `recommended_weight` (`LATERAL_INHIBITION_WEIGHT`).
+//! `output_competition_to_coordinated_candidates` packages each candidate
+//! as a single `AddSynapse` operation inside a coordinated structural
+//! candidate.
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts for neural-network statistics (Issue #873).
+
+use std::collections::{HashMap, HashSet};
+
+use crate::analysis::constants::MIN_DISCOVERY_SAMPLE_COUNT;
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
+use crate::types::DiscoverRecord;
+use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson};
+
+/// Activation threshold above which an output neuron is considered to be
+/// firing strongly on a given sample. Chosen to sit comfortably inside the
+/// upper half of the unit interval so that genuine co-activation patterns
+/// (both outputs trying to "win" the same sample) are picked up while
+/// near-zero noise is excluded.
+const CO_ACTIVATION_THRESHOLD: f32 = 0.5;
+
+/// Initial inhibitory weight for proposed lateral connections. Small
+/// magnitude — the recommendation is structural; the optimiser is expected
+/// to tune it. Negative so the receiving neuron is *suppressed* when the
+/// sending neuron fires.
+const LATERAL_INHIBITION_WEIGHT: f32 = -0.1;
+
+/// Scale factor applied to the co-activation score when estimating the
+/// creature-level score gain. Kept small so output-competition candidates
+/// rank against the rest of the candidate set without dominating it.
+const COMPETITION_GAIN_SCALE: f32 = 0.01;
+
+/// A proposed inhibitory connection between two output neurons.
+#[derive(Debug, Clone)]
+pub struct OutputCompetitionCandidate {
+    /// Source output neuron (the inhibitor — fires first in evaluation order).
+    pub from_output_uuid: String,
+    /// Target output neuron (the suppressed neuron).
+    pub to_output_uuid: String,
+    /// Recommended initial weight for the inhibitory synapse. Always
+    /// negative; see the private `LATERAL_INHIBITION_WEIGHT` constant.
+    pub recommended_weight: f32,
+    /// Co-activation score in `[0, 1]` — the mean of `min(a, b)` over
+    /// samples where both outputs cross the co-activation threshold.
+    pub co_activation_score: f32,
+    /// Number of aligned co-activated samples that supported this candidate.
+    pub sample_count: usize,
+    /// Estimated creature-level score gain from applying the inhibition.
+    pub estimated_improvement: f32,
+}
+
+/// Whether a descriptor's topology gates the output-competition detector.
+fn role_aware_topology(descriptor: &TaskDescriptor) -> bool {
+    matches!(
+        descriptor.target_topology,
+        TargetTopology::OneHot | TargetTopology::Simplex
+    )
+}
+
+/// Detect output competition under `OneHot` / `Simplex` topologies.
+///
+/// Returns an empty vector for any other descriptor (regression guard for
+/// `OTHER` / `Unknown` / `Independent` / `Margin`).
+///
+/// # Arguments
+/// * `creature` — the creature whose output neurons are inspected.
+/// * `neuron_records` — recorded `(uuid, records)` pairs. Only output-neuron
+///   entries are consulted; entries for non-outputs are ignored.
+/// * `descriptor` — the task descriptor; only `OneHot` / `Simplex`
+///   topologies activate detection.
+#[must_use]
+pub fn detect_output_competition(
+    creature: &CreatureJson,
+    neuron_records: &[(String, Vec<DiscoverRecord>)],
+    descriptor: &TaskDescriptor,
+) -> Vec<OutputCompetitionCandidate> {
+    if !role_aware_topology(descriptor) {
+        return Vec::new();
+    }
+
+    // Collect output neurons in their `creature.neurons[]` order so that
+    // any emitted `AddSynapse(a -> b)` respects forward-only evaluation.
+    let output_neurons: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if output_neurons.len() < 2 {
+        return Vec::new();
+    }
+
+    // Existing synapse set — we never propose a duplicate.
+    let existing: HashSet<(&str, &str)> = creature
+        .synapses
+        .iter()
+        .map(|s| (s.from_uuid.as_str(), s.to_uuid.as_str()))
+        .collect();
+
+    // Records lookup by uuid.
+    let records_map: HashMap<&str, &Vec<DiscoverRecord>> = neuron_records
+        .iter()
+        .map(|(uuid, records)| (uuid.as_str(), records))
+        .collect();
+
+    let mut candidates = Vec::new();
+
+    for i in 0..output_neurons.len() {
+        for j in (i + 1)..output_neurons.len() {
+            let a = output_neurons[i];
+            let b = output_neurons[j];
+
+            if existing.contains(&(a, b)) {
+                continue;
+            }
+
+            let (Some(a_records), Some(b_records)) = (records_map.get(a), records_map.get(b))
+            else {
+                continue;
+            };
+
+            let Some((co_activation_score, sample_count)) = co_activation(a_records, b_records)
+            else {
+                continue;
+            };
+
+            if sample_count < MIN_DISCOVERY_SAMPLE_COUNT {
+                continue;
+            }
+
+            candidates.push(OutputCompetitionCandidate {
+                from_output_uuid: a.to_string(),
+                to_output_uuid: b.to_string(),
+                recommended_weight: LATERAL_INHIBITION_WEIGHT,
+                co_activation_score,
+                sample_count,
+                estimated_improvement: co_activation_score * COMPETITION_GAIN_SCALE,
+            });
+        }
+    }
+
+    candidates.sort_by(|a, b| b.estimated_improvement.total_cmp(&a.estimated_improvement));
+    candidates
+}
+
+/// Compute a co-activation score between two output neurons' records.
+///
+/// Returns `Some((score, count))` where:
+/// - `count` is the number of *aligned* samples (matched by `obs_index`) on
+///   which both neurons cross the co-activation threshold.
+/// - `score` is the mean of `min(a.activation, b.activation)` over those
+///   co-activated samples — bounded in `[threshold, 1]` for bounded-unipolar
+///   outputs.
+///
+/// Returns `None` when no aligned co-activated samples exist.
+fn co_activation(
+    a_records: &[DiscoverRecord],
+    b_records: &[DiscoverRecord],
+) -> Option<(f32, usize)> {
+    let b_by_idx: HashMap<u32, f32> = b_records
+        .iter()
+        .map(|r| (r.obs_index, r.activation))
+        .collect();
+
+    let mut count = 0_usize;
+    let mut sum_min = 0.0_f32;
+
+    for r in a_records {
+        let Some(&b_act) = b_by_idx.get(&r.obs_index) else {
+            continue;
+        };
+        if r.activation > CO_ACTIVATION_THRESHOLD && b_act > CO_ACTIVATION_THRESHOLD {
+            count += 1;
+            sum_min += r.activation.min(b_act);
+        }
+    }
+
+    if count == 0 {
+        return None;
+    }
+
+    Some((sum_min / count as f32, count))
+}
+
+/// Package output-competition candidates as coordinated structural
+/// candidates with a single `AddSynapse` operation each.
+#[must_use]
+pub fn output_competition_to_coordinated_candidates(
+    candidates: &[OutputCompetitionCandidate],
+) -> Vec<CoordinatedStructuralCandidateJson> {
+    let mut results = Vec::with_capacity(candidates.len());
+
+    for c in candidates {
+        results.push(CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: c.from_output_uuid.clone(),
+                to_neuron_uuid: c.to_output_uuid.clone(),
+                weight: c.recommended_weight,
+            }],
+            expected_creature_score_gain: c.estimated_improvement,
+            comment: Some(format!(
+                "Output competition: {} ↔ {} co-fire on {} samples (score {:.3}) → propose inhibitory synapse (weight {:.3})",
+                c.from_output_uuid,
+                c.to_output_uuid,
+                c.sample_count,
+                c.co_activation_score,
+                c.recommended_weight,
+            )),
+        });
+    }
+
+    results.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NeuronJson, SynapseJson};
+
+    fn rec(uuid: &str, idx: u32, activation: f32) -> DiscoverRecord {
+        DiscoverRecord {
+            obs_index: idx,
+            neuron_uuid: uuid.to_string(),
+            value: Some(0.0),
+            activation,
+            errors: vec![0.0],
+        }
+    }
+
+    fn neuron(uuid: &str, neuron_type: &str) -> NeuronJson {
+        NeuronJson {
+            uuid: uuid.to_string(),
+            neuron_type: neuron_type.to_string(),
+            squash: "LOGISTIC".to_string(),
+            bias: 0.0,
+        }
+    }
+
+    fn creature_with_two_outputs() -> CreatureJson {
+        CreatureJson {
+            neurons: vec![
+                neuron("input-1", "input"),
+                neuron("output-a", "output"),
+                neuron("output-b", "output"),
+            ],
+            synapses: vec![SynapseJson {
+                from_uuid: "input-1".to_string(),
+                to_uuid: "output-a".to_string(),
+                weight: 0.1,
+                synapse_type: None,
+            }],
+            input: 1,
+            output: 2,
+        }
+    }
+
+    #[test]
+    fn co_activation_returns_none_for_disjoint_records() {
+        let a: Vec<_> = (0..30).map(|i| rec("a", i, 0.9)).collect();
+        let b: Vec<_> = (0..30).map(|i| rec("b", i, 0.1)).collect();
+        assert!(co_activation(&a, &b).is_none());
+    }
+
+    #[test]
+    fn co_activation_counts_only_aligned_pairs_above_threshold() {
+        let a: Vec<_> = (0..30).map(|i| rec("a", i, 0.8)).collect();
+        let b: Vec<_> = (0..30).map(|i| rec("b", i, 0.9)).collect();
+        let (score, count) = co_activation(&a, &b).expect("co-activated");
+        assert_eq!(count, 30);
+        assert!((score - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn neutral_descriptor_skips_detection() {
+        let creature = creature_with_two_outputs();
+        let records = vec![
+            (
+                "output-a".to_string(),
+                (0..30).map(|i| rec("output-a", i, 0.9)).collect(),
+            ),
+            (
+                "output-b".to_string(),
+                (0..30).map(|i| rec("output-b", i, 0.9)).collect(),
+            ),
+        ];
+        let candidates = detect_output_competition(&creature, &records, &TaskDescriptor::neutral());
+        assert!(candidates.is_empty());
+    }
+}

--- a/src/analysis/task_descriptor.rs
+++ b/src/analysis/task_descriptor.rs
@@ -1,0 +1,310 @@
+//! Task descriptor for discovery consumers (Issue #1312).
+//!
+//! A [`TaskDescriptor`] is a small, FFI-free summary of the **shape of the
+//! supervised-learning task** a recorded creature was trained against. It is
+//! derived purely from the cost-function name (and the network's output
+//! count) and carries no per-record data.
+//!
+//! Detectors and recommenders consult the descriptor to gate behaviour that
+//! depends on the structural assumptions of the loss:
+//!
+//! - **Target topology** — are the outputs independent scalars, a one-hot
+//!   class label, a soft-max simplex, or a signed margin?
+//! - **Target range** — what numeric range can the recorded target take?
+//! - **Output squash family** — what activation shape is compatible with the
+//!   loss on the final layer?
+//!
+//! The mapping is exhaustive for the seven built-in NEAT-AI costs listed in
+//! the issue. Any other name — including `OTHER` and any unrecognised /
+//! absent string — falls back to [`TaskDescriptor::neutral`], which encodes
+//! "we know nothing; don't gate on this".
+//!
+//! This module is intentionally pure: it has no FFI surface, no I/O, and no
+//! dependency on other discovery modules. Wiring the descriptor through the
+//! FFI ingest path and consumer detectors is tracked separately (see
+//! issue #1314 and the per-consumer issues that reference #1312).
+
+/// Topology of the recorded targets vector for a single training sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TargetTopology {
+    /// Each output is an independent scalar target (e.g. regression, BCE).
+    Independent,
+    /// Targets form a one-hot class label (exactly one output is `1`, the
+    /// rest are `0`) and the model produces per-class scores.
+    OneHot,
+    /// Targets sit on the probability simplex; the output layer is expected
+    /// to be a soft-max producing values summing to one.
+    Simplex,
+    /// Margin-based target — used by hinge-style losses where the recorded
+    /// target is a signed margin label rather than a probability.
+    Margin,
+    /// Topology is unknown or not constrained by the cost. Detectors should
+    /// fall back to their generic, pre-Issue-#1312 behaviour.
+    #[default]
+    Unknown,
+}
+
+/// Numeric range the recorded targets can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TargetRange {
+    /// Targets are unbounded reals.
+    #[default]
+    Unbounded,
+    /// Targets are in `[0, 1]`.
+    Unit,
+    /// Targets are non-negative reals (`>= 0`).
+    Positive,
+    /// Targets are in `[-1, 1]`.
+    SignedUnit,
+}
+
+/// Family of activation functions that is compatible with the loss on the
+/// final layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputSquashFamily {
+    /// Bounded, unipolar squash (range `[0, 1]`): LOGISTIC, `BIPOLAR_SIGMOID`
+    /// rescaled to unipolar, etc.
+    BoundedUnipolar,
+    /// Bounded, bipolar squash (range `[-1, 1]`): TANH, `BIPOLAR_SIGMOID`.
+    BoundedBipolar,
+    /// Non-negative output (range `[0, +inf)`): RELU, SOFTPLUS, ABSOLUTE.
+    Positive,
+    /// Unbounded real output: IDENTITY, SELU on large inputs.
+    Unbounded,
+    /// No constraint imposed by the loss. Detectors should not gate on the
+    /// output activation family.
+    #[default]
+    Any,
+}
+
+/// Cost-function-derived description of the supervised-learning task.
+///
+/// Constructed via [`TaskDescriptor::from_name`] or
+/// [`TaskDescriptor::neutral`]. The struct is `Copy` and trivially cheap to
+/// pass by value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskDescriptor {
+    /// Topology of the targets vector.
+    pub target_topology: TargetTopology,
+    /// Numeric range of recorded targets.
+    pub target_range: TargetRange,
+    /// Output squash family compatible with the loss.
+    pub output_squash_family: OutputSquashFamily,
+    /// Number of output neurons in the network. Captured so that consumers
+    /// can sanity-check topology assumptions (e.g. `OneHot` requires more
+    /// than one output to be meaningful).
+    pub num_outputs: usize,
+}
+
+impl TaskDescriptor {
+    /// Neutral descriptor — used when the cost name is absent, unrecognised,
+    /// or explicitly `OTHER`. Encodes "we know nothing; don't gate on this".
+    ///
+    /// `num_outputs` is set to `0` because the neutral descriptor carries
+    /// no information about the network's shape. Call
+    /// [`TaskDescriptor::from_name`] when the output count matters.
+    #[must_use]
+    pub const fn neutral() -> Self {
+        Self {
+            target_topology: TargetTopology::Unknown,
+            target_range: TargetRange::Unbounded,
+            output_squash_family: OutputSquashFamily::Any,
+            num_outputs: 0,
+        }
+    }
+
+    /// Map a NEAT-AI cost name (case-insensitive) and the network's output
+    /// count onto a [`TaskDescriptor`].
+    ///
+    /// Recognised names: `MSE`, `MAE`, `MAPE`, `MSLE`,
+    /// `BINARY_CROSS_ENTROPY`, `CROSS_ENTROPY`, `HINGE`, `CATEGORICAL_ERROR`.
+    /// Any other input — including `OTHER`, empty strings, and arbitrary
+    /// unknown names — returns [`TaskDescriptor::neutral`].
+    #[must_use]
+    pub fn from_name(name: &str, num_outputs: usize) -> Self {
+        match name.to_ascii_uppercase().as_str() {
+            "MSE" | "MAE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Unbounded,
+                output_squash_family: OutputSquashFamily::Unbounded,
+                num_outputs,
+            },
+            "MAPE" | "MSLE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Positive,
+                output_squash_family: OutputSquashFamily::Positive,
+                num_outputs,
+            },
+            "BINARY_CROSS_ENTROPY" | "BINARYCROSSENTROPY" | "BCE" => Self {
+                target_topology: TargetTopology::Independent,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            "CROSS_ENTROPY" | "CROSSENTROPY" | "CE" => Self {
+                target_topology: TargetTopology::Simplex,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            "HINGE" => Self {
+                target_topology: TargetTopology::Margin,
+                target_range: TargetRange::SignedUnit,
+                output_squash_family: OutputSquashFamily::BoundedBipolar,
+                num_outputs,
+            },
+            "CATEGORICAL_ERROR" | "CATEGORICALERROR" => Self {
+                target_topology: TargetTopology::OneHot,
+                target_range: TargetRange::Unit,
+                output_squash_family: OutputSquashFamily::BoundedUnipolar,
+                num_outputs,
+            },
+            // OTHER and every unrecognised / absent name collapse to neutral.
+            _ => Self::neutral(),
+        }
+    }
+}
+
+impl Default for TaskDescriptor {
+    fn default() -> Self {
+        Self::neutral()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neutral_is_unknown_unbounded_any() {
+        let d = TaskDescriptor::neutral();
+        assert_eq!(d.target_topology, TargetTopology::Unknown);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Any);
+        assert_eq!(d.num_outputs, 0);
+    }
+
+    #[test]
+    fn default_descriptor_equals_neutral() {
+        assert_eq!(TaskDescriptor::default(), TaskDescriptor::neutral());
+    }
+
+    #[test]
+    fn mse_maps_to_independent_unbounded_unbounded() {
+        let d = TaskDescriptor::from_name("MSE", 3);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        assert_eq!(d.num_outputs, 3);
+    }
+
+    #[test]
+    fn mae_maps_to_independent_unbounded_unbounded() {
+        let d = TaskDescriptor::from_name("MAE", 5);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unbounded);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        assert_eq!(d.num_outputs, 5);
+    }
+
+    #[test]
+    fn mape_maps_to_independent_positive_positive() {
+        let d = TaskDescriptor::from_name("MAPE", 2);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Positive);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Positive);
+        assert_eq!(d.num_outputs, 2);
+    }
+
+    #[test]
+    fn msle_maps_to_independent_positive_positive() {
+        let d = TaskDescriptor::from_name("MSLE", 4);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Positive);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::Positive);
+        assert_eq!(d.num_outputs, 4);
+    }
+
+    #[test]
+    fn binary_cross_entropy_maps_to_independent_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("BINARY_CROSS_ENTROPY", 1);
+        assert_eq!(d.target_topology, TargetTopology::Independent);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 1);
+    }
+
+    #[test]
+    fn cross_entropy_maps_to_simplex_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("CROSS_ENTROPY", 10);
+        assert_eq!(d.target_topology, TargetTopology::Simplex);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 10);
+    }
+
+    #[test]
+    fn hinge_maps_to_margin_signed_unit_bounded_bipolar() {
+        let d = TaskDescriptor::from_name("HINGE", 1);
+        assert_eq!(d.target_topology, TargetTopology::Margin);
+        assert_eq!(d.target_range, TargetRange::SignedUnit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedBipolar);
+        assert_eq!(d.num_outputs, 1);
+    }
+
+    #[test]
+    fn categorical_error_maps_to_onehot_unit_bounded_unipolar() {
+        let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 7);
+        assert_eq!(d.target_topology, TargetTopology::OneHot);
+        assert_eq!(d.target_range, TargetRange::Unit);
+        assert_eq!(d.output_squash_family, OutputSquashFamily::BoundedUnipolar);
+        assert_eq!(d.num_outputs, 7);
+    }
+
+    #[test]
+    fn other_collapses_to_neutral() {
+        assert_eq!(
+            TaskDescriptor::from_name("OTHER", 4),
+            TaskDescriptor::neutral(),
+        );
+    }
+
+    #[test]
+    fn unrecognised_name_collapses_to_neutral() {
+        assert_eq!(
+            TaskDescriptor::from_name("EXOTIC_LOSS", 8),
+            TaskDescriptor::neutral(),
+        );
+    }
+
+    #[test]
+    fn empty_name_collapses_to_neutral() {
+        assert_eq!(TaskDescriptor::from_name("", 2), TaskDescriptor::neutral(),);
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive() {
+        for name in ["mse", "Mse", "mSe", "MSE"] {
+            let d = TaskDescriptor::from_name(name, 1);
+            assert_eq!(d.target_topology, TargetTopology::Independent);
+            assert_eq!(d.target_range, TargetRange::Unbounded);
+            assert_eq!(d.output_squash_family, OutputSquashFamily::Unbounded);
+        }
+        for name in ["hinge", "Hinge", "HINGE"] {
+            let d = TaskDescriptor::from_name(name, 1);
+            assert_eq!(d.target_topology, TargetTopology::Margin);
+        }
+    }
+
+    #[test]
+    fn num_outputs_is_preserved_verbatim() {
+        for n in [0_usize, 1, 7, 1024] {
+            assert_eq!(TaskDescriptor::from_name("MSE", n).num_outputs, n);
+            assert_eq!(TaskDescriptor::from_name("CROSS_ENTROPY", n).num_outputs, n);
+            // Unrecognised names go through neutral(), which always has 0
+            // outputs by design — the caller should not be relying on the
+            // value when the cost is unknown.
+            assert_eq!(TaskDescriptor::from_name("OTHER", n).num_outputs, 0);
+        }
+    }
+}

--- a/src/analysis/task_descriptor.rs
+++ b/src/analysis/task_descriptor.rs
@@ -19,10 +19,15 @@
 //! absent string — falls back to [`TaskDescriptor::neutral`], which encodes
 //! "we know nothing; don't gate on this".
 //!
-//! This module is intentionally pure: it has no FFI surface, no I/O, and no
-//! dependency on other discovery modules. Wiring the descriptor through the
-//! FFI ingest path and consumer detectors is tracked separately (see
-//! issue #1314 and the per-consumer issues that reference #1312).
+//! The descriptor itself is intentionally pure (no FFI surface, no I/O) but
+//! it exposes a small projection — [`TaskDescriptor::cost_function_hint`] —
+//! that maps the task shape onto the [`crate::analysis::cost_function_hint::CostFunctionHint`]
+//! used by the implied-target reconstruction guard (issue #1317). Wiring the
+//! descriptor through the FFI ingest path and the remaining per-consumer
+//! sites is tracked separately (see issue #1314 and the per-consumer issues
+//! that reference #1312).
+
+use crate::analysis::cost_function_hint::CostFunctionHint;
 
 /// Topology of the recorded targets vector for a single training sample.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -163,6 +168,63 @@ impl TaskDescriptor {
             _ => Self::neutral(),
         }
     }
+
+    /// Map this descriptor onto a [`CostFunctionHint`] for the
+    /// target-reconstruction guard (issue #1317).
+    ///
+    /// The guard is consulted by detectors that reconstruct an "implied
+    /// target" as `activation ± error` (see
+    /// `src/analysis/cost_function_hint.rs`, issue #1250). That identity
+    /// only holds for **linear-residual** costs — those whose recorded
+    /// error obeys `error = target − output` (or its negation).
+    ///
+    /// Mapping rules:
+    ///
+    /// - `MSE` / `MAE` — `Independent` topology with `Unbounded` range ⇒
+    ///   [`CostFunctionHint::LinearResidual`].
+    /// - `BINARY_CROSS_ENTROPY` — `Independent` topology with `Unit` range
+    ///   and `BoundedUnipolar` outputs ⇒ [`CostFunctionHint::LinearResidual`]
+    ///   (NEAT-AI records BCE error as `target − output`).
+    /// - `CROSS_ENTROPY` — `Simplex` topology ⇒
+    ///   [`CostFunctionHint::LinearResidual`].
+    /// - `MAPE` / `MSLE` — `Independent` topology with `Positive` range ⇒
+    ///   [`CostFunctionHint::NonLinearResidual`].
+    /// - `HINGE` — `Margin` topology ⇒ [`CostFunctionHint::NonLinearResidual`].
+    /// - `CATEGORICAL_ERROR` — `OneHot` topology ⇒
+    ///   [`CostFunctionHint::NonLinearResidual`].
+    /// - Neutral / unknown / `OTHER` descriptors ⇒
+    ///   [`CostFunctionHint::NonLinearResidual`] (conservative skip — see
+    ///   issue #1317 acceptance criterion: "OTHER / Unknown / absent ⇒
+    ///   conservative skip").
+    ///
+    /// The conservative-skip mapping for neutral descriptors is intentional:
+    /// the existing [`CostFunctionHint::Unknown`] variant preserves the
+    /// pre-Issue-#1250 "assume linear" behaviour for callers that have not
+    /// been migrated, but at the dispatch level we want the *absence* of a
+    /// cost identity to gate the reconstruction-dependent detectors off so
+    /// they cannot emit spurious candidates against an unknown loss shape.
+    #[must_use]
+    pub fn cost_function_hint(&self) -> CostFunctionHint {
+        use OutputSquashFamily as F;
+        use TargetRange as R;
+        use TargetTopology as T;
+
+        match (
+            self.target_topology,
+            self.target_range,
+            self.output_squash_family,
+        ) {
+            // MSE / MAE
+            (T::Independent, R::Unbounded, F::Unbounded) => CostFunctionHint::LinearResidual,
+            // BINARY_CROSS_ENTROPY
+            (T::Independent, R::Unit, F::BoundedUnipolar) => CostFunctionHint::LinearResidual,
+            // CROSS_ENTROPY
+            (T::Simplex, R::Unit, _) => CostFunctionHint::LinearResidual,
+            // Everything else — MAPE / MSLE (Independent + Positive),
+            // HINGE (Margin), CATEGORICAL_ERROR (OneHot), neutral (Unknown).
+            _ => CostFunctionHint::NonLinearResidual,
+        }
+    }
 }
 
 impl Default for TaskDescriptor {
@@ -294,6 +356,56 @@ mod tests {
             let d = TaskDescriptor::from_name(name, 1);
             assert_eq!(d.target_topology, TargetTopology::Margin);
         }
+    }
+
+    #[test]
+    fn cost_function_hint_for_linear_residual_costs() {
+        // Issue #1317: MSE, MAE, BCE, CE map to LinearResidual.
+        for name in ["MSE", "MAE", "BINARY_CROSS_ENTROPY", "CROSS_ENTROPY"] {
+            let descriptor = TaskDescriptor::from_name(name, 4);
+            assert_eq!(
+                descriptor.cost_function_hint(),
+                CostFunctionHint::LinearResidual,
+                "{name} descriptor should map to LinearResidual",
+            );
+        }
+    }
+
+    #[test]
+    fn cost_function_hint_for_non_linear_residual_costs() {
+        // Issue #1317: MAPE, MSLE, HINGE, CATEGORICAL_ERROR map to
+        // NonLinearResidual so the reconstruction-dependent detectors skip.
+        for name in ["MAPE", "MSLE", "HINGE", "CATEGORICAL_ERROR"] {
+            let descriptor = TaskDescriptor::from_name(name, 4);
+            assert_eq!(
+                descriptor.cost_function_hint(),
+                CostFunctionHint::NonLinearResidual,
+                "{name} descriptor should map to NonLinearResidual",
+            );
+        }
+    }
+
+    #[test]
+    fn cost_function_hint_for_neutral_is_conservative_skip() {
+        // Issue #1317 acceptance: OTHER / Unknown / absent ⇒ conservative
+        // skip. The neutral descriptor maps to NonLinearResidual to gate
+        // the implied-target reconstructions off when we know nothing
+        // about the loss shape.
+        assert_eq!(
+            TaskDescriptor::neutral().cost_function_hint(),
+            CostFunctionHint::NonLinearResidual,
+            "neutral descriptor must conservatively skip",
+        );
+        assert_eq!(
+            TaskDescriptor::from_name("OTHER", 3).cost_function_hint(),
+            CostFunctionHint::NonLinearResidual,
+            "OTHER descriptor must conservatively skip",
+        );
+        assert_eq!(
+            TaskDescriptor::from_name("EXOTIC_LOSS", 3).cost_function_hint(),
+            CostFunctionHint::NonLinearResidual,
+            "Unrecognised descriptor must conservatively skip",
+        );
     }
 
     #[test]

--- a/src/analysis/task_descriptor.rs
+++ b/src/analysis/task_descriptor.rs
@@ -22,15 +22,18 @@
 //! The descriptor itself is intentionally pure (no FFI surface, no I/O) but
 //! it exposes a small projection — [`TaskDescriptor::cost_function_hint`] —
 //! that maps the task shape onto the [`crate::analysis::cost_function_hint::CostFunctionHint`]
-//! used by the implied-target reconstruction guard (issue #1317). Wiring the
-//! descriptor through the FFI ingest path and the remaining per-consumer
-//! sites is tracked separately (see issue #1314 and the per-consumer issues
-//! that reference #1312).
+//! used by the implied-target reconstruction guard (issue #1317). The FFI
+//! ingest path now also carries an optional `task_descriptor` field on the
+//! discovery FFI inputs (Issue #1314) — pure plumbing, no consumer reads it
+//! yet. The remaining per-consumer wiring is tracked separately (see the
+//! consumer issues that reference #1312).
+
+use serde::Deserialize;
 
 use crate::analysis::cost_function_hint::CostFunctionHint;
 
 /// Topology of the recorded targets vector for a single training sample.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum TargetTopology {
     /// Each output is an independent scalar target (e.g. regression, BCE).
     Independent,
@@ -50,7 +53,7 @@ pub enum TargetTopology {
 }
 
 /// Numeric range the recorded targets can take.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum TargetRange {
     /// Targets are unbounded reals.
     #[default]
@@ -65,7 +68,7 @@ pub enum TargetRange {
 
 /// Family of activation functions that is compatible with the loss on the
 /// final layer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 pub enum OutputSquashFamily {
     /// Bounded, unipolar squash (range `[0, 1]`): LOGISTIC, `BIPOLAR_SIGMOID`
     /// rescaled to unipolar, etc.
@@ -87,7 +90,8 @@ pub enum OutputSquashFamily {
 /// Constructed via [`TaskDescriptor::from_name`] or
 /// [`TaskDescriptor::neutral`]. The struct is `Copy` and trivially cheap to
 /// pass by value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TaskDescriptor {
     /// Topology of the targets vector.
     pub target_topology: TargetTopology,

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -261,6 +261,8 @@ pub(crate) fn build_analyze_all_input_from_parallel(
         max_discovery_wall_clock_minutes: input.max_discovery_wall_clock_minutes,
         failure_cache: input.failure_cache,
         discovery_outcome_log: input.discovery_outcome_log,
+        // Issue #1317: forward the cost-function identity into analysis.
+        cost_name: input.cost_name,
     }
 }
 

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -328,11 +328,16 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
     // Uses an RAII guard so the counter is decremented even on panic.
     let _active_guard = crate::cancellation::AnalysisActiveGuard::new();
 
-    let rank_result = focus::rank_focus_neurons(
+    // Issue #1318: forward the optional task descriptor so OneHot / Margin
+    // topologies activate margin-aware focus ranking. Other topologies
+    // (Independent / Simplex / Unknown / OTHER) and `None` get the existing
+    // unweighted ranking.
+    let rank_result = focus::rank_focus_neurons_with_descriptor(
         &input.parquet_file,
         &input.creature,
         input.max_results,
         input.cost_of_growth,
+        input.task_descriptor.as_ref(),
     );
 
     match rank_result {

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -108,6 +108,17 @@ pub struct AnalyzeParallelInput {
     /// runs in [`analysis::discovery_mode::DiscoveryMode::Normal`].
     #[serde(default)]
     pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
+    /// Cost-function name in use by NEAT-AI (Issue #1317).
+    ///
+    /// Forwarded into the implied-target reconstruction guard so
+    /// reconstruction-dependent detectors are enabled for linear-residual
+    /// costs (`MSE` / `MAE` / `CROSS_ENTROPY`) and skipped for non-linear
+    /// ones (`MAPE` / `MSLE` / `HINGE` / `CATEGORICAL_ERROR`). When absent
+    /// or unrecognised the guard conservatively skips those detectors.
+    /// See `src/analysis/cost_function_hint.rs` and issue #1250 for the
+    /// underlying defect.
+    #[serde(default)]
+    pub cost_name: Option<String>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -245,6 +256,11 @@ pub struct AnalyzeAllInput {
     /// See `AnalyzeParallelInput` for full documentation.
     #[serde(default)]
     pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
+    /// Cost-function name in use by NEAT-AI (Issue #1317).
+    ///
+    /// See `AnalyzeParallelInput::cost_name` for the full contract.
+    #[serde(default)]
+    pub cost_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -5,6 +5,7 @@
 use serde::Deserialize;
 
 use crate::analysis;
+use crate::analysis::task_descriptor::TaskDescriptor;
 
 use super::{CreatureJson, TrainingRecord};
 
@@ -20,6 +21,13 @@ pub struct RecordDiscoveryInput {
     pub record_indices: Option<Vec<usize>>,
     #[serde(default)]
     pub timeout_seconds: Option<u64>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// FFI request payload for
@@ -119,6 +127,13 @@ pub struct AnalyzeParallelInput {
     /// underlying defect.
     #[serde(default)]
     pub cost_name: Option<String>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// Internal input structure for synapse analysis (used by `analyze_all`)
@@ -277,6 +292,13 @@ pub struct RankFocusNeuronsInput {
     /// Issue #132: Pass this from NEAT-AI's configured costOfGrowth for consistency.
     #[serde(default)]
     pub cost_of_growth: Option<f32>,
+    /// Optional task-shape descriptor forwarded by the producer (Issue #1314).
+    ///
+    /// Pure plumbing for now — no recommendation generator reads this yet.
+    /// When absent, consumers should treat it as
+    /// [`TaskDescriptor::neutral`].
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -208,6 +208,13 @@ pub struct AnalyzeNeuronsInput {
     /// When absent or empty, cooldown uses the static configured thresholds.
     #[serde(default)]
     pub discovery_outcome_log: Option<analysis::discovery_mode::DiscoveryOutcomeLog>,
+    /// Task-shape descriptor derived from `AnalyzeAllInput::cost_name`
+    /// (Issue #1319). Threaded down so the neuron post-processing path can
+    /// bias per-class allocation under a `OneHot` descriptor. `None` (or a
+    /// non-`OneHot` topology) preserves the existing allocation verbatim —
+    /// regression guard.
+    #[serde(default)]
+    pub task_descriptor: Option<TaskDescriptor>,
 }
 
 /// Internal input structure for combined analysis (used by `analyze_parallel`)

--- a/src/focus/impact.rs
+++ b/src/focus/impact.rs
@@ -894,6 +894,101 @@ pub fn compute_impacts_with_contract(
     compute_impacts_internal_with_stats_and_contract(creature, grouped_records, contract)
 }
 
+/// Smoothing constant for converting per-observation margin into a weight
+/// (Issue #1318). Prevents weight explosion when margin is zero and bounds
+/// the maximum weight to `1.0 / MARGIN_WEIGHT_EPS`.
+pub const MARGIN_WEIGHT_EPS: f32 = 0.05;
+
+/// Compute per-observation decision margin from recorded output activations
+/// (Issue #1318).
+///
+/// For `OneHot` / `Margin` classification topologies, the network's decision is the
+/// argmax over output activations. The **decision margin** for an observation is
+/// the gap between the top-1 and top-2 output activation: small margin ⇒ the
+/// decision is fragile, and a change that nudges the margin matters even when
+/// it does not yet flip the argmax. Large margin ⇒ the decision is dominant,
+/// and a change of similar magnitude is comparatively worthless.
+///
+/// Observations with fewer than two finite output activations are skipped.
+/// The returned map keys are `obs_index` values; observations absent from the
+/// map should be treated by callers as having an unknown / neutral margin.
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider fails to load any output
+/// neuron's records.
+pub fn compute_per_obs_margins(
+    creature: &CreatureJson,
+    grouped_records: &dyn RecordProvider,
+) -> Result<HashMap<u32, f32>> {
+    let output_uuids: Vec<&str> = creature
+        .neurons
+        .iter()
+        .filter(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.as_str())
+        .collect();
+
+    if output_uuids.len() < 2 {
+        // Margin is undefined when there are fewer than two outputs.
+        return Ok(HashMap::new());
+    }
+
+    // Collect per-observation output activations.
+    let mut obs_to_acts: HashMap<u32, Vec<f32>> = HashMap::new();
+    for uuid in &output_uuids {
+        match grouped_records.get(uuid)? {
+            None => continue,
+            Some(records) => {
+                for record in records.iter() {
+                    if record.activation.is_finite() {
+                        obs_to_acts
+                            .entry(record.obs_index)
+                            .or_default()
+                            .push(record.activation);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut margins: HashMap<u32, f32> = HashMap::with_capacity(obs_to_acts.len());
+    for (obs, acts) in obs_to_acts {
+        if acts.len() < 2 {
+            continue;
+        }
+        // Find top-1 and top-2 in a single pass.
+        let mut top1 = f32::NEG_INFINITY;
+        let mut top2 = f32::NEG_INFINITY;
+        for &v in &acts {
+            if v > top1 {
+                top2 = top1;
+                top1 = v;
+            } else if v > top2 {
+                top2 = v;
+            }
+        }
+        if top2.is_finite() {
+            margins.insert(obs, (top1 - top2).max(0.0));
+        }
+    }
+    Ok(margins)
+}
+
+/// Convert per-observation margins into per-observation weights for
+/// margin-aware error aggregation (Issue #1318).
+///
+/// Weight = `1.0 / (margin + MARGIN_WEIGHT_EPS)`. Small-margin observations
+/// (decision near a flip) get high weight; wide-margin observations (decision
+/// dominant) get low weight. This is the per-observation reweighting used by
+/// the `OneHot` / `Margin` focus ranking path.
+#[must_use]
+pub fn margin_weights_from_margins(margins: &HashMap<u32, f32>) -> HashMap<u32, f32> {
+    margins
+        .iter()
+        .map(|(&obs, &m)| (obs, 1.0 / (m.max(0.0) + MARGIN_WEIGHT_EPS)))
+        .collect()
+}
+
 /// Public version that computes impacts with activation-based selection statistics.
 ///
 /// When activation records are provided, this function computes actual win probabilities

--- a/src/focus/mod.rs
+++ b/src/focus/mod.rs
@@ -40,13 +40,15 @@ pub use gradient::{GradientFlowStats, compute_gradient_flow_stats};
 
 // From impact
 pub use impact::{
-    ConsumerContract, OutputGate, compute_impacts_public, compute_impacts_with_activations,
-    compute_impacts_with_contract, compute_selection_stats, derive_regime_threshold_from_records,
+    ConsumerContract, MARGIN_WEIGHT_EPS, OutputGate, compute_impacts_public,
+    compute_impacts_with_activations, compute_impacts_with_contract, compute_per_obs_margins,
+    compute_selection_stats, derive_regime_threshold_from_records, margin_weights_from_margins,
 };
 
 // From ranking
 pub use ranking::{
     FocusLazyReason, FocusLoadingMode, RankFocusStats, RankedNeuron, RecordProvider,
     RemovalCandidate, SelectionStats, SynapseCounts, calculate_removal_savings,
-    decide_loading_mode_for_budget, rank_focus_neurons, rank_focus_neurons_with_history,
+    decide_loading_mode_for_budget, rank_focus_neurons, rank_focus_neurons_with_descriptor,
+    rank_focus_neurons_with_history, rank_focus_neurons_with_history_and_descriptor,
 };

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -31,12 +31,16 @@ use removal_candidates::{detect_constant_neuron_removals, identify_removal_candi
 use score_calculation::{
     activation_frequency_from_records, average_absolute_error_from_records,
     compute_frequency_factor, mean_absolute_activation_from_records,
+    weighted_average_absolute_error_from_records,
 };
 
 use super::gradient::{
     build_squash_map, compute_gradient_flow_factor, compute_gradient_flow_for_neuron,
 };
-use super::impact::compute_impacts_with_activations;
+use super::impact::{
+    compute_impacts_with_activations, compute_per_obs_margins, margin_weights_from_margins,
+};
+use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::analysis::utils::{
     bytes_to_mb_ceil, check_memory_for_parquet, estimate_parquet_in_memory_bytes, verbose_enabled,
 };
@@ -305,9 +309,14 @@ fn log_focus_ranking_summary(
 }
 
 /// Compute max output error across all output neurons.
+///
+/// When `obs_weights` is provided (`OneHot` / `Margin` descriptors), the per-output
+/// error is reweighted by the per-observation margin weight so the clamp scale
+/// stays consistent with the margin-weighted per-neuron error (Issue #1318).
 fn compute_max_output_error(
     creature: &CreatureJson,
     records_provider: &dyn RecordProvider,
+    obs_weights: Option<&std::collections::HashMap<u32, f32>>,
 ) -> Result<f32> {
     let output_neurons: Vec<&NeuronJson> = creature
         .neurons
@@ -323,7 +332,10 @@ fn compute_max_output_error(
         .iter()
         .map(|neuron| {
             let records = get_records_or_error(records_provider, &neuron.uuid)?;
-            Ok(average_absolute_error_from_records(&records))
+            Ok(weighted_average_absolute_error_from_records(
+                &records,
+                obs_weights,
+            ))
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -331,18 +343,27 @@ fn compute_max_output_error(
 }
 
 /// Build ranked neurons from selectable neurons with their metrics.
+///
+/// When `obs_weights` is provided (`OneHot` / `Margin` descriptors), per-neuron
+/// errors are aggregated using the per-observation margin weight rather than
+/// the unweighted mean. Issue #1318.
 fn build_ranked_neurons(
     selectable: &[&NeuronJson],
     records_provider: &dyn RecordProvider,
     impact_map: &std::collections::HashMap<String, f32>,
     squash_map: &std::collections::HashMap<String, String>,
     max_output_error: f32,
+    obs_weights: Option<&std::collections::HashMap<u32, f32>>,
 ) -> Result<Vec<RankedNeuron>> {
     selectable
         .par_iter()
         .map(|neuron| -> Result<RankedNeuron> {
             let records = get_records_or_error(records_provider, &neuron.uuid)?;
-            let raw_error = average_absolute_error_from_records(&records);
+            let raw_error = if obs_weights.is_some() {
+                weighted_average_absolute_error_from_records(&records, obs_weights)
+            } else {
+                average_absolute_error_from_records(&records)
+            };
             let structural_impact = *impact_map.get(&neuron.uuid).unwrap_or(&0.0);
             let mean_activation = mean_absolute_activation_from_records(&records);
 
@@ -386,6 +407,44 @@ pub fn rank_focus_neurons(
     creature: &CreatureJson,
     max_results: Option<usize>,
     cost_of_growth: Option<f32>,
+) -> Result<RankFocusStats> {
+    rank_focus_neurons_with_descriptor(parquet_file, creature, max_results, cost_of_growth, None)
+}
+
+/// Returns `true` when the descriptor's target topology should activate
+/// margin-aware focus ranking (Issue #1318). Currently `OneHot` and `Margin`.
+fn descriptor_activates_margin_ranking(descriptor: Option<&TaskDescriptor>) -> bool {
+    descriptor.is_some_and(|d| {
+        matches!(
+            d.target_topology,
+            TargetTopology::OneHot | TargetTopology::Margin
+        )
+    })
+}
+
+/// Rank focus neurons with an optional [`TaskDescriptor`] (Issue #1318).
+///
+/// When the descriptor reports a `OneHot` or `Margin` topology, the per-neuron
+/// error component of the ranking score is replaced with a **margin-weighted**
+/// average — observations where the network's decision margin (top-1 vs top-2
+/// output activation) is small contribute more, observations where the margin
+/// is wide contribute less. This targets the plateau where margin-improving
+/// changes that don't yet flip an argmax otherwise look worthless.
+///
+/// For `OTHER` / `Unknown` / `Independent` / `Simplex` topologies and for
+/// `None`, the ranking falls back to the existing arithmetic-mean error path
+/// (regression guard).
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider or impact computation
+/// fails.
+pub fn rank_focus_neurons_with_descriptor(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
+    descriptor: Option<&TaskDescriptor>,
 ) -> Result<RankFocusStats> {
     let start = Instant::now();
     let selectable: Vec<&NeuronJson> = creature
@@ -434,7 +493,25 @@ pub fn rank_focus_neurons(
             .context("Failed to read discovery records for all selectable neurons")?;
     }
 
-    let max_output_error = compute_max_output_error(creature, records_provider.as_ref())?;
+    // Issue #1318: Under OneHot / Margin descriptors, compute per-observation
+    // margin weights from output activations. These reweight per-neuron error
+    // aggregation so candidates whose error mass lands on close-margin
+    // observations rank above those whose error mass lands on already-dominant
+    // decisions. Other topologies (Independent / Simplex / Unknown / None) fall
+    // back to the unweighted mean (regression guard).
+    let obs_weights = if descriptor_activates_margin_ranking(descriptor) {
+        let margins = compute_per_obs_margins(creature, records_provider.as_ref())?;
+        if margins.is_empty() {
+            None
+        } else {
+            Some(margin_weights_from_margins(&margins))
+        }
+    } else {
+        None
+    };
+
+    let max_output_error =
+        compute_max_output_error(creature, records_provider.as_ref(), obs_weights.as_ref())?;
 
     // Use activation-based impact calculation for more accurate MIN/MAX/IF statistics
     let impact_map = compute_impacts_with_activations(creature, records_provider.as_ref())?;
@@ -451,6 +528,7 @@ pub fn rank_focus_neurons(
         &impact_map,
         &squash_map,
         max_output_error,
+        obs_weights.as_ref(),
     )?;
 
     // Sort by weighted score (error × impact × gradient_factor × frequency_factor) to prioritise neurons that:
@@ -643,6 +721,34 @@ pub fn rank_focus_neurons_with_history(
     cost_of_growth: Option<f32>,
     history: Option<&DiscoveryHistory>,
 ) -> Result<RankFocusStats> {
+    rank_focus_neurons_with_history_and_descriptor(
+        parquet_file,
+        creature,
+        max_results,
+        cost_of_growth,
+        history,
+        None,
+    )
+}
+
+/// History-aware variant of [`rank_focus_neurons_with_descriptor`] (Issue #1318).
+///
+/// Combines the historical success multiplier with the margin-aware error
+/// reweighting under `OneHot` / `Margin` topologies. Behaviour is identical to
+/// [`rank_focus_neurons_with_history`] for other topologies and for `None`.
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider or impact computation
+/// fails.
+pub fn rank_focus_neurons_with_history_and_descriptor(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
+    history: Option<&DiscoveryHistory>,
+    descriptor: Option<&TaskDescriptor>,
+) -> Result<RankFocusStats> {
     let start = Instant::now();
     let selectable: Vec<&NeuronJson> = creature
         .neurons
@@ -690,7 +796,20 @@ pub fn rank_focus_neurons_with_history(
             .context("Failed to read discovery records for all selectable neurons")?;
     }
 
-    let max_output_error = compute_max_output_error(creature, records_provider.as_ref())?;
+    // Issue #1318: Same margin-aware reweighting as `rank_focus_neurons_with_descriptor`.
+    let obs_weights = if descriptor_activates_margin_ranking(descriptor) {
+        let margins = compute_per_obs_margins(creature, records_provider.as_ref())?;
+        if margins.is_empty() {
+            None
+        } else {
+            Some(margin_weights_from_margins(&margins))
+        }
+    } else {
+        None
+    };
+
+    let max_output_error =
+        compute_max_output_error(creature, records_provider.as_ref(), obs_weights.as_ref())?;
 
     // Use activation-based impact calculation for more accurate MIN/MAX/IF statistics
     let impact_map = compute_impacts_with_activations(creature, records_provider.as_ref())?;
@@ -708,6 +827,7 @@ pub fn rank_focus_neurons_with_history(
         &impact_map,
         &squash_map,
         max_output_error,
+        obs_weights.as_ref(),
     )?;
 
     // Sort by weighted score with optional history factor, gradient flow factor, and frequency factor

--- a/src/focus/ranking/score_calculation.rs
+++ b/src/focus/ranking/score_calculation.rs
@@ -67,6 +67,46 @@ pub(super) fn average_absolute_error_from_records(records: &[DiscoverRecord]) ->
     if count == 0 { 0.0 } else { sum / count as f32 }
 }
 
+/// Margin-weighted average absolute error (Issue #1318).
+///
+/// When `obs_weights` is provided, each record's contribution is multiplied by
+/// the per-observation weight before averaging. Observations absent from the
+/// map default to weight `1.0` (i.e. they contribute as in the unweighted mean).
+///
+/// When `obs_weights` is `None`, this is identical to
+/// [`average_absolute_error_from_records`] — used by the regression guard so
+/// callers without an `OneHot` / `Margin` descriptor get the legacy ranking.
+pub(super) fn weighted_average_absolute_error_from_records(
+    records: &[DiscoverRecord],
+    obs_weights: Option<&HashMap<u32, f32>>,
+) -> f32 {
+    let Some(weights) = obs_weights else {
+        return average_absolute_error_from_records(records);
+    };
+
+    let mut weighted_sum = 0.0f32;
+    let mut weight_total = 0.0f32;
+
+    for record in records {
+        let w = weights.get(&record.obs_index).copied().unwrap_or(1.0);
+        if !w.is_finite() || w <= 0.0 {
+            continue;
+        }
+        for err in &record.errors {
+            if err.is_finite() {
+                weighted_sum += w * err.abs();
+                weight_total += w;
+            }
+        }
+    }
+
+    if weight_total <= 0.0 {
+        0.0
+    } else {
+        weighted_sum / weight_total
+    }
+}
+
 /// Compute mean absolute activation from discovery records.
 /// Sum of |activation| divided by number of finite records.
 ///

--- a/src/record/tests.rs
+++ b/src/record/tests.rs
@@ -66,6 +66,7 @@ fn create_test_input() -> RecordDiscoveryInput {
         binary_file_path: None,
         record_indices: None,
         timeout_seconds: None,
+        task_descriptor: None,
     }
 }
 

--- a/tests/activation/complement_via_identity.rs
+++ b/tests/activation/complement_via_identity.rs
@@ -127,6 +127,7 @@ fn test_complement_is_discovered_as_identity_not_inverse() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/issue_1315_role_task_aware_scan.rs
+++ b/tests/activation/issue_1315_role_task_aware_scan.rs
@@ -1,0 +1,113 @@
+//! Issue #1315 — the activation/squash scan candidate set is role- and
+//! task-aware.
+//!
+//! Acceptance criteria:
+//! - Under a OneHot/Simplex descriptor, the scan offers bounded squashes
+//!   for **output** neurons and the existing set for **hidden** neurons.
+//! - `OTHER` / `Unknown` / absent ⇒ current scan set (regression guard).
+
+use neat_ai_discovery::analysis::activation::{
+    ACTIVATION_SPECS, BOUNDED_OUTPUT_SCAN_NAMES, NeuronRole, scan_specs_for_role,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+fn spec_names(
+    specs: &[&'static neat_ai_discovery::analysis::activation::ActivationCandidateSpec],
+) -> Vec<&'static str> {
+    specs.iter().map(|s| s.name).collect()
+}
+
+#[test]
+fn onehot_output_scan_is_bounded_only() {
+    let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 5);
+    let names = spec_names(&scan_specs_for_role(NeuronRole::Output, &d));
+
+    // Bounded set members that exist in ACTIVATION_SPECS must be present.
+    assert!(names.contains(&"LOGISTIC"));
+    assert!(names.contains(&"BIPOLAR"));
+
+    // Unbounded hidden-layer favourites must NOT appear.
+    for unbounded in ["GELU", "ELU", "Mish", "Softplus", "IDENTITY", "ReLU6"] {
+        assert!(
+            !names.contains(&unbounded),
+            "{unbounded} must be excluded from the OneHot output scan",
+        );
+    }
+
+    // Every reported name belongs to the documented bounded-subset.
+    for name in &names {
+        assert!(BOUNDED_OUTPUT_SCAN_NAMES.contains(name));
+    }
+}
+
+#[test]
+fn simplex_output_scan_is_bounded_only() {
+    let d = TaskDescriptor::from_name("CROSS_ENTROPY", 4);
+    let names = spec_names(&scan_specs_for_role(NeuronRole::Output, &d));
+
+    assert!(names.contains(&"LOGISTIC"));
+    assert!(names.contains(&"BIPOLAR"));
+    for unbounded in ["GELU", "ELU", "Mish"] {
+        assert!(!names.contains(&unbounded));
+    }
+}
+
+#[test]
+fn onehot_hidden_scan_is_full_set() {
+    let d = TaskDescriptor::from_name("CATEGORICAL_ERROR", 5);
+    let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+    assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+}
+
+#[test]
+fn simplex_hidden_scan_is_full_set() {
+    let d = TaskDescriptor::from_name("CROSS_ENTROPY", 4);
+    let specs = scan_specs_for_role(NeuronRole::Hidden, &d);
+    assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+}
+
+#[test]
+fn other_cost_is_regression_safe_for_both_roles() {
+    let d = TaskDescriptor::from_name("OTHER", 3);
+    for role in [NeuronRole::Output, NeuronRole::Hidden] {
+        let specs = scan_specs_for_role(role, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "OTHER must preserve the full scan set for {role:?}",
+        );
+    }
+}
+
+#[test]
+fn absent_descriptor_is_regression_safe_for_both_roles() {
+    // Absent ≡ neutral().
+    let d = TaskDescriptor::neutral();
+    for role in [NeuronRole::Output, NeuronRole::Hidden] {
+        let specs = scan_specs_for_role(role, &d);
+        assert_eq!(specs.len(), ACTIVATION_SPECS.len());
+    }
+}
+
+#[test]
+fn independent_output_keeps_full_scan() {
+    // MSE / MAE / MAPE / MSLE / BCE / HINGE all have target_topology that
+    // is *not* OneHot or Simplex, so the scan must keep its full set
+    // (Issue #1315 only narrows OneHot / Simplex output scans).
+    for cost in [
+        "MSE",
+        "MAE",
+        "MAPE",
+        "MSLE",
+        "BINARY_CROSS_ENTROPY",
+        "HINGE",
+    ] {
+        let d = TaskDescriptor::from_name(cost, 3);
+        let specs = scan_specs_for_role(NeuronRole::Output, &d);
+        assert_eq!(
+            specs.len(),
+            ACTIVATION_SPECS.len(),
+            "Cost {cost} must keep the full output scan",
+        );
+    }
+}

--- a/tests/activation/leaky_relu_filtered.rs
+++ b/tests/activation/leaky_relu_filtered.rs
@@ -74,6 +74,7 @@ fn add_neuron_candidates_do_not_include_leaky_relu() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/main.rs
+++ b/tests/activation/main.rs
@@ -8,6 +8,7 @@ mod activation_coverage_neat_ai_registry;
 mod activation_overflow_protection_f32;
 mod complement_via_identity;
 mod discrete_activation_filtering;
+mod issue_1315_role_task_aware_scan;
 mod issue_417_increase_change_squash_rate;
 mod issue_768_activation_properties;
 mod leaky_relu_filtered;

--- a/tests/activation/relu_adjacent_filtered.rs
+++ b/tests/activation/relu_adjacent_filtered.rs
@@ -78,6 +78,7 @@ fn add_neuron_candidates_do_not_include_relu_adjacent_squashes() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/activation/step_hidden_neuron_prediction.rs
+++ b/tests/activation/step_hidden_neuron_prediction.rs
@@ -173,6 +173,7 @@ fn test_step_hidden_neuron_prediction_vs_reality() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -266,6 +267,7 @@ fn test_identity_zero_bias_should_not_be_recommended() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -373,6 +375,7 @@ fn test_step_output_neuron_no_identity_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/analysis_timeout.rs
+++ b/tests/analysis/analysis_timeout.rs
@@ -203,6 +203,7 @@ fn neuron_analysis_respects_deadline() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let start = Instant::now();
@@ -289,6 +290,7 @@ fn focus_neurons_are_randomised_across_runs() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).expect("Analysis should complete successfully");

--- a/tests/analysis/fixed_vs_optimised_params.rs
+++ b/tests/analysis/fixed_vs_optimised_params.rs
@@ -156,6 +156,7 @@ fn test_optimised_params_vary_by_sample() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).unwrap();
@@ -236,6 +237,7 @@ fn test_conservative_params_more_stable_across_samples() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let subset_result = analyze_neurons(&subset_input).unwrap();
@@ -371,6 +373,7 @@ fn test_relu_fixed_params_consistent_across_samples() {
             temperature: 1.0,
             failure_cache: None,
             discovery_outcome_log: None,
+            task_descriptor: None,
         };
 
         let result = analyze_neurons(&input).unwrap();

--- a/tests/analysis/issue_1131_calibration_correction.rs
+++ b/tests/analysis/issue_1131_calibration_correction.rs
@@ -190,6 +190,7 @@ fn analyze_all_exposes_calibration_corrections_in_metadata() {
         temperature: 1.0,
         failure_cache: Some(failure_cache),
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -281,6 +282,7 @@ fn calibration_corrections_are_deterministic() {
         temperature: 1.0,
         failure_cache: Some(failure_cache.clone()),
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let r1 = analyze_all(&make_input()).expect("run 1");
@@ -341,6 +343,7 @@ fn no_failure_cache_leaves_corrections_empty() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_1132_conservative_mode.rs
+++ b/tests/analysis/issue_1132_conservative_mode.rs
@@ -136,6 +136,7 @@ fn make_input(parquet_file: String, outcome_log: Option<DiscoveryOutcomeLog>) ->
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: outcome_log,
+        cost_name: None,
     }
 }
 

--- a/tests/analysis/issue_1202_drought_diagnostic.rs
+++ b/tests/analysis/issue_1202_drought_diagnostic.rs
@@ -138,6 +138,7 @@ fn make_input(parquet_file: String, outcomes: Vec<bool>) -> AnalyzeAllInput {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: Some(DiscoveryOutcomeLog::from_outcomes(outcomes)),
+        cost_name: None,
     }
 }
 

--- a/tests/analysis/issue_1317_cost_identity_wiring.rs
+++ b/tests/analysis/issue_1317_cost_identity_wiring.rs
@@ -1,0 +1,207 @@
+//! Tests for Issue #1317: Wire the cost identity into the
+//! target-reconstruction guard.
+//!
+//! The dispatch path threads a [`CostFunctionHint`] derived from the
+//! incoming cost-function name (via [`TaskDescriptor`]) into the two
+//! detectors that reconstruct an implied target from `activation ± error`:
+//!
+//! - `output_squash_mismatch::detect_output_squash_mismatches` (Strategy 4).
+//! - `high_error_squash_exploration::detect_high_error_squash_candidates`.
+//!
+//! These tests verify the wiring at three layers:
+//!
+//! 1. [`TaskDescriptor::cost_function_hint`] maps each recognised cost name
+//!    onto the right [`CostFunctionHint`] variant, with `OTHER` / unknown /
+//!    neutral collapsing to a conservative skip (`NonLinearResidual`).
+//! 2. The per-detector cost-hint contract from Issue #1250 — already
+//!    exercised by `tests/detection/issue_1250_implied_target_cost_hint.rs`
+//!    — keeps holding once the dispatch wiring is in place.
+//! 3. The FFI request structs now accept an optional `cost_name` field and
+//!    serde round-trips it.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::cost_function_hint::CostFunctionHint;
+use neat_ai_discovery::analysis::detection::high_error_squash_exploration::detect_high_error_squash_candidates_with_cost_hint;
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::types::DiscoverRecord;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn make_record(
+    uuid: &str,
+    idx: u32,
+    value: Option<f32>,
+    activation: f32,
+    error: f32,
+) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value,
+        activation,
+        errors: vec![error],
+    }
+}
+
+/// 50 high-error TANH samples where the recorded "target" is a linear ramp
+/// (the MSE convention used by the existing Issue #1250 test fixtures).
+fn high_error_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..50)
+        .map(|i| {
+            let pre_act = (i as f32 - 25.0) / 8.0;
+            let output = pre_act.tanh();
+            let target = pre_act;
+            let error = output - target;
+            make_record(uuid, i, Some(pre_act), output, error)
+        })
+        .collect()
+}
+
+// =============================================================================
+// 1. TaskDescriptor → CostFunctionHint mapping
+// =============================================================================
+
+#[test]
+fn task_descriptor_maps_linear_costs_to_linear_residual() {
+    for name in ["MSE", "MAE", "BINARY_CROSS_ENTROPY", "CROSS_ENTROPY"] {
+        let descriptor = TaskDescriptor::from_name(name, 3);
+        assert_eq!(
+            descriptor.cost_function_hint(),
+            CostFunctionHint::LinearResidual,
+            "{name} descriptor must map to LinearResidual",
+        );
+    }
+}
+
+#[test]
+fn task_descriptor_maps_non_linear_costs_to_non_linear_residual() {
+    for name in ["MAPE", "MSLE", "HINGE", "CATEGORICAL_ERROR"] {
+        let descriptor = TaskDescriptor::from_name(name, 3);
+        assert_eq!(
+            descriptor.cost_function_hint(),
+            CostFunctionHint::NonLinearResidual,
+            "{name} descriptor must map to NonLinearResidual",
+        );
+    }
+}
+
+#[test]
+fn task_descriptor_for_other_or_neutral_is_conservative_skip() {
+    // Issue #1317 acceptance: OTHER / Unknown / absent ⇒ conservative skip.
+    // The conservative-skip value is `NonLinearResidual` — it gates the
+    // reconstruction-dependent detectors off so they cannot emit spurious
+    // candidates against an unknown cost shape.
+    let cases = ["OTHER", "EXOTIC_LOSS", ""];
+    for name in cases {
+        let descriptor = TaskDescriptor::from_name(name, 3);
+        assert_eq!(
+            descriptor.cost_function_hint(),
+            CostFunctionHint::NonLinearResidual,
+            "{name:?} must map to a conservative skip",
+        );
+    }
+    assert_eq!(
+        TaskDescriptor::neutral().cost_function_hint(),
+        CostFunctionHint::NonLinearResidual,
+        "neutral descriptor must map to a conservative skip",
+    );
+}
+
+// =============================================================================
+// 2. Detector gating under the wired-up hints
+// =============================================================================
+
+#[test]
+fn linear_descriptor_runs_high_error_squash_detector() {
+    // A LinearResidual descriptor (MSE) must keep the implied-target
+    // reconstruction enabled.
+    let records = high_error_records("h1");
+    let neurons = vec![("h1".to_string(), "TANH".to_string(), 0.0)];
+    let neuron_records = vec![("h1".to_string(), records)];
+
+    let hint = TaskDescriptor::from_name("MSE", 1).cost_function_hint();
+    let candidates =
+        detect_high_error_squash_candidates_with_cost_hint(&neurons, &neuron_records, hint);
+
+    assert!(
+        !candidates.is_empty(),
+        "Linear-residual descriptor must keep high-error squash exploration running",
+    );
+}
+
+#[test]
+fn non_linear_descriptor_skips_high_error_squash_detector() {
+    let records = high_error_records("h1");
+    let neurons = vec![("h1".to_string(), "TANH".to_string(), 0.0)];
+    let neuron_records = vec![("h1".to_string(), records)];
+
+    for name in ["MAPE", "MSLE", "HINGE", "CATEGORICAL_ERROR"] {
+        let hint = TaskDescriptor::from_name(name, 1).cost_function_hint();
+        let candidates =
+            detect_high_error_squash_candidates_with_cost_hint(&neurons, &neuron_records, hint);
+        assert!(
+            candidates.is_empty(),
+            "{name}: non-linear descriptor must gate high-error squash exploration off",
+        );
+    }
+}
+
+#[test]
+fn neutral_descriptor_skips_high_error_squash_detector() {
+    // Issue #1317 acceptance: absent / OTHER / Unknown ⇒ conservative skip.
+    let records = high_error_records("h1");
+    let neurons = vec![("h1".to_string(), "TANH".to_string(), 0.0)];
+    let neuron_records = vec![("h1".to_string(), records)];
+
+    let hint = TaskDescriptor::neutral().cost_function_hint();
+    let candidates =
+        detect_high_error_squash_candidates_with_cost_hint(&neurons, &neuron_records, hint);
+    assert!(
+        candidates.is_empty(),
+        "Neutral descriptor must conservatively gate high-error squash exploration off",
+    );
+}
+
+// Note: `output_squash_mismatch` Strategy 4 gating is covered by
+// `tests/detection/issue_1250_implied_target_cost_hint.rs`. The dispatch
+// wiring here uses the same `detect_output_squash_mismatches_with_cost_hint`
+// entry point, so no per-strategy duplication is needed.
+
+// =============================================================================
+// 3. FFI request structs accept an optional `cost_name`
+// =============================================================================
+
+#[test]
+fn analyze_parallel_input_round_trips_cost_name() {
+    // Issue #1317: FFI ingest carries the cost-function name into analysis.
+    // A payload that omits it must default to `None`; one that supplies it
+    // must round-trip the value.
+    use neat_ai_discovery::AnalyzeParallelInput;
+
+    let payload_without = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": []
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload_without).expect("parse");
+    assert!(
+        parsed.cost_name.is_none(),
+        "Absent cost_name must deserialize to None",
+    );
+
+    let payload_with = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "costName": "MAPE"
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload_with).expect("parse");
+    assert_eq!(
+        parsed.cost_name.as_deref(),
+        Some("MAPE"),
+        "Supplied cost_name must round-trip verbatim",
+    );
+}

--- a/tests/analysis/issue_419_parallel_discovery_execution.rs
+++ b/tests/analysis/issue_419_parallel_discovery_execution.rs
@@ -117,6 +117,7 @@ fn run_analysis(parquet_file: &str) -> Vec<f32> {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -215,6 +216,7 @@ fn parallel_discovery_metadata_consistent() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_527_diagnostic_tracking.rs
+++ b/tests/analysis/issue_527_diagnostic_tracking.rs
@@ -106,6 +106,7 @@ fn hidden_neuron_reported_as_filtered_in_neuron_diagnostics() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");
@@ -163,6 +164,7 @@ fn input_neuron_reported_as_filtered_in_neuron_diagnostics() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/analysis/issue_557_audit_discovery_strategies.rs
+++ b/tests/analysis/issue_557_audit_discovery_strategies.rs
@@ -142,6 +142,7 @@ fn all_candidates_have_positive_expected_score_gain() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -231,6 +232,7 @@ fn metadata_consistent_after_positive_gain_filtering() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/issue_568_async_pipeline.rs
+++ b/tests/analysis/issue_568_async_pipeline.rs
@@ -169,6 +169,7 @@ fn async_pipeline_produces_valid_analysis_results() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -238,6 +239,7 @@ fn async_pipeline_is_deterministic_with_fixed_seed() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result1 = analyze_all(&make_input()).expect("Run 1 should succeed");

--- a/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
+++ b/tests/analysis/issue_930_change_squash_suboptimal_activation.rs
@@ -232,6 +232,7 @@ fn run_analysis() -> Vec<neat_ai_discovery::CoordinatedStructuralCandidateJson> 
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");
@@ -390,6 +391,7 @@ fn test_analyze_all_finds_change_squash_candidate() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -27,6 +27,7 @@ mod issue_1162_calibration_per_target_squash;
 mod issue_1165_calibration_miss_logging;
 mod issue_1202_drought_diagnostic;
 mod issue_1204_adaptive_target_cooldown;
+mod issue_1317_cost_identity_wiring;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;

--- a/tests/analysis/split_error_all_activations.rs
+++ b/tests/analysis/split_error_all_activations.rs
@@ -152,6 +152,7 @@ fn test_non_relu_activations_use_split_error_evaluation() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -286,6 +287,7 @@ fn test_skewed_errors_return_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/analysis/split_error_fallback_candidates.rs
+++ b/tests/analysis/split_error_fallback_candidates.rs
@@ -169,6 +169,7 @@ fn regression_split_error_must_return_fallback_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -352,6 +353,7 @@ fn test_fallback_candidates_below_threshold_are_returned() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/ffi/issue_1314_task_descriptor_plumbing.rs
+++ b/tests/ffi/issue_1314_task_descriptor_plumbing.rs
@@ -1,0 +1,213 @@
+//! Tests for Issue #1314: optional `task_descriptor` plumbing on the
+//! discovery FFI inputs.
+//!
+//! The three FFI request structs — [`RecordDiscoveryInput`],
+//! [`AnalyzeParallelInput`], and [`RankFocusNeuronsInput`] — accept an
+//! optional `task_descriptor` field. The field is pure plumbing in this
+//! issue: no recommendation generator reads it yet.
+//!
+//! Acceptance criteria checked here:
+//!
+//! - A payload that omits `task_descriptor` deserialises cleanly and the
+//!   resulting `Option<TaskDescriptor>` is `None` — consumers treat that
+//!   as [`TaskDescriptor::neutral`].
+//! - A payload that supplies a structured `task_descriptor` round-trips
+//!   the value verbatim.
+//! - Adding the field does not break any existing payload shape (the
+//!   regression guard).
+
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetRange, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::{AnalyzeParallelInput, RankFocusNeuronsInput, RecordDiscoveryInput};
+
+// =============================================================================
+// RecordDiscoveryInput
+// =============================================================================
+
+#[test]
+fn record_discovery_input_omits_task_descriptor_to_none() {
+    // RecordDiscoveryInput uses snake_case at the top level.
+    let payload = r#"{
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "training_data": [],
+        "temp_dir": "/tmp/x"
+    }"#;
+    let parsed: RecordDiscoveryInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    // None must collapse to neutral() at the consumer site.
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn record_discovery_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "training_data": [],
+        "temp_dir": "/tmp/x",
+        "task_descriptor": {
+            "targetTopology": "OneHot",
+            "targetRange": "Unit",
+            "outputSquashFamily": "BoundedUnipolar",
+            "numOutputs": 5
+        }
+    }"#;
+    let parsed: RecordDiscoveryInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::OneHot);
+    assert_eq!(descriptor.target_range, TargetRange::Unit);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedUnipolar
+    );
+    assert_eq!(descriptor.num_outputs, 5);
+}
+
+// =============================================================================
+// AnalyzeParallelInput
+// =============================================================================
+
+#[test]
+fn analyze_parallel_input_omits_task_descriptor_to_none() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": []
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn analyze_parallel_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "taskDescriptor": {
+            "targetTopology": "Margin",
+            "targetRange": "SignedUnit",
+            "outputSquashFamily": "BoundedBipolar",
+            "numOutputs": 1
+        }
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::Margin);
+    assert_eq!(descriptor.target_range, TargetRange::SignedUnit);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedBipolar
+    );
+    assert_eq!(descriptor.num_outputs, 1);
+}
+
+#[test]
+fn analyze_parallel_input_accepts_neutral_descriptor() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "taskDescriptor": {
+            "targetTopology": "Unknown",
+            "targetRange": "Unbounded",
+            "outputSquashFamily": "Any",
+            "numOutputs": 0
+        }
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor, TaskDescriptor::neutral());
+}
+
+// =============================================================================
+// RankFocusNeuronsInput
+// =============================================================================
+
+#[test]
+fn rank_focus_neurons_input_omits_task_descriptor_to_none() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0}
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.task_descriptor.is_none(),
+        "absent task_descriptor must deserialise to None",
+    );
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn rank_focus_neurons_input_supplied_task_descriptor_round_trips() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "taskDescriptor": {
+            "targetTopology": "Independent",
+            "targetRange": "Unbounded",
+            "outputSquashFamily": "Unbounded",
+            "numOutputs": 3
+        }
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    let descriptor = parsed.task_descriptor.expect("task_descriptor present");
+    assert_eq!(descriptor.target_topology, TargetTopology::Independent);
+    assert_eq!(descriptor.target_range, TargetRange::Unbounded);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::Unbounded
+    );
+    assert_eq!(descriptor.num_outputs, 3);
+}
+
+// =============================================================================
+// Back-compat / regression guard
+// =============================================================================
+
+#[test]
+fn payload_without_task_descriptor_still_parses_all_existing_fields() {
+    // Verify that adding the optional field has not perturbed how an
+    // existing payload (carrying every other previously-supported field)
+    // is parsed. This is the "no behaviour change" guard from the issue.
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": ["a", "b"],
+        "maxSynapseCandidates": 16,
+        "maxNeuronCandidates": 8,
+        "analysisDeadlineMs": 1000,
+        "randomSeed": 42,
+        "temperature": 1.25,
+        "maxAnalysisMemoryMb": 512,
+        "maxDiscoveryWallClockMinutes": 5,
+        "costName": "MSE"
+    }"#;
+    let parsed: AnalyzeParallelInput = serde_json::from_str(payload).expect("parse");
+    assert_eq!(parsed.focus_neurons, vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(parsed.max_synapse_candidates, Some(16));
+    assert_eq!(parsed.max_neuron_candidates, Some(8));
+    assert_eq!(parsed.analysis_deadline_ms, Some(1000));
+    assert_eq!(parsed.random_seed, Some(42));
+    assert!((parsed.temperature - 1.25).abs() < 1e-6);
+    assert_eq!(parsed.max_analysis_memory_mb, Some(512));
+    assert_eq!(parsed.max_discovery_wall_clock_minutes, Some(5));
+    assert_eq!(parsed.cost_name.as_deref(), Some("MSE"));
+    assert!(parsed.task_descriptor.is_none());
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -7,6 +7,7 @@ mod issue_1027_memory_usage_ffi;
 mod issue_1028_memory_budget;
 mod issue_1184_recurrent_synapse_rejection;
 mod issue_1188_grq3_strip_pattern_rejection;
+mod issue_1314_task_descriptor_plumbing;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;

--- a/tests/focus/issue_1318_margin_aware_ranking.rs
+++ b/tests/focus/issue_1318_margin_aware_ranking.rs
@@ -1,0 +1,492 @@
+//! Issue #1318: Margin-aware candidate ranking for argmax/margin costs.
+//!
+//! Under a `OneHot` / `Margin` task descriptor, focus ranking should reflect
+//! the **decision margin** (top-1 vs top-2 output activation) rather than the
+//! raw residual. Observations whose decision is on the edge — where the margin
+//! is small — contribute more weight to a candidate's score than observations
+//! whose decision is already dominant.
+//!
+//! These tests verify:
+//! 1. With a `OneHot` / `Margin` descriptor, the hidden neuron whose error
+//!    lands on close-margin observations ranks above one whose error lands on
+//!    wide-margin observations even when their unweighted mean errors match.
+//! 2. With `Independent` / `Simplex` / `Unknown` / `OTHER` / absent descriptors
+//!    the legacy unweighted ranking is preserved (regression guard).
+//! 3. [`compute_per_obs_margins`] correctly extracts the top-1 minus top-2 gap
+//!    from recorded output activations.
+
+#![allow(clippy::cast_precision_loss)] // Test arithmetic only.
+use std::sync::Arc;
+
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetRange, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::focus::{
+    MARGIN_WEIGHT_EPS, compute_per_obs_margins, margin_weights_from_margins, rank_focus_neurons,
+    rank_focus_neurons_with_descriptor,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use tempfile::NamedTempFile;
+
+/// Build a creature with three outputs and two hidden neurons. Each hidden
+/// neuron feeds all three outputs so structural impacts are roughly balanced.
+fn make_three_class_creature() -> CreatureJson {
+    let neurons = vec![
+        NeuronJson {
+            uuid: "h1".into(),
+            neuron_type: "hidden".into(),
+            squash: "IDENTITY".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "h2".into(),
+            neuron_type: "hidden".into(),
+            squash: "IDENTITY".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-0".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-1".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+        NeuronJson {
+            uuid: "out-2".into(),
+            neuron_type: "output".into(),
+            squash: "LOGISTIC".into(),
+            bias: 0.0,
+        },
+    ];
+    let synapses = vec![
+        SynapseJson {
+            from_uuid: "input-0".into(),
+            to_uuid: "h1".into(),
+            weight: 1.0,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "input-0".into(),
+            to_uuid: "h2".into(),
+            weight: 1.0,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-0".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-1".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h1".into(),
+            to_uuid: "out-2".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-0".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-1".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+        SynapseJson {
+            from_uuid: "h2".into(),
+            to_uuid: "out-2".into(),
+            weight: 0.5,
+            synapse_type: None,
+        },
+    ];
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 1,
+        output: 3,
+    }
+}
+
+fn record(obs_index: u32, uuid: &str, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index,
+        neuron_uuid: uuid.into(),
+        value: Some(activation),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn write_temp_parquet(records: &[DiscoverRecord]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().expect("create temp file");
+    write_records_to_parquet(tmp.path().to_str().unwrap(), records).expect("write parquet");
+    tmp
+}
+
+/// Build the standard fixture used by the ranking tests: two observations,
+/// one with a close margin and one with a wide margin. h1 has its error
+/// concentrated on the close-margin observation, h2 on the wide-margin one.
+fn build_margin_fixture() -> (CreatureJson, NamedTempFile) {
+    let creature = make_three_class_creature();
+
+    // Observation 0 — close margin: top1=0.51 (out-0), top2=0.50 (out-1).
+    // Observation 1 — wide margin:  top1=0.95 (out-0), top2=0.10 (out-1).
+    let records = vec![
+        // out-0
+        record(0, "out-0", 0.51, 0.0),
+        record(1, "out-0", 0.95, 0.0),
+        // out-1
+        record(0, "out-1", 0.50, 0.0),
+        record(1, "out-1", 0.10, 0.0),
+        // out-2
+        record(0, "out-2", 0.05, 0.0),
+        record(1, "out-2", 0.05, 0.0),
+        // h1 has high error on close-margin obs, low error on wide obs.
+        record(0, "h1", 0.5, 0.9),
+        record(1, "h1", 0.5, 0.1),
+        // h2 has the mirror: low error on close-margin obs, high error on wide.
+        record(0, "h2", 0.5, 0.1),
+        record(1, "h2", 0.5, 0.9),
+    ];
+
+    let tmp = write_temp_parquet(&records);
+    (creature, tmp)
+}
+
+// =============================================================================
+// compute_per_obs_margins
+// =============================================================================
+
+#[test]
+fn margins_reflect_top1_minus_top2_per_observation() {
+    let (creature, tmp) = build_margin_fixture();
+
+    // Re-load the parquet via an eager provider through the public ranking API
+    // — we go through the public path so we know we are exercising the same
+    // record-provider used in production.
+    use neat_ai_discovery::parquet_format::read_all_records_grouped_by_neuron;
+    let grouped =
+        read_all_records_grouped_by_neuron(tmp.path().to_str().unwrap()).expect("read records");
+
+    struct InMemoryProvider {
+        records: std::collections::HashMap<String, Arc<Vec<DiscoverRecord>>>,
+    }
+
+    impl neat_ai_discovery::focus::RecordProvider for InMemoryProvider {
+        fn get(&self, neuron_uuid: &str) -> anyhow::Result<Option<Arc<Vec<DiscoverRecord>>>> {
+            Ok(self.records.get(neuron_uuid).cloned())
+        }
+        fn len(&self) -> usize {
+            self.records.len()
+        }
+    }
+
+    let provider = InMemoryProvider {
+        records: grouped.into_iter().map(|(k, v)| (k, Arc::new(v))).collect(),
+    };
+
+    let margins = compute_per_obs_margins(&creature, &provider).expect("margins");
+    assert!(
+        (margins[&0] - 0.01).abs() < 1e-4,
+        "obs 0 margin: {}",
+        margins[&0]
+    );
+    assert!(
+        (margins[&1] - 0.85).abs() < 1e-4,
+        "obs 1 margin: {}",
+        margins[&1]
+    );
+}
+
+#[test]
+fn margin_weights_upweight_small_margins() {
+    let mut margins = std::collections::HashMap::new();
+    margins.insert(0u32, 0.01_f32);
+    margins.insert(1u32, 0.85_f32);
+
+    let weights = margin_weights_from_margins(&margins);
+
+    let w_close = weights[&0];
+    let w_wide = weights[&1];
+
+    assert!(
+        w_close > w_wide,
+        "close-margin weight {w_close} must exceed wide-margin weight {w_wide}"
+    );
+    // Sanity check the exact formula: w = 1 / (margin + eps).
+    assert!(
+        (w_close - 1.0 / (0.01 + MARGIN_WEIGHT_EPS)).abs() < 1e-4,
+        "close weight does not match formula: {w_close}"
+    );
+}
+
+// =============================================================================
+// Ranking under OneHot / Margin descriptors
+// =============================================================================
+
+fn one_hot_descriptor() -> TaskDescriptor {
+    TaskDescriptor {
+        target_topology: TargetTopology::OneHot,
+        target_range: TargetRange::Unit,
+        output_squash_family: OutputSquashFamily::BoundedUnipolar,
+        num_outputs: 3,
+    }
+}
+
+fn margin_descriptor() -> TaskDescriptor {
+    TaskDescriptor {
+        target_topology: TargetTopology::Margin,
+        target_range: TargetRange::SignedUnit,
+        output_squash_family: OutputSquashFamily::BoundedBipolar,
+        num_outputs: 3,
+    }
+}
+
+#[test]
+fn one_hot_descriptor_promotes_close_margin_error_neuron() {
+    let (creature, tmp) = build_margin_fixture();
+    let descriptor = one_hot_descriptor();
+
+    let result = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("rank focus neurons");
+
+    let h1_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h1")
+        .expect("h1 ranked");
+    let h2_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h2")
+        .expect("h2 ranked");
+
+    assert!(
+        h1_pos < h2_pos,
+        "Under OneHot, h1 (error on close margin) at {h1_pos} must rank above h2 \
+         (error on wide margin) at {h2_pos}"
+    );
+}
+
+#[test]
+fn margin_descriptor_promotes_close_margin_error_neuron() {
+    let (creature, tmp) = build_margin_fixture();
+    let descriptor = margin_descriptor();
+
+    let result = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("rank focus neurons");
+
+    let h1_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h1")
+        .expect("h1 ranked");
+    let h2_pos = result
+        .neurons
+        .iter()
+        .position(|n| n.neuron_uuid == "h2")
+        .expect("h2 ranked");
+
+    assert!(
+        h1_pos < h2_pos,
+        "Under Margin, h1 (error on close margin) at {h1_pos} must rank above h2 \
+         (error on wide margin) at {h2_pos}"
+    );
+}
+
+#[test]
+fn one_hot_descriptor_changes_total_error_for_close_margin_neuron() {
+    // Direct numeric guard: under OneHot, h1's reweighted total_error must be
+    // strictly larger than h2's. Under no descriptor the two are equal.
+    let (creature, tmp) = build_margin_fixture();
+
+    let baseline =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("baseline");
+    let h1_baseline = baseline
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h1")
+        .expect("h1");
+    let h2_baseline = baseline
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h2")
+        .expect("h2");
+    assert!(
+        (h1_baseline.total_error - h2_baseline.total_error).abs() < 1e-6,
+        "baseline: equal mean errors expected, got h1={} h2={}",
+        h1_baseline.total_error,
+        h2_baseline.total_error
+    );
+
+    let descriptor = one_hot_descriptor();
+    let onehot = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("onehot");
+    let h1_onehot = onehot
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h1")
+        .expect("h1");
+    let h2_onehot = onehot
+        .neurons
+        .iter()
+        .find(|n| n.neuron_uuid == "h2")
+        .expect("h2");
+    assert!(
+        h1_onehot.total_error > h2_onehot.total_error,
+        "under OneHot: h1 total_error {} must exceed h2 {}",
+        h1_onehot.total_error,
+        h2_onehot.total_error,
+    );
+}
+
+// =============================================================================
+// Regression guard — non-margin topologies preserve legacy behaviour
+// =============================================================================
+
+#[test]
+fn no_descriptor_matches_legacy_ranking() {
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+    let with_none = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        None,
+    )
+    .expect("with_none");
+
+    assert_eq!(legacy.neurons.len(), with_none.neurons.len());
+    for (a, b) in legacy.neurons.iter().zip(with_none.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn unknown_descriptor_matches_legacy_ranking() {
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::neutral(); // Unknown / OTHER / absent.
+    let with_neutral = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with neutral descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_neutral.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn independent_descriptor_matches_legacy_ranking() {
+    // MSE / MAE / BCE produce Independent topology; the margin path must NOT
+    // engage here.
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::from_name("MSE", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::Independent);
+    let with_indep = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with independent descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_indep.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}
+
+#[test]
+fn simplex_descriptor_matches_legacy_ranking() {
+    // CROSS_ENTROPY yields Simplex topology — also not in the margin-aware
+    // set (top-1 vs top-2 attribution does not match the softmax structure).
+    let (creature, tmp) = build_margin_fixture();
+
+    let legacy =
+        rank_focus_neurons(tmp.path().to_str().unwrap(), &creature, None, None).expect("legacy");
+
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::Simplex);
+    let with_simplex = rank_focus_neurons_with_descriptor(
+        tmp.path().to_str().unwrap(),
+        &creature,
+        None,
+        None,
+        Some(&descriptor),
+    )
+    .expect("with simplex descriptor");
+
+    for (a, b) in legacy.neurons.iter().zip(with_simplex.neurons.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid, "ordering must match");
+        assert!(
+            (a.total_error - b.total_error).abs() < 1e-6,
+            "total_error must match for {}",
+            a.neuron_uuid
+        );
+    }
+}

--- a/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
+++ b/tests/focus/issue_156_hidden_focus_neurons_filtered.rs
@@ -127,6 +127,7 @@ fn issue_156_hidden_focus_neurons_are_filtered_when_output_only_mode_is_enabled(
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("analysis should succeed");

--- a/tests/focus/main.rs
+++ b/tests/focus/main.rs
@@ -9,6 +9,7 @@ mod focus_gradient;
 mod focus_layers;
 mod focus_ranking;
 mod issue_1172_focus_ranking_memory_budget;
+mod issue_1318_margin_aware_ranking;
 mod issue_156_hidden_focus_neurons_filtered;
 mod issue_182_focus_unused_observations;
 mod issue_222_hierarchical_focus;

--- a/tests/gpu/gpu_activation_shaders.rs
+++ b/tests/gpu/gpu_activation_shaders.rs
@@ -134,6 +134,7 @@ fn test_mish_gpu_shader_produces_correct_results() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -266,6 +267,7 @@ fn test_all_new_activations_produce_candidates() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/gpu/gpu_work_queue.rs
+++ b/tests/gpu/gpu_work_queue.rs
@@ -157,6 +157,7 @@ fn neuron_analysis_works_with_gpu_work_queue() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     // Run analysis - this uses the GPU work queue internally

--- a/tests/gpu/issue_953_gpu_queue_deadline.rs
+++ b/tests/gpu/issue_953_gpu_queue_deadline.rs
@@ -92,6 +92,7 @@ fn neuron_analysis_with_deadline_completes() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis with deadline should succeed");
@@ -177,6 +178,7 @@ fn analysis_with_expired_deadline_returns_promptly() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let start = std::time::Instant::now();

--- a/tests/gpu_timing.rs
+++ b/tests/gpu_timing.rs
@@ -334,6 +334,7 @@ fn neuron_analysis_timing_collected() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -511,6 +511,7 @@ fn test_analyze_neurons_returns_non_zero_bias() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -609,6 +610,7 @@ fn test_bias_values_are_activation_specific() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -881,6 +883,7 @@ fn test_add_neuron_finds_candidates_with_correlated_errors() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -992,6 +995,7 @@ fn test_add_neuron_with_hard_tanh_target_uses_bias_aware_weight() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1093,6 +1097,7 @@ fn test_bias_improves_neuron_performance() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1225,6 +1230,7 @@ fn test_hidden_neurons_are_analysed_not_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)
@@ -1390,6 +1396,7 @@ fn test_hidden_neuron_candidates_have_impact_discounted_predictions() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = neat_ai_discovery::analysis::analyze_neurons(&analyze_input)

--- a/tests/issue_1320_task_calibrated_thresholds.rs
+++ b/tests/issue_1320_task_calibrated_thresholds.rs
@@ -1,0 +1,189 @@
+//! Tests for cost-aware early-termination / drought thresholds (Issue #1320).
+//!
+//! Verifies that the SPRT early-termination config and the drought-diagnostic
+//! threshold can be calibrated from a [`TaskDescriptor`]. Classification tasks
+//! (one-hot, simplex, margin) get more lenient (later-firing) thresholds so
+//! per-sample sparse improvements are not misread as "drought" / "no
+//! improvement", while regression and unknown / OTHER descriptors retain the
+//! current defaults (regression guard).
+
+use neat_ai_discovery::analysis::drought_diagnostic::drought_threshold_for_task;
+use neat_ai_discovery::analysis::early_termination::EarlyTerminationConfig;
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+// =============================================================================
+// EarlyTerminationConfig::for_task
+// =============================================================================
+
+#[test]
+fn early_termination_for_neutral_descriptor_matches_default() {
+    // Regression guard: OTHER / Unknown / absent should preserve the current
+    // pre-Issue-#1320 defaults exactly.
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::neutral());
+
+    assert_eq!(calibrated.enabled, default.enabled);
+    assert_eq!(calibrated.alpha, default.alpha);
+    assert_eq!(calibrated.beta, default.beta);
+    assert_eq!(calibrated.threshold, default.threshold);
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.check_interval, default.check_interval);
+}
+
+#[test]
+fn early_termination_for_other_cost_matches_default() {
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("OTHER", 4));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_unrecognised_cost_matches_default() {
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("EXOTIC_LOSS", 3));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_mse_matches_default_regression_guard() {
+    // MSE is the canonical unbounded regression cost — current thresholds are
+    // already calibrated to it, so for_task should not move them.
+    let default = EarlyTerminationConfig::default();
+    let calibrated = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("MSE", 1));
+    assert_eq!(calibrated.min_samples, default.min_samples);
+    assert_eq!(calibrated.threshold, default.threshold);
+}
+
+#[test]
+fn early_termination_for_categorical_error_requires_more_evidence() {
+    // CATEGORICAL_ERROR is binary-ish per sample — a 0.1 error already implies
+    // ~90% accuracy. Per-sample improvement signal is sparse, so we must
+    // require more samples and tighter SPRT before deciding.
+    let default = EarlyTerminationConfig::default();
+    let calibrated =
+        EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 10));
+    assert!(
+        calibrated.min_samples > default.min_samples,
+        "classification should require more samples (got {}, default {})",
+        calibrated.min_samples,
+        default.min_samples,
+    );
+    assert!(
+        calibrated.threshold > default.threshold,
+        "classification should require a stricter SPRT threshold (got {}, default {})",
+        calibrated.threshold,
+        default.threshold,
+    );
+}
+
+#[test]
+fn early_termination_for_cross_entropy_matches_classification_profile() {
+    // CROSS_ENTROPY → Simplex topology → classification profile.
+    let cross = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CROSS_ENTROPY", 5));
+    let cat = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    assert_eq!(cross.min_samples, cat.min_samples);
+    assert_eq!(cross.threshold, cat.threshold);
+}
+
+#[test]
+fn early_termination_for_hinge_matches_classification_profile() {
+    let hinge = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("HINGE", 1));
+    let cat = EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    assert_eq!(hinge.min_samples, cat.min_samples);
+    assert_eq!(hinge.threshold, cat.threshold);
+}
+
+#[test]
+fn early_termination_evaluator_inherits_calibrated_min_samples() {
+    // The evaluator built from a calibrated config should pick up the larger
+    // min_samples count; verify the wiring from the field to the evaluator.
+    let calibrated =
+        EarlyTerminationConfig::for_task(&TaskDescriptor::from_name("CATEGORICAL_ERROR", 5));
+    let evaluator = calibrated.create_evaluator();
+    // The evaluator exposes its decision; with 30 strongly-positive samples it
+    // would normally trip is_strongly_beneficial at 30, but classification
+    // needs more — the calibrated config bumps min_samples past 30 so the
+    // heuristic short-circuit must wait.
+    let mut e = evaluator;
+    e.add_batch(28, 2);
+    assert!(
+        !e.is_strongly_beneficial(),
+        "calibrated min_samples must gate is_strongly_beneficial above 30",
+    );
+}
+
+// =============================================================================
+// drought_threshold_for_task
+// =============================================================================
+
+#[test]
+fn drought_threshold_for_neutral_is_unchanged() {
+    // Regression guard: OTHER / Unknown / absent ⇒ base threshold.
+    assert_eq!(drought_threshold_for_task(5, &TaskDescriptor::neutral()), 5);
+    assert_eq!(drought_threshold_for_task(7, &TaskDescriptor::default()), 7);
+}
+
+#[test]
+fn drought_threshold_for_other_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("OTHER", 4)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_unrecognised_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("EXOTIC_LOSS", 4)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_mse_is_unchanged() {
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("MSE", 1)),
+        5,
+    );
+    assert_eq!(
+        drought_threshold_for_task(5, &TaskDescriptor::from_name("MAE", 1)),
+        5,
+    );
+}
+
+#[test]
+fn drought_threshold_for_classification_is_larger() {
+    // Classification: sparse per-sample signal → longer trailing streak is
+    // expected, so the drought threshold should fire later.
+    for name in ["CATEGORICAL_ERROR", "CROSS_ENTROPY", "HINGE"] {
+        let descriptor = TaskDescriptor::from_name(name, 10);
+        let calibrated = drought_threshold_for_task(5, &descriptor);
+        assert!(
+            calibrated > 5,
+            "{name}: drought threshold must scale up for classification (got {calibrated})",
+        );
+    }
+}
+
+#[test]
+fn drought_threshold_for_classification_scales_with_base() {
+    // The calibration is multiplicative-ish — a higher base should still come
+    // out higher after calibration.
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 10);
+    let low = drought_threshold_for_task(5, &descriptor);
+    let high = drought_threshold_for_task(20, &descriptor);
+    assert!(
+        high > low,
+        "calibrated threshold should respect base ordering"
+    );
+}
+
+#[test]
+fn drought_threshold_saturates_safely() {
+    // u32::MAX as base must not overflow.
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 10);
+    let out = drought_threshold_for_task(u32::MAX, &descriptor);
+    assert_eq!(out, u32::MAX);
+}

--- a/tests/neuron/issue_834_lock_free_error_collection.rs
+++ b/tests/neuron/issue_834_lock_free_error_collection.rs
@@ -162,6 +162,7 @@ fn test_lock_free_error_collection_many_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -245,6 +245,7 @@ fn test_add_neuron_between_hidden_neurons() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -357,6 +358,7 @@ fn test_hidden_neuron_candidate_properties() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");

--- a/tests/neuron/issue_926_add_neuron_between_hidden.rs
+++ b/tests/neuron/issue_926_add_neuron_between_hidden.rs
@@ -474,6 +474,7 @@ fn test_analyze_all_finds_hidden_neuron_candidate() {
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/recommendation/issue_1313_role_aware_output_squash.rs
+++ b/tests/recommendation/issue_1313_role_aware_output_squash.rs
@@ -1,0 +1,213 @@
+//! Tests for Issue #1313: Role-aware activation recommendation.
+//!
+//! When the [`TaskDescriptor`] reports a `OneHot` or `Simplex` target
+//! topology, **output-neuron** activation recommendations must be drawn
+//! from the descriptor's `output_squash_family` (a bounded family such
+//! as LOGISTIC / sigmoid). Hidden-neuron recommendations and the
+//! neutral / `OTHER` descriptor path are unchanged.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. With a `CATEGORICAL_ERROR` (or other OneHot/Simplex) descriptor,
+//!    output-neuron activation recommendations come from the bounded
+//!    family.
+//! 2. Hidden-neuron recommendations are unchanged.
+//! 3. `OTHER` / `Unknown` / absent descriptor ⇒ current behaviour
+//!    (regression guard).
+//! 4. Focused: small net with an unbounded output squash + one-hot
+//!    descriptor ⇒ recommends a bounded unipolar squash for the
+//!    output neuron.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::recommendation::activation_recommendation::{
+    recommend_activation_function, recommend_activation_function_for_role,
+};
+use neat_ai_discovery::analysis::task_descriptor::{
+    OutputSquashFamily, TargetTopology, TaskDescriptor,
+};
+use neat_ai_discovery::types::DiscoverRecord;
+
+fn record(uuid: &str, idx: u32, activation: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(activation),
+        activation,
+        errors: vec![0.01],
+    }
+}
+
+/// 80 records spread across an unbounded range — the classifier sees
+/// these as a Uniform distribution, and the unconstrained recommender
+/// would prefer something like TANH / IDENTITY / RELU. Used as the raw
+/// material for "output neuron currently has an unbounded squash" tests.
+fn unbounded_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..80)
+        .map(|i| record(uuid, i, -8.0 + (i as f32) * 0.2))
+        .collect()
+}
+
+/// Set of squash names that constitute the bounded-unipolar output family.
+/// Recommendations under a OneHot/Simplex descriptor must land in this set.
+fn bounded_unipolar_family() -> &'static [&'static str] {
+    &["LOGISTIC", "STEP"]
+}
+
+// =============================================================================
+// 1. OneHot + unbounded output squash ⇒ recommends a bounded unipolar squash
+// =============================================================================
+
+#[test]
+fn one_hot_descriptor_recommends_bounded_unipolar_for_output_neuron() {
+    let records = unbounded_records("output-0");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+    assert_eq!(descriptor.target_topology, TargetTopology::OneHot);
+    assert_eq!(
+        descriptor.output_squash_family,
+        OutputSquashFamily::BoundedUnipolar
+    );
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor)
+            .expect("OneHot + unbounded output squash must produce a recommendation");
+
+    assert_eq!(recommendation.current_squash, "IDENTITY");
+    assert!(
+        bounded_unipolar_family().contains(&recommendation.recommended_squash.as_str()),
+        "Expected recommendation in bounded-unipolar family, got {}",
+        recommendation.recommended_squash
+    );
+}
+
+// =============================================================================
+// 2. Simplex (CROSS_ENTROPY) + unbounded output squash ⇒ same bounded family
+// =============================================================================
+
+#[test]
+fn simplex_descriptor_recommends_bounded_unipolar_for_output_neuron() {
+    let records = unbounded_records("output-0");
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 5);
+    assert_eq!(descriptor.target_topology, TargetTopology::Simplex);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "RELU", true, &descriptor)
+            .expect("Simplex + RELU output must produce a recommendation");
+
+    assert!(
+        bounded_unipolar_family().contains(&recommendation.recommended_squash.as_str()),
+        "Expected bounded-unipolar recommendation under Simplex, got {}",
+        recommendation.recommended_squash
+    );
+}
+
+// =============================================================================
+// 3. Neutral / OTHER descriptor ⇒ falls back to existing recommender
+// =============================================================================
+
+#[test]
+fn neutral_descriptor_falls_back_to_existing_behaviour() {
+    let records = unbounded_records("output-0");
+    let neutral = TaskDescriptor::neutral();
+
+    let role_aware = recommend_activation_function_for_role(&records, "IDENTITY", true, &neutral);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    match (role_aware, legacy) {
+        (Some(a), Some(b)) => {
+            assert_eq!(
+                a.recommended_squash, b.recommended_squash,
+                "Neutral descriptor must mirror legacy recommendation"
+            );
+        }
+        (None, None) => {}
+        (a, b) => panic!(
+            "Neutral descriptor must mirror legacy recommender; got role_aware={:?} legacy={:?}",
+            a.map(|r| r.recommended_squash),
+            b.map(|r| r.recommended_squash),
+        ),
+    }
+}
+
+// =============================================================================
+// 4. OTHER cost name ⇒ neutral descriptor ⇒ existing behaviour
+// =============================================================================
+
+#[test]
+fn other_cost_descriptor_falls_back_to_existing_behaviour() {
+    let records = unbounded_records("output-0");
+    let other = TaskDescriptor::from_name("OTHER", 3);
+    assert_eq!(other, TaskDescriptor::neutral());
+
+    let role_aware = recommend_activation_function_for_role(&records, "IDENTITY", true, &other);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    assert_eq!(
+        role_aware.map(|r| r.recommended_squash),
+        legacy.map(|r| r.recommended_squash),
+        "OTHER cost must produce the legacy recommendation",
+    );
+}
+
+// =============================================================================
+// 5. Hidden neurons are NOT biased to the descriptor's family
+// =============================================================================
+
+#[test]
+fn one_hot_descriptor_does_not_bias_hidden_neuron_recommendation() {
+    let records = unbounded_records("hidden-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let hidden_rec =
+        recommend_activation_function_for_role(&records, "IDENTITY", false, &descriptor);
+    let legacy = recommend_activation_function(&records, "IDENTITY");
+
+    assert_eq!(
+        hidden_rec.map(|r| r.recommended_squash),
+        legacy.map(|r| r.recommended_squash),
+        "Hidden-neuron path must mirror legacy recommender even under OneHot",
+    );
+}
+
+// =============================================================================
+// 6. Output neuron already in the bounded family ⇒ no recommendation
+// =============================================================================
+
+#[test]
+fn output_neuron_already_in_family_yields_no_recommendation() {
+    // Build records that are themselves already in [0, 1] — typical for a
+    // sigmoid output. The role-aware recommender should not propose a
+    // change when the current squash already matches the descriptor
+    // family and the data fits.
+    let records: Vec<DiscoverRecord> = (0..80)
+        .map(|i| record("output-0", i, (i as f32) / 80.0))
+        .collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "LOGISTIC", true, &descriptor);
+
+    assert!(
+        recommendation.is_none(),
+        "Output neuron already on LOGISTIC under OneHot should not be re-recommended (got {:?})",
+        recommendation.map(|r| r.recommended_squash),
+    );
+}
+
+// =============================================================================
+// 7. Insufficient samples ⇒ None (regression guard)
+// =============================================================================
+
+#[test]
+fn insufficient_samples_returns_none_for_output_role() {
+    let records: Vec<DiscoverRecord> = (0..5).map(|i| record("output-0", i, 0.5)).collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+
+    let recommendation =
+        recommend_activation_function_for_role(&records, "IDENTITY", true, &descriptor);
+
+    assert!(
+        recommendation.is_none(),
+        "Should not recommend with insufficient samples"
+    );
+}

--- a/tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs
+++ b/tests/recommendation/issue_1316_output_bias_drift_one_hot_capacity_starvation.rs
@@ -1,0 +1,374 @@
+//! Tests for Issue #1316: Weight output bias-drift detection by class prior.
+//!
+//! Under `OneHot` / `Simplex` target topologies, an output neuron whose class
+//! has positive support but whose activation never crosses a saturating
+//! threshold for that class is suffering capacity starvation. The role-aware
+//! detector flags / weights up those neurons for growth. For every other
+//! descriptor (`Independent`, `Margin`, `Unknown`, `OTHER`) the behaviour
+//! must be identical to the legacy detector — regression guard.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. Under a `OneHot` descriptor, an output neuron that stays unsaturated for
+//!    a well-supported class is flagged / weighted up for growth.
+//! 2. `OTHER` / `Unknown` / absent ⇒ current behaviour (regression guard).
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::recommendation::output_bias_drift::{
+    detect_output_bias_drift, detect_output_bias_drift_with_descriptor,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn creature_with_one_output() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-1", "output", 0.0),
+        ],
+        synapses: vec![synapse("input-1", "output-1", 0.5)],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// 60 records — 30 with target=1.0 (positive support) and 30 with target=0.0.
+/// On the positive-support samples the activation never crosses the
+/// saturating threshold (peaks at ~0.55), so the neuron is capacity-starved.
+fn capacity_starved_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                // Positive-support class: target=1, activation stuck near 0.5,
+                // error = target - activation ≈ +0.45 (positive bias drift).
+                make_record(uuid, i, 1.0, 0.55, 0.45)
+            } else {
+                make_record(uuid, i, 0.0, 0.05, -0.05)
+            }
+        })
+        .collect()
+}
+
+/// 60 records that are *both* a capacity-starvation case under `OneHot` AND a
+/// legacy bias-drift case (mean error positive, >70% same-sign errors). Used
+/// to verify the role-aware path boosts the existing candidate.
+fn capacity_starved_and_biased_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                make_record(uuid, i, 1.0, 0.55, 0.45)
+            } else {
+                // Off-class records still record a positive error (e.g. global
+                // upward shift) so the legacy detector sees a majority-positive
+                // error signal and emits a candidate.
+                make_record(uuid, i, 0.0, 0.05, 0.10)
+            }
+        })
+        .collect()
+}
+
+/// 60 records — output neuron *does* reach the saturating region on its
+/// positive-support class (activation peaks at ~0.95 for target=1).
+fn well_saturated_records(uuid: &str) -> Vec<DiscoverRecord> {
+    (0..60)
+        .map(|i| {
+            if i < 30 {
+                make_record(uuid, i, 1.0, 0.95, 0.05)
+            } else {
+                make_record(uuid, i, 0.0, 0.05, -0.05)
+            }
+        })
+        .collect()
+}
+
+// =============================================================================
+// 1. OneHot descriptor flags a capacity-starved output neuron
+// =============================================================================
+#[test]
+fn one_hot_descriptor_flags_capacity_starved_output_neuron() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    assert!(
+        !candidates.is_empty(),
+        "OneHot + capacity-starved output must produce a candidate",
+    );
+    let starved = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .expect("capacity-starved output-1 must be present");
+    assert!(
+        starved.capacity_starved,
+        "candidate must be marked capacity_starved under OneHot",
+    );
+}
+
+// =============================================================================
+// 2. Simplex descriptor (CROSS_ENTROPY) — same flag fires
+// =============================================================================
+#[test]
+fn simplex_descriptor_flags_capacity_starved_output_neuron() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 3);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    let starved = candidates
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .expect("Simplex + capacity-starved output must produce a candidate");
+    assert!(
+        starved.capacity_starved,
+        "candidate must be marked capacity_starved under Simplex",
+    );
+}
+
+// =============================================================================
+// 3. Saturated output under OneHot — capacity_starved is false
+// =============================================================================
+#[test]
+fn one_hot_does_not_flag_well_saturated_output() {
+    let creature = creature_with_one_output();
+    let records = well_saturated_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    // The neuron may or may not emit a bias-drift candidate from its
+    // residual errors; what must NOT happen is the capacity-starved flag.
+    for c in &candidates {
+        assert!(
+            !c.capacity_starved,
+            "well-saturated output must not be flagged capacity_starved (got {})",
+            c.neuron_uuid,
+        );
+    }
+}
+
+// =============================================================================
+// 4. Neutral descriptor ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn neutral_descriptor_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let neutral = TaskDescriptor::neutral();
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &neutral,
+    );
+
+    assert_eq!(
+        legacy.len(),
+        role_aware.len(),
+        "Neutral descriptor must return the same number of candidates as legacy detector",
+    );
+    for (a, b) in legacy.iter().zip(role_aware.iter()) {
+        assert_eq!(a.neuron_uuid, b.neuron_uuid);
+        assert!(
+            !b.capacity_starved,
+            "Neutral descriptor must never set capacity_starved",
+        );
+        assert!(
+            (a.estimated_improvement - b.estimated_improvement).abs() < 1e-6,
+            "Neutral descriptor must not boost estimated_improvement",
+        );
+    }
+}
+
+// =============================================================================
+// 5. OTHER cost ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn other_cost_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let other = TaskDescriptor::from_name("OTHER", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &other,
+    );
+
+    assert_eq!(legacy.len(), role_aware.len());
+    for c in &role_aware {
+        assert!(
+            !c.capacity_starved,
+            "OTHER descriptor must never set capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 6. Independent descriptor (MSE) ⇒ legacy behaviour (regression guard)
+// =============================================================================
+#[test]
+fn mse_descriptor_matches_legacy_detector() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_records("output-1");
+    let mse = TaskDescriptor::from_name("MSE", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &mse,
+    );
+
+    assert_eq!(legacy.len(), role_aware.len());
+    for c in &role_aware {
+        assert!(
+            !c.capacity_starved,
+            "MSE descriptor must never set capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 7. Class with no positive support is not flagged even when unsaturated.
+// =============================================================================
+#[test]
+fn class_without_positive_support_is_not_flagged() {
+    let creature = creature_with_one_output();
+    // All records have target=0.0 — no positive support for this class.
+    let records: Vec<DiscoverRecord> = (0..60)
+        .map(|i| make_record("output-1", i, 0.0, 0.05, -0.05))
+        .collect();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    for c in &candidates {
+        assert!(
+            !c.capacity_starved,
+            "Class with no positive support must not be flagged capacity_starved",
+        );
+    }
+}
+
+// =============================================================================
+// 8. Weight-up: starved candidate has higher estimated_improvement than the
+//    same neuron under the legacy detector.
+// =============================================================================
+#[test]
+fn capacity_starved_candidate_is_weighted_up_vs_legacy() {
+    let creature = creature_with_one_output();
+    let records = capacity_starved_and_biased_records("output-1");
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let legacy = detect_output_bias_drift(&creature, &[("output-1".to_string(), records.clone())]);
+    let role_aware = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("output-1".to_string(), records)],
+        &descriptor,
+    );
+
+    let legacy_gain = legacy
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .map(|c| c.estimated_improvement)
+        .expect("Legacy detector must emit a candidate for the biased output neuron");
+    let role_gain = role_aware
+        .iter()
+        .find(|c| c.neuron_uuid == "output-1")
+        .map(|c| c.estimated_improvement)
+        .expect("Role-aware detector must emit a candidate for the biased output neuron");
+
+    assert!(
+        role_gain > legacy_gain,
+        "capacity-starved candidate must be weighted up: role_gain={role_gain}, legacy_gain={legacy_gain}",
+    );
+}
+
+// =============================================================================
+// 9. Hidden neurons are excluded from capacity-starvation flagging.
+// =============================================================================
+#[test]
+fn hidden_neuron_is_not_flagged_capacity_starved() {
+    // A creature with a hidden neuron; output bias drift only looks at outputs
+    // anyway, so this is mostly a sanity check that the role-aware path
+    // doesn't accidentally pull hidden neurons into the candidate set.
+    let creature = CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("hidden-1", "hidden", 0.0),
+            neuron("output-1", "output", 0.0),
+        ],
+        synapses: vec![
+            synapse("input-1", "hidden-1", 0.5),
+            synapse("hidden-1", "output-1", 0.5),
+        ],
+        input: 1,
+        output: 1,
+    };
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    // Hidden neuron records also have positive support and low activation,
+    // but the output detector must ignore them.
+    let hidden_records = capacity_starved_records("hidden-1");
+    let candidates = detect_output_bias_drift_with_descriptor(
+        &creature,
+        &[("hidden-1".to_string(), hidden_records)],
+        &descriptor,
+    );
+
+    assert!(
+        candidates.iter().all(|c| c.neuron_uuid != "hidden-1"),
+        "Hidden neurons must never appear in output_bias_drift candidates",
+    );
+}

--- a/tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs
+++ b/tests/recommendation/issue_1319_one_hot_per_class_capacity_allocation.rs
@@ -1,0 +1,272 @@
+//! Tests for Issue #1319: Per-class capacity allocation under `one_hot` using
+//! the existing per-target failure counters.
+//!
+//! Under a `OneHot` task descriptor the growth/candidate budget must skew
+//! toward output neurons (classes) with the highest per-target failure
+//! counts. For every other descriptor (`Independent`, `Margin`, `Unknown`,
+//! `OTHER`, absent) the existing allocation must hold verbatim — regression
+//! guard.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::collections::HashMap;
+
+use neat_ai_discovery::CandidateNeuronJson;
+use neat_ai_discovery::analysis::one_hot_class_allocation::{
+    apply_class_priority_spread, compute_class_failure_counts,
+};
+use neat_ai_discovery::analysis::scoring::calibration_correction::FailureCacheEntry;
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+
+fn fc_entry(target_uuid: &str) -> FailureCacheEntry {
+    FailureCacheEntry {
+        change_type: "add-neurons".to_string(),
+        expected_error_reduction: 0.1,
+        actual_error_reduction: -0.01,
+        target_squash: None,
+        variant_key: None,
+        target_uuid: Some(target_uuid.to_string()),
+        improved_count: None,
+        total_count: None,
+    }
+}
+
+fn candidate(target_uuid: &str, gain: f32) -> CandidateNeuronJson {
+    CandidateNeuronJson {
+        source_neuron_uuid: format!("source-{target_uuid}-{gain}"),
+        target_neuron_uuid: target_uuid.to_string(),
+        source_neuron_index: None,
+        target_neuron_index: None,
+        incoming_weight: 1.0,
+        outgoing_weight: 1.0,
+        squash: format!("SQUASH-{gain}"),
+        bias: 0.0,
+        comment: None,
+        target_neuron_impact: 1.0,
+        expected_creature_error_reduction: gain,
+        expected_creature_score_gain: gain,
+        improved_count: 10,
+        total_count: 10,
+        improvement_magnitude_ratio: None,
+        target_neuron_stats: None,
+        prediction_confidence: 0.5,
+        expected_score_gain_confidence_interval: [gain, gain],
+        target_saturation_factor: None,
+        variant_key: None,
+    }
+}
+
+/// Acceptance #1: under `OneHot`, per-class failure counts derived from
+/// `failure_cache` map output neurons to their cumulative failure count.
+#[test]
+fn one_hot_descriptor_computes_per_class_failure_counts() {
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 3);
+    let cache = vec![
+        fc_entry("output-A"),
+        fc_entry("output-A"),
+        fc_entry("output-A"),
+        fc_entry("output-B"),
+        fc_entry("hidden-X"), // hidden, must not be counted as a class
+    ];
+
+    let outputs: std::collections::HashSet<String> = ["output-A", "output-B", "output-C"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    let counts = compute_class_failure_counts(&descriptor, &cache, |uuid| outputs.contains(uuid))
+        .expect("OneHot descriptor must produce a failure-count map");
+
+    assert_eq!(counts.get("output-A").copied(), Some(3));
+    assert_eq!(counts.get("output-B").copied(), Some(1));
+    // Output-C never failed — must be absent (not present with 0).
+    assert!(!counts.contains_key("output-C"));
+    // Hidden neurons must never appear in the class-failure map.
+    assert!(!counts.contains_key("hidden-X"));
+}
+
+/// Acceptance #2: non-OneHot descriptors yield `None`, locking the caller
+/// into the existing allocation path (regression guard).
+#[test]
+fn neutral_descriptor_yields_no_class_failure_counts() {
+    let cache = vec![fc_entry("output-A")];
+    let outputs: std::collections::HashSet<String> =
+        ["output-A"].into_iter().map(String::from).collect();
+
+    assert!(
+        compute_class_failure_counts(&TaskDescriptor::neutral(), &cache, |u| outputs.contains(u))
+            .is_none(),
+        "neutral descriptor must opt out of per-class allocation",
+    );
+
+    let mse = TaskDescriptor::from_name("MSE", 3);
+    assert!(
+        compute_class_failure_counts(&mse, &cache, |u| outputs.contains(u)).is_none(),
+        "Independent descriptor must opt out of per-class allocation",
+    );
+
+    let other = TaskDescriptor::from_name("OTHER", 3);
+    assert!(
+        compute_class_failure_counts(&other, &cache, |u| outputs.contains(u)).is_none(),
+        "OTHER descriptor must opt out of per-class allocation",
+    );
+
+    let hinge = TaskDescriptor::from_name("HINGE", 1);
+    assert!(
+        compute_class_failure_counts(&hinge, &cache, |u| outputs.contains(u)).is_none(),
+        "Margin descriptor must opt out of per-class allocation",
+    );
+}
+
+/// Acceptance #3: under `OneHot` priority, the highest-failure-count classes
+/// occupy the front of the reordered candidate list — pulling growth budget
+/// toward the worst-performing classes ahead of the per-target cap.
+#[test]
+fn class_priority_spread_pulls_worst_classes_to_front() {
+    // target-A: 6 candidates, gain dominant.
+    // target-B: 1 candidate, mid gain.
+    // target-C: 1 candidate, low gain.
+    // target-D: 1 candidate, even lower gain.
+    let mut candidates = vec![
+        candidate("target-A", 0.99),
+        candidate("target-A", 0.95),
+        candidate("target-A", 0.92),
+        candidate("target-A", 0.90),
+        candidate("target-A", 0.87),
+        candidate("target-A", 0.85),
+        candidate("target-B", 0.50),
+        candidate("target-C", 0.40),
+        candidate("target-D", 0.30),
+    ];
+    // Pre-sort by gain to mirror the documented precondition.
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+
+    // Priority: D worst, then C, then B; A unseen (priority 0).
+    let mut priority: HashMap<String, u32> = HashMap::new();
+    priority.insert("target-D".to_string(), 9);
+    priority.insert("target-C".to_string(), 6);
+    priority.insert("target-B".to_string(), 3);
+
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    let front: Vec<&str> = candidates[0..3]
+        .iter()
+        .map(|c| c.target_neuron_uuid.as_str())
+        .collect();
+    assert_eq!(
+        front,
+        vec!["target-D", "target-C", "target-B"],
+        "front of the list must lead with the worst-performing classes",
+    );
+    // No candidate dropped.
+    assert_eq!(candidates.len(), 9);
+    // Tail retains the remaining target-A candidates in gain order.
+    let tail_a_gains: Vec<f32> = candidates[3..]
+        .iter()
+        .filter(|c| c.target_neuron_uuid == "target-A")
+        .map(|c| c.expected_creature_score_gain)
+        .collect();
+    let mut sorted_a = tail_a_gains.clone();
+    sorted_a.sort_by(|a, b| b.total_cmp(a));
+    assert_eq!(
+        tail_a_gains, sorted_a,
+        "target-A tail must remain in gain-descending order",
+    );
+}
+
+/// Acceptance #4 (regression guard): an empty priority map is a no-op — the
+/// gain-sorted order is preserved verbatim. Equivalent to running on a
+/// neutral / OTHER descriptor.
+#[test]
+fn empty_priority_map_is_a_noop() {
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-B", 0.5),
+        candidate("target-C", 0.4),
+        candidate("target-D", 0.3),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let before: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+
+    apply_class_priority_spread(&mut candidates, &HashMap::new(), 3);
+
+    let after: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+    assert_eq!(
+        before, after,
+        "empty priority map must not reorder candidates",
+    );
+}
+
+/// Acceptance #5: priority spread keeps the highest-gain representative for
+/// each priority target — within a class, gain order still decides which
+/// candidate occupies the spread slot.
+#[test]
+fn class_priority_spread_keeps_highest_gain_representative() {
+    // target-B has two candidates with very different gains.
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-B", 0.05),
+        candidate("target-B", 0.6),
+        candidate("target-C", 0.4),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let mut priority = HashMap::new();
+    priority.insert("target-B".to_string(), 7);
+    priority.insert("target-C".to_string(), 5);
+
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    // Front: target-B (priority 7, gain 0.6), target-C (priority 5, gain 0.4),
+    // target-A (priority 0, gain 0.9).
+    assert_eq!(candidates[0].target_neuron_uuid, "target-B");
+    assert!((candidates[0].expected_creature_score_gain - 0.6).abs() < f32::EPSILON);
+    assert_eq!(candidates[1].target_neuron_uuid, "target-C");
+    assert_eq!(candidates[2].target_neuron_uuid, "target-A");
+}
+
+/// Acceptance #6: if the pool has fewer distinct targets than the spread
+/// requires, the function falls through and preserves gain-order — same
+/// contract as the legacy `apply_distinct_target_spread`.
+#[test]
+fn class_priority_spread_falls_through_when_pool_too_narrow() {
+    let mut candidates = vec![
+        candidate("target-A", 0.9),
+        candidate("target-A", 0.8),
+        candidate("target-B", 0.6),
+    ];
+    candidates.sort_by(|a, b| {
+        b.expected_creature_score_gain
+            .total_cmp(&a.expected_creature_score_gain)
+    });
+    let before: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+
+    let mut priority = HashMap::new();
+    priority.insert("target-A".to_string(), 5);
+
+    // min_distinct=3 but only 2 distinct targets — must no-op.
+    apply_class_priority_spread(&mut candidates, &priority, 3);
+
+    let after: Vec<(String, f32)> = candidates
+        .iter()
+        .map(|c| (c.target_neuron_uuid.clone(), c.expected_creature_score_gain))
+        .collect();
+    assert_eq!(before, after);
+}

--- a/tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs
+++ b/tests/recommendation/issue_1321_output_competition_lateral_inhibition.rs
@@ -1,0 +1,368 @@
+//! Tests for Issue #1321: Output competition / lateral-inhibition recommender
+//! under `OneHot` / `Simplex` target topologies.
+//!
+//! Acceptance criteria from the issue:
+//!
+//! 1. Under a `OneHot`/`Simplex` descriptor, the recommender proposes
+//!    inhibitory output↔output connections (or a normalisation hint) when
+//!    two output neurons co-fire on the same samples.
+//! 2. `OTHER` / `Unknown` / absent ⇒ nothing emitted (regression guard).
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::CoordinatedStructuralOpJson;
+use neat_ai_discovery::analysis::recommendation::output_competition::{
+    detect_output_competition, output_competition_to_coordinated_candidates,
+};
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+
+fn make_record(uuid: &str, idx: u32, value: f32, activation: f32, error: f32) -> DiscoverRecord {
+    DiscoverRecord {
+        obs_index: idx,
+        neuron_uuid: uuid.to_string(),
+        value: Some(value),
+        activation,
+        errors: vec![error],
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, bias: f32) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+/// Creature with one input feeding two output neurons (forward-only order
+/// preserves `output-a` before `output-b`).
+fn creature_with_two_outputs() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-a", "output", 0.0),
+            neuron("output-b", "output", 0.0),
+        ],
+        synapses: vec![
+            synapse("input-1", "output-a", 0.5),
+            synapse("input-1", "output-b", 0.5),
+        ],
+        input: 1,
+        output: 2,
+    }
+}
+
+fn creature_with_one_output() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            neuron("input-1", "input", 0.0),
+            neuron("output-a", "output", 0.0),
+        ],
+        synapses: vec![synapse("input-1", "output-a", 0.5)],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// Records where two output neurons fire strongly on the same samples —
+/// classic "competition" pattern that lateral inhibition should resolve.
+fn co_firing_records() -> Vec<(String, Vec<DiscoverRecord>)> {
+    let mut a_records = Vec::new();
+    let mut b_records = Vec::new();
+    for i in 0..40 {
+        // On every sample both outputs fire strongly: this is the
+        // co-activation pattern we want to inhibit. Target alternates
+        // between the two classes so neither output is the dominant
+        // truth signal.
+        let (target_a, target_b) = if i % 2 == 0 { (1.0, 0.0) } else { (0.0, 1.0) };
+        a_records.push(make_record("output-a", i, target_a, 0.85, target_a - 0.85));
+        b_records.push(make_record("output-b", i, target_b, 0.80, target_b - 0.80));
+    }
+    vec![
+        ("output-a".to_string(), a_records),
+        ("output-b".to_string(), b_records),
+    ]
+}
+
+/// Records where two output neurons fire on disjoint sample sets — they
+/// are *not* competing. No lateral inhibition should be proposed.
+fn disjoint_firing_records() -> Vec<(String, Vec<DiscoverRecord>)> {
+    let mut a_records = Vec::new();
+    let mut b_records = Vec::new();
+    for i in 0..40 {
+        if i < 20 {
+            // a fires strongly, b stays low.
+            a_records.push(make_record("output-a", i, 1.0, 0.90, 0.10));
+            b_records.push(make_record("output-b", i, 0.0, 0.05, -0.05));
+        } else {
+            // b fires strongly, a stays low.
+            a_records.push(make_record("output-a", i, 0.0, 0.05, -0.05));
+            b_records.push(make_record("output-b", i, 1.0, 0.90, 0.10));
+        }
+    }
+    vec![
+        ("output-a".to_string(), a_records),
+        ("output-b".to_string(), b_records),
+    ]
+}
+
+// =============================================================================
+// 1. OneHot descriptor emits at least one inhibitory output↔output candidate.
+// =============================================================================
+#[test]
+fn one_hot_descriptor_emits_inhibitory_recommendation() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        !candidates.is_empty(),
+        "OneHot + co-firing outputs must produce at least one lateral-inhibition candidate",
+    );
+    for c in &candidates {
+        assert!(
+            c.recommended_weight < 0.0,
+            "lateral inhibition must use a negative weight (got {})",
+            c.recommended_weight,
+        );
+        assert_ne!(
+            c.from_output_uuid, c.to_output_uuid,
+            "self-loops must not be proposed",
+        );
+    }
+}
+
+// =============================================================================
+// 2. Simplex descriptor (CROSS_ENTROPY) — same behaviour.
+// =============================================================================
+#[test]
+fn simplex_descriptor_emits_inhibitory_recommendation() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CROSS_ENTROPY", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        !candidates.is_empty(),
+        "Simplex + co-firing outputs must produce a candidate",
+    );
+    assert!(candidates.iter().all(|c| c.recommended_weight < 0.0));
+}
+
+// =============================================================================
+// 3. Neutral / Unknown descriptor — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn unknown_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let neutral = TaskDescriptor::neutral();
+
+    let candidates = detect_output_competition(&creature, &records, &neutral);
+
+    assert!(
+        candidates.is_empty(),
+        "Unknown descriptor must produce no candidates (got {})",
+        candidates.len(),
+    );
+}
+
+// =============================================================================
+// 4. OTHER descriptor — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn other_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let other = TaskDescriptor::from_name("OTHER", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &other);
+
+    assert!(candidates.is_empty(), "OTHER descriptor must emit nothing");
+}
+
+// =============================================================================
+// 5. Independent descriptor (MSE) — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn independent_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let mse = TaskDescriptor::from_name("MSE", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &mse);
+
+    assert!(
+        candidates.is_empty(),
+        "Independent (MSE) descriptor must emit nothing",
+    );
+}
+
+// =============================================================================
+// 6. Margin descriptor (HINGE) — nothing emitted (regression guard).
+// =============================================================================
+#[test]
+fn margin_descriptor_emits_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let hinge = TaskDescriptor::from_name("HINGE", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &hinge);
+
+    assert!(
+        candidates.is_empty(),
+        "Margin (HINGE) descriptor must emit nothing",
+    );
+}
+
+// =============================================================================
+// 7. Single-output network — nothing to compete with.
+// =============================================================================
+#[test]
+fn single_output_emits_nothing() {
+    let creature = creature_with_one_output();
+    let records = vec![(
+        "output-a".to_string(),
+        (0..40)
+            .map(|i| make_record("output-a", i, 1.0, 0.85, 0.15))
+            .collect(),
+    )];
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 1);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        candidates.is_empty(),
+        "Single-output network cannot exhibit output competition",
+    );
+}
+
+// =============================================================================
+// 8. Non-competing outputs (disjoint firing) — nothing emitted.
+// =============================================================================
+#[test]
+fn non_competing_outputs_emit_nothing() {
+    let creature = creature_with_two_outputs();
+    let records = disjoint_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    assert!(
+        candidates.is_empty(),
+        "Outputs that fire on disjoint samples are not competing — none expected, got {}",
+        candidates.len(),
+    );
+}
+
+// =============================================================================
+// 9. Existing output→output synapse is not duplicated.
+// =============================================================================
+#[test]
+fn existing_synapse_is_not_duplicated() {
+    let mut creature = creature_with_two_outputs();
+    // Pre-existing inhibitory synapse output-a → output-b — the recommender
+    // must not propose another AddSynapse for the same pair.
+    creature
+        .synapses
+        .push(synapse("output-a", "output-b", -0.2));
+
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    for c in &candidates {
+        assert!(
+            !(c.from_output_uuid == "output-a" && c.to_output_uuid == "output-b"),
+            "must not propose an AddSynapse for an existing (output-a → output-b) pair",
+        );
+    }
+}
+
+// =============================================================================
+// 10. The coordinated-candidate converter emits AddSynapse operations with a
+//     negative weight (inhibitory connection).
+// =============================================================================
+#[test]
+fn coordinated_candidates_use_add_synapse_with_negative_weight() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+    assert!(!candidates.is_empty(), "test prerequisite");
+
+    let coordinated = output_competition_to_coordinated_candidates(&candidates);
+    assert_eq!(
+        coordinated.len(),
+        candidates.len(),
+        "each candidate maps to exactly one coordinated candidate",
+    );
+    for c in &coordinated {
+        assert_eq!(c.operations.len(), 1, "single AddSynapse op per candidate");
+        match &c.operations[0] {
+            CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid,
+                to_neuron_uuid,
+                weight,
+            } => {
+                assert_ne!(from_neuron_uuid, to_neuron_uuid);
+                assert!(
+                    *weight < 0.0,
+                    "lateral inhibition must use a negative weight (got {weight})",
+                );
+            }
+            other => panic!("expected AddSynapse, got {other:?}"),
+        }
+        assert!(
+            c.expected_creature_score_gain >= 0.0,
+            "expected gain must be non-negative",
+        );
+    }
+}
+
+// =============================================================================
+// 11. Forward-only ordering: only proposals where `from` precedes `to` in
+//     `creature.neurons[]` are emitted.
+// =============================================================================
+#[test]
+fn forward_only_ordering_is_respected() {
+    let creature = creature_with_two_outputs();
+    let records = co_firing_records();
+    let descriptor = TaskDescriptor::from_name("CATEGORICAL_ERROR", 2);
+
+    let candidates = detect_output_competition(&creature, &records, &descriptor);
+
+    let index_of = |uuid: &str| {
+        creature
+            .neurons
+            .iter()
+            .position(|n| n.uuid == uuid)
+            .expect("uuid must exist in creature.neurons")
+    };
+
+    for c in &candidates {
+        assert!(
+            index_of(&c.from_output_uuid) < index_of(&c.to_output_uuid),
+            "candidate {} → {} violates forward-only ordering",
+            c.from_output_uuid,
+            c.to_output_uuid,
+        );
+    }
+}

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -8,6 +8,7 @@ mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
 mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
+mod issue_1321_output_competition_lateral_inhibition;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod issue_1059_disable_batch_successful;
 mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
+mod issue_1313_role_aware_output_squash;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -7,6 +7,7 @@ mod issue_1059_disable_batch_successful;
 mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
+mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;
 mod issue_230_multi_hop_candidate_analysis;

--- a/tests/recommendation/main.rs
+++ b/tests/recommendation/main.rs
@@ -8,6 +8,7 @@ mod issue_1247_categorical_error_hardening;
 mod issue_1249_categorical_error_sse_gating;
 mod issue_1313_role_aware_output_squash;
 mod issue_1316_output_bias_drift_one_hot_capacity_starvation;
+mod issue_1319_one_hot_per_class_capacity_allocation;
 mod issue_1321_output_competition_lateral_inhibition;
 mod issue_189_synergistic_discovery;
 mod issue_202_epistatic_neuron_pairs;

--- a/tests/regression/regression_v0_1_123.rs
+++ b/tests/regression/regression_v0_1_123.rs
@@ -140,6 +140,7 @@ fn regression_hidden_neurons_must_be_analyzed_not_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -274,6 +275,7 @@ fn regression_low_improvement_fallback_candidates_must_be_filtered() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -543,6 +545,7 @@ fn regression_discounted_hidden_neurons_must_meet_minimum_threshold() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -732,6 +735,7 @@ fn regression_impact_discounted_neurons_must_appear_in_response() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/scoring/issue_486_neuron_error_distribution.rs
+++ b/tests/scoring/issue_486_neuron_error_distribution.rs
@@ -100,6 +100,7 @@ fn test_neuron_analysis_populates_error_distribution() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -201,6 +202,7 @@ fn test_neuron_analysis_no_errors_returns_none() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");
@@ -308,6 +310,7 @@ fn test_neuron_analysis_error_distribution_multiple_targets() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Neuron analysis should succeed");

--- a/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
+++ b/tests/synapse/analyze_all_deadline_prioritises_synapses.rs
@@ -127,6 +127,7 @@ fn synapse_analysis_runs_under_deadline() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -177,6 +178,7 @@ fn metadata_indicates_target_value_available() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -222,6 +224,7 @@ fn metadata_indicates_target_value_not_available() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -273,6 +276,7 @@ fn metadata_indicates_saturation_aware_simulation_used() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -321,6 +325,7 @@ fn candidate_counts_tracked_correctly() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");
@@ -432,6 +437,7 @@ fn truncation_reflected_in_candidate_counts() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("Analysis should succeed");

--- a/tests/synapse/issue_927_remove_harmful_synapse.rs
+++ b/tests/synapse/issue_927_remove_harmful_synapse.rs
@@ -437,6 +437,7 @@ fn test_analyze_all_finds_harmful_synapse() {
         max_discovery_wall_clock_minutes: None,
         failure_cache: None,
         discovery_outcome_log: None,
+        cost_name: None,
     };
 
     let result = analyze_all(&input).expect("analyze_all should succeed");

--- a/tests/synapse/source_variance_discounting.rs
+++ b/tests/synapse/source_variance_discounting.rs
@@ -133,6 +133,7 @@ fn test_constant_source_gives_zero_improvement() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -236,6 +237,7 @@ fn test_low_variance_source_discounts_prediction() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -339,6 +341,7 @@ fn test_high_variance_source_not_discounted() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");
@@ -449,6 +452,7 @@ fn test_constant_vs_varying_source_comparison() {
         temperature: 1.0,
         failure_cache: None,
         discovery_outcome_log: None,
+        task_descriptor: None,
     };
 
     let result = analyze_neurons(&input).expect("Analysis should succeed");


### PR DESCRIPTION
## Milestone: Cost Name

This PR merges the completed milestone branch into Develop.
Closes #1332

### Issues addressed
- #1321: Output competition / lateral-inhibition recommender under one_hot/simplex (stretch)
- #1320: Cost-aware early-termination / drought thresholds from the TaskDescriptor
- #1319: Per-class capacity allocation under one_hot using existing failure trackers
- #1318: Margin-aware candidate ranking for argmax/margin costs (OneHot/Margin)
- #1317: Wire the cost identity into the target-reconstruction guard (#1250)
- #1316: Weight output bias-drift detection by class prior (capacity starvation under one_hot)
- #1315: Make the activation/squash scan candidate set role- and task-aware (output→bounded, hidden→unbounded)
- #1314: Accept optional task_descriptor on the discovery FFI inputs (neutral default, no consumer change)
- #1313: Role-aware activation recommendation: bias output-neuron squash to the task's family (OneHot/Simplex)
- #1312: Define the TaskDescriptor type + cost-name mapping (pure, no FFI)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.