### PR TITLE
Precompute input-neuron UUID strings per batch (Issue #1368)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,10 @@ harness = false
 name = "parquet_loading_comparison"
 harness = false
 
+[[bench]]
+name = "input_uuid_precompute"
+harness = false
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/benches/input_uuid_precompute.rs
+++ b/benches/input_uuid_precompute.rs
@@ -1,0 +1,66 @@
+//! Benchmark for Issue #1368: input-neuron UUID string construction on the
+//! per-observation recording hot path.
+//!
+//! `src/record/processing.rs` builds the fixed set of input UUIDs
+//! (`input-0`, `input-1`, …) for every recorded observation. The old code
+//! called `format!("input-{i}")` inside the inner per-observation loop, so the
+//! same handful of strings were re-allocated `n_records × n_inputs` times. The
+//! new code precomputes the UUIDs once per batch and clones the cached `String`
+//! per use.
+//!
+//! These two benchmarks isolate the two strategies so the allocation churn
+//! removed by the precompute is directly measurable.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// Old strategy: format a fresh `String` for every input on every observation.
+fn format_per_observation(n_records: usize, n_inputs: usize) -> usize {
+    let mut total = 0usize;
+    for _ in 0..n_records {
+        for input_index in 0..n_inputs {
+            let uuid = format!("input-{input_index}");
+            total += black_box(uuid).len();
+        }
+    }
+    total
+}
+
+/// New strategy: precompute the UUIDs once, then clone the cached string per use.
+fn precompute_once(n_records: usize, n_inputs: usize) -> usize {
+    let input_uuids: Vec<String> = (0..n_inputs).map(|i| format!("input-{i}")).collect();
+    let mut total = 0usize;
+    for _ in 0..n_records {
+        for cached in &input_uuids {
+            let uuid = cached.clone();
+            total += black_box(uuid).len();
+        }
+    }
+    total
+}
+
+fn bench_input_uuid_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("input_uuid_precompute");
+
+    // Recording hot path: thousands of observations × tens-to-hundreds of inputs.
+    for &(n_records, n_inputs) in &[(2_000usize, 32usize), (2_000, 128), (5_000, 64)] {
+        let id = format!("{n_records}rec_{n_inputs}in");
+
+        group.bench_with_input(
+            BenchmarkId::new("format_per_observation", &id),
+            &(n_records, n_inputs),
+            |b, &(r, i)| b.iter(|| black_box(format_per_observation(r, i))),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("precompute_once", &id),
+            &(n_records, n_inputs),
+            |b, &(r, i)| b.iter(|| black_box(precompute_once(r, i))),
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_input_uuid_construction);
+criterion_main!(benches);

--- a/docs/archive/pr-summaries/pr-summary-1368.md
+++ b/docs/archive/pr-summaries/pr-summary-1368.md
@@ -1,0 +1,62 @@
+# Precompute input-neuron UUID strings instead of formatting per observation
+
+## Summary
+
+`src/record/processing.rs` allocated a fresh `String` for every input on every
+training record — `format!("input-{input_index}")` ran inside the inner
+per-observation loop, so the fixed set of input UUIDs (`input-0`, `input-1`, …)
+was re-formatted `n_records × n_inputs` times. The set is constant for the whole
+batch, so this was pure, avoidable allocation churn on the recording hot path.
+
+The UUIDs are now precomputed **once per batch** into a `Vec<String>` (sized to
+the widest training record), and the per-observation loop performs an in-bounds
+cache lookup plus a single `String` clone. Behaviour is identical — the same
+`input-N` UUIDs and values are recorded for every observation.
+
+The minimal-scope cached-`String` clone was chosen over an `Arc<str>` handle:
+`DiscoverRecord::neuron_uuid` is an owned `String` used across serialisation and
+many callers, so threading an `Arc<str>` through it would be invasive and out of
+scope for this issue.
+
+Closes #1368.
+
+## Evidence
+
+This is a backend/CLI change with no web interface to screenshot. Evidence is a
+criterion micro-benchmark (`benches/input_uuid_precompute.rs`) isolating the two
+strategies — `format!` per observation (old) vs precompute-once-and-clone (new):
+
+| Workload (records × inputs) | Format per observation (old) | Precompute once (new) | Improvement |
+|-----------------------------|------------------------------|-----------------------|-------------|
+| 2,000 × 32                   | 2.3805 ms                    | 1.3778 ms             | ~42% faster |
+| 2,000 × 128                  | 9.7641 ms                    | 5.2985 ms             | ~46% faster |
+| 5,000 × 64                   | 14.901 ms                    | 6.9152 ms             | ~54% faster |
+
+Run with:
+
+```bash
+cargo bench --bench input_uuid_precompute
+```
+
+### Recording data flow
+
+```mermaid
+flowchart TD
+    A[process_training_data] --> B[Precompute input_uuids once per batch]
+    B --> C{For each training record}
+    C --> D[Append non-input neuron records]
+    C --> E[For each input: clone cached input_uuids index]
+    E --> F[Write batch atomically per observation]
+    D --> F
+```
+
+## Test Plan
+
+- Added `src/record/tests.rs::test_record_discovery_data_input_uuids_stable_across_observations`
+  — records three observations with two inputs each, reads the Parquet back, and
+  asserts `input-0` / `input-1` records carry the correct `obs_index`, value, and
+  activation for every observation (regression guard pinning the unchanged
+  behaviour).
+- Existing record-processing tests stay green (13 `record::tests` pass), confirming
+  identical UUIDs are recorded.
+- Full `./quality.sh` passes (fmt, clippy `-D warnings`, check, tests, doc, release build).

--- a/src/record/processing.rs
+++ b/src/record/processing.rs
@@ -18,6 +18,21 @@ pub fn process_training_data(
 ) -> Result<()> {
     let mut wrote_any_records = false;
 
+    // Precompute the fixed input-neuron UUID strings once for the whole batch
+    // (`input-0`, `input-1`, …) instead of re-allocating them per observation
+    // (Issue #1368). Size to the widest training record so every per-observation
+    // index is an in-bounds cache lookup followed by a single clone.
+    let max_inputs = input
+        .training_data
+        .iter()
+        .map(|record| record.input.len())
+        .max()
+        .unwrap_or(0)
+        .max(input.creature.input);
+    let input_uuids: Vec<String> = (0..max_inputs)
+        .map(|index| format!("input-{index}"))
+        .collect();
+
     for (relative_idx, training_record) in input.training_data.iter().enumerate() {
         let obs_index_u32 = obs_indices[relative_idx];
 
@@ -61,12 +76,16 @@ pub fn process_training_data(
             ));
         }
 
-        // Record input neuron activations for GPU-assisted analysis
+        // Record input neuron activations for GPU-assisted analysis. UUIDs are
+        // looked up from the precomputed cache rather than formatted per record.
         for (input_index, value) in training_record.input.iter().enumerate() {
-            let input_uuid = format!("input-{input_index}");
-
-            let record =
-                DiscoverRecord::new(obs_index_u32, input_uuid, Some(*value), *value, Vec::new());
+            let record = DiscoverRecord::new(
+                obs_index_u32,
+                input_uuids[input_index].clone(),
+                Some(*value),
+                *value,
+                Vec::new(),
+            );
 
             batch_records.push(record);
         }

--- a/src/record/tests.rs
+++ b/src/record/tests.rs
@@ -727,3 +727,65 @@ fn test_record_discovery_data_skips_non_existent_neurons() {
         "Should have 0 records for non-existent-neuron (should be skipped)"
     );
 }
+
+#[test]
+fn test_record_discovery_data_input_uuids_stable_across_observations() {
+    // Regression guard for Issue #1368: the input-neuron UUIDs are precomputed
+    // once per batch rather than formatted per observation. This test pins the
+    // observable behaviour — identical `input-N` UUIDs and the matching input
+    // values are recorded for every observation.
+    let temp_dir = TempDir::new().unwrap();
+    let mut input = create_test_input();
+    input.temp_dir = temp_dir.path().to_str().unwrap().to_string();
+
+    // Three observations, each with two inputs (matches creature.input == 2).
+    input.training_data = (0..3)
+        .map(|i| crate::TrainingRecord {
+            input: vec![i as f32 * 0.5, i as f32 * 0.5 + 0.25],
+            output: vec![i as f32],
+            neuron_data: Some(vec![crate::NeuronData {
+                neuron_uuid: "output-0".to_string(),
+                activation: i as f32,
+                value: Some(i as f32),
+                errors: vec![0.0],
+            }]),
+        })
+        .collect();
+    input.record_indices = None;
+
+    let result = record_discovery_data(&input).unwrap();
+    let parquet_file = Path::new(&result.temp_dir).join(&result.file);
+
+    use crate::parquet_format::read_records_from_parquet;
+
+    // input-0 records: one per observation, value equal to the recorded input.
+    let mut input0 = read_records_from_parquet(parquet_file.to_str().unwrap(), "input-0").unwrap();
+    input0.sort_by_key(|r| r.obs_index);
+    assert_eq!(
+        input0.len(),
+        3,
+        "Should have one input-0 record per observation"
+    );
+    for (i, record) in input0.iter().enumerate() {
+        let expected = i as f32 * 0.5;
+        assert_eq!(record.obs_index, i as u32);
+        assert_eq!(record.value, Some(expected));
+        assert_eq!(record.activation, expected);
+        assert!(record.errors.is_empty());
+    }
+
+    // input-1 records: same structure, second input value.
+    let mut input1 = read_records_from_parquet(parquet_file.to_str().unwrap(), "input-1").unwrap();
+    input1.sort_by_key(|r| r.obs_index);
+    assert_eq!(
+        input1.len(),
+        3,
+        "Should have one input-1 record per observation"
+    );
+    for (i, record) in input1.iter().enumerate() {
+        let expected = i as f32 * 0.5 + 0.25;
+        assert_eq!(record.obs_index, i as u32);
+        assert_eq!(record.value, Some(expected));
+        assert_eq!(record.activation, expected);
+    }
+}


### PR DESCRIPTION
# Precompute input-neuron UUID strings instead of formatting per observation

## Summary

`src/record/processing.rs` allocated a fresh `String` for every input on every
training record — `format!("input-{input_index}")` ran inside the inner
per-observation loop, so the fixed set of input UUIDs (`input-0`, `input-1`, …)
was re-formatted `n_records × n_inputs` times. The set is constant for the whole
batch, so this was pure, avoidable allocation churn on the recording hot path.

The UUIDs are now precomputed **once per batch** into a `Vec<String>` (sized to
the widest training record), and the per-observation loop performs an in-bounds
cache lookup plus a single `String` clone. Behaviour is identical — the same
`input-N` UUIDs and values are recorded for every observation.

The minimal-scope cached-`String` clone was chosen over an `Arc<str>` handle:
`DiscoverRecord::neuron_uuid` is an owned `String` used across serialisation and
many callers, so threading an `Arc<str>` through it would be invasive and out of
scope for this issue.

Closes #1368.

## Evidence

This is a backend/CLI change with no web interface to screenshot. Evidence is a
criterion micro-benchmark (`benches/input_uuid_precompute.rs`) isolating the two
strategies — `format!` per observation (old) vs precompute-once-and-clone (new):

| Workload (records × inputs) | Format per observation (old) | Precompute once (new) | Improvement |
|-----------------------------|------------------------------|-----------------------|-------------|
| 2,000 × 32                   | 2.3805 ms                    | 1.3778 ms             | ~42% faster |
| 2,000 × 128                  | 9.7641 ms                    | 5.2985 ms             | ~46% faster |
| 5,000 × 64                   | 14.901 ms                    | 6.9152 ms             | ~54% faster |

Run with:

```bash
cargo bench --bench input_uuid_precompute
```

### Recording data flow

```mermaid
flowchart TD
    A[process_training_data] --> B[Precompute input_uuids once per batch]
    B --> C{For each training record}
    C --> D[Append non-input neuron records]
    C --> E[For each input: clone cached input_uuids index]
    E --> F[Write batch atomically per observation]
    D --> F
```

## Test Plan

- Added `src/record/tests.rs::test_record_discovery_data_input_uuids_stable_across_observations`
  — records three observations with two inputs each, reads the Parquet back, and
  asserts `input-0` / `input-1` records carry the correct `obs_index`, value, and
  activation for every observation (regression guard pinning the unchanged
  behaviour).
- Existing record-processing tests stay green (13 `record::tests` pass), confirming
  identical UUIDs are recorded.
- Full `./quality.sh` passes (fmt, clippy `-D warnings`, check, tests, doc, release build).



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqexlcl8-e87088`<!-- vibe-worker-issue-1368 -->