### PR TITLE
Document includeSynapseAnalysis / includeNeuronAnalysis gating fields (Issue #1372)

### DIFF
--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -109,6 +109,48 @@ When `NEAT_AI_DISCOVERY_MH_TEMPERATURE` is also set, Metropolis-Hastings
 probabilistic acceptance is applied to synapse candidates, allowing
 occasionally weaker candidates through to maintain search diversity.
 
+### Phase Gating (`includeSynapseAnalysis` / `includeNeuronAnalysis`)
+
+`analyze_parallel` runs two independent analysis phases — synapse discovery and
+neuron discovery. Each phase can be switched off so a caller can run
+neuron-only or synapse-only discovery (for example, to spend the full time
+budget on one phase, or to skip a phase that is not relevant to the current
+generation).
+
+- **Field**: `includeSynapseAnalysis` (optional `bool`)
+- **Field**: `includeNeuronAnalysis` (optional `bool`)
+- **Default**: `true` for both — when the field is absent the corresponding
+  phase runs, preserving existing behaviour.
+- **Behaviour when `false`**: the corresponding phase is skipped entirely (no
+  GPU work is submitted for it) and **its output fields are omitted from the
+  response JSON** rather than emitted as empty values.
+
+When `includeSynapseAnalysis` is `false`, the following fields are absent from
+the output:
+
+- `helpfulSynapses`
+- `harmfulSynapses`
+- `synapseDiagnostics`
+- `synapseGpuUsed`
+- `synapseMetadata`
+- `synapseWeightUpdates`
+- `coordinatedStructuralCandidates`
+- `candidateClusters`
+
+When `includeNeuronAnalysis` is `false`, the following fields are absent:
+
+- `helpfulNeurons`
+- `neuronDiagnostics`
+- `neuronGpuUsed`
+- `neuronMetadata`
+
+When **both** are `false`, both phases are skipped and the call returns early
+with `success: true` and none of the phase-specific fields above. Callers must
+therefore treat a missing field as "phase not run", not as "phase ran and found
+nothing" — the absence of, say, `helpfulSynapses` means synapse analysis was
+disabled, whereas an empty `helpfulSynapses: []` means it ran and produced no
+candidates.
+
 ### Cancellation Signal (Issue #1047)
 
 Allows the host process to request graceful shutdown of in-flight analysis

--- a/docs/archive/pr-summaries/pr-summary-1372.md
+++ b/docs/archive/pr-summaries/pr-summary-1372.md
@@ -1,0 +1,67 @@
+# Document phase-gating fields in FFI_API.md
+
+## Summary
+
+`AnalyzeAllInput` (used by `analyze_parallel`) exposes two optional booleans —
+`includeSynapseAnalysis` and `includeNeuronAnalysis` — that let a caller skip an
+entire analysis phase, enabling neuron-only or synapse-only discovery. These
+fields were undocumented in `docs/FFI_API.md`, making the capability invisible to
+FFI callers and easy to break unknowingly.
+
+This change adds a **Phase Gating** subsection to the *Analysis Parameters*
+section of `docs/FFI_API.md` documenting both fields: wire names, optional `bool`
+type, default of `true`, and the precise skip behaviour. Closes #1372.
+
+The skip-output shape was verified against the source before writing:
+
+- `src/analysis/orchestration.rs:270-271` — both default to `true` via
+  `unwrap_or(true)`.
+- `src/analysis/orchestration.rs:507-540` — when a flag is `false` the matching
+  phase input is `None`, so the phase is skipped and no GPU work is submitted.
+- `src/ffi_internal/analysis.rs:97-208` — a skipped phase yields `None` for every
+  one of its output fields, and each such field carries
+  `#[serde(skip_serializing_if = "Option::is_none")]`
+  (`src/ffi_types/responses/analysis.rs`), so the fields are **omitted** from the
+  response JSON rather than emitted as empty values.
+- When both flags are `false`, `analyze_all` returns early
+  (`orchestration.rs:319-331`) and the call still reports `success: true`.
+
+The documented contrast — a **missing** field means "phase not run", whereas an
+empty array means "phase ran, no candidates" — follows directly from this code.
+
+```mermaid
+flowchart TD
+    A[analyze_parallel input] --> B{includeSynapseAnalysis?}
+    A --> C{includeNeuronAnalysis?}
+    B -- false --> D[synapse phase skipped<br/>synapse fields omitted]
+    B -- true/absent --> E[synapse phase runs]
+    C -- false --> F[neuron phase skipped<br/>neuron fields omitted]
+    C -- true/absent --> G[neuron phase runs]
+    D --> H{both false?}
+    F --> H
+    H -- yes --> I[early return, success: true]
+```
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot and no Rust source
+modified. Verification performed:
+
+- `markdownlint-cli2 docs/FFI_API.md` → **0 error(s)** under the repo's
+  `.markdownlint-cli2.jsonc` config.
+- Field names, defaults, and skip behaviour cross-checked against
+  `src/ffi_types/requests.rs`, `src/analysis/orchestration.rs`,
+  `src/ffi_internal/analysis.rs`, and `src/ffi_types/responses/analysis.rs`
+  (see Summary).
+
+No Rust code was changed, so the compile/clippy/test steps of `./quality.sh`
+exercise unchanged source; the relevant gate for this change is markdownlint,
+which passes.
+
+## Test Plan
+
+No new automated tests — this is a documentation-only change and the gating
+behaviour it describes is already exercised by existing tests that construct
+`AnalyzeAllInput` with these fields (e.g.
+`src/analysis/implementation_tests/synapse_analysis_tests.rs:714-715`). Adding a
+source-grep "test" for the doc text would violate the repo's testing guidelines.


### PR DESCRIPTION
# Document phase-gating fields in FFI_API.md

## Summary

`AnalyzeAllInput` (used by `analyze_parallel`) exposes two optional booleans —
`includeSynapseAnalysis` and `includeNeuronAnalysis` — that let a caller skip an
entire analysis phase, enabling neuron-only or synapse-only discovery. These
fields were undocumented in `docs/FFI_API.md`, making the capability invisible to
FFI callers and easy to break unknowingly.

This change adds a **Phase Gating** subsection to the *Analysis Parameters*
section of `docs/FFI_API.md` documenting both fields: wire names, optional `bool`
type, default of `true`, and the precise skip behaviour. Closes #1372.

The skip-output shape was verified against the source before writing:

- `src/analysis/orchestration.rs:270-271` — both default to `true` via
  `unwrap_or(true)`.
- `src/analysis/orchestration.rs:507-540` — when a flag is `false` the matching
  phase input is `None`, so the phase is skipped and no GPU work is submitted.
- `src/ffi_internal/analysis.rs:97-208` — a skipped phase yields `None` for every
  one of its output fields, and each such field carries
  `#[serde(skip_serializing_if = "Option::is_none")]`
  (`src/ffi_types/responses/analysis.rs`), so the fields are **omitted** from the
  response JSON rather than emitted as empty values.
- When both flags are `false`, `analyze_all` returns early
  (`orchestration.rs:319-331`) and the call still reports `success: true`.

The documented contrast — a **missing** field means "phase not run", whereas an
empty array means "phase ran, no candidates" — follows directly from this code.

```mermaid
flowchart TD
    A[analyze_parallel input] --> B{includeSynapseAnalysis?}
    A --> C{includeNeuronAnalysis?}
    B -- false --> D[synapse phase skipped<br/>synapse fields omitted]
    B -- true/absent --> E[synapse phase runs]
    C -- false --> F[neuron phase skipped<br/>neuron fields omitted]
    C -- true/absent --> G[neuron phase runs]
    D --> H{both false?}
    F --> H
    H -- yes --> I[early return, success: true]
```

## Evidence

Documentation-only change — no web interface to screenshot and no Rust source
modified. Verification performed:

- `markdownlint-cli2 docs/FFI_API.md` → **0 error(s)** under the repo's
  `.markdownlint-cli2.jsonc` config.
- Field names, defaults, and skip behaviour cross-checked against
  `src/ffi_types/requests.rs`, `src/analysis/orchestration.rs`,
  `src/ffi_internal/analysis.rs`, and `src/ffi_types/responses/analysis.rs`
  (see Summary).

No Rust code was changed, so the compile/clippy/test steps of `./quality.sh`
exercise unchanged source; the relevant gate for this change is markdownlint,
which passes.

## Test Plan

No new automated tests — this is a documentation-only change and the gating
behaviour it describes is already exercised by existing tests that construct
`AnalyzeAllInput` with these fields (e.g.
`src/analysis/implementation_tests/synapse_analysis_tests.rs:714-715`). Adding a
source-grep "test" for the doc text would violate the repo's testing guidelines.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqf31da0-b6fd2a`<!-- vibe-worker-issue-1372 -->