### PR TITLE
Eliminate cross-phase parquet reload: load discovery records once per cycle, share across focus selection and analyze_all (Issue #1406)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ src/
 │   ├── mod.rs                # Public API, re-exports
 │   ├── schema.rs             # Schema definitions and validation
 │   ├── writer.rs             # Parquet writing and serialisation
-│   └── reader.rs             # Parquet reading and deserialisation
+│   ├── reader.rs             # Parquet reading and deserialisation
+│   └── shared_records.rs     # Cross-phase single-decode cache (Issue #1406)
 ├── export/                   # Visualisation snapshot export (Issue #980)
 │   ├── mod.rs                # Public API, re-exports
 │   ├── types.rs              # Snapshot structs, export options, stats types

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,9 +2037,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/archive/pr-summaries/pr-summary-1406.md
+++ b/docs/archive/pr-summaries/pr-summary-1406.md
@@ -1,0 +1,85 @@
+# PR Summary — Issue #1406
+
+## Summary
+
+Eliminate the cross-phase parquet reload. Focus selection
+(`rank_focus_neurons`) and the analysis phase (`analyze_all` →
+`RecordCache::new_adaptive`) are two separate FFI calls that each fully decoded
+the same parquet file from scratch. On large files that second full scan — the
+"parquet reload" — consumed a meaningful slice of the analysis deadline before
+any synapse/neuron work began, a primary driver of the GRQ-23 starvation.
+
+This introduces a **process-side single-decode cache** (Issue option 2): a
+single entry keyed by the parquet file's path, byte length, and modification
+time (`src/parquet_format/shared_records.rs`). When focus selection decodes the
+file on the preload path, it populates the cache; when the analysis phase loads
+records for the same file moments later, it reuses that decode instead of
+scanning the file again. A changed file (new recording → new size/mtime)
+invalidates the entry automatically, and an explicit `invalidate()` is exposed
+for control and tests.
+
+Records are stored behind nested `Arc`s so the analysis cache reuses each
+neuron's records with a cheap `Arc` clone (zero record copy). Focus ranking
+keeps sorting its own copy by `obs_index`, and the analysis cache keeps decode
+order — both orderings are byte-identical to the pre-cache behaviour, so neither
+focus nor analysis output changes.
+
+Closes #1406.
+
+## Evidence
+
+This is a backend/Rust change with no web interface — no screenshot applies.
+Verification is via tests and the per-file decode counter
+(`shared_records::decodes_for_path`), which mirrors the acceptance criterion
+"the parquet is read once across the two phases".
+
+### Data flow — before vs after
+
+```mermaid
+flowchart TB
+    subgraph Before["Before — two full decodes per cycle"]
+        F1[FFI: rank_focus_neurons] --> R1[(decode parquet #1)]
+        A1[FFI: analyze_parallel] --> R2[(decode parquet #2)]
+    end
+    subgraph After["After — one decode per cycle"]
+        F2[FFI: rank_focus_neurons] --> C{shared_records cache<br/>key = path+len+mtime}
+        C -- miss --> D[(decode parquet once)]
+        D --> S[(Arc-shared grouped records)]
+        A2[FFI: analyze_parallel] --> C
+        C -- hit --> S
+    end
+```
+
+### Acceptance criteria
+
+- **Single full record load across the two phases** — verified by
+  `focus_then_analysis_decodes_parquet_once`: after focus selection then the
+  analysis `RecordCache::new_adaptive`, `decodes_for_path(path) == 1`. The
+  analysis phase's `profile.record_phase("parquet_loading", …)` therefore drops
+  to near-zero on the cache hit.
+- **No behavioural change to focus/analysis outputs** — focus keeps its
+  `obs_index` sort, analysis keeps decode order; existing focus (165) and
+  recording/cache (84) integration tests pass unchanged.
+- **Loading-strategy decisions (#1376) remain correct** — only the *preload*
+  paths share their decode; lazy/streaming/LRU low-memory paths are untouched.
+- **A test asserts the parquet is read once across the two phases** — added (see
+  Test Plan).
+
+## Test Plan
+
+New integration binary `tests/issue_1406_shared_parquet_decode.rs` (its own
+process, `#[serial]`, so the process-global cache has a single user at a time
+and the decode counter is deterministic):
+
+- `second_load_is_a_cache_hit` — a repeat load of the same file does not decode
+  again and hands back the identical shared decode (`Arc::ptr_eq`); `invalidate`
+  clears the slot.
+- `changed_file_invalidates_cache` — rewriting the file with a different length
+  decodes fresh and never serves stale records.
+- `focus_then_analysis_decodes_parquet_once` — the acceptance-criterion test:
+  `rank_focus_neurons` then `RecordCache::new_adaptive` on the same parquet
+  decode the file exactly once.
+
+Regression coverage: existing `tests/focus` and `tests/recording`
+(including `issue_648_deadline_aware_parquet_loading`) suites pass with the
+shared cache in place.

--- a/src/analysis/cache/mod.rs
+++ b/src/analysis/cache/mod.rs
@@ -179,22 +179,29 @@ impl RecordCache {
         parquet_file: &str,
         deadline: Option<std::time::SystemTime>,
     ) -> Result<Self> {
-        use crate::parquet_format::read_all_records_grouped_by_neuron_with_deadline;
+        use crate::parquet_format::shared_records::load_grouped_records_shared;
         use std::time::Instant;
 
         let start = Instant::now();
-        let grouped = read_all_records_grouped_by_neuron_with_deadline(parquet_file, deadline)?;
+        // Issue #1406: reuse the grouped decode produced by the focus-selection
+        // phase when it ran on the same parquet file this cycle. On a cache hit
+        // no second full scan occurs, freeing the analysis deadline for the
+        // synapse / neuron work. The records keep their decode order (matching
+        // the previous direct read) so analysis output is unchanged.
+        let shared = load_grouped_records_shared(parquet_file, deadline)?;
         let elapsed = start.elapsed();
 
-        // Pre-populate the cache with OnceLock-wrapped records
+        // Pre-populate the cache with OnceLock-wrapped records. Each neuron's
+        // records are Arc-shared with the cache, so this is a cheap clone of the
+        // Arc rather than the underlying Vec.
         let cache: RwLock<HashMap<String, Arc<CachedNeuronRecords>>> = RwLock::new(
-            grouped
-                .into_iter()
+            shared
+                .iter()
                 .map(|(k, v)| {
                     let cell = OnceLock::new();
                     // OnceLock::set can't fail here - cell was just created
-                    cell.set(Ok(Arc::new(v))).ok();
-                    (k, Arc::new(cell))
+                    cell.set(Ok(Arc::clone(v))).ok();
+                    (k.clone(), Arc::new(cell))
                 })
                 .collect(),
         );

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -52,6 +52,7 @@ use crate::config::{
 use crate::discovery_history::DiscoveryHistory;
 use crate::ffi_types::DiscoveryError;
 use crate::parquet_format::read_all_records_grouped_by_neuron;
+use crate::parquet_format::shared_records::load_grouped_records_shared;
 use crate::{CoordinatedStructuralCandidateJson, CreatureJson, NeuronJson};
 use anyhow::{Context, Result};
 use rayon::prelude::*;
@@ -412,10 +413,13 @@ fn decide_with_budget(
             })
         }
         FocusLoadingMode::Preload => {
-            let records = read_all_records_grouped_by_neuron(parquet_file)
+            // Issue #1406: decode through the process-shared cache so the
+            // following analysis phase can reuse this load instead of scanning
+            // the same parquet file a second time.
+            let shared = load_grouped_records_shared(parquet_file, None)
                 .context("Failed to read discovery records from parquet file")?;
             Ok(LoadingDecision {
-                provider: Arc::new(EagerRecordProvider::new(records)),
+                provider: Arc::new(EagerRecordProvider::from_shared(&shared)),
                 mode,
                 reason,
                 budget_mb: Some(budget_mb),
@@ -446,10 +450,12 @@ fn decide_with_auto_detect(
 
     match mode {
         FocusLoadingMode::Preload => {
-            let records = read_all_records_grouped_by_neuron(parquet_file)
+            // Issue #1406: decode through the process-shared cache (see the
+            // budget-path branch) so the analysis phase reuses this load.
+            let shared = load_grouped_records_shared(parquet_file, None)
                 .context("Failed to read discovery records from parquet file")?;
             Ok(LoadingDecision {
-                provider: Arc::new(EagerRecordProvider::new(records)),
+                provider: Arc::new(EagerRecordProvider::from_shared(&shared)),
                 mode,
                 reason,
                 budget_mb: None,

--- a/src/focus/ranking/record_providers.rs
+++ b/src/focus/ranking/record_providers.rs
@@ -30,12 +30,23 @@ pub(super) struct EagerRecordProvider {
 }
 
 impl EagerRecordProvider {
-    pub(super) fn new(records: HashMap<String, Vec<DiscoverRecord>>) -> Self {
-        let records = records
-            .into_iter()
-            .map(|(uuid, mut recs)| {
-                recs.sort_by_key(|r| r.obs_index);
-                (uuid, Arc::new(recs))
+    /// Build an eager provider from the process-shared grouped records
+    /// (Issue #1406).
+    ///
+    /// The shared cache hands back records in decode order behind `Arc`s; focus
+    /// ranking needs them sorted by `obs_index` (matching [`Self::new`]), so we
+    /// clone each neuron's records to sort our own copy. This keeps focus output
+    /// byte-identical while letting the analysis phase reuse the same decode
+    /// without a second parquet scan.
+    pub(super) fn from_shared(
+        shared: &crate::parquet_format::shared_records::SharedGroupedRecords,
+    ) -> Self {
+        let records = shared
+            .iter()
+            .map(|(uuid, recs)| {
+                let mut sorted = (**recs).clone();
+                sorted.sort_by_key(|r| r.obs_index);
+                (uuid.clone(), Arc::new(sorted))
             })
             .collect();
         Self { records }

--- a/src/parquet_format/mod.rs
+++ b/src/parquet_format/mod.rs
@@ -7,6 +7,7 @@
 
 mod reader;
 pub mod schema;
+pub mod shared_records;
 mod writer;
 
 // Re-export public API at the parquet_format level for backward compatibility

--- a/src/parquet_format/shared_records.rs
+++ b/src/parquet_format/shared_records.rs
@@ -1,0 +1,146 @@
+//! Process-wide single-decode cache for grouped discovery records (Issue #1406).
+//!
+//! Focus selection and the analysis phase are two separate FFI calls that each
+//! used to read the same parquet file from scratch. On large files that second
+//! full decode — the "parquet reload" — consumed a meaningful slice of the
+//! analysis deadline before any synapse / neuron work began.
+//!
+//! This module decodes the grouped discovery records **once per discovery
+//! cycle** and shares them across both phases. The cache holds a single entry
+//! keyed by the parquet file's path, byte length, and modification time. When
+//! the second phase requests the same file, the already-decoded records are
+//! returned without touching disk. A changed file (a new recording produces a
+//! new mtime / size) invalidates the entry automatically, and back-to-back
+//! cycles on different files reuse the single slot.
+//!
+//! Records are stored behind nested `Arc`s so the analysis phase can reuse each
+//! neuron's records without copying. Focus ranking sorts its own copy by
+//! `obs_index`; the analysis cache consumes the records in decode order. Both
+//! orderings match the pre-cache behaviour, so no analysis or focus output
+//! changes.
+
+use crate::parquet_format::read_all_records_grouped_by_neuron_with_deadline;
+use crate::types::DiscoverRecord;
+use anyhow::Result;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Grouped discovery records keyed by neuron UUID. Each neuron's records are
+/// shared behind an `Arc` so consumers reuse them without copying.
+pub type SharedGroupedRecords = HashMap<String, Arc<Vec<DiscoverRecord>>>;
+
+/// Identity of a cached parquet decode. Two requests share the cached records
+/// only when the path, byte length, and modification time all match.
+#[derive(Clone, PartialEq, Eq)]
+struct CacheKey {
+    path: String,
+    len: u64,
+    mtime_nanos: Option<u128>,
+}
+
+impl CacheKey {
+    /// Derive the cache key from the file's current metadata. Missing metadata
+    /// (e.g. the path no longer exists) falls back to a zero length and absent
+    /// mtime, so a later successful stat naturally counts as a different key.
+    fn for_path(path: &str) -> Self {
+        let meta = std::fs::metadata(path).ok();
+        let len = meta.as_ref().map_or(0, std::fs::Metadata::len);
+        let mtime_nanos = meta
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos());
+        Self {
+            path: path.to_string(),
+            len,
+            mtime_nanos,
+        }
+    }
+}
+
+/// The single cached decode plus a count of how many times the currently
+/// resident file has been decoded. The count resets whenever a different file
+/// takes the slot, keeping it bounded to the active cycle.
+struct CacheSlot {
+    key: CacheKey,
+    records: Arc<SharedGroupedRecords>,
+    decodes: u64,
+}
+
+static CACHE: LazyLock<Mutex<Option<CacheSlot>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Load the grouped discovery records for `path`, reusing a prior decode when
+/// the same file (path + length + mtime) was already loaded this cycle.
+///
+/// On a cache hit the records are returned without any disk access, so a
+/// discovery cycle that runs focus selection then analysis on the same parquet
+/// decodes the file exactly once. On a miss the file is decoded via
+/// [`read_all_records_grouped_by_neuron_with_deadline`], stored, and returned.
+///
+/// `deadline` applies only to the decode on a miss; a hit ignores it because no
+/// loading occurs.
+pub fn load_grouped_records_shared(
+    path: &str,
+    deadline: Option<SystemTime>,
+) -> Result<Arc<SharedGroupedRecords>> {
+    let key = CacheKey::for_path(path);
+
+    // Fast path: return the cached decode when the file identity is unchanged.
+    {
+        let slot = CACHE.lock();
+        if let Some(existing) = slot.as_ref()
+            && existing.key == key
+        {
+            tracing::debug!(
+                target: "neat_ai_discovery::parquet_format::shared_records",
+                path,
+                "reusing shared grouped records (cache hit) — skipping parquet reload",
+            );
+            return Ok(Arc::clone(&existing.records));
+        }
+    }
+
+    // Miss: decode the file outside the lock so callers for other files are not
+    // blocked on this (potentially slow) read.
+    let grouped = read_all_records_grouped_by_neuron_with_deadline(path, deadline)?;
+    let shared: Arc<SharedGroupedRecords> = Arc::new(
+        grouped
+            .into_iter()
+            .map(|(uuid, recs)| (uuid, Arc::new(recs)))
+            .collect(),
+    );
+
+    let mut slot = CACHE.lock();
+    // Re-check under the lock: a concurrent caller may have decoded the same
+    // file while we read. Reuse theirs and count both decodes for honesty.
+    if let Some(existing) = slot.as_mut()
+        && existing.key == key
+    {
+        existing.decodes = existing.decodes.saturating_add(1);
+        return Ok(Arc::clone(&existing.records));
+    }
+    *slot = Some(CacheSlot {
+        key,
+        records: Arc::clone(&shared),
+        decodes: 1,
+    });
+    Ok(shared)
+}
+
+/// Number of times the file currently cached for `path` has been decoded since
+/// it took the cache slot. Returns `0` when a different file (or nothing) is
+/// resident. Used to verify the parquet is decoded once across the focus and
+/// analysis phases (Issue #1406).
+#[must_use]
+pub fn decodes_for_path(path: &str) -> u64 {
+    let slot = CACHE.lock();
+    slot.as_ref()
+        .filter(|s| s.key.path == path)
+        .map_or(0, |s| s.decodes)
+}
+
+/// Drop any cached records. Exposed for explicit invalidation and tests.
+pub fn invalidate() {
+    *CACHE.lock() = None;
+}

--- a/tests/issue_1406_shared_parquet_decode.rs
+++ b/tests/issue_1406_shared_parquet_decode.rs
@@ -1,0 +1,208 @@
+//! Issue #1406: Eliminate the cross-phase parquet reload.
+//!
+//! Focus selection (`rank_focus_neurons`) and the analysis record load
+//! (`RecordCache::new_adaptive`, built fresh inside `analyze_all`) are two
+//! separate FFI calls that each used to scan the full parquet from scratch. The
+//! process-shared single-decode cache lets the second phase reuse the first
+//! phase's grouped decode, so a discovery cycle reads the file at most once.
+//!
+//! These tests live in their own integration binary (process) and are
+//! `#[serial]`, so the process-global shared cache has a single user at a time —
+//! the per-file decode counter is therefore deterministic. The analysis GPU
+//! work is not exercised here: the reload this issue removes happens during
+//! record loading, before any GPU dispatch.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::cache::RecordCache;
+use neat_ai_discovery::focus::{FocusLoadingMode, rank_focus_neurons};
+use neat_ai_discovery::parquet_format::shared_records::{
+    decodes_for_path, invalidate, load_grouped_records_shared,
+};
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use serial_test::serial;
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+
+/// Small forward-only creature: a handful of hidden neurons feeding one output.
+fn make_creature(hidden: usize) -> CreatureJson {
+    let mut neurons = Vec::new();
+    let mut synapses = Vec::new();
+
+    for i in 0..hidden {
+        let uuid = format!("h{i}");
+        neurons.push(NeuronJson {
+            uuid: uuid.clone(),
+            neuron_type: "hidden".to_string(),
+            squash: "TANH".to_string(),
+            bias: 0.0,
+        });
+        synapses.push(SynapseJson {
+            from_uuid: "in-0".to_string(),
+            to_uuid: uuid.clone(),
+            weight: 1.0,
+            synapse_type: None,
+        });
+        synapses.push(SynapseJson {
+            from_uuid: uuid,
+            to_uuid: "out".to_string(),
+            weight: 1.0,
+            synapse_type: None,
+        });
+    }
+
+    neurons.push(NeuronJson {
+        uuid: "out".to_string(),
+        neuron_type: "output".to_string(),
+        squash: "LOGISTIC".to_string(),
+        bias: 0.0,
+    });
+
+    CreatureJson {
+        neurons,
+        synapses,
+        input: 1,
+        output: 1,
+    }
+}
+
+fn make_records(uuid: &str, seed: usize, count: u32) -> Vec<DiscoverRecord> {
+    (0..count)
+        .map(|i| DiscoverRecord {
+            obs_index: i,
+            neuron_uuid: uuid.to_string(),
+            value: Some(0.1 + 0.01 * (seed as f32 + i as f32)),
+            activation: 0.2 + 0.03 * seed as f32,
+            errors: vec![0.05 + 0.02 * seed as f32],
+        })
+        .collect()
+}
+
+fn write_temp_parquet(records: &[DiscoverRecord]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().expect("create temp file");
+    write_records_to_parquet(tmp.path().to_str().unwrap(), records).expect("write parquet");
+    tmp
+}
+
+/// A second load of the same file is a cache hit: no second decode, identical
+/// shared data handed back.
+#[test]
+#[serial]
+fn second_load_is_a_cache_hit() {
+    let records = vec![
+        DiscoverRecord::new(1, "neuron-1".to_string(), Some(0.5), 0.7, vec![0.1]),
+        DiscoverRecord::new(0, "neuron-1".to_string(), Some(0.6), 0.8, vec![0.2]),
+        DiscoverRecord::new(0, "neuron-2".to_string(), Some(0.3), 0.5, vec![0.05]),
+    ];
+    let tmp = write_temp_parquet(&records);
+    let path = tmp.path().to_str().unwrap();
+    invalidate();
+
+    let first = load_grouped_records_shared(path, None).unwrap();
+    assert_eq!(decodes_for_path(path), 1, "first load should decode once");
+
+    let second = load_grouped_records_shared(path, None).unwrap();
+    assert_eq!(
+        decodes_for_path(path),
+        1,
+        "second load on the same file must not decode again",
+    );
+
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "the second load must hand back the identical shared decode",
+    );
+    assert_eq!(first.get("neuron-1").unwrap().len(), 2);
+    assert_eq!(first.get("neuron-2").unwrap().len(), 1);
+
+    invalidate();
+    assert_eq!(decodes_for_path(path), 0, "invalidate clears the slot");
+}
+
+/// A changed file (different length / mtime) invalidates the cache and decodes
+/// fresh, so stale records are never served.
+#[test]
+#[serial]
+fn changed_file_invalidates_cache() {
+    let records = vec![
+        DiscoverRecord::new(0, "neuron-1".to_string(), Some(0.5), 0.7, vec![0.1]),
+        DiscoverRecord::new(0, "neuron-2".to_string(), Some(0.3), 0.5, vec![0.05]),
+    ];
+    let tmp = write_temp_parquet(&records);
+    let path = tmp.path().to_str().unwrap();
+    invalidate();
+
+    let _ = load_grouped_records_shared(path, None).unwrap();
+    assert_eq!(decodes_for_path(path), 1);
+
+    // Rewrite with substantially more records so the byte length differs — a
+    // robust key change even when the filesystem mtime resolution is coarse
+    // enough that the rewrite shares the original timestamp.
+    let bigger: Vec<DiscoverRecord> = (0..64)
+        .map(|i| DiscoverRecord::new(i, "neuron-3".to_string(), Some(0.1), 0.2, vec![0.9, 0.8]))
+        .collect();
+    write_records_to_parquet(path, &bigger).unwrap();
+
+    let reloaded = load_grouped_records_shared(path, None).unwrap();
+    assert_eq!(
+        decodes_for_path(path),
+        1,
+        "a changed file decodes fresh and resets the per-file counter",
+    );
+    assert!(reloaded.contains_key("neuron-3"));
+    assert!(!reloaded.contains_key("neuron-1"));
+
+    invalidate();
+}
+
+/// The acceptance criterion: focus selection followed by the analysis record
+/// load on the same parquet file performs exactly one decode.
+#[test]
+#[serial]
+fn focus_then_analysis_decodes_parquet_once() {
+    const HIDDEN: usize = 6;
+    const PER_NEURON: u32 = 32;
+
+    let creature = make_creature(HIDDEN);
+    let mut records = Vec::new();
+    for i in 0..HIDDEN {
+        records.extend(make_records(&format!("h{i}"), i + 1, PER_NEURON));
+    }
+    records.extend(make_records("out", HIDDEN + 1, PER_NEURON));
+
+    let tmp = write_temp_parquet(&records);
+    let path = tmp.path().to_str().unwrap();
+
+    // Fresh cycle: ensure no stale slot from an earlier test.
+    invalidate();
+
+    // Phase 1 — focus selection. A small file stays on the preload path, which
+    // populates the shared decode.
+    let stats = rank_focus_neurons(path, &creature, None, None).expect("focus ranking succeeds");
+    assert_eq!(
+        stats.loading_mode,
+        FocusLoadingMode::Preload,
+        "small fixture should use the preload path that shares its decode",
+    );
+    assert_eq!(
+        decodes_for_path(path),
+        1,
+        "focus selection should decode the parquet exactly once",
+    );
+
+    // Phase 2 — the analysis record load. This is the cache `analyze_all` builds
+    // per invocation; it must reuse the focus decode rather than scan the file
+    // again.
+    let cache = RecordCache::new_adaptive(path).expect("analysis cache builds");
+    assert!(!cache.is_empty(), "analysis cache should hold the records");
+
+    assert_eq!(
+        decodes_for_path(path),
+        1,
+        "analysis must reuse the focus decode — no second full parquet scan",
+    );
+
+    invalidate();
+}


### PR DESCRIPTION
# PR Summary — Issue #1406

## Summary

Eliminate the cross-phase parquet reload. Focus selection
(`rank_focus_neurons`) and the analysis phase (`analyze_all` →
`RecordCache::new_adaptive`) are two separate FFI calls that each fully decoded
the same parquet file from scratch. On large files that second full scan — the
"parquet reload" — consumed a meaningful slice of the analysis deadline before
any synapse/neuron work began, a primary driver of the GRQ-23 starvation.

This introduces a **process-side single-decode cache** (Issue option 2): a
single entry keyed by the parquet file's path, byte length, and modification
time (`src/parquet_format/shared_records.rs`). When focus selection decodes the
file on the preload path, it populates the cache; when the analysis phase loads
records for the same file moments later, it reuses that decode instead of
scanning the file again. A changed file (new recording → new size/mtime)
invalidates the entry automatically, and an explicit `invalidate()` is exposed
for control and tests.

Records are stored behind nested `Arc`s so the analysis cache reuses each
neuron's records with a cheap `Arc` clone (zero record copy). Focus ranking
keeps sorting its own copy by `obs_index`, and the analysis cache keeps decode
order — both orderings are byte-identical to the pre-cache behaviour, so neither
focus nor analysis output changes.

Closes #1406.

## Evidence

This is a backend/Rust change with no web interface — no screenshot applies.
Verification is via tests and the per-file decode counter
(`shared_records::decodes_for_path`), which mirrors the acceptance criterion
"the parquet is read once across the two phases".

### Data flow — before vs after

```mermaid
flowchart TB
    subgraph Before["Before — two full decodes per cycle"]
        F1[FFI: rank_focus_neurons] --> R1[(decode parquet #1)]
        A1[FFI: analyze_parallel] --> R2[(decode parquet #2)]
    end
    subgraph After["After — one decode per cycle"]
        F2[FFI: rank_focus_neurons] --> C{shared_records cache<br/>key = path+len+mtime}
        C -- miss --> D[(decode parquet once)]
        D --> S[(Arc-shared grouped records)]
        A2[FFI: analyze_parallel] --> C
        C -- hit --> S
    end
```

### Acceptance criteria

- **Single full record load across the two phases** — verified by
  `focus_then_analysis_decodes_parquet_once`: after focus selection then the
  analysis `RecordCache::new_adaptive`, `decodes_for_path(path) == 1`. The
  analysis phase's `profile.record_phase("parquet_loading", …)` therefore drops
  to near-zero on the cache hit.
- **No behavioural change to focus/analysis outputs** — focus keeps its
  `obs_index` sort, analysis keeps decode order; existing focus (165) and
  recording/cache (84) integration tests pass unchanged.
- **Loading-strategy decisions (#1376) remain correct** — only the *preload*
  paths share their decode; lazy/streaming/LRU low-memory paths are untouched.
- **A test asserts the parquet is read once across the two phases** — added (see
  Test Plan).

## Test Plan

New integration binary `tests/issue_1406_shared_parquet_decode.rs` (its own
process, `#[serial]`, so the process-global cache has a single user at a time
and the decode counter is deterministic):

- `second_load_is_a_cache_hit` — a repeat load of the same file does not decode
  again and hands back the identical shared decode (`Arc::ptr_eq`); `invalidate`
  clears the slot.
- `changed_file_invalidates_cache` — rewriting the file with a different length
  decodes fresh and never serves stale records.
- `focus_then_analysis_decodes_parquet_once` — the acceptance-criterion test:
  `rank_focus_neurons` then `RecordCache::new_adaptive` on the same parquet
  decode the file exactly once.

Regression coverage: existing `tests/focus` and `tests/recording`
(including `issue_648_deadline_aware_parquet_loading`) suites pass with the
shared cache in place.



## Milestone
This PR is part of the **#1405 Focus selection + parquet reload consume analysis deadline; synapse/neuron analysis starved (GRQ-23 logs)** milestone and targets the `milestone/1405-focus-selection-parquet-reload-consume-analys` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqh72n7e-1d1eaa`<!-- vibe-worker-issue-1406 -->