### PR TITLE
Fix Mermaid frontmatter breaking validator in two docs (Issue #1379)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.83"
+version = "0.74.84"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.83"
+version = "0.74.84"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/IMPACT_CALCULATION.md
+++ b/docs/IMPACT_CALCULATION.md
@@ -155,11 +155,6 @@ The impact calculation is **squash-aware** to handle special activation function
 **STEP** and **BIPOLAR** are threshold (binary) functions:
 
 ```mermaid
----
-config:
-  themeVariables:
-    fontSize: 14px
----
 graph TD
     subgraph STEP["🎚️ STEP(x)"]
         direction TB

--- a/docs/archive/pr-summaries/pr-summary-1379.md
+++ b/docs/archive/pr-summaries/pr-summary-1379.md
@@ -1,0 +1,52 @@
+## Summary
+
+Fixed two pre-existing Mermaid quality-gate failures tracked by the baseline
+carryover tracker. Both diagrams began their fenced ` ```mermaid ` block with a
+YAML frontmatter section (`--- ... ---`), which the Mermaid validator misreads
+as the diagram type, reporting `Unknown Mermaid diagram type: ---`. Closes #1379.
+
+The carried-over findings were:
+
+- `docs/IMPACT_CALCULATION.md:157` — frontmatter setting a cosmetic
+  `themeVariables.fontSize`. Removed the frontmatter so the block opens with the
+  recognised `graph TD` diagram type. The font-size override was purely
+  cosmetic and is not required for the diagram to render.
+- `docs/discoveries/monotonicity.md:18` — frontmatter setting a `title`.
+  Moved the title into the chart body using the inline `title "..."` directive
+  that `xychart-beta` supports natively, so no information is lost and the block
+  opens with the recognised `xychart-beta` diagram type.
+
+## Evidence
+
+This is a documentation-only change (no Rust or shell code touched), so there is
+no UI or benchmark evidence. Verification was performed by scanning every
+` ```mermaid ` block under `docs/` for blocks whose first non-blank content line
+is `---`:
+
+```text
+=== remaining frontmatter mermaid blocks (should be none) ===
+NONE FOUND - good
+```
+
+Before the fix, that scan reported the two carried-over findings:
+
+```text
+docs/IMPACT_CALCULATION.md:158: ---
+docs/discoveries/monotonicity.md:19: ---
+```
+
+Both diagrams now begin with a valid diagram-type token (`graph TD` and
+`xychart-beta` respectively), which is what the Mermaid validator keys on.
+
+`quality.sh` was not run: it performs `cargo upgrade --incompatible` plus a full
+release build, which would pull unrelated dependency bumps into a
+documentation-only PR (violating change scope). No Rust or shell sources were
+modified.
+
+## Test Plan
+
+- Scanned all `docs/**/*.md` Mermaid blocks for a leading `---` frontmatter line
+  and confirmed zero remain (the same check that reproduced the two findings).
+- Confirmed the two edited blocks now open with a recognised Mermaid diagram
+  type and that the `xychart-beta` title is preserved via the inline `title`
+  directive.

--- a/docs/discoveries/monotonicity.md
+++ b/docs/discoveries/monotonicity.md
@@ -16,10 +16,8 @@ be split or restructured.
 > 🚨 A non-monotonic neuron sends **contradictory signals** to downstream neurons — it cannot consistently reduce error by adjusting its activation in any single direction.
 
 ```mermaid
----
-title: "U-Shaped Activation vs Error (Non-Monotonic Neuron)"
----
 xychart-beta
+    title "U-Shaped Activation vs Error (Non-Monotonic Neuron)"
     x-axis "Activation" [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
     y-axis "Error" 0.0 --> 1.0
     line [0.8, 0.7, 0.4, 0.2, 0.12, 0.1, 0.12, 0.3, 0.5, 0.7, 0.85]


### PR DESCRIPTION
## Summary

Fixed two pre-existing Mermaid quality-gate failures tracked by the baseline
carryover tracker. Both diagrams began their fenced ` ```mermaid ` block with a
YAML frontmatter section (`--- ... ---`), which the Mermaid validator misreads
as the diagram type, reporting `Unknown Mermaid diagram type: ---`. Closes #1379.

The carried-over findings were:

- `docs/IMPACT_CALCULATION.md:157` — frontmatter setting a cosmetic
  `themeVariables.fontSize`. Removed the frontmatter so the block opens with the
  recognised `graph TD` diagram type. The font-size override was purely
  cosmetic and is not required for the diagram to render.
- `docs/discoveries/monotonicity.md:18` — frontmatter setting a `title`.
  Moved the title into the chart body using the inline `title "..."` directive
  that `xychart-beta` supports natively, so no information is lost and the block
  opens with the recognised `xychart-beta` diagram type.

## Evidence

This is a documentation-only change (no Rust or shell code touched), so there is
no UI or benchmark evidence. Verification was performed by scanning every
` ```mermaid ` block under `docs/` for blocks whose first non-blank content line
is `---`:

```text
=== remaining frontmatter mermaid blocks (should be none) ===
NONE FOUND - good
```

Before the fix, that scan reported the two carried-over findings:

```text
docs/IMPACT_CALCULATION.md:158: ---
docs/discoveries/monotonicity.md:19: ---
```

Both diagrams now begin with a valid diagram-type token (`graph TD` and
`xychart-beta` respectively), which is what the Mermaid validator keys on.

`quality.sh` was not run: it performs `cargo upgrade --incompatible` plus a full
release build, which would pull unrelated dependency bumps into a
documentation-only PR (violating change scope). No Rust or shell sources were
modified.

## Test Plan

- Scanned all `docs/**/*.md` Mermaid blocks for a leading `---` frontmatter line
  and confirmed zero remain (the same check that reproduced the two findings).
- Confirmed the two edited blocks now open with a recognised Mermaid diagram
  type and that the `xychart-beta` title is preserved via the inline `title`
  directive.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqf1tvpw-f4bf71`<!-- vibe-worker-issue-1379 -->