### PR TITLE
Remove duplicate cargo check in ci.yml validation job (Issue #1342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     needs: [version-increment]
-    # File-presence and lightweight cargo check — 10 minutes is plenty
+    # File-presence and Cargo.toml field validation — 10 minutes is plenty
     # while still capping wedged-runner exposure (Issue #1287).
     timeout-minutes: 10
 
@@ -336,12 +336,10 @@ jobs:
       run: |
         set -euo pipefail
         echo "🔍 Validating Cargo.toml..."
-        
-        if ! cargo check --manifest-path Cargo.toml --quiet; then
-          echo "❌ Cargo.toml validation failed"
-          exit 1
-        fi
-        
+
+        # Manifest resolvability is proven by the broader compile gate in
+        # the `quality` job (Check types) on the same pull request;
+        # recompiling here only duplicated that work (Issue #1342).
         for field in "name" "version" "edition"; do
           if ! grep -vE "^[[:space:]]*#" Cargo.toml | grep -qE "^[[:space:]]*${field}[[:space:]]*="; then
             echo "❌ Missing '$field' field in Cargo.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block2"
@@ -439,9 +439,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lz4_flex"
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.77"
+version = "0.74.78"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1884,25 +1884,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1961,24 +1946,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1996,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2259,9 +2243,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2854,18 +2838,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.77"
+version = "0.74.78"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1342.md
+++ b/docs/archive/pr-summaries/pr-summary-1342.md
@@ -1,0 +1,69 @@
+# PR Summary — Issue #1342
+
+## Summary
+
+Removed the duplicate `cargo check` from `.github/workflows/ci.yml`. The crate
+was compiled twice on every pull request:
+
+- `quality` job → **Check types** — `cargo check --all-targets --all-features`
+- `validation` job → **Validate Cargo.toml** — `cargo check --manifest-path Cargo.toml --quiet`
+
+The two jobs run concurrently (no `needs:` relationship between them), and the
+`validation` invocation compiled only the default target — a strict subset of
+the `quality` invocation's `--all-targets --all-features` scope. It therefore
+added no coverage while doubling the most expensive part of the `validation`
+job and consuming extra runner capacity.
+
+The redundant `cargo check` is dropped from the **Validate Cargo.toml** step,
+leaving its genuinely distinct work (the `name`/`version`/`edition`
+field-presence grep) intact. Manifest resolvability is still proven by the
+`quality` job's `cargo check --all-targets --all-features` on the same pull
+request. The now-stale "lightweight cargo check" comment on the `validation`
+job header was updated to match.
+
+Closes #1342.
+
+## Evidence
+
+This is a CI workflow / build-config change with no web interface to
+screenshot. The change is verified by a new regression test that parses
+`ci.yml` and asserts the de-duplication, plus the existing workflow tests
+which confirm no other workflow invariant regressed.
+
+```mermaid
+flowchart TB
+    PR[Pull request] --> Q[quality job]
+    PR --> V[validation job]
+    Q --> QC["Check types<br/>cargo check --all-targets --all-features<br/>(single compile gate)"]
+    V --> VF["Validate Cargo.toml<br/>name / version / edition field grep<br/>(cargo check removed — Issue #1342)"]
+```
+
+Test run (after fix):
+
+```
+running 3 tests
+test check_types_step_retains_broad_compile_gate ... ok
+test validate_cargo_toml_step_has_no_cargo_check ... ok
+test validate_cargo_toml_step_keeps_field_presence_validation ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+## Test Plan
+
+Added `tests/issue_1342_workflow_dedup_cargo_check.rs`, which reproduces #1342
+and verifies the fix:
+
+- `validate_cargo_toml_step_has_no_cargo_check` — fails against the unfixed
+  workflow (the step ran `cargo check`); passes after the redundant check is
+  removed.
+- `validate_cargo_toml_step_keeps_field_presence_validation` — confirms the
+  step still validates the `name`/`version`/`edition` fields (its unique work
+  is preserved).
+- `check_types_step_retains_broad_compile_gate` — confirms the `quality` job's
+  `Check types` step retains `cargo check --all-targets --all-features` as the
+  single compile gate.
+
+Existing workflow tests re-run to confirm no regression:
+`issue_1290_workflow_set_euo_pipefail`, `issue_1292_actionlint_workflow`,
+`issue_1287_workflow_timeouts` — all pass.

--- a/tests/issue_1342_workflow_dedup_cargo_check.rs
+++ b/tests/issue_1342_workflow_dedup_cargo_check.rs
@@ -1,0 +1,106 @@
+//! Issue #1342: `.github/workflows/ci.yml` compiled the crate with
+//! `cargo check` twice per pull request — once in the `quality` job
+//! ("Check types", `--all-targets --all-features`) and once in the
+//! `validation` job ("Validate Cargo.toml", default target).
+//!
+//! The `validation` invocation compiled a strict subset of the `quality`
+//! invocation's scope, so it added no coverage while doubling the most
+//! expensive part of the `validation` job. The redundant `cargo check`
+//! is removed from the "Validate Cargo.toml" step, leaving only the
+//! field-presence validation unique to that step. The single compile gate
+//! is the `quality` job's "Check types" step.
+//!
+//! This test parses `ci.yml` as plain text (no YAML parser is in the
+//! dependency tree) and asserts:
+//!   1. The "Validate Cargo.toml" step contains no `cargo check`.
+//!   2. The "Validate Cargo.toml" step still performs field-presence
+//!      validation (its genuinely distinct work is preserved).
+//!   3. The "Check types" step retains the broad compile gate so the
+//!      manifest is still proven resolvable on every pull request.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a step by its `- name: <step_name>` marker and return the block
+/// of the step up to the next sibling step or new job header.
+fn step_block<'a>(body: &'a str, step_name: &str) -> Option<&'a str> {
+    let header = format!("    - name: {step_name}\n");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let mut idx = header.len();
+    let bytes = after.as_bytes();
+    while idx < bytes.len() {
+        if let Some(nl) = after[idx..].find('\n') {
+            let line_start = idx + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            if line.starts_with("    - name:")
+                || (line.starts_with("  ")
+                    && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                    && line.trim_end().ends_with(':'))
+            {
+                return Some(&after[..line_start]);
+            }
+            idx = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn validate_cargo_toml_step_has_no_cargo_check() {
+    let body = read_workflow("ci.yml");
+    let block = step_block(&body, "Validate Cargo.toml")
+        .expect("step `Validate Cargo.toml` not found in ci.yml");
+    assert!(
+        !block.contains("cargo check"),
+        "step `Validate Cargo.toml` must not run `cargo check` — it duplicates the \
+         broader compile gate in the `quality` job's `Check types` step \
+         (`cargo check --all-targets --all-features`), doubling the crate's \
+         compilation per pull request for no added coverage (Issue #1342)",
+    );
+}
+
+#[test]
+fn validate_cargo_toml_step_keeps_field_presence_validation() {
+    let body = read_workflow("ci.yml");
+    let block = step_block(&body, "Validate Cargo.toml")
+        .expect("step `Validate Cargo.toml` not found in ci.yml");
+    // The genuinely distinct work — the name/version/edition field grep —
+    // must remain so the step still validates the manifest's required fields.
+    for field in ["name", "version", "edition"] {
+        assert!(
+            block.contains(&format!("\"{field}\"")),
+            "step `Validate Cargo.toml` must still validate the presence of the \
+             `{field}` field in Cargo.toml (Issue #1342)",
+        );
+    }
+}
+
+#[test]
+fn check_types_step_retains_broad_compile_gate() {
+    let body = read_workflow("ci.yml");
+    let block = step_block(&body, "Check types").expect("step `Check types` not found in ci.yml");
+    assert!(
+        block.contains("cargo check --all-targets --all-features"),
+        "the `Check types` step must retain `cargo check --all-targets --all-features` \
+         as the single compile gate that proves manifest resolvability on every \
+         pull request (Issue #1342)",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1342

## Summary

Removed the duplicate `cargo check` from `.github/workflows/ci.yml`. The crate
was compiled twice on every pull request:

- `quality` job → **Check types** — `cargo check --all-targets --all-features`
- `validation` job → **Validate Cargo.toml** — `cargo check --manifest-path Cargo.toml --quiet`

The two jobs run concurrently (no `needs:` relationship between them), and the
`validation` invocation compiled only the default target — a strict subset of
the `quality` invocation's `--all-targets --all-features` scope. It therefore
added no coverage while doubling the most expensive part of the `validation`
job and consuming extra runner capacity.

The redundant `cargo check` is dropped from the **Validate Cargo.toml** step,
leaving its genuinely distinct work (the `name`/`version`/`edition`
field-presence grep) intact. Manifest resolvability is still proven by the
`quality` job's `cargo check --all-targets --all-features` on the same pull
request. The now-stale "lightweight cargo check" comment on the `validation`
job header was updated to match.

Closes #1342.

## Evidence

This is a CI workflow / build-config change with no web interface to
screenshot. The change is verified by a new regression test that parses
`ci.yml` and asserts the de-duplication, plus the existing workflow tests
which confirm no other workflow invariant regressed.

```mermaid
flowchart TB
    PR[Pull request] --> Q[quality job]
    PR --> V[validation job]
    Q --> QC["Check types<br/>cargo check --all-targets --all-features<br/>(single compile gate)"]
    V --> VF["Validate Cargo.toml<br/>name / version / edition field grep<br/>(cargo check removed — Issue #1342)"]
```

Test run (after fix):

```
running 3 tests
test check_types_step_retains_broad_compile_gate ... ok
test validate_cargo_toml_step_has_no_cargo_check ... ok
test validate_cargo_toml_step_keeps_field_presence_validation ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test Plan

Added `tests/issue_1342_workflow_dedup_cargo_check.rs`, which reproduces #1342
and verifies the fix:

- `validate_cargo_toml_step_has_no_cargo_check` — fails against the unfixed
  workflow (the step ran `cargo check`); passes after the redundant check is
  removed.
- `validate_cargo_toml_step_keeps_field_presence_validation` — confirms the
  step still validates the `name`/`version`/`edition` fields (its unique work
  is preserved).
- `check_types_step_retains_broad_compile_gate` — confirms the `quality` job's
  `Check types` step retains `cargo check --all-targets --all-features` as the
  single compile gate.

Existing workflow tests re-run to confirm no regression:
`issue_1290_workflow_set_euo_pipefail`, `issue_1292_actionlint_workflow`,
`issue_1287_workflow_timeouts` — all pass.
