### PR TITLE
Base eager/lazy focus-ranking decision on real available memory (Issue #1376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.80"
+version = "0.74.81"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.80"
+version = "0.74.81"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1376.md
+++ b/docs/archive/pr-summaries/pr-summary-1376.md
@@ -1,0 +1,68 @@
+## Summary
+
+The focus-ranking eager-vs-lazy loading decision selected **lazy** (the slow
+path) even when GBs of RAM were free. In the GRQ-13 evidence the host had
+**~2990 MB available** yet a ~1.6 GB parquet projection was rejected, dropping
+the run onto the slow path.
+
+Root cause: the auto-detect (no explicit budget) path called
+`check_memory_for_parquet`, whose **50%-of-total-RAM cap** rejected the
+projection. When the container reported a small total, a 1.6 GB projection
+exceeded 50% of total and fell back to lazy despite ample *available* memory.
+
+This change bases the auto-detect decision on **real OS-available memory minus
+a configurable safety margin**: pre-load whenever
+`projected ≤ available − margin`. The margin defaults to 1 GB (headroom for GPU
+buffers / system / allocator slack) and is overridable via
+`NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB`. The explicit
+`NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` override (#1172) is
+**unchanged**.
+
+With the GRQ-13 numbers: `usable = 2990 − 1024 = 1966 MB ≥ 1593 MB → Preload`.
+
+Closes #1376.
+
+### Deno regression avoided
+
+N/A — this is a Rust repository.
+
+## Evidence
+
+Backend/CLI change — no UI to screenshot. Verified via unit and integration
+tests calling the real decision helpers with fixed memory figures (including the
+GRQ-13 numbers) and through the full `./quality.sh` gate (fmt, clippy, check,
+test, release build) passing cleanly.
+
+```mermaid
+flowchart TD
+    A[load_records_provider] --> B{explicit budget set?}
+    B -- yes --> C[decide_with_budget #1172 unchanged]
+    B -- no --> D[decide_with_auto_detect #1376]
+    D --> E[available = get_memory_info]
+    E --> F{"projected ≤ available − margin?"}
+    F -- yes --> G[Preload — fast path]
+    F -- no --> H[Lazy + WARN — MemoryPressure]
+```
+
+## Test Plan
+
+Unit tests — `src/analysis/utils/memory_tests.rs` (`parquet_preload_fits_available`):
+- `test_preload_fits_when_projection_under_available_minus_margin`
+- `test_preload_does_not_fit_when_projection_exceeds_usable`
+- `test_preload_fits_grq13_numbers` — ≈1.6 GB projection, ≈3 GB free → Preload
+- `test_preload_boundary_equal_fits` — `<=` boundary, one byte over → lazy
+- `test_preload_margin_larger_than_available_saturates_to_lazy` — no underflow
+- `test_preload_zero_margin_uses_full_available`
+
+Integration tests — `tests/focus/issue_1376_focus_ranking_available_memory.rs`
+(`decide_loading_mode_for_available_memory` + `focus_ranking_memory_margin_mb`):
+- `grq13_numbers_choose_preload`
+- `projection_over_usable_chooses_lazy_memory_pressure`
+- `boundary_equal_to_usable_preloads`
+- `margin_exceeding_available_falls_back_to_lazy_without_panic`
+- `margin_config_unset_uses_default` / `_honours_override` / `_honours_zero` /
+  `_invalid_falls_back_to_default`
+
+Regression guards (unchanged, still pass):
+- `tests/focus/issue_1172_focus_ranking_memory_budget.rs` (7 tests)
+- `tests/ffi/issue_1028_memory_budget.rs` (11 tests)

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -342,6 +342,28 @@ pub fn estimate_parquet_in_memory_bytes(parquet_file: &str) -> u64 {
     file_size.saturating_mul(PARQUET_MEMORY_MULTIPLIER)
 }
 
+/// Decide whether a projected parquet pre-load fits within OS-available
+/// memory after reserving a safety margin (Issue #1376).
+///
+/// Returns `true` (pre-load is safe) when
+/// `projected_bytes <= available_bytes − margin_bytes`. Uses saturating
+/// subtraction so a margin larger than available memory yields `0` usable
+/// bytes (lazy) rather than underflowing.
+///
+/// This is a pure function so the eager-vs-lazy decision can be unit-tested
+/// against fixed memory figures (e.g. the GRQ-13 numbers: ~1.6 GB projection
+/// with ~3 GB available → fits → pre-load) without sampling live system
+/// memory.
+#[must_use]
+pub const fn parquet_preload_fits_available(
+    projected_bytes: u64,
+    available_bytes: u64,
+    margin_bytes: u64,
+) -> bool {
+    let usable = available_bytes.saturating_sub(margin_bytes);
+    projected_bytes <= usable
+}
+
 /// Convert bytes to whole megabytes, rounding up so non-zero sizes always
 /// produce at least 1 MB.
 pub const fn bytes_to_mb_ceil(bytes: u64) -> u64 {

--- a/src/analysis/utils/memory_tests.rs
+++ b/src/analysis/utils/memory_tests.rs
@@ -54,6 +54,78 @@ fn test_memory_tier_high_threshold() {
 }
 
 // =============================================================================
+// Available-Memory Pre-load Decision Tests (Issue #1376)
+// =============================================================================
+
+const MB: u64 = 1024 * 1024;
+
+#[test]
+fn test_preload_fits_when_projection_under_available_minus_margin() {
+    // 1 GB projection, 4 GB available, 1 GB margin → usable 3 GB → fits.
+    assert!(parquet_preload_fits_available(
+        1024 * MB,
+        4096 * MB,
+        1024 * MB
+    ));
+}
+
+#[test]
+fn test_preload_does_not_fit_when_projection_exceeds_usable() {
+    // 3.5 GB projection, 4 GB available, 1 GB margin → usable 3 GB → lazy.
+    assert!(!parquet_preload_fits_available(
+        3584 * MB,
+        4096 * MB,
+        1024 * MB
+    ));
+}
+
+#[test]
+fn test_preload_fits_grq13_numbers() {
+    // GRQ-13 regression: parquet 531.10 MB → ×3 ≈ 1593 MB projection, with
+    // ~2990 MB available and the default 1 GB margin. usable = 2990 − 1024 =
+    // 1966 MB ≥ 1593 MB → must pre-load (stay on the fast path), not lazy.
+    let projected_bytes = 1593 * MB;
+    let available_bytes = 2990 * MB;
+    let margin_bytes = 1024 * MB;
+    assert!(parquet_preload_fits_available(
+        projected_bytes,
+        available_bytes,
+        margin_bytes
+    ));
+}
+
+#[test]
+fn test_preload_boundary_equal_fits() {
+    // Exactly equal to usable budget still fits (<=, not <).
+    assert!(parquet_preload_fits_available(
+        3072 * MB,
+        4096 * MB,
+        1024 * MB
+    ));
+    // One byte over does not.
+    assert!(!parquet_preload_fits_available(
+        3072 * MB + 1,
+        4096 * MB,
+        1024 * MB
+    ));
+}
+
+#[test]
+fn test_preload_margin_larger_than_available_saturates_to_lazy() {
+    // Margin larger than available → 0 usable bytes → only a 0-byte projection
+    // "fits"; any real projection is lazy. No underflow panic.
+    assert!(!parquet_preload_fits_available(MB, 512 * MB, 1024 * MB));
+    assert!(parquet_preload_fits_available(0, 512 * MB, 1024 * MB));
+}
+
+#[test]
+fn test_preload_zero_margin_uses_full_available() {
+    // With no margin the full available memory is usable.
+    assert!(parquet_preload_fits_available(2048 * MB, 2048 * MB, 0));
+    assert!(!parquet_preload_fits_available(2048 * MB + 1, 2048 * MB, 0));
+}
+
+// =============================================================================
 // Parquet Memory Check Tests
 // =============================================================================
 

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -50,7 +50,8 @@ pub use memory::{
     check_memory_for_parquet, check_memory_pressure_and_cancel, check_system_memory_requirements,
     detect_memory_pressure, detect_memory_tier, estimate_parquet_in_memory_bytes, get_memory_info,
     get_work_queue_capacity, get_work_queue_capacity_for_tier, is_memory_budget_exceeded,
-    validate_parquet_memory_requirements, would_cancel_for_memory_pressure,
+    parquet_preload_fits_available, validate_parquet_memory_requirements,
+    would_cancel_for_memory_pressure,
 };
 
 // Re-export platform setup functions

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,7 +36,8 @@
 //! | `NEAT_AI_DISCOVERY_CONSERVATIVE_GAIN_MULTIPLIER` | f32 | `10.0` | Multiplier applied to `COORDINATED_MIN_EXPECTED_GAIN` in conservative mode (Issue #1132) |
 //! | `NEAT_AI_DISCOVERY_DROUGHT_LOG_THRESHOLD` | u32 | `5` | Consecutive trailing empty discovery passes at which the drought diagnostic warn log fires and `droughtDiagnostic` populates on FFI metadata (Issue #1202) |
 //! | `NEAT_AI_DISCOVERY_DROUGHT_RESET_AFTER_EPOCHS` | u32 | unset | Operator escape hatch: force a one-shot reset of failed-candidate cache entries and active target cooldowns after this many consecutive empty discovery passes (Issue #1205). Default unset (off). |
-//! | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | u64 | unset | Cap eager pre-load size in `focus::rank_focus_neurons` (Issue #1172). When set, projected size = file size × 3; lazy mode is selected with a structured `info` log when the projection exceeds the budget. When unset, behaviour matches the prior auto-detect heuristic. |
+//! | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | u64 | unset | Cap eager pre-load size in `focus::rank_focus_neurons` (Issue #1172). When set, projected size = file size × 3; lazy mode is selected with a structured `info` log when the projection exceeds the budget. When unset, the auto-detect path (Issue #1376) is used. |
+//! | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB` | u64 | `1024` | Safety margin reserved from real OS-available memory in the auto-detect (no explicit budget) eager-vs-lazy decision (Issue #1376). Pre-load is chosen when `projected ≤ available − margin`, keeping hosts with GBs free on the fast path. `0` reserves no margin. |
 //! | `NEAT_AI_DISCOVERY_MIN_EXPECTED_GAIN` | f32 | `1e-5` | Absolute minimum `expected_creature_score_gain` for emitted add-neuron / add-synapse candidates (Issue #1191). Clamped to `[0.0, 1e-2]`. |
 //!
 //! ## Observability Variables

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -375,6 +375,42 @@ pub fn focus_ranking_memory_budget_mb() -> Option<u64> {
     }
 }
 
+/// Default safety margin (in megabytes) reserved from OS-available memory
+/// before the focus ranker pre-loads a parquet file (Issue #1376).
+pub const DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB: u64 = 1024;
+
+/// Get the focus ranking memory safety margin in megabytes (Issue #1376).
+///
+/// When no explicit `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` is set,
+/// the eager-vs-lazy decision is based on **real OS-available memory** minus
+/// this margin. The margin reserves headroom for GPU buffers, the system, and
+/// allocator slack so a pre-load that *just* fits does not push the host into
+/// swap.
+///
+/// Override with `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB`. Falls back
+/// to [`DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB`] when the variable is unset,
+/// empty, or non-numeric. A value of `0` is honoured (no margin reserved).
+pub fn focus_ranking_memory_margin_mb() -> u64 {
+    let Ok(raw) = std::env::var("NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB") else {
+        return DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB;
+    }
+    match trimmed.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::debug!(
+                raw_value = trimmed,
+                "Ignoring invalid NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB \
+                 (expected a non-negative integer in megabytes)"
+            );
+            DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB
+        }
+    }
+}
+
 /// Default streaming session TTL in seconds (1 hour).
 pub const DEFAULT_SESSION_TTL_SECS: u64 = 3600;
 

--- a/src/focus/mod.rs
+++ b/src/focus/mod.rs
@@ -49,6 +49,7 @@ pub use impact::{
 pub use ranking::{
     FocusLazyReason, FocusLoadingMode, RankFocusStats, RankedNeuron, RecordProvider,
     RemovalCandidate, SelectionStats, SynapseCounts, calculate_removal_savings,
-    decide_loading_mode_for_budget, rank_focus_neurons, rank_focus_neurons_with_descriptor,
-    rank_focus_neurons_with_history, rank_focus_neurons_with_history_and_descriptor,
+    decide_loading_mode_for_available_memory, decide_loading_mode_for_budget, rank_focus_neurons,
+    rank_focus_neurons_with_descriptor, rank_focus_neurons_with_history,
+    rank_focus_neurons_with_history_and_descriptor,
 };

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -42,9 +42,10 @@ use super::impact::{
 };
 use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::analysis::utils::{
-    bytes_to_mb_ceil, check_memory_for_parquet, estimate_parquet_in_memory_bytes, verbose_enabled,
+    bytes_to_mb_ceil, estimate_parquet_in_memory_bytes, get_memory_info,
+    parquet_preload_fits_available, verbose_enabled,
 };
-use crate::config::focus_ranking_memory_budget_mb;
+use crate::config::{focus_ranking_memory_budget_mb, focus_ranking_memory_margin_mb};
 use crate::discovery_history::DiscoveryHistory;
 use crate::parquet_format::read_all_records_grouped_by_neuron;
 use crate::{CoordinatedStructuralCandidateJson, CreatureJson, NeuronJson};
@@ -86,8 +87,8 @@ pub enum FocusLazyReason {
     /// `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` was set and the
     /// projected pre-load size exceeded it.
     Budget,
-    /// No explicit budget was set and the system memory check
-    /// ([`check_memory_for_parquet`]) reported insufficient memory.
+    /// No explicit budget was set and the projected pre-load did not fit
+    /// within real OS-available memory after the safety margin (Issue #1376).
     MemoryPressure,
 }
 
@@ -182,6 +183,33 @@ pub fn decide_loading_mode_for_budget(
     }
 }
 
+/// Pure decision helper for the auto-detect (no explicit budget) path
+/// (Issue #1376).
+///
+/// Bases the eager-vs-lazy decision on **real OS-available memory** with a
+/// safety margin reserved for the system / GPU buffers, rather than the
+/// 50%-of-total-RAM cap that previously rejected mid-sized parquet files on
+/// hosts with plenty of free memory (the GRQ-13 regression: ~1.6 GB projection
+/// dropped to lazy despite ~3 GB free).
+///
+/// Pre-loads when `projected_bytes <= available_bytes − margin_bytes`,
+/// otherwise selects lazy mode with [`FocusLazyReason::MemoryPressure`].
+///
+/// Exposed publicly so unit tests can exercise the available-memory branch
+/// directly without sampling live system memory.
+#[must_use]
+pub fn decide_loading_mode_for_available_memory(
+    projected_bytes: u64,
+    available_bytes: u64,
+    margin_bytes: u64,
+) -> (FocusLoadingMode, FocusLazyReason) {
+    if parquet_preload_fits_available(projected_bytes, available_bytes, margin_bytes) {
+        (FocusLoadingMode::Preload, FocusLazyReason::None)
+    } else {
+        (FocusLoadingMode::Lazy, FocusLazyReason::MemoryPressure)
+    }
+}
+
 /// Load records provider, taking the optional configurable memory budget into
 /// account.
 ///
@@ -190,9 +218,11 @@ pub fn decide_loading_mode_for_budget(
 ///   projected in-memory size (file size × 3) is compared against the budget.
 ///   Lazy mode is selected with a structured `info` log when the projection
 ///   exceeds the budget.
-/// - When the budget is unset, the existing `check_memory_for_parquet`
-///   heuristic is used (auto-detect plus `WARN` on fallback) so behaviour on
-///   big hosts is unchanged.
+/// - When the budget is unset, the auto-detect path compares the projection
+///   against real OS-available memory minus a configurable safety margin
+///   (Issue #1376). Pre-load is chosen whenever the projection fits, so hosts
+///   with GBs free stay on the fast path; lazy mode (with a `WARN`) is reserved
+///   for genuinely memory-constrained hosts.
 fn load_records_provider(
     parquet_file: &str,
     selectable: &[&NeuronJson],
@@ -211,7 +241,7 @@ fn load_records_provider(
         );
     }
 
-    decide_with_auto_detect(parquet_file, selectable, projected_mb)
+    decide_with_auto_detect(parquet_file, selectable, projected_bytes, projected_mb)
 }
 
 /// Build a lazy record provider whose cache is sized to the ranking working set
@@ -297,32 +327,49 @@ fn decide_with_budget(
 fn decide_with_auto_detect(
     parquet_file: &str,
     selectable: &[&NeuronJson],
+    projected_bytes: u64,
     projected_mb: u64,
 ) -> Result<LoadingDecision> {
-    match check_memory_for_parquet(parquet_file) {
-        Ok(()) => {
+    const BYTES_PER_MB: u64 = 1024 * 1024;
+
+    // Issue #1376: base the decision on real OS-available memory minus a safety
+    // margin, rather than the 50%-of-total-RAM cap that dropped mid-sized
+    // parquet files onto the slow lazy path while GBs of RAM were free.
+    let (available_bytes, _total_bytes) = get_memory_info();
+    let margin_mb = focus_ranking_memory_margin_mb();
+    let margin_bytes = margin_mb.saturating_mul(BYTES_PER_MB);
+    let available_mb = bytes_to_mb_ceil(available_bytes);
+
+    let (mode, reason) =
+        decide_loading_mode_for_available_memory(projected_bytes, available_bytes, margin_bytes);
+
+    match mode {
+        FocusLoadingMode::Preload => {
             let records = read_all_records_grouped_by_neuron(parquet_file)
                 .context("Failed to read discovery records from parquet file")?;
             Ok(LoadingDecision {
                 provider: Arc::new(EagerRecordProvider::new(records)),
-                mode: FocusLoadingMode::Preload,
-                reason: FocusLazyReason::None,
+                mode,
+                reason,
                 budget_mb: None,
                 projected_mb,
             })
         }
-        Err(memory_error) => {
+        FocusLoadingMode::Lazy => {
             tracing::warn!(
-                "Insufficient memory for full pre-load in focus ranking. \
-                 Using lazy-loading mode (slower but memory-efficient)."
+                target: "neat_ai_discovery::focus::ranking",
+                mode = FocusLoadingMode::Lazy.as_str(),
+                reason = reason.as_str(),
+                projected_mb,
+                available_mb,
+                margin_mb,
+                "Insufficient available memory for full pre-load in focus ranking. \
+                 Using lazy-loading mode (slower but memory-efficient).",
             );
-            if verbose_enabled() {
-                tracing::debug!(error = %memory_error, "Memory check failed");
-            }
             Ok(LoadingDecision {
                 provider: build_lazy_provider(parquet_file, selectable),
-                mode: FocusLoadingMode::Lazy,
-                reason: FocusLazyReason::MemoryPressure,
+                mode,
+                reason,
                 budget_mb: None,
                 projected_mb,
             })

--- a/tests/focus/issue_1376_focus_ranking_available_memory.rs
+++ b/tests/focus/issue_1376_focus_ranking_available_memory.rs
@@ -1,0 +1,130 @@
+//! Issue #1376: Eager/lazy focus-ranking decision based on real available RAM.
+//!
+//! The auto-detect (no explicit budget) path previously gated on a
+//! 50%-of-total-RAM cap, which dropped mid-sized parquet files onto the slow
+//! lazy path while GBs of RAM were free (the GRQ-13 regression: ~1.6 GB
+//! projection chosen lazy despite ~2990 MB available).
+//!
+//! These tests exercise the pure decision helper
+//! `decide_loading_mode_for_available_memory` directly so the available-memory
+//! branch is covered deterministically, including the GRQ-13 numbers.
+
+use neat_ai_discovery::config::{
+    DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB, focus_ranking_memory_margin_mb,
+};
+use neat_ai_discovery::focus::{
+    FocusLazyReason, FocusLoadingMode, decide_loading_mode_for_available_memory,
+};
+use serial_test::serial;
+
+const MB: u64 = 1024 * 1024;
+const MARGIN_ENV: &str = "NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB";
+
+/// RAII guard that sets/restores `MARGIN_ENV` for a single test.
+struct MarginEnvGuard {
+    previous: Option<String>,
+}
+
+impl MarginEnvGuard {
+    fn set(value: &str) -> Self {
+        let previous = std::env::var(MARGIN_ENV).ok();
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
+        unsafe { std::env::set_var(MARGIN_ENV, value) };
+        Self { previous }
+    }
+
+    fn unset() -> Self {
+        let previous = std::env::var(MARGIN_ENV).ok();
+        // SAFETY: Serialised via #[serial] — no concurrent env access.
+        unsafe { std::env::remove_var(MARGIN_ENV) };
+        Self { previous }
+    }
+}
+
+impl Drop for MarginEnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            // SAFETY: Serialised via #[serial] — no concurrent env access.
+            Some(v) => unsafe { std::env::set_var(MARGIN_ENV, v) },
+            // SAFETY: Serialised via #[serial] — no concurrent env access.
+            None => unsafe { std::env::remove_var(MARGIN_ENV) },
+        }
+    }
+}
+
+#[test]
+fn grq13_numbers_choose_preload() {
+    // Parquet 531.10 MB → ×3 ≈ 1593 MB projection, ~2990 MB available, default
+    // 1 GB margin. usable = 2990 − 1024 = 1966 MB ≥ 1593 MB → Preload.
+    let (mode, reason) = decide_loading_mode_for_available_memory(1593 * MB, 2990 * MB, 1024 * MB);
+    assert_eq!(mode, FocusLoadingMode::Preload);
+    assert_eq!(reason, FocusLazyReason::None);
+}
+
+#[test]
+fn projection_over_usable_chooses_lazy_memory_pressure() {
+    // 3.5 GB projection, 4 GB available, 1 GB margin → usable 3 GB → Lazy.
+    let (mode, reason) = decide_loading_mode_for_available_memory(3584 * MB, 4096 * MB, 1024 * MB);
+    assert_eq!(mode, FocusLoadingMode::Lazy);
+    assert_eq!(reason, FocusLazyReason::MemoryPressure);
+}
+
+#[test]
+fn boundary_equal_to_usable_preloads() {
+    // projected == available − margin → fits (<=, not <).
+    let (mode, reason) = decide_loading_mode_for_available_memory(3072 * MB, 4096 * MB, 1024 * MB);
+    assert_eq!(mode, FocusLoadingMode::Preload);
+    assert_eq!(reason, FocusLazyReason::None);
+
+    // One byte over the usable budget tips to lazy.
+    let (mode_over, reason_over) =
+        decide_loading_mode_for_available_memory(3072 * MB + 1, 4096 * MB, 1024 * MB);
+    assert_eq!(mode_over, FocusLoadingMode::Lazy);
+    assert_eq!(reason_over, FocusLazyReason::MemoryPressure);
+}
+
+#[test]
+fn margin_exceeding_available_falls_back_to_lazy_without_panic() {
+    // Saturating subtraction: margin > available → 0 usable bytes → lazy for
+    // any real projection (no underflow).
+    let (mode, reason) = decide_loading_mode_for_available_memory(MB, 512 * MB, 1024 * MB);
+    assert_eq!(mode, FocusLoadingMode::Lazy);
+    assert_eq!(reason, FocusLazyReason::MemoryPressure);
+}
+
+#[test]
+#[serial]
+fn margin_config_unset_uses_default() {
+    let _guard = MarginEnvGuard::unset();
+    assert_eq!(
+        focus_ranking_memory_margin_mb(),
+        DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB
+    );
+    assert_eq!(DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB, 1024);
+}
+
+#[test]
+#[serial]
+fn margin_config_honours_override() {
+    let _guard = MarginEnvGuard::set("2048");
+    assert_eq!(focus_ranking_memory_margin_mb(), 2048);
+}
+
+#[test]
+#[serial]
+fn margin_config_honours_zero() {
+    // Zero is a valid choice (reserve no margin), distinct from the budget env
+    // var where 0 means "unset".
+    let _guard = MarginEnvGuard::set("0");
+    assert_eq!(focus_ranking_memory_margin_mb(), 0);
+}
+
+#[test]
+#[serial]
+fn margin_config_invalid_falls_back_to_default() {
+    let _guard = MarginEnvGuard::set("not-a-number");
+    assert_eq!(
+        focus_ranking_memory_margin_mb(),
+        DEFAULT_FOCUS_RANKING_MEMORY_MARGIN_MB
+    );
+}

--- a/tests/focus/main.rs
+++ b/tests/focus/main.rs
@@ -11,6 +11,7 @@ mod focus_ranking;
 mod issue_1172_focus_ranking_memory_budget;
 mod issue_1318_margin_aware_ranking;
 mod issue_1374_lazy_focus_ranking_single_pass;
+mod issue_1376_focus_ranking_available_memory;
 mod issue_156_hidden_focus_neurons_filtered;
 mod issue_182_focus_unused_observations;
 mod issue_222_hierarchical_focus;


### PR DESCRIPTION
## Summary

The focus-ranking eager-vs-lazy loading decision selected **lazy** (the slow
path) even when GBs of RAM were free. In the GRQ-13 evidence the host had
**~2990 MB available** yet a ~1.6 GB parquet projection was rejected, dropping
the run onto the slow path.

Root cause: the auto-detect (no explicit budget) path called
`check_memory_for_parquet`, whose **50%-of-total-RAM cap** rejected the
projection. When the container reported a small total, a 1.6 GB projection
exceeded 50% of total and fell back to lazy despite ample *available* memory.

This change bases the auto-detect decision on **real OS-available memory minus
a configurable safety margin**: pre-load whenever
`projected ≤ available − margin`. The margin defaults to 1 GB (headroom for GPU
buffers / system / allocator slack) and is overridable via
`NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_MARGIN_MB`. The explicit
`NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` override (#1172) is
**unchanged**.

With the GRQ-13 numbers: `usable = 2990 − 1024 = 1966 MB ≥ 1593 MB → Preload`.

Closes #1376.

### Deno regression avoided

N/A — this is a Rust repository.

## Evidence

Backend/CLI change — no UI to screenshot. Verified via unit and integration
tests calling the real decision helpers with fixed memory figures (including the
GRQ-13 numbers) and through the full `./quality.sh` gate (fmt, clippy, check,
test, release build) passing cleanly.

```mermaid
flowchart TD
    A[load_records_provider] --> B{explicit budget set?}
    B -- yes --> C[decide_with_budget #1172 unchanged]
    B -- no --> D[decide_with_auto_detect #1376]
    D --> E[available = get_memory_info]
    E --> F{"projected ≤ available − margin?"}
    F -- yes --> G[Preload — fast path]
    F -- no --> H[Lazy + WARN — MemoryPressure]
```

## Test Plan

Unit tests — `src/analysis/utils/memory_tests.rs` (`parquet_preload_fits_available`):
- `test_preload_fits_when_projection_under_available_minus_margin`
- `test_preload_does_not_fit_when_projection_exceeds_usable`
- `test_preload_fits_grq13_numbers` — ≈1.6 GB projection, ≈3 GB free → Preload
- `test_preload_boundary_equal_fits` — `<=` boundary, one byte over → lazy
- `test_preload_margin_larger_than_available_saturates_to_lazy` — no underflow
- `test_preload_zero_margin_uses_full_available`

Integration tests — `tests/focus/issue_1376_focus_ranking_available_memory.rs`
(`decide_loading_mode_for_available_memory` + `focus_ranking_memory_margin_mb`):
- `grq13_numbers_choose_preload`
- `projection_over_usable_chooses_lazy_memory_pressure`
- `boundary_equal_to_usable_preloads`
- `margin_exceeding_available_falls_back_to_lazy_without_panic`
- `margin_config_unset_uses_default` / `_honours_override` / `_honours_zero` /
  `_invalid_falls_back_to_default`

Regression guards (unchanged, still pass):
- `tests/focus/issue_1172_focus_ranking_memory_budget.rs` (7 tests)
- `tests/ffi/issue_1028_memory_budget.rs` (11 tests)



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqed6zi1-7bff2a`<!-- vibe-worker-issue-1376 -->