### PR TITLE
Document focus-selection design end-to-end (Issue #1386)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.86"
+version = "0.74.87"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.86"
+version = "0.74.87"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/README.md
+++ b/README.md
@@ -300,6 +300,21 @@ success rates, see [docs/DISCOVERY_TYPES.md](docs/DISCOVERY_TYPES.md).
 For impact calculation details, see
 [docs/IMPACT_CALCULATION.md](docs/IMPACT_CALCULATION.md).
 
+## 🎯 Focus Selection
+
+Discovery cannot evaluate *every* neuron within a run's budget, so each run
+**focuses** on a small set (about half a dozen, ~6) of selectable neurons. That
+focus list started as a *random* pick, moved to an **impact-weighted ranking**
+(`rank_focus_neurons*`, `src/focus/`) that scores neurons by their estimated
+effect on the output error, and now runs under a **wall-clock budget**
+(`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS`, default 120 s). On budget overrun
+the crate returns a retryable `Timeout` and the caller falls back to an instant,
+**error-guided** local ranking (not a literal random pick).
+
+The full design — rationale, history, performance guard, fallback semantics, and
+env knobs — is documented end-to-end in
+[docs/FOCUS_SELECTION.md](docs/FOCUS_SELECTION.md).
+
 ## ⚙️ Configuration
 
 ### 🔧 Environment Variables
@@ -559,6 +574,7 @@ graph TD
 | [AGENTS.md](AGENTS.md) | Coding guidelines and invariants for AI agents |
 | [docs/DISCOVERY_TYPES.md](docs/DISCOVERY_TYPES.md) | All discovery types with success/failure rates |
 | [docs/IMPACT_CALCULATION.md](docs/IMPACT_CALCULATION.md) | Neuron impact calculation details |
+| [docs/FOCUS_SELECTION.md](docs/FOCUS_SELECTION.md) | Focus-selection design end-to-end: why ~6 neurons, random → impact-weighted ranking, the wall-clock budget guard, and the error-guided fallback |
 | [docs/ANALYSIS_DEEP_DIVE.md](docs/ANALYSIS_DEEP_DIVE.md) | Detailed analysis workflow and detection algorithms |
 | [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) | GPU performance tuning, troubleshooting, and debugging |
 | [docs/FFI_API.md](docs/FFI_API.md) | Full FFI API reference and JSON interface |

--- a/docs/FOCUS_SELECTION.md
+++ b/docs/FOCUS_SELECTION.md
@@ -1,0 +1,119 @@
+# Focus Selection
+
+This document captures the **focus-selection design end-to-end** — why each
+discovery run focuses on a small subset of neurons, how selection evolved from a
+random pick to an impact-weighted ranking, the performance guard that bounds the
+ranking, and the fallback the caller uses when the budget is exceeded.
+
+It exists so the next "please confirm my understanding of the focus logic"
+request is a single doc link rather than a code spelunk (Issue #1382, #1386).
+
+---
+
+## 1. Why a focus subset at all
+
+Discovery cannot evaluate *every* neuron in a network within the per-run
+evaluation budget — the cost grows with the number of candidate targets and the
+size of the recorded discovery dataset. Each run therefore **focuses** on a
+small set (about half a dozen, ~6) of *selectable* neurons and concentrates the
+analysis budget there.
+
+A "selectable" neuron is one that can usefully be tuned: input and constant
+neurons are excluded (see `is_selectable_neuron_type` in
+[`src/focus/ranking/mod.rs`](../src/focus/ranking/mod.rs)). Keeping the focus set
+small is what makes a discovery pass complete inside its wall-clock budget.
+
+## 2. Selection history — random → impact-weighted
+
+The focus list was originally a **random** pick from the selectable neurons.
+Random selection is fast, but it can land on neurons that have little effect on
+the network's output(s), wasting the run's budget on targets that cannot move
+the error.
+
+Selection therefore moved to an **impact-weighted ranking**. The
+`rank_focus_neurons*` family in [`src/focus/`](../src/focus/) scores each neuron
+by its estimated effect on the output error (structural impact, gradient flow,
+activation frequency, and recorded error) and returns the neurons ordered by
+that score, so the caller can take the strongest ~6.
+
+Relevant entry points (re-exported from `crate::focus::*`):
+
+- `rank_focus_neurons` / `rank_focus_neurons_with_descriptor`
+- `rank_focus_neurons_with_history` /
+  `rank_focus_neurons_with_history_and_descriptor`
+
+Impact scoring details live in
+[docs/IMPACT_CALCULATION.md](IMPACT_CALCULATION.md).
+
+## 3. The performance guard
+
+Impact-weighted ranking is more expensive than a random pick, and a pathological
+run can be *much* more expensive — incident #1373 measured a single ranking pass
+at **1 h 11 m**, which blew the entire discovery wall-clock budget.
+
+Ranking now runs under a layered performance guard:
+
+| Guard | Mechanism | Issue |
+|-------|-----------|-------|
+| **Wall-clock budget** | `FocusDeadline` checks the deadline between passes and inside the per-neuron loops; on overrun it aborts with a structured retryable `Timeout`. Configured by `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` (default 120 s). | #1375 |
+| **Single-pass record loading** | Records are loaded once and reused across the ranking passes instead of re-read per neuron. | #1374 |
+| **Eager vs lazy decision** | `decide_loading_mode_for_available_memory` / `decide_loading_mode_for_budget` choose an eager pre-load or a lazy per-neuron loader based on available memory and the projected dataset size (file × 3), capped by `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB`. | #1376, #1172 |
+| **Perf-cliff observability** | A lazy pass at or above `NEAT_AI_DISCOVERY_FOCUS_RANKING_PERF_CLIFF_MS` (default 60 s) emits one explicit perf-cliff `WARN` naming the neuron count and projected dataset size (`lazy_pass_exceeds_perf_cliff`). | #1377 |
+
+## 4. The fallback — error-guided, not literal random
+
+When the wall-clock budget is exceeded, the crate aborts the ranking with a
+structured, **retryable** `DiscoveryError::Timeout { deadline_ms }`. The caller
+(NEAT-AI) then falls back to its **instant local ranking path**.
+
+> **Nuance worth stating plainly.** That fallback is **error-guided**: it ranks
+> the viable neurons from their recorded errors. It is **not** a literal
+> uniform-random pick. The original request was *"just do a random selection,"*
+> and the implemented fallback is *at least as good as* random and *equally
+> fast* (it is instant), so it satisfies the spirit of "fast, no extra budget"
+> while avoiding random's habit of landing on low-impact neurons.
+
+**Confirmation status (open):** whether *error-guided-and-instant* fully
+satisfies the original intent, or whether a *literal* random fallback is
+required, is a product decision for the issue author. This is recorded as an
+open question on Issue #1386 — update this section with the author's answer once
+confirmed. Until then, the behaviour described above (error-guided, instant) is
+the implemented and documented design.
+
+## 5. The environment knobs
+
+All knobs are defined in the README
+[Environment Variables](../README.md#-environment-variables) table:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` | `120000` | Wall-clock budget for focus ranking; overrun aborts with a retryable `Timeout`. `0` disables; other values clamp to `[1000, 3600000]` (#1375, #1385). |
+| `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | unset | Cap the eager pre-load size; projected size (file × 3) above the cap forces lazy mode with a structured `info` log (#1172). |
+| `NEAT_AI_DISCOVERY_FOCUS_RANKING_PERF_CLIFF_MS` | `60000` | Perf-cliff threshold for a *lazy* pass; at/above it emits one perf-cliff `WARN`. Preload never trips it. `0` disables (#1377). |
+
+---
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    A[Discovery run starts] --> B{Budget covers all neurons?}
+    B -- No, never --> C[Focus on ~6 selectable neurons]
+    C --> D[Impact-weighted ranking<br/>rank_focus_neurons*]
+    D --> E{Within wall-clock budget?<br/>FOCUS_RANKING_BUDGET_MS}
+    E -- Yes --> F[Return neurons ranked by output-error impact]
+    E -- No, budget exceeded --> G[Abort with retryable Timeout]
+    G --> H[Caller fallback:<br/>instant error-guided local ranking]
+    F --> I[Take top ~6 as focus set]
+    H --> I
+    I --> J[Run discovery over the focus set]
+```
+
+## See also
+
+- [docs/IMPACT_CALCULATION.md](IMPACT_CALCULATION.md) — how neuron impact is
+  estimated.
+- [`src/focus/`](../src/focus/) — the ranking implementation
+  (`ranking/mod.rs`, `impact.rs`, `gradient.rs`, `layers.rs`, `allocation.rs`).
+- Issues: #1373 (incident), #1374, #1375, #1376, #1377, #1385 (guard work);
+  #1382, #1386 (this confirmation).

--- a/docs/archive/pr-summaries/pr-summary-1386.md
+++ b/docs/archive/pr-summaries/pr-summary-1386.md
@@ -1,0 +1,69 @@
+## Summary
+
+Documented the **focus-selection design end-to-end** in one discoverable place so
+the next "please confirm my understanding of the focus logic" request is a doc
+link rather than a code spelunk. Documentation-only — no code change. Closes #1386.
+
+- Added [`docs/FOCUS_SELECTION.md`](../../FOCUS_SELECTION.md) covering all five
+  points from the issue:
+  1. **Why a focus subset** — discovery cannot evaluate every neuron within the
+     run budget, so each run focuses on ~6 selectable neurons.
+  2. **Selection history** — random pick → impact-weighted ranking
+     (`rank_focus_neurons*`, `src/focus/`) scoring neurons by estimated output-error
+     impact.
+  3. **Performance guard** — wall-clock budget (#1375), single-pass loading
+     (#1374), available-memory eager/lazy decision (#1376, #1172), perf-cliff
+     observability (#1377); incident #1373 (1 h 11 m) context.
+  4. **Fallback** — on budget abort the crate returns a retryable `Timeout` and the
+     caller falls back to its **instant, error-guided** local ranking, stated
+     explicitly as *not* a literal uniform-random pick. The literal-random-vs-
+     error-guided confirmation is recorded as an **open author question** (see
+     below) per the acceptance criteria.
+  5. **Env knobs** — links the existing `NEAT_AI_DISCOVERY_FOCUS_RANKING_*` rows.
+- Added a short **🎯 Focus Selection** section to `README.md` summarising the
+  design and linking the new doc, plus an Additional Documentation table row.
+
+### Fallback semantics — author confirmation (open)
+
+The implemented fallback is **error-guided and instant** (ranks viable neurons
+from recorded errors), which is at least as good as random and equally fast. The
+issue asks whether this satisfies the original *"just do a random selection"*
+intent or whether a literal random fallback is required. This is a product
+decision for the author; the doc states the semantics explicitly and flags the
+question, and a comment has been posted on Issue #1386 requesting confirmation.
+The doc will be updated with the answer once recorded.
+
+## Evidence
+
+Backend/documentation-only change — no web interface to screenshot.
+
+- `markdownlint-cli2 docs/FOCUS_SELECTION.md README.md` → **0 errors** (61 files
+  linted).
+- No Rust source touched, so the Rust quality gates (clippy/check/test/build) are
+  unaffected.
+
+End-to-end focus-selection flow documented in the new doc:
+
+```mermaid
+flowchart TD
+    A[Discovery run starts] --> B{Budget covers all neurons?}
+    B -- No, never --> C[Focus on ~6 selectable neurons]
+    C --> D[Impact-weighted ranking<br/>rank_focus_neurons*]
+    D --> E{Within wall-clock budget?}
+    E -- Yes --> F[Return neurons ranked by output-error impact]
+    E -- No --> G[Abort with retryable Timeout]
+    G --> H[Caller fallback:<br/>instant error-guided local ranking]
+    F --> I[Take top ~6 as focus set]
+    H --> I
+    I --> J[Run discovery over the focus set]
+```
+
+## Test Plan
+
+No automated tests — the change is documentation only (no public functions added
+or modified). Validation performed:
+
+- `markdownlint-cli2` on the new doc and README — passes with 0 errors.
+- Manual review that every module/issue reference resolves
+  (`src/focus/ranking/mod.rs`, `docs/IMPACT_CALCULATION.md`, env-var rows in
+  `README.md`).


### PR DESCRIPTION
## Summary

Documented the **focus-selection design end-to-end** in one discoverable place so
the next "please confirm my understanding of the focus logic" request is a doc
link rather than a code spelunk. Documentation-only — no code change. Closes #1386.

- Added [`docs/FOCUS_SELECTION.md`](../../FOCUS_SELECTION.md) covering all five
  points from the issue:
  1. **Why a focus subset** — discovery cannot evaluate every neuron within the
     run budget, so each run focuses on ~6 selectable neurons.
  2. **Selection history** — random pick → impact-weighted ranking
     (`rank_focus_neurons*`, `src/focus/`) scoring neurons by estimated output-error
     impact.
  3. **Performance guard** — wall-clock budget (#1375), single-pass loading
     (#1374), available-memory eager/lazy decision (#1376, #1172), perf-cliff
     observability (#1377); incident #1373 (1 h 11 m) context.
  4. **Fallback** — on budget abort the crate returns a retryable `Timeout` and the
     caller falls back to its **instant, error-guided** local ranking, stated
     explicitly as *not* a literal uniform-random pick. The literal-random-vs-
     error-guided confirmation is recorded as an **open author question** (see
     below) per the acceptance criteria.
  5. **Env knobs** — links the existing `NEAT_AI_DISCOVERY_FOCUS_RANKING_*` rows.
- Added a short **🎯 Focus Selection** section to `README.md` summarising the
  design and linking the new doc, plus an Additional Documentation table row.

### Fallback semantics — author confirmation (open)

The implemented fallback is **error-guided and instant** (ranks viable neurons
from recorded errors), which is at least as good as random and equally fast. The
issue asks whether this satisfies the original *"just do a random selection"*
intent or whether a literal random fallback is required. This is a product
decision for the author; the doc states the semantics explicitly and flags the
question, and a comment has been posted on Issue #1386 requesting confirmation.
The doc will be updated with the answer once recorded.

## Evidence

Backend/documentation-only change — no web interface to screenshot.

- `markdownlint-cli2 docs/FOCUS_SELECTION.md README.md` → **0 errors** (61 files
  linted).
- No Rust source touched, so the Rust quality gates (clippy/check/test/build) are
  unaffected.

End-to-end focus-selection flow documented in the new doc:

```mermaid
flowchart TD
    A[Discovery run starts] --> B{Budget covers all neurons?}
    B -- No, never --> C[Focus on ~6 selectable neurons]
    C --> D[Impact-weighted ranking<br/>rank_focus_neurons*]
    D --> E{Within wall-clock budget?}
    E -- Yes --> F[Return neurons ranked by output-error impact]
    E -- No --> G[Abort with retryable Timeout]
    G --> H[Caller fallback:<br/>instant error-guided local ranking]
    F --> I[Take top ~6 as focus set]
    H --> I
    I --> J[Run discovery over the focus set]
```

## Test Plan

No automated tests — the change is documentation only (no public functions added
or modified). Validation performed:

- `markdownlint-cli2` on the new doc and README — passes with 0 errors.
- Manual review that every module/issue reference resolves
  (`src/focus/ranking/mod.rs`, `docs/IMPACT_CALCULATION.md`, env-var rows in
  `README.md`).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqf81qz2-8ce352`<!-- vibe-worker-issue-1386 -->