### PR TITLE
Share MIN/MAX synapse key via Arc in impact attribution (Issue #1370)

### DIFF
--- a/benches/impact_uuid_cloning.rs
+++ b/benches/impact_uuid_cloning.rs
@@ -10,9 +10,14 @@
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
 use criterion::{Criterion, criterion_group, criterion_main};
 use neat_ai_discovery::focus::SelectionStats;
-use neat_ai_discovery::focus::compute_impacts_public;
+use neat_ai_discovery::focus::{
+    RecordProvider, compute_impacts_public, compute_impacts_with_activations,
+};
+use neat_ai_discovery::types::DiscoverRecord;
 use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::collections::HashMap;
 use std::hint::black_box;
+use std::sync::Arc;
 
 /// Build a network with many synapses to stress adjacency map construction and
 /// impact traversal cloning. Each hidden neuron connects to every output.
@@ -183,9 +188,92 @@ fn bench_adjacency_construction(c: &mut Criterion) {
     group.finish();
 }
 
+/// In-memory record provider for benchmarking the selection-stats path.
+struct InMemoryProvider {
+    records: HashMap<String, Arc<Vec<DiscoverRecord>>>,
+}
+
+impl RecordProvider for InMemoryProvider {
+    fn get(&self, neuron_uuid: &str) -> anyhow::Result<Option<Arc<Vec<DiscoverRecord>>>> {
+        Ok(self.records.get(neuron_uuid).cloned())
+    }
+    fn len(&self) -> usize {
+        self.records.len()
+    }
+}
+
+/// Build a MINIMUM-squash network plus per-input activation records so that
+/// `compute_impacts_with_activations` exercises `compute_min_stats` — the hot
+/// loop that clones the `(from_uuid, to_uuid)` key once per record (Issue #1370).
+fn build_selection_with_records(inputs: usize, obs_count: u32) -> (CreatureJson, InMemoryProvider) {
+    let mut neurons = Vec::with_capacity(inputs + 1);
+    let mut synapses = Vec::with_capacity(inputs);
+    let mut records: HashMap<String, Arc<Vec<DiscoverRecord>>> = HashMap::with_capacity(inputs);
+
+    for i in 0..inputs {
+        let uuid = format!("input-{i}");
+        neurons.push(NeuronJson {
+            uuid: uuid.clone(),
+            neuron_type: "input".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        });
+        synapses.push(SynapseJson {
+            from_uuid: uuid.clone(),
+            to_uuid: "min-neuron".to_string(),
+            weight: 1.0 + 0.1 * i as f32,
+            synapse_type: None,
+        });
+        let recs: Vec<DiscoverRecord> = (0..obs_count)
+            .map(|obs| {
+                DiscoverRecord::new(
+                    obs,
+                    uuid.clone(),
+                    None,
+                    (obs as f32 * 0.01) + i as f32,
+                    Vec::new(),
+                )
+            })
+            .collect();
+        records.insert(uuid, Arc::new(recs));
+    }
+
+    neurons.push(NeuronJson {
+        uuid: "min-neuron".to_string(),
+        neuron_type: "output".to_string(),
+        squash: "MINIMUM".to_string(),
+        bias: 0.0,
+    });
+
+    let creature = CreatureJson {
+        input: inputs,
+        output: 1,
+        neurons,
+        synapses,
+    };
+
+    (creature, InMemoryProvider { records })
+}
+
+/// Benchmark the selection-stats path (`compute_min_stats`) where the
+/// per-record synapse-key clone lives (Issue #1370).
+fn bench_selection_stats_records(c: &mut Criterion) {
+    let mut group = c.benchmark_group("selection_stats_records");
+
+    for &(inputs, obs) in &[(20usize, 500u32), (100, 1000), (200, 2000)] {
+        let (creature, provider) = build_selection_with_records(inputs, obs);
+        group.bench_function(format!("min_{inputs}inputs_{obs}obs"), |b| {
+            b.iter(|| black_box(compute_impacts_with_activations(&creature, &provider).unwrap()));
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_impact_uuid_cloning,
-    bench_adjacency_construction
+    bench_adjacency_construction,
+    bench_selection_stats_records
 );
 criterion_main!(benches);

--- a/docs/archive/pr-summaries/pr-summary-1370.md
+++ b/docs/archive/pr-summaries/pr-summary-1370.md
@@ -1,0 +1,71 @@
+# Avoid residual per-record synapse-key tuple clones in impact attribution
+
+## Summary
+
+`compute_min_stats` / `compute_max_stats` in `src/focus/impact.rs` build a
+per-observation map of synapse contributions. Issue #976 hoisted the
+`(from_uuid, to_uuid)` key out of the inner records loop, but the residual
+`key.clone()` still cloned **two heap `String`s per record per synapse** when
+pushing into `obs_contributions`.
+
+This change wraps the key once as `Arc<(String, String)>` outside the records
+loop and `Arc::clone`s it per push — turning two `String` allocations per record
+into a single atomic refcount bump. The key is only ever hashed/compared
+downstream (`win_counts` lookup, never mutated), so the swap is transparent and
+impact-attribution outputs are unchanged.
+
+Closes #1370.
+
+## What changed
+
+- `SynapseContribution` type alias: `((String, String), f32)` →
+  `(Arc<(String, String)>, f32)`.
+- Per-record push now uses `Arc::clone(&key)` instead of `key.clone()`.
+- The `win_counts` win-counting loop dereferences the `Arc` (`key.as_ref()`) for
+  its `HashMap<(String, String), u32>` lookup/insert. `win_counts` and the
+  `SelectionStats` output type are unchanged, so the downstream consumer
+  (`compute_impact_with_shared_cache`) needs no changes.
+
+```mermaid
+flowchart LR
+    A["synapse loop"] --> B["key = Arc::new((from, to))"]
+    B --> C["record loop"]
+    C --> D["push (Arc::clone(&key), weighted)<br/>1 atomic bump, was 2 String clones"]
+    D --> E["win-counting: key.as_ref() lookup"]
+    E --> F["SelectionStats (String,String) — unchanged"]
+```
+
+## Evidence (performance)
+
+Backend-only change — no UI. Justified with the existing focus benchmark
+(`benches/impact_uuid_cloning.rs`). The pre-existing cases drove
+`compute_impacts_public` with `None` records, which never reaches the selection-
+stats path; a `selection_stats_records` group was added that drives
+`compute_impacts_with_activations` with an in-memory record provider over
+MINIMUM neurons, exercising `compute_min_stats` directly.
+
+| Benchmark case | Before | After | Change |
+|---|---|---|---|
+| `min_20inputs_500obs` | 943.4 µs | 418.6 µs | **−56.2 %** |
+| `min_100inputs_1000obs` | 8.338 ms | 2.020 ms | **−75.8 %** |
+| `min_200inputs_2000obs` | 40.57 ms | 7.372 ms | **−81.8 %** |
+
+Criterion reported `p = 0.00 < 0.05` ("Performance has improved") for all three
+cases. The gain grows with record count, confirming the win is allocation-bound
+as predicted.
+
+## Test Plan
+
+- **New** `tests/focus/issue_1370_arc_synapse_key.rs`:
+  - `minimum_win_proportional_impact_is_unchanged` — MINIMUM neuron where one
+    synapse wins 3/4 observations gets 0.75 impact, the other 0.25.
+  - `maximum_ties_split_impact_equally` — every-observation tie drives the
+    multi-winner branch of the win-counting loop; both synapses get win
+    probability 1.0.
+- **Existing, stay green** — `tests/activation/activation_based_impact.rs`
+  (MIN/MAX/IF selection-stats correctness) and the full `tests/focus` suite
+  (161 tests) confirm impact-attribution outputs are unchanged.
+- Quality gate: `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo check --all-targets --all-features`, and the doc build all pass. (The
+  `quality.sh` dependency-upgrade step hit a transient crates.io network error
+  unrelated to this change; the code-quality steps were run directly.)

--- a/src/focus/impact.rs
+++ b/src/focus/impact.rs
@@ -13,6 +13,7 @@ use rayon::prelude::*;
 
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Apply the squash-bounded contribution cap (Issue #1300).
 ///
@@ -153,7 +154,12 @@ pub fn compute_selection_stats(
 
 /// A synapse key paired with its weighted activation contribution.
 /// Used internally for tracking which synapse wins in MIN/MAX calculations.
-type SynapseContribution = ((String, String), f32);
+///
+/// The key is shared via `Arc` so the per-record push into `obs_contributions`
+/// is a single atomic refcount bump rather than two heap `String` clones
+/// (Issue #1370). The key is only ever hashed/compared downstream, never
+/// mutated, so the shared ownership is transparent.
+type SynapseContribution = (Arc<(String, String)>, f32);
 
 /// Map from observation index to list of synapse contributions for that observation.
 /// Used to determine which synapse wins (has min/max value) for each observation.
@@ -177,16 +183,17 @@ fn compute_min_stats(
         match grouped_records.get(&synapse.from_uuid)? {
             None => continue,
             Some(records) => {
-                // Hoist key creation outside inner loop (Issue #976):
-                // clone once per synapse, not once per record.
-                let key = (synapse.from_uuid.clone(), synapse.to_uuid.clone());
+                // Hoist key creation outside inner loop (Issue #976) and share it
+                // via Arc so each per-record push is one atomic refcount bump
+                // rather than two String clones (Issue #1370).
+                let key = Arc::new((synapse.from_uuid.clone(), synapse.to_uuid.clone()));
                 for record in records.iter() {
                     if record.activation.is_finite() {
                         let weighted = synapse.weight * record.activation;
                         obs_contributions
                             .entry(record.obs_index)
                             .or_default()
-                            .push((key.clone(), weighted));
+                            .push((Arc::clone(&key), weighted));
                     }
                 }
             }
@@ -217,10 +224,10 @@ fn compute_min_stats(
 
         // Avoid cloning key when it already exists in win_counts (Issue #976)
         for (key, _) in winners {
-            if let Some(count) = win_counts.get_mut(key) {
+            if let Some(count) = win_counts.get_mut(key.as_ref()) {
                 *count += 1;
             } else {
-                win_counts.insert(key.clone(), 1);
+                win_counts.insert(key.as_ref().clone(), 1);
             }
         }
     }
@@ -255,16 +262,17 @@ fn compute_max_stats(
         match grouped_records.get(&synapse.from_uuid)? {
             None => continue,
             Some(records) => {
-                // Hoist key creation outside inner loop (Issue #976):
-                // clone once per synapse, not once per record.
-                let key = (synapse.from_uuid.clone(), synapse.to_uuid.clone());
+                // Hoist key creation outside inner loop (Issue #976) and share it
+                // via Arc so each per-record push is one atomic refcount bump
+                // rather than two String clones (Issue #1370).
+                let key = Arc::new((synapse.from_uuid.clone(), synapse.to_uuid.clone()));
                 for record in records.iter() {
                     if record.activation.is_finite() {
                         let weighted = synapse.weight * record.activation;
                         obs_contributions
                             .entry(record.obs_index)
                             .or_default()
-                            .push((key.clone(), weighted));
+                            .push((Arc::clone(&key), weighted));
                     }
                 }
             }
@@ -295,10 +303,10 @@ fn compute_max_stats(
 
         // Avoid cloning key when it already exists in win_counts (Issue #976)
         for (key, _) in winners {
-            if let Some(count) = win_counts.get_mut(key) {
+            if let Some(count) = win_counts.get_mut(key.as_ref()) {
                 *count += 1;
             } else {
-                win_counts.insert(key.clone(), 1);
+                win_counts.insert(key.as_ref().clone(), 1);
             }
         }
     }

--- a/tests/focus/issue_1370_arc_synapse_key.rs
+++ b/tests/focus/issue_1370_arc_synapse_key.rs
@@ -1,0 +1,123 @@
+//! Regression tests for Issue #1370: sharing the per-record synapse key via
+//! `Arc` in the MIN/MAX selection-stats path must not change the computed
+//! impact attribution.
+//!
+//! The change replaced a per-record `(String, String)` clone in
+//! `compute_min_stats` / `compute_max_stats` with an `Arc`-shared key. The key
+//! is only hashed/compared (never mutated) downstream, so the win-probability
+//! outputs must be byte-for-byte identical. These tests assert on the observable
+//! outcome (win-proportional impact), not on how the key is stored.
+
+use neat_ai_discovery::focus::RecordProvider;
+use neat_ai_discovery::focus::compute_impacts_with_activations;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Minimal in-memory record provider keyed by neuron UUID.
+struct InMemoryProvider {
+    records: HashMap<String, Arc<Vec<DiscoverRecord>>>,
+}
+
+impl RecordProvider for InMemoryProvider {
+    fn get(&self, neuron_uuid: &str) -> anyhow::Result<Option<Arc<Vec<DiscoverRecord>>>> {
+        Ok(self.records.get(neuron_uuid).cloned())
+    }
+    fn len(&self) -> usize {
+        self.records.len()
+    }
+}
+
+fn neuron(uuid: &str, neuron_type: &str, squash: &str) -> NeuronJson {
+    NeuronJson {
+        uuid: uuid.to_string(),
+        neuron_type: neuron_type.to_string(),
+        squash: squash.to_string(),
+        bias: 0.0,
+    }
+}
+
+fn synapse(from: &str, to: &str, weight: f32) -> SynapseJson {
+    SynapseJson {
+        from_uuid: from.to_string(),
+        to_uuid: to.to_string(),
+        weight,
+        synapse_type: None,
+    }
+}
+
+fn records_for(uuid: &str, activations: &[f32]) -> Arc<Vec<DiscoverRecord>> {
+    Arc::new(
+        activations
+            .iter()
+            .enumerate()
+            .map(|(obs, &a)| {
+                let obs = u32::try_from(obs).expect("obs index fits in u32");
+                DiscoverRecord::new(obs, uuid.to_string(), Some(a), a, Vec::new())
+            })
+            .collect(),
+    )
+}
+
+/// A MINIMUM neuron where `a` wins 3/4 observations and `b` wins 1/4 must give
+/// `a` ~3× the impact of `b`. Exercises the per-record key push that now shares
+/// an `Arc`.
+#[test]
+fn minimum_win_proportional_impact_is_unchanged() {
+    let creature = CreatureJson {
+        neurons: vec![
+            neuron("a", "hidden", "IDENTITY"),
+            neuron("b", "hidden", "IDENTITY"),
+            neuron("min-out", "output", "MINIMUM"),
+        ],
+        synapses: vec![synapse("a", "min-out", 1.0), synapse("b", "min-out", 1.0)],
+        input: 0,
+        output: 1,
+    };
+
+    // obs0..2: a smaller (a wins). obs3: b smaller (b wins).
+    let mut records = HashMap::new();
+    records.insert("a".to_string(), records_for("a", &[0.1, 0.1, 0.1, 0.9]));
+    records.insert("b".to_string(), records_for("b", &[0.9, 0.9, 0.9, 0.05]));
+    let provider = InMemoryProvider { records };
+
+    let impacts = compute_impacts_with_activations(&creature, &provider).unwrap();
+    let a = impacts["a"];
+    let b = impacts["b"];
+
+    // a wins 3/4 → impact 0.75; b wins 1/4 → impact 0.25.
+    assert!((a - 0.75).abs() < 1e-6, "a impact {a} expected ~0.75");
+    assert!((b - 0.25).abs() < 1e-6, "b impact {b} expected ~0.25");
+}
+
+/// A MAXIMUM neuron where every observation is a tie must split the impact
+/// equally. Ties drive the multi-winner branch of the win-counting loop, where
+/// the shared key is inserted into `win_counts`.
+#[test]
+fn maximum_ties_split_impact_equally() {
+    let creature = CreatureJson {
+        neurons: vec![
+            neuron("a", "hidden", "IDENTITY"),
+            neuron("b", "hidden", "IDENTITY"),
+            neuron("max-out", "output", "MAXIMUM"),
+        ],
+        synapses: vec![synapse("a", "max-out", 1.0), synapse("b", "max-out", 1.0)],
+        input: 0,
+        output: 1,
+    };
+
+    // Identical activations every observation → both win every time (tie).
+    let mut records = HashMap::new();
+    records.insert("a".to_string(), records_for("a", &[0.5, 0.5, 0.5]));
+    records.insert("b".to_string(), records_for("b", &[0.5, 0.5, 0.5]));
+    let provider = InMemoryProvider { records };
+
+    let impacts = compute_impacts_with_activations(&creature, &provider).unwrap();
+    let a = impacts["a"];
+    let b = impacts["b"];
+
+    // Both win 3/3 observations → both get full win probability 1.0.
+    assert!((a - 1.0).abs() < 1e-6, "a impact {a} expected ~1.0");
+    assert!((b - 1.0).abs() < 1e-6, "b impact {b} expected ~1.0");
+}

--- a/tests/focus/main.rs
+++ b/tests/focus/main.rs
@@ -10,6 +10,7 @@ mod focus_layers;
 mod focus_ranking;
 mod issue_1172_focus_ranking_memory_budget;
 mod issue_1318_margin_aware_ranking;
+mod issue_1370_arc_synapse_key;
 mod issue_1374_lazy_focus_ranking_single_pass;
 mod issue_1375_focus_ranking_budget;
 mod issue_1376_focus_ranking_available_memory;


### PR DESCRIPTION
# Avoid residual per-record synapse-key tuple clones in impact attribution

## Summary

`compute_min_stats` / `compute_max_stats` in `src/focus/impact.rs` build a
per-observation map of synapse contributions. Issue #976 hoisted the
`(from_uuid, to_uuid)` key out of the inner records loop, but the residual
`key.clone()` still cloned **two heap `String`s per record per synapse** when
pushing into `obs_contributions`.

This change wraps the key once as `Arc<(String, String)>` outside the records
loop and `Arc::clone`s it per push — turning two `String` allocations per record
into a single atomic refcount bump. The key is only ever hashed/compared
downstream (`win_counts` lookup, never mutated), so the swap is transparent and
impact-attribution outputs are unchanged.

Closes #1370.

## What changed

- `SynapseContribution` type alias: `((String, String), f32)` →
  `(Arc<(String, String)>, f32)`.
- Per-record push now uses `Arc::clone(&key)` instead of `key.clone()`.
- The `win_counts` win-counting loop dereferences the `Arc` (`key.as_ref()`) for
  its `HashMap<(String, String), u32>` lookup/insert. `win_counts` and the
  `SelectionStats` output type are unchanged, so the downstream consumer
  (`compute_impact_with_shared_cache`) needs no changes.

```mermaid
flowchart LR
    A["synapse loop"] --> B["key = Arc::new((from, to))"]
    B --> C["record loop"]
    C --> D["push (Arc::clone(&key), weighted)<br/>1 atomic bump, was 2 String clones"]
    D --> E["win-counting: key.as_ref() lookup"]
    E --> F["SelectionStats (String,String) — unchanged"]
```

## Evidence (performance)

Backend-only change — no UI. Justified with the existing focus benchmark
(`benches/impact_uuid_cloning.rs`). The pre-existing cases drove
`compute_impacts_public` with `None` records, which never reaches the selection-
stats path; a `selection_stats_records` group was added that drives
`compute_impacts_with_activations` with an in-memory record provider over
MINIMUM neurons, exercising `compute_min_stats` directly.

| Benchmark case | Before | After | Change |
|---|---|---|---|
| `min_20inputs_500obs` | 943.4 µs | 418.6 µs | **−56.2 %** |
| `min_100inputs_1000obs` | 8.338 ms | 2.020 ms | **−75.8 %** |
| `min_200inputs_2000obs` | 40.57 ms | 7.372 ms | **−81.8 %** |

Criterion reported `p = 0.00 < 0.05` ("Performance has improved") for all three
cases. The gain grows with record count, confirming the win is allocation-bound
as predicted.

## Test Plan

- **New** `tests/focus/issue_1370_arc_synapse_key.rs`:
  - `minimum_win_proportional_impact_is_unchanged` — MINIMUM neuron where one
    synapse wins 3/4 observations gets 0.75 impact, the other 0.25.
  - `maximum_ties_split_impact_equally` — every-observation tie drives the
    multi-winner branch of the win-counting loop; both synapses get win
    probability 1.0.
- **Existing, stay green** — `tests/activation/activation_based_impact.rs`
  (MIN/MAX/IF selection-stats correctness) and the full `tests/focus` suite
  (161 tests) confirm impact-attribution outputs are unchanged.
- Quality gate: `cargo clippy --all-targets --all-features -- -D warnings`,
  `cargo check --all-targets --all-features`, and the doc build all pass. (The
  `quality.sh` dependency-upgrade step hit a transient crates.io network error
  unrelated to this change; the code-quality steps were run directly.)



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqf0kj3z-ba8736`<!-- vibe-worker-issue-1370 -->