### PR TITLE
Reject non-finite expected gains before ranking candidates (Issue #1367)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1367.md
+++ b/docs/archive/pr-summaries/pr-summary-1367.md
@@ -1,0 +1,58 @@
+## Summary
+
+Candidate ranking sorts coordinated-structural candidates by
+`expected_creature_score_gain` using `total_cmp`. While panic-safe, `total_cmp`
+orders a positive `NaN` **above** `+∞`, so a candidate with a `NaN` (or `±∞`)
+gain would sort to the **top** and be returned as the *best* candidate. There
+was no finiteness guard anywhere in `candidate_aggregation.rs` or
+`candidate_diversity.rs`. A non-finite gain is not a valid positive expected
+improvement, and returning one wastes the controller's ablation-test budget on a
+meaningless candidate — exactly the cost the mission exists to avoid.
+
+This PR adds a finiteness filter that drops candidates whose
+`expected_creature_score_gain` is not finite (`!x.is_finite()`) **before**
+diversity reranking / final selection, and records the drop in the existing
+rejection breakdown so it stays observable.
+
+Changes:
+- New `reject_non_finite_gains()` in `candidate_aggregation.rs` — retains only
+  finite-gain candidates, preserving the relative order of survivors, and
+  returns the dropped count.
+- Wired into `merge_coordinated_structural_replacements` (before the sort /
+  diversity rerank) and into `apply_final_coordinated_gain_floor` (the
+  unconditional final selection gate before the FFI response). The latter also
+  closes the `+∞ >= floor` gap, where an infinite gain would otherwise survive
+  the existing noise-floor comparison.
+- New stable rejection reason `non_finite_gain` (`REJECTION_NON_FINITE_GAIN`),
+  added to `ALL_REJECTION_REASONS` and the friendly-summary mapping.
+
+Closes #1367.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+new TDD tests and the full `./quality.sh` gate (fmt, clippy `-D warnings`,
+check, all tests, release build) passing cleanly.
+
+```mermaid
+flowchart LR
+    A[Coordinated candidates] --> B{is_finite?}
+    B -- "NaN / ±∞" --> R[Dropped\nrecord non_finite_gain]
+    B -- finite --> C[Diversity rerank / final gain floor]
+    C --> D[Returned candidates]
+```
+
+## Test Plan
+
+Added `tests/issue_1367_non_finite_gain_rejection.rs`:
+- `reject_non_finite_gains_drops_non_finite_and_preserves_order` — feeds a set
+  containing `NaN`, `+∞` and `-∞` plus several finite candidates; asserts the
+  three non-finite entries are dropped and the finite survivors keep their
+  original order.
+- `final_gate_rejects_non_finite_and_records_breakdown` — feeds a `NaN`-gain and
+  a `+∞`-gain candidate plus finite candidates through
+  `apply_final_coordinated_gain_floor`; asserts neither non-finite candidate is
+  returned, all finite candidates survive, and the rejection breakdown records
+  `non_finite_gain == 2`.
+
+Full suite: `./quality.sh` passes (all unit + integration tests green).

--- a/src/analysis/candidate_aggregation.rs
+++ b/src/analysis/candidate_aggregation.rs
@@ -70,6 +70,24 @@ pub fn apply_coordinated_gain_floor_with_multiplier(
     u32::try_from(before.saturating_sub(candidates.len())).unwrap_or(u32::MAX)
 }
 
+/// Remove coordinated-structural candidates whose `expected_creature_score_gain`
+/// is not finite (`NaN` or `±∞`) (Issue #1367).
+///
+/// Ranking sorts by `expected_creature_score_gain` via `total_cmp`, which
+/// orders a positive `NaN` **above** `+∞` — so a non-finite gain would sort to
+/// the top and be returned as the *best* candidate, wasting the controller's
+/// ablation-test budget on a meaningless candidate. A non-finite gain is not a
+/// valid positive improvement, so it is dropped here before any reranking or
+/// final selection. The relative order of the finite survivors is preserved.
+///
+/// Returns the number of candidates removed so callers can record the drop in
+/// the structured rejection breakdown.
+pub fn reject_non_finite_gains(candidates: &mut Vec<CoordinatedStructuralCandidateJson>) -> u32 {
+    let before = candidates.len();
+    candidates.retain(|c| c.expected_creature_score_gain.is_finite());
+    u32::try_from(before.saturating_sub(candidates.len())).unwrap_or(u32::MAX)
+}
+
 /// Apply the final coordinated-structural gain floor to a synapse result and
 /// refresh dependent metadata (Issue #1139).
 ///
@@ -100,7 +118,18 @@ pub fn apply_final_coordinated_gain_floor(
     discovery_mode: super::discovery_mode::DiscoveryMode,
     conservative_multiplier: f32,
 ) -> u32 {
-    use super::diagnostics::rejection_reasons::REJECTION_BELOW_EXPECTED_GAIN_FLOOR;
+    use super::diagnostics::rejection_reasons::{
+        REJECTION_BELOW_EXPECTED_GAIN_FLOOR, REJECTION_NON_FINITE_GAIN,
+    };
+
+    // Issue #1367: Drop non-finite gains (NaN / ±∞) before the floor comparison.
+    // `total_cmp`-based ranking would otherwise sort a positive NaN above +∞ and
+    // return it as the best candidate, and `+∞ >= floor` would survive the floor.
+    let non_finite = reject_non_finite_gains(&mut synapse.coordinated_structural_candidates);
+    synapse
+        .metadata
+        .rejection_breakdown
+        .record_many_u32(REJECTION_NON_FINITE_GAIN, non_finite);
 
     let gain_multiplier = super::discovery_mode::coordinated_gain_multiplier_for_mode(
         discovery_mode,
@@ -168,9 +197,21 @@ pub(crate) fn merge_coordinated_structural_replacements(
     diversify: bool,
 ) {
     use crate::analysis::diagnostics::rejection_reasons::{
-        REJECTION_BELOW_MULTI_OP_FLOOR, REJECTION_NON_POSITIVE_GAIN,
+        REJECTION_BELOW_MULTI_OP_FLOOR, REJECTION_NON_FINITE_GAIN, REJECTION_NON_POSITIVE_GAIN,
     };
 
+    if replacements.is_empty() {
+        return;
+    }
+
+    // Issue #1367: Drop non-finite gains (NaN / ±∞) before any sort or rerank.
+    // `total_cmp` orders a positive NaN above +∞, so a non-finite candidate
+    // would otherwise sort to the top and be returned as the best candidate.
+    let dropped_non_finite = reject_non_finite_gains(&mut replacements);
+    synapse
+        .metadata
+        .rejection_breakdown
+        .record_many_u32(REJECTION_NON_FINITE_GAIN, dropped_non_finite);
     if replacements.is_empty() {
         return;
     }

--- a/src/analysis/diagnostics/rejection_reasons.rs
+++ b/src/analysis/diagnostics/rejection_reasons.rs
@@ -33,6 +33,15 @@ pub const REJECTION_BELOW_MULTI_OP_FLOOR: &str = "below_multi_op_floor";
 /// Candidate's expected gain was non-positive after pre-filtering.
 pub const REJECTION_NON_POSITIVE_GAIN: &str = "non_positive_gain";
 
+/// Candidate's expected gain was not finite (`NaN` or `±∞`) (Issue #1367).
+///
+/// Ranking sorts by `expected_creature_score_gain` via `total_cmp`, which
+/// orders a positive `NaN` above `+∞`, so a non-finite gain would otherwise
+/// sort to the top and be returned as the *best* candidate. A non-finite gain
+/// is not a valid positive improvement and is dropped before reranking / final
+/// selection.
+pub const REJECTION_NON_FINITE_GAIN: &str = "non_finite_gain";
+
 /// Target saturation discount collapsed the expected gain to (near) zero.
 pub const REJECTION_SATURATION_DISCOUNTED_TO_ZERO: &str = "saturation_discounted_to_zero";
 
@@ -156,6 +165,7 @@ pub const ALL_REJECTION_REASONS: &[&str] = &[
     REJECTION_BELOW_EXPECTED_GAIN_FLOOR,
     REJECTION_BELOW_MULTI_OP_FLOOR,
     REJECTION_NON_POSITIVE_GAIN,
+    REJECTION_NON_FINITE_GAIN,
     REJECTION_SATURATION_DISCOUNTED_TO_ZERO,
     REJECTION_PESSIMISM_DISCOUNTED_TO_ZERO,
     REJECTION_INTERFERENCE_FILTERED,
@@ -310,6 +320,7 @@ fn friendly_reason(reason: &str) -> String {
             crate::analysis::constants::MIN_COORDINATED_MULTI_OP_GAIN
         ),
         REJECTION_NON_POSITIVE_GAIN => "non-positive expected gain".to_string(),
+        REJECTION_NON_FINITE_GAIN => "non-finite expected gain (NaN or ±∞)".to_string(),
         REJECTION_SATURATION_DISCOUNTED_TO_ZERO => {
             "saturation discount collapsed expected gain to zero".to_string()
         }

--- a/tests/issue_1367_non_finite_gain_rejection.rs
+++ b/tests/issue_1367_non_finite_gain_rejection.rs
@@ -1,0 +1,123 @@
+//! Regression tests for Issue #1367 — reject non-finite expected gains before
+//! ranking and returning candidates.
+//!
+//! Candidate ranking sorts by `expected_creature_score_gain` using `total_cmp`,
+//! which orders a positive `NaN` **above** `+∞`. A candidate whose gain is
+//! `NaN` or `±∞` would therefore sort to the top and be returned as the *best*
+//! candidate — wasting the controller's ablation-test budget on a meaningless
+//! candidate. The library's contract is to only return candidates expected to
+//! improve the creature's score; a non-finite gain is not a valid positive
+//! improvement and must be dropped (and the drop recorded in the rejection
+//! breakdown) before reranking / final selection.
+
+use neat_ai_discovery::analysis::candidate_aggregation::{
+    apply_final_coordinated_gain_floor, reject_non_finite_gains,
+};
+use neat_ai_discovery::analysis::diagnostics::rejection_reasons::REJECTION_NON_FINITE_GAIN;
+use neat_ai_discovery::analysis::discovery_mode::DiscoveryMode;
+use neat_ai_discovery::analysis::shared::{AnalyzeSynapsesResult, SynapseAnalysisMetadata};
+use neat_ai_discovery::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+
+fn empty_synapse_result() -> AnalyzeSynapsesResult {
+    AnalyzeSynapsesResult {
+        helpful_synapses: Vec::new(),
+        harmful_synapses: Vec::new(),
+        synapse_weight_updates: Vec::new(),
+        coordinated_structural_candidates: Vec::new(),
+        candidate_clusters: Vec::new(),
+        gpu_used: false,
+        no_candidate_reasons: Vec::new(),
+        metadata: SynapseAnalysisMetadata {
+            candidates_found: 0,
+            candidates_returned: 0,
+            ..Default::default()
+        },
+    }
+}
+
+fn single_op_candidate(gain: f32, label: &str) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveSynapse {
+            from_neuron_uuid: "a".to_string(),
+            to_neuron_uuid: "b".to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some(label.to_string()),
+    }
+}
+
+/// The pure filter removes `NaN` and `±∞` candidates, preserves the relative
+/// order of the finite survivors, and returns the dropped count.
+#[test]
+fn reject_non_finite_gains_drops_non_finite_and_preserves_order() {
+    let mut candidates = vec![
+        single_op_candidate(1.0, "finite-1"),
+        single_op_candidate(f32::NAN, "nan"),
+        single_op_candidate(0.5, "finite-2"),
+        single_op_candidate(f32::INFINITY, "pos-inf"),
+        single_op_candidate(0.25, "finite-3"),
+        single_op_candidate(f32::NEG_INFINITY, "neg-inf"),
+    ];
+
+    let dropped = reject_non_finite_gains(&mut candidates);
+
+    assert_eq!(dropped, 3, "three non-finite candidates should be dropped");
+    let labels: Vec<&str> = candidates
+        .iter()
+        .map(|c| c.comment.as_deref().unwrap_or(""))
+        .collect();
+    assert_eq!(
+        labels,
+        vec!["finite-1", "finite-2", "finite-3"],
+        "finite candidates must survive in their original order"
+    );
+}
+
+/// The final selection gate (`apply_final_coordinated_gain_floor`) must drop
+/// `NaN` / `+∞` candidates and record the drop in the rejection breakdown so it
+/// stays observable, while leaving the finite candidates ranked normally.
+#[test]
+fn final_gate_rejects_non_finite_and_records_breakdown() {
+    let mut syn = empty_synapse_result();
+    syn.coordinated_structural_candidates = vec![
+        single_op_candidate(f32::NAN, "nan"),
+        single_op_candidate(1.0, "finite-high"),
+        single_op_candidate(f32::INFINITY, "pos-inf"),
+        single_op_candidate(0.5, "finite-mid"),
+        single_op_candidate(0.25, "finite-low"),
+    ];
+
+    apply_final_coordinated_gain_floor(&mut syn, DiscoveryMode::Normal, 1.0);
+
+    // Neither non-finite candidate survives.
+    let labels: Vec<&str> = syn
+        .coordinated_structural_candidates
+        .iter()
+        .map(|c| c.comment.as_deref().unwrap_or(""))
+        .collect();
+    assert!(
+        !labels.contains(&"nan") && !labels.contains(&"pos-inf"),
+        "non-finite candidates must not be returned, got {labels:?}"
+    );
+    assert_eq!(
+        labels.len(),
+        3,
+        "exactly the three finite candidates should remain, got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"finite-high")
+            && labels.contains(&"finite-mid")
+            && labels.contains(&"finite-low"),
+        "all finite candidates should survive, got {labels:?}"
+    );
+
+    // The rejection breakdown reflects the dropped non-finite count.
+    assert_eq!(
+        syn.metadata
+            .rejection_breakdown
+            .counts()
+            .get(REJECTION_NON_FINITE_GAIN),
+        Some(&2),
+        "breakdown should record two non-finite drops"
+    );
+}


### PR DESCRIPTION
## Summary

Candidate ranking sorts coordinated-structural candidates by
`expected_creature_score_gain` using `total_cmp`. While panic-safe, `total_cmp`
orders a positive `NaN` **above** `+∞`, so a candidate with a `NaN` (or `±∞`)
gain would sort to the **top** and be returned as the *best* candidate. There
was no finiteness guard anywhere in `candidate_aggregation.rs` or
`candidate_diversity.rs`. A non-finite gain is not a valid positive expected
improvement, and returning one wastes the controller's ablation-test budget on a
meaningless candidate — exactly the cost the mission exists to avoid.

This PR adds a finiteness filter that drops candidates whose
`expected_creature_score_gain` is not finite (`!x.is_finite()`) **before**
diversity reranking / final selection, and records the drop in the existing
rejection breakdown so it stays observable.

Changes:
- New `reject_non_finite_gains()` in `candidate_aggregation.rs` — retains only
  finite-gain candidates, preserving the relative order of survivors, and
  returns the dropped count.
- Wired into `merge_coordinated_structural_replacements` (before the sort /
  diversity rerank) and into `apply_final_coordinated_gain_floor` (the
  unconditional final selection gate before the FFI response). The latter also
  closes the `+∞ >= floor` gap, where an infinite gain would otherwise survive
  the existing noise-floor comparison.
- New stable rejection reason `non_finite_gain` (`REJECTION_NON_FINITE_GAIN`),
  added to `ALL_REJECTION_REASONS` and the friendly-summary mapping.

Closes #1367.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
new TDD tests and the full `./quality.sh` gate (fmt, clippy `-D warnings`,
check, all tests, release build) passing cleanly.

```mermaid
flowchart LR
    A[Coordinated candidates] --> B{is_finite?}
    B -- "NaN / ±∞" --> R[Dropped\nrecord non_finite_gain]
    B -- finite --> C[Diversity rerank / final gain floor]
    C --> D[Returned candidates]
```

## Test Plan

Added `tests/issue_1367_non_finite_gain_rejection.rs`:
- `reject_non_finite_gains_drops_non_finite_and_preserves_order` — feeds a set
  containing `NaN`, `+∞` and `-∞` plus several finite candidates; asserts the
  three non-finite entries are dropped and the finite survivors keep their
  original order.
- `final_gate_rejects_non_finite_and_records_breakdown` — feeds a `NaN`-gain and
  a `+∞`-gain candidate plus finite candidates through
  `apply_final_coordinated_gain_floor`; asserts neither non-finite candidate is
  returned, all finite candidates survive, and the rejection breakdown records
  `non_finite_gain == 2`.

Full suite: `./quality.sh` passes (all unit + integration tests green).



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqeue5cs-a33c29`<!-- vibe-worker-issue-1367 -->