### PR TITLE
Harden FFI task_descriptor against malformed payloads (Issue #1402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.87"
+version = "0.74.88"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.87"
+version = "0.74.88"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1402.md
+++ b/docs/archive/pr-summaries/pr-summary-1402.md
@@ -1,0 +1,73 @@
+# PR Summary — Issue #1402
+
+## Summary
+
+A malformed or wrong-cased `taskDescriptor` no longer fails the whole
+discovery FFI JSON parse. Previously, Issue #1314 plumbed the optional
+`task_descriptor` field through with a strict `serde` derive: an **absent**
+field defaulted to `None`, but a **present-but-invalid** field aborted the
+*entire* request deserialisation. When NEAT-AI (#2785) forwarded the internal
+TypeScript descriptor shape (`"outputSquashFamily": "unbounded"`, lowercase)
+instead of the documented PascalCase wire shape, `analyze_parallel` failed
+with an `unknown variant "unbounded"` input JSON parse error, silently
+disabling Rust synapse/neuron analysis for the selected focus neurons.
+
+This change adds a permissive consumer-side adapter
+(`deserialize_permissive_task_descriptor`) on the three external FFI input
+structs — `RecordDiscoveryInput`, `AnalyzeParallelInput`, and
+`RankFocusNeuronsInput`. The field is buffered into a `serde_json::Value` and
+then strictly converted; on any error it logs once (`tracing::warn!`) and
+falls back to `TaskDescriptor::neutral()` rather than failing the call. Valid
+wire payloads still round-trip verbatim. The real producer-side fix remains
+NEAT-AI#3012; this is the defensive hardening so a future producer mistake
+cannot silently break analysis again.
+
+Closes #1402.
+
+## Evidence
+
+This is a backend/library change with no web interface, so no screenshot
+applies. Verified via the new regression tests (red → green) and the full
+`./quality.sh` gate (clippy, type check, tests, docs, release build — all
+green).
+
+### Deserialisation flow
+
+```mermaid
+flowchart TD
+    A["taskDescriptor field present"] --> B["Buffer into serde_json::Value"]
+    B --> C{"Strict from_value::&lt;TaskDescriptor&gt;"}
+    C -->|Ok| D["Some(descriptor) — round-trips verbatim"]
+    C -->|Err| E["warn! once + Some(TaskDescriptor::neutral())"]
+    F["taskDescriptor absent"] --> G["None — collapses to neutral() at consumer"]
+```
+
+### TDD red → green
+
+Before the fix, all six new tests failed with the
+`unknown variant "unbounded"` input JSON parse error. After applying
+the permissive adapter, all six pass and the existing #1314 contract tests
+remain green.
+
+## Test Plan
+
+New file `tests/ffi/issue_1402_lowercase_task_descriptor_regression.rs`:
+
+- `analyze_parallel_input_with_lowercase_task_descriptor_falls_back_to_neutral`
+  — the exact NEAT-AI MSE producer payload deserialises and collapses to
+  `neutral()`.
+- `analyze_parallel_internal_does_not_return_input_json_parse_error` — drives
+  the real `analyze_parallel_internal` entry point and asserts no
+  `Failed to parse input JSON` error.
+- `record_discovery_input_with_lowercase_task_descriptor_falls_back_to_neutral`
+  and `rank_focus_neurons_input_with_lowercase_task_descriptor_falls_back_to_neutral`
+  — same hardening on the other two external inputs.
+- `lowercase_enum_strings_never_fail_top_level_parse` — explicit regression
+  guard over several malformed enum strings, unknown fields, and a
+  `numOutputs` type mismatch.
+- `non_object_task_descriptor_falls_back_to_neutral` — a non-object
+  descriptor (bare string) also falls back rather than failing.
+
+Unchanged contract tests (`tests/ffi/issue_1314_task_descriptor_plumbing.rs`)
+confirm valid PascalCase/camelCase payloads still round-trip verbatim and
+absent fields still deserialise to `None`.

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -2,12 +2,65 @@
 //!
 //! All `*Input` types used at the FFI boundary for deserialising JSON requests.
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 use crate::analysis;
 use crate::analysis::task_descriptor::TaskDescriptor;
 
 use super::{CreatureJson, TrainingRecord};
+
+/// Permissive deserialiser for the optional `task_descriptor` FFI field
+/// (Issue #1402).
+///
+/// Issue #1314 plumbed the field through with a strict derive: an **absent**
+/// field defaults to `None`, but a **present-but-malformed** field (wrong
+/// enum casing, unexpected shape, type mismatch) failed the *entire* FFI
+/// request to deserialise. That surfaced in production as a
+/// "Failed to parse input JSON: unknown variant `unbounded`" error when
+/// NEAT-AI #2785 forwarded the internal TypeScript descriptor shape instead
+/// of the documented `PascalCase` wire shape, silently disabling Rust
+/// synapse/neuron analysis.
+///
+/// This adapter buffers the field into a [`serde_json::Value`] and then
+/// attempts the strict conversion. On any error it logs once and falls back
+/// to [`TaskDescriptor::neutral`] — "we know nothing; don't gate on this" —
+/// rather than failing the whole call. Valid wire payloads still round-trip
+/// verbatim.
+fn deserialize_permissive_task_descriptor<'de, D>(
+    deserializer: D,
+) -> Result<Option<TaskDescriptor>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Buffer the field so a malformed subtree cannot abort the parent parse.
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    match serde_json::from_value::<TaskDescriptor>(value.clone()) {
+        Ok(descriptor) => Ok(Some(descriptor)),
+        Err(error) => {
+            warn_malformed_task_descriptor_once(&value, &error);
+            Ok(Some(TaskDescriptor::neutral()))
+        }
+    }
+}
+
+/// Emit a single `warn!` for a malformed `task_descriptor`, regardless of how
+/// many requests carry the same bad shape. Repeated producer mistakes would
+/// otherwise flood the logs on every discovery call.
+fn warn_malformed_task_descriptor_once(value: &serde_json::Value, error: &serde_json::Error) {
+    use std::sync::Once;
+    static WARN_ONCE: Once = Once::new();
+    WARN_ONCE.call_once(|| {
+        tracing::warn!(
+            malformed_task_descriptor = %value,
+            error = %error,
+            "task_descriptor failed strict parse; falling back to TaskDescriptor::neutral() \
+             (Issue #1402). Producer should send the PascalCase wire shape.",
+        );
+    });
+}
 
 /// JSON input for `record_discovery` function
 #[derive(Debug, Deserialize, Clone)]
@@ -25,8 +78,9 @@ pub struct RecordDiscoveryInput {
     ///
     /// Pure plumbing for now — no recommendation generator reads this yet.
     /// When absent, consumers should treat it as
-    /// [`TaskDescriptor::neutral`].
-    #[serde(default)]
+    /// [`TaskDescriptor::neutral`]. A present-but-malformed descriptor falls
+    /// back to neutral rather than failing the whole request (Issue #1402).
+    #[serde(default, deserialize_with = "deserialize_permissive_task_descriptor")]
     pub task_descriptor: Option<TaskDescriptor>,
 }
 
@@ -131,8 +185,9 @@ pub struct AnalyzeParallelInput {
     ///
     /// Pure plumbing for now — no recommendation generator reads this yet.
     /// When absent, consumers should treat it as
-    /// [`TaskDescriptor::neutral`].
-    #[serde(default)]
+    /// [`TaskDescriptor::neutral`]. A present-but-malformed descriptor falls
+    /// back to neutral rather than failing the whole request (Issue #1402).
+    #[serde(default, deserialize_with = "deserialize_permissive_task_descriptor")]
     pub task_descriptor: Option<TaskDescriptor>,
 }
 
@@ -303,8 +358,9 @@ pub struct RankFocusNeuronsInput {
     ///
     /// Pure plumbing for now — no recommendation generator reads this yet.
     /// When absent, consumers should treat it as
-    /// [`TaskDescriptor::neutral`].
-    #[serde(default)]
+    /// [`TaskDescriptor::neutral`]. A present-but-malformed descriptor falls
+    /// back to neutral rather than failing the whole request (Issue #1402).
+    #[serde(default, deserialize_with = "deserialize_permissive_task_descriptor")]
     pub task_descriptor: Option<TaskDescriptor>,
 }
 

--- a/tests/ffi/issue_1402_lowercase_task_descriptor_regression.rs
+++ b/tests/ffi/issue_1402_lowercase_task_descriptor_regression.rs
@@ -1,0 +1,182 @@
+//! Regression tests for Issue #1402: a malformed / wrong-cased
+//! `taskDescriptor` must never fail the whole `analyze_parallel` (or any
+//! discovery FFI) JSON parse. It must parse to the correct descriptor or
+//! fall back to [`TaskDescriptor::neutral`].
+//!
+//! Background: Issue #1314 added optional `task_descriptor` plumbing with
+//! `#[serde(default)]` for the **absent** case. When the field is **present
+//! but invalid** — as it was when NEAT-AI #2785 forwarded the internal
+//! TypeScript descriptor shape (`"outputSquashFamily": "unbounded"`,
+//! lowercase) instead of the `PascalCase` wire shape — the entire FFI request
+//! failed to deserialise with:
+//!
+//! ```text
+//! Invalid input: Failed to parse input JSON: unknown variant `unbounded`,
+//! expected one of `BoundedUnipolar`, `BoundedBipolar`, `Positive`,
+//! `Unbounded`, `Any`
+//! ```
+//!
+//! Discovery degraded: focus selection completed, but the Rust
+//! synapse/neuron analysis was unavailable. These tests lock in the
+//! defensive consumer-side hardening so a future producer mistake cannot
+//! silently break analysis again.
+
+use neat_ai_discovery::analysis::task_descriptor::TaskDescriptor;
+use neat_ai_discovery::{
+    AnalyzeParallelInput, RankFocusNeuronsInput, RecordDiscoveryInput, analyze_parallel_internal,
+};
+
+/// The exact `taskDescriptor` subtree NEAT-AI currently emits for MSE — the
+/// internal TypeScript shape: lowercase enum strings and TS-side field names
+/// (`topology` / `range`) that do not match the Rust wire contract.
+const NEAT_AI_MSE_TASK_DESCRIPTOR: &str = r#"{
+    "costName": "MSE",
+    "topology": "independent",
+    "range": "unbounded",
+    "outputSquashFamily": "unbounded"
+}"#;
+
+// =============================================================================
+// 1. Failing regression test (red on current Develop): the producer payload
+//    must deserialise rather than fail the whole input JSON parse.
+// =============================================================================
+
+#[test]
+fn analyze_parallel_input_with_lowercase_task_descriptor_falls_back_to_neutral() {
+    let payload = format!(
+        r#"{{
+            "parquetFile": "/tmp/x.parquet",
+            "creature": {{"neurons": [], "synapses": [], "input": 0, "output": 0}},
+            "focusNeurons": [],
+            "taskDescriptor": {NEAT_AI_MSE_TASK_DESCRIPTOR}
+        }}"#
+    );
+    let parsed: AnalyzeParallelInput =
+        serde_json::from_str(&payload).expect("malformed taskDescriptor must not fail input parse");
+    // The malformed descriptor falls back to neutral rather than failing.
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+        "lowercase/unknown taskDescriptor must collapse to neutral()",
+    );
+}
+
+#[test]
+fn analyze_parallel_internal_does_not_return_input_json_parse_error() {
+    // Drive the real FFI entry point. The malformed taskDescriptor must not
+    // produce a "Failed to parse input JSON" error. A missing parquet file
+    // is an acceptable downstream error — what must NOT happen is the
+    // top-level input parse failing on the descriptor.
+    let payload = format!(
+        r#"{{
+            "parquetFile": "/tmp/nonexistent-issue-1402.parquet",
+            "creature": {{"neurons": [], "synapses": [], "input": 0, "output": 0}},
+            "focusNeurons": [],
+            "taskDescriptor": {NEAT_AI_MSE_TASK_DESCRIPTOR}
+        }}"#
+    );
+    let result_json =
+        analyze_parallel_internal(&payload).expect("internal call should return JSON");
+    assert!(
+        !result_json.contains("Failed to parse input JSON"),
+        "malformed taskDescriptor must not cause an input JSON parse failure, got: {result_json}",
+    );
+}
+
+// =============================================================================
+// 2. Record-discovery and rank-focus inputs harden the same way.
+// =============================================================================
+
+#[test]
+fn record_discovery_input_with_lowercase_task_descriptor_falls_back_to_neutral() {
+    // RecordDiscoveryInput uses snake_case at the top level.
+    let payload = format!(
+        r#"{{
+            "creature": {{"neurons": [], "synapses": [], "input": 0, "output": 0}},
+            "training_data": [],
+            "temp_dir": "/tmp/x",
+            "task_descriptor": {NEAT_AI_MSE_TASK_DESCRIPTOR}
+        }}"#
+    );
+    let parsed: RecordDiscoveryInput = serde_json::from_str(&payload)
+        .expect("malformed task_descriptor must not fail input parse");
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+#[test]
+fn rank_focus_neurons_input_with_lowercase_task_descriptor_falls_back_to_neutral() {
+    let payload = format!(
+        r#"{{
+            "parquetFile": "/tmp/x.parquet",
+            "creature": {{"neurons": [], "synapses": [], "input": 0, "output": 0}},
+            "taskDescriptor": {NEAT_AI_MSE_TASK_DESCRIPTOR}
+        }}"#
+    );
+    let parsed: RankFocusNeuronsInput =
+        serde_json::from_str(&payload).expect("malformed taskDescriptor must not fail input parse");
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}
+
+// =============================================================================
+// 3. Explicit regression guard — individual lowercase enum strings and
+//    unknown fields must never cause a top-level FFI parse failure.
+// =============================================================================
+
+#[test]
+fn lowercase_enum_strings_never_fail_top_level_parse() {
+    // Each of these is an invalid enum string or an unknown field shape that
+    // the strict #1314 derive would reject. All must collapse to neutral.
+    let malformed_descriptors = [
+        r#"{"targetTopology": "independent"}"#,
+        r#"{"targetRange": "unbounded"}"#,
+        r#"{"outputSquashFamily": "bounded_unipolar"}"#,
+        r#"{"targetTopology": "one_hot", "targetRange": "unit"}"#,
+        r#"{"completely": "unexpected", "shape": 42}"#,
+        // A type mismatch on numOutputs must also be tolerated.
+        r#"{"targetTopology": "Independent", "numOutputs": "five"}"#,
+    ];
+    for descriptor in malformed_descriptors {
+        let payload = format!(
+            r#"{{
+                "parquetFile": "/tmp/x.parquet",
+                "creature": {{"neurons": [], "synapses": [], "input": 0, "output": 0}},
+                "focusNeurons": [],
+                "taskDescriptor": {descriptor}
+            }}"#
+        );
+        let parsed: AnalyzeParallelInput = serde_json::from_str(&payload)
+            .unwrap_or_else(|e| panic!("descriptor {descriptor} must not fail parse: {e}"));
+        assert_eq!(
+            parsed.task_descriptor.unwrap_or_default(),
+            TaskDescriptor::neutral(),
+            "malformed descriptor {descriptor} must collapse to neutral()",
+        );
+    }
+}
+
+// =============================================================================
+// 4. A `taskDescriptor` that is not even an object (e.g. a bare string)
+//    must still not break the top-level parse.
+// =============================================================================
+
+#[test]
+fn non_object_task_descriptor_falls_back_to_neutral() {
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "focusNeurons": [],
+        "taskDescriptor": "unbounded"
+    }"#;
+    let parsed: AnalyzeParallelInput =
+        serde_json::from_str(payload).expect("non-object taskDescriptor must not fail input parse");
+    assert_eq!(
+        parsed.task_descriptor.unwrap_or_default(),
+        TaskDescriptor::neutral(),
+    );
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -8,6 +8,7 @@ mod issue_1028_memory_budget;
 mod issue_1184_recurrent_synapse_rejection;
 mod issue_1188_grq3_strip_pattern_rejection;
 mod issue_1314_task_descriptor_plumbing;
+mod issue_1402_lowercase_task_descriptor_regression;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
# PR Summary — Issue #1402

## Summary

A malformed or wrong-cased `taskDescriptor` no longer fails the whole
discovery FFI JSON parse. Previously, Issue #1314 plumbed the optional
`task_descriptor` field through with a strict `serde` derive: an **absent**
field defaulted to `None`, but a **present-but-invalid** field aborted the
*entire* request deserialisation. When NEAT-AI (#2785) forwarded the internal
TypeScript descriptor shape (`"outputSquashFamily": "unbounded"`, lowercase)
instead of the documented PascalCase wire shape, `analyze_parallel` failed
with an `unknown variant "unbounded"` input JSON parse error, silently
disabling Rust synapse/neuron analysis for the selected focus neurons.

This change adds a permissive consumer-side adapter
(`deserialize_permissive_task_descriptor`) on the three external FFI input
structs — `RecordDiscoveryInput`, `AnalyzeParallelInput`, and
`RankFocusNeuronsInput`. The field is buffered into a `serde_json::Value` and
then strictly converted; on any error it logs once (`tracing::warn!`) and
falls back to `TaskDescriptor::neutral()` rather than failing the call. Valid
wire payloads still round-trip verbatim. The real producer-side fix remains
NEAT-AI#3012; this is the defensive hardening so a future producer mistake
cannot silently break analysis again.

Closes #1402.

## Evidence

This is a backend/library change with no web interface, so no screenshot
applies. Verified via the new regression tests (red → green) and the full
`./quality.sh` gate (clippy, type check, tests, docs, release build — all
green).

### Deserialisation flow

```mermaid
flowchart TD
    A["taskDescriptor field present"] --> B["Buffer into serde_json::Value"]
    B --> C{"Strict from_value::&lt;TaskDescriptor&gt;"}
    C -->|Ok| D["Some(descriptor) — round-trips verbatim"]
    C -->|Err| E["warn! once + Some(TaskDescriptor::neutral())"]
    F["taskDescriptor absent"] --> G["None — collapses to neutral() at consumer"]
```

### TDD red → green

Before the fix, all six new tests failed with the
`unknown variant "unbounded"` input JSON parse error. After applying
the permissive adapter, all six pass and the existing #1314 contract tests
remain green.

## Test Plan

New file `tests/ffi/issue_1402_lowercase_task_descriptor_regression.rs`:

- `analyze_parallel_input_with_lowercase_task_descriptor_falls_back_to_neutral`
  — the exact NEAT-AI MSE producer payload deserialises and collapses to
  `neutral()`.
- `analyze_parallel_internal_does_not_return_input_json_parse_error` — drives
  the real `analyze_parallel_internal` entry point and asserts no
  `Failed to parse input JSON` error.
- `record_discovery_input_with_lowercase_task_descriptor_falls_back_to_neutral`
  and `rank_focus_neurons_input_with_lowercase_task_descriptor_falls_back_to_neutral`
  — same hardening on the other two external inputs.
- `lowercase_enum_strings_never_fail_top_level_parse` — explicit regression
  guard over several malformed enum strings, unknown fields, and a
  `numOutputs` type mismatch.
- `non_object_task_descriptor_falls_back_to_neutral` — a non-object
  descriptor (bare string) also falls back rather than failing.

Unchanged contract tests (`tests/ffi/issue_1314_task_descriptor_plumbing.rs`)
confirm valid PascalCase/camelCase payloads still round-trip verbatim and
absent fields still deserialise to `None`.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqgjn1na-89713b`<!-- vibe-worker-issue-1402 -->