### PR TITLE
Add all-failure and all-success boundary tests for early-termination SPRT (Issue #1371)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1371.md
+++ b/docs/archive/pr-summaries/pr-summary-1371.md
@@ -1,0 +1,57 @@
+## Summary
+
+Added two extreme boundary tests for the early-termination SPRT in
+`tests/analysis/early_termination.rs`, covering the all-failure (`k = 0, n > 0`)
+and all-success (`k = n`) inputs that the existing suite never exercised. These
+are the boundary of the "certain harm / certain benefit" regime and the inputs
+most likely to expose a `log(0)` / divide-by-zero / saturation bug in the
+log-likelihood-ratio and SPRT-bound maths.
+
+No production change was required: `SequentialEvaluator::new` already clamps
+`alpha`/`beta` away from 0/1, `log_likelihood_ratio` clamps `p0`/`p1` to a valid
+range, and the `is_strongly_harmful` / `is_strongly_beneficial` heuristics drive
+the correct early decision. Both extremes produce a finite LLR and the expected
+`Reject` / `Accept` decision well before all samples are consumed. The tests now
+stand as regression guards.
+
+Closes #1371. Part of #1364.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified via the
+test suite:
+
+```
+running 14 tests
+test early_termination::test_all_failures_triggers_early_reject ... ok
+test early_termination::test_all_successes_triggers_early_accept ... ok
+... (12 existing tests) ...
+test result: ok. 14 passed; 0 failed
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, check, full test suite, release build).
+
+Both new tests assert on the **observable decision** and LLR finiteness (the
+WHAT), not internal counters (the HOW), consistent with the test-audit direction
+in #2689 / #2690.
+
+```mermaid
+flowchart LR
+    A[all-failure samples<br/>k=0, n>0] --> B[log_likelihood_ratio<br/>stays finite]
+    B --> C[is_strongly_harmful<br/>ratio &lt; 0.3]
+    C --> D[should_stop → Reject]
+    E[all-success samples<br/>k=n] --> F[log_likelihood_ratio<br/>stays finite]
+    F --> G[is_strongly_beneficial<br/>ratio &gt; 0.7]
+    G --> H[should_stop → Accept]
+```
+
+## Test Plan
+
+- Added `tests/analysis/early_termination.rs::test_all_failures_triggers_early_reject`
+  — feeds 1000 all-negative samples; asserts the LLR stays finite on every step
+  and the evaluator reaches `Reject` before consuming all samples, with the
+  positive count remaining zero.
+- Added `tests/analysis/early_termination.rs::test_all_successes_triggers_early_accept`
+  — symmetric all-positive case; asserts a finite LLR and an early `Accept`, with
+  the negative count remaining zero.
+- All 14 tests in the module pass; full `./quality.sh` gate is green.

--- a/tests/analysis/early_termination.rs
+++ b/tests/analysis/early_termination.rs
@@ -348,3 +348,80 @@ fn test_log_likelihood_ratio() {
     assert!(ratio1 > 0.0, "80% positive should have positive LLR");
     assert!(ratio2 < 0.0, "20% positive should have negative LLR");
 }
+
+/// Boundary case (Issue #1371): every sample is a failure (`k = 0, n > 0`).
+///
+/// This is the extreme of the "certain harm" regime. It is the input most
+/// likely to expose a `log(0)` / divide-by-zero / saturation bug in the
+/// log-likelihood-ratio and SPRT-bound maths. We assert on the observable
+/// decision (the WHAT) — the evaluator must reach `Reject` well before all
+/// samples are consumed — and that the LLR stays finite throughout.
+#[test]
+fn test_all_failures_triggers_early_reject() {
+    let mut evaluator = SequentialEvaluator::new(0.01, 0.01, 0.0);
+    let total_samples = 1_000;
+
+    for _ in 0..total_samples {
+        evaluator.add_sample(false); // every sample a failure: k stays 0
+
+        // The LLR must never become NaN or infinite, even at the extreme.
+        let llr = evaluator.log_likelihood_ratio();
+        assert!(
+            llr.is_finite(),
+            "LLR must stay finite for all-failure input, got {llr}"
+        );
+
+        if let EarlyTerminationDecision::Reject = evaluator.should_stop() {
+            assert!(
+                evaluator.sample_count() < total_samples,
+                "Expected early Reject before consuming all {total_samples} samples, got {} samples",
+                evaluator.sample_count()
+            );
+            assert_eq!(
+                evaluator.positive_count(),
+                0,
+                "All-failure input must leave the positive count at zero"
+            );
+            return;
+        }
+    }
+
+    panic!("Expected early Reject for an all-failure candidate (k = 0)");
+}
+
+/// Boundary case (Issue #1371): every sample is a success (`k = n`).
+///
+/// Symmetric to [`test_all_failures_triggers_early_reject`] — the extreme of
+/// the "certain benefit" regime. Assert the evaluator reaches `Accept` early
+/// and the LLR remains finite.
+#[test]
+fn test_all_successes_triggers_early_accept() {
+    let mut evaluator = SequentialEvaluator::new(0.01, 0.01, 0.0);
+    let total_samples = 1_000;
+
+    for _ in 0..total_samples {
+        evaluator.add_sample(true); // every sample a success: k == n
+
+        let llr = evaluator.log_likelihood_ratio();
+        assert!(
+            llr.is_finite(),
+            "LLR must stay finite for all-success input, got {llr}"
+        );
+
+        if let EarlyTerminationDecision::Accept = evaluator.should_stop() {
+            assert!(
+                evaluator.sample_count() < total_samples,
+                "Expected early Accept before consuming all {total_samples} samples, got {} samples",
+                evaluator.sample_count()
+            );
+            assert_eq!(
+                evaluator.negative_count(),
+                0,
+                "All-success input must leave the negative count at zero"
+            );
+            return;
+        }
+    }
+
+    panic!("Expected early Accept for an all-success candidate (k = n)");
+}


### PR DESCRIPTION
## Summary

Added two extreme boundary tests for the early-termination SPRT in
`tests/analysis/early_termination.rs`, covering the all-failure (`k = 0, n > 0`)
and all-success (`k = n`) inputs that the existing suite never exercised. These
are the boundary of the "certain harm / certain benefit" regime and the inputs
most likely to expose a `log(0)` / divide-by-zero / saturation bug in the
log-likelihood-ratio and SPRT-bound maths.

No production change was required: `SequentialEvaluator::new` already clamps
`alpha`/`beta` away from 0/1, `log_likelihood_ratio` clamps `p0`/`p1` to a valid
range, and the `is_strongly_harmful` / `is_strongly_beneficial` heuristics drive
the correct early decision. Both extremes produce a finite LLR and the expected
`Reject` / `Accept` decision well before all samples are consumed. The tests now
stand as regression guards.

Closes #1371. Part of #1364.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified via the
test suite:

```
running 14 tests
test early_termination::test_all_failures_triggers_early_reject ... ok
test early_termination::test_all_successes_triggers_early_accept ... ok
... (12 existing tests) ...
test result: ok. 14 passed; 0 failed
```

`./quality.sh` passes cleanly (fmt, clippy, check, full test suite, release build).

Both new tests assert on the **observable decision** and LLR finiteness (the
WHAT), not internal counters (the HOW), consistent with the test-audit direction
in #2689 / #2690.

```mermaid
flowchart LR
    A[all-failure samples<br/>k=0, n>0] --> B[log_likelihood_ratio<br/>stays finite]
    B --> C[is_strongly_harmful<br/>ratio &lt; 0.3]
    C --> D[should_stop → Reject]
    E[all-success samples<br/>k=n] --> F[log_likelihood_ratio<br/>stays finite]
    F --> G[is_strongly_beneficial<br/>ratio &gt; 0.7]
    G --> H[should_stop → Accept]
```

## Test Plan

- Added `tests/analysis/early_termination.rs::test_all_failures_triggers_early_reject`
  — feeds 1000 all-negative samples; asserts the LLR stays finite on every step
  and the evaluator reaches `Reject` before consuming all samples, with the
  positive count remaining zero.
- Added `tests/analysis/early_termination.rs::test_all_successes_triggers_early_accept`
  — symmetric all-positive case; asserts a finite LLR and an early `Accept`, with
  the negative count remaining zero.
- All 14 tests in the module pass; full `./quality.sh` gate is green.



## Milestone
This PR is part of the **Improvements** milestone and targets the `milestone/improvements` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqf1tvpw-f4bf71`<!-- vibe-worker-issue-1371 -->