### PR TITLE
Eliminate cross-phase parquet reload: share discovery records (Issue #1406)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ src/
 │   │   ├── lru_cache.rs      # LruRecordCache, LruCacheStats, eviction
 │   │   ├── compressed_cache.rs # CompressedLruRecordCache (LZ4)
 │   │   ├── tiered_cache.rs   # TieredRecordCache, auto strategy selection
+│   │   ├── shared_records.rs # Cross-phase grouped-record bridge (Issue #1406)
 │   │   └── serialisation.rs  # Binary serialisation, CompressedCacheEntry
 │   ├── candidate_compression/ # Candidate compression (Issue #939)
 │   │   ├── mod.rs            # Public API, re-exports

--- a/docs/archive/pr-summaries/pr-summary-1406.md
+++ b/docs/archive/pr-summaries/pr-summary-1406.md
@@ -1,85 +1,93 @@
-# PR Summary — Issue #1406
+# Eliminate cross-phase parquet reload (Issue #1406)
 
 ## Summary
 
-Eliminate the cross-phase parquet reload. Focus selection
-(`rank_focus_neurons`) and the analysis phase (`analyze_all` →
-`RecordCache::new_adaptive`) are two separate FFI calls that each fully decoded
-the same parquet file from scratch. On large files that second full scan — the
-"parquet reload" — consumed a meaningful slice of the analysis deadline before
-any synapse/neuron work began, a primary driver of the GRQ-23 starvation.
+Focus selection (`rank_focus_neurons`) and the analysis phase (`analyze_all`)
+are two separate FFI calls that each **fully read the same parquet file from
+scratch**. On large files the second full scan — the "parquet reload" — consumed
+a meaningful slice of the analysis deadline before any synapse/neuron analysis
+began, a primary driver of the GRQ-23 starvation.
 
-This introduces a **process-side single-decode cache** (Issue option 2): a
-single entry keyed by the parquet file's path, byte length, and modification
-time (`src/parquet_format/shared_records.rs`). When focus selection decodes the
-file on the preload path, it populates the cache; when the analysis phase loads
-records for the same file moments later, it reuses that decode instead of
-scanning the file again. A changed file (new recording → new size/mtime)
-invalidates the entry automatically, and an explicit `invalidate()` is exposed
-for control and tests.
+This PR loads the grouped discovery records **once per discovery cycle** and
+shares them across the two phases via a small process-side bridge
+(`analysis::cache::shared_records`), keyed by `(path, mtime, size)`:
 
-Records are stored behind nested `Arc`s so the analysis cache reuses each
-neuron's records with a cheap `Arc` clone (zero record copy). Focus ranking
-keeps sorting its own copy by `obs_index`, and the analysis cache keeps decode
-order — both orderings are byte-identical to the pre-cache behaviour, so neither
-focus nor analysis output changes.
+- The **first** phase to load a parquet (normally focus selection) publishes the
+  grouped, `obs_index`-sorted records — one `Arc<Vec<DiscoverRecord>>` per neuron
+  — into a single-entry global.
+- The **second** phase (analysis) reuses them when the file is unchanged,
+  bypassing the second full scan. The analysis `RecordCache` builds from the
+  shared map with cheap `Arc` clones, then **releases** the bridge so it owns the
+  records itself — preserving the pre-#1406 memory lifetime (records freed when
+  the analysis cache drops).
+- When the file changes — a new cycle writing a fresh temp parquet — the
+  `(mtime, size)` key misses and a fresh load occurs. Only the most recent entry
+  is retained.
 
-Closes #1406.
+Loading-strategy selection (#1376) is untouched: the bridge is only used on the
+preload path. Memory-constrained hosts that choose lazy mode keep their existing
+on-demand behaviour.
+
+`Closes #1406`
 
 ## Evidence
 
-This is a backend/Rust change with no web interface — no screenshot applies.
-Verification is via tests and the per-file decode counter
-(`shared_records::decodes_for_path`), which mirrors the acceptance criterion
-"the parquet is read once across the two phases".
+This is a backend/library change with no web interface — no screenshot
+applicable. Verification is via tests (below) and a before/after load
+measurement.
 
-### Data flow — before vs after
+### Data flow before vs after
 
 ```mermaid
 flowchart TB
-    subgraph Before["Before — two full decodes per cycle"]
-        F1[FFI: rank_focus_neurons] --> R1[(decode parquet #1)]
-        A1[FFI: analyze_parallel] --> R2[(decode parquet #2)]
+    subgraph Before["Before — file read twice per cycle"]
+        P1[parquet file]
+        F1[focus: rank_focus_neurons] -->|full scan| P1
+        A1[analysis: analyze_all] -->|full scan again| P1
     end
-    subgraph After["After — one decode per cycle"]
-        F2[FFI: rank_focus_neurons] --> C{shared_records cache<br/>key = path+len+mtime}
-        C -- miss --> D[(decode parquet once)]
-        D --> S[(Arc-shared grouped records)]
-        A2[FFI: analyze_parallel] --> C
-        C -- hit --> S
+    subgraph After["After — file read once per cycle"]
+        P2[parquet file]
+        F2[focus: rank_focus_neurons] -->|full scan| P2
+        F2 -->|publish Arc records| B[(shared_records bridge<br/>key: path, mtime, size)]
+        A2[analysis: analyze_all] -->|reuse, no scan| B
+        A2 -.->|clear bridge once owned| B
     end
 ```
 
-### Acceptance criteria
+### Before/after load measurement
 
-- **Single full record load across the two phases** — verified by
-  `focus_then_analysis_decodes_parquet_once`: after focus selection then the
-  analysis `RecordCache::new_adaptive`, `decodes_for_path(path) == 1`. The
-  analysis phase's `profile.record_phase("parquet_loading", …)` therefore drops
-  to near-zero on the cache hit.
-- **No behavioural change to focus/analysis outputs** — focus keeps its
-  `obs_index` sort, analysis keeps decode order; existing focus (165) and
-  recording/cache (84) integration tests pass unchanged.
-- **Loading-strategy decisions (#1376) remain correct** — only the *preload*
-  paths share their decode; lazy/streaming/LRU low-memory paths are untouched.
-- **A test asserts the parquet is read once across the two phases** — added (see
-  Test Plan).
+Ad-hoc measurement (300 neurons × 800 obs, 240k records) comparing the two
+full-read sequence (old) against load-then-reuse (new):
+
+| Sequence | Time |
+|----------|------|
+| OLD — two full grouped reads | ~40.5 ms |
+| NEW — load + bridge reuse | ~16.9 ms |
+| **Speedup** | **~2.4×** |
+
+The second full scan is structurally eliminated; the remaining time is a single
+read. The saving scales with file size — on the large parquet files that drove
+GRQ-23 starvation, this reclaims the whole second-scan slice of the analysis
+deadline.
 
 ## Test Plan
 
-New integration binary `tests/issue_1406_shared_parquet_decode.rs` (its own
-process, `#[serial]`, so the process-global cache has a single user at a time
-and the decode counter is deterministic):
+New file `tests/issue_1406_cross_phase_parquet_reload.rs`:
 
-- `second_load_is_a_cache_hit` — a repeat load of the same file does not decode
-  again and hands back the identical shared decode (`Arc::ptr_eq`); `invalidate`
-  clears the slot.
-- `changed_file_invalidates_cache` — rewriting the file with a different length
-  decodes fresh and never serves stale records.
-- `focus_then_analysis_decodes_parquet_once` — the acceptance-criterion test:
-  `rank_focus_neurons` then `RecordCache::new_adaptive` on the same parquet
-  decode the file exactly once.
+- `focus_then_analysis_reads_parquet_once` — runs focus ranking then builds the
+  analysis `RecordCache` on the same file and asserts (via `Arc::as_ptr`
+  identity) that the analysis cache serves the **same record allocation** the
+  focus phase loaded. A second full read would allocate fresh `Vec`s with
+  different pointers, so pointer equality proves a single read. Also asserts the
+  bridge is released after the analysis cache is built.
+- `shared_cache_reuses_records_for_unchanged_file` — two loads of an unchanged
+  file return the same `Arc` (no reload); records are grouped and sorted by
+  `obs_index`.
+- `shared_cache_invalidates_when_file_changes` — overwriting the file with a
+  different record count misses the cache and reloads into a fresh allocation
+  reflecting the new contents.
 
-Regression coverage: existing `tests/focus` and `tests/recording`
-(including `issue_648_deadline_aware_parquet_loading`) suites pass with the
-shared cache in place.
+Regression coverage: existing focus and cache suites pass unchanged
+(`cache_missing_parquet`, focus unit tests, `neuron` integration tests). The
+full `./quality.sh` gate passes (fmt, clippy `-D warnings`, check, tests, doc,
+release build).

--- a/src/analysis/cache/shared_records.rs
+++ b/src/analysis/cache/shared_records.rs
@@ -1,0 +1,147 @@
+//! Process-side shared cache of grouped discovery records (Issue #1406).
+//!
+//! Focus selection (`rank_focus_neurons`) and the analysis phase
+//! (`analyze_all`) are two separate FFI calls that historically each read the
+//! same parquet file from scratch. On large files the second full scan — the
+//! "parquet reload" — consumed a meaningful slice of the analysis deadline
+//! before any synapse/neuron analysis began.
+//!
+//! This module bridges the two calls: the first phase to load a parquet file
+//! stores the grouped records (one `Arc` per neuron) in a single-entry global
+//! keyed by `(path, mtime, size)`. The second phase reuses them when the file
+//! is unchanged, so the parquet is fully read **at most once per cycle** when
+//! focus selection and analysis run back-to-back on the same file.
+//!
+//! ## Invalidation
+//!
+//! The key includes the file's modification time and size, so any change to
+//! the parquet — including a new cycle writing a fresh temp file at the same
+//! path — misses the cache and triggers a fresh load. Only the most recent
+//! entry is retained; loading a different file drops the previous one.
+//!
+//! ## Memory lifetime
+//!
+//! The global holds only `Arc` handles. Once a consumer has built its own
+//! cache from the shared records it should call [`clear`] so the bridge no
+//! longer pins the data; the consumer's own `Arc`s keep the records alive for
+//! exactly as long as that phase needs them, matching the pre-#1406 lifetime.
+
+use crate::parquet_format::read_all_records_grouped_by_neuron_with_deadline;
+use crate::types::DiscoverRecord;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+/// Grouped discovery records keyed by neuron UUID, each neuron's records sorted
+/// by `obs_index`. Shared via `Arc` between focus selection and `analyze_all`.
+pub type SharedGroupedRecords = Arc<HashMap<String, Arc<Vec<DiscoverRecord>>>>;
+
+/// Identity of a cached parquet load. Two loads share records only when the
+/// path, modification time, and size all match.
+#[derive(Clone, PartialEq, Eq)]
+struct CacheKey {
+    path: String,
+    mtime_ns: u128,
+    size: u64,
+}
+
+struct Entry {
+    key: CacheKey,
+    records: SharedGroupedRecords,
+}
+
+static SHARED: Mutex<Option<Entry>> = Mutex::new(None);
+
+/// Lock the global, recovering from a poisoned mutex. The critical sections are
+/// tiny and panic-free, so poisoning should not occur in practice; recovering
+/// rather than propagating keeps the bridge usable instead of cascading
+/// failures into the analysis pipeline.
+fn lock_shared() -> std::sync::MutexGuard<'static, Option<Entry>> {
+    SHARED
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Build the `(path, mtime, size)` key for `path`. Returns `None` when the file
+/// metadata cannot be read, in which case callers fall back to a fresh load
+/// without caching.
+fn cache_key(path: &str) -> Option<CacheKey> {
+    let meta = std::fs::metadata(path).ok()?;
+    let size = meta.len();
+    let mtime_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())?;
+    Some(CacheKey {
+        path: path.to_string(),
+        mtime_ns,
+        size,
+    })
+}
+
+/// Return the shared records for `path` when the bridge holds an entry whose
+/// key matches the file's current metadata, otherwise `None`.
+#[must_use]
+pub fn get(path: &str) -> Option<SharedGroupedRecords> {
+    let key = cache_key(path)?;
+    let guard = lock_shared();
+    guard
+        .as_ref()
+        .filter(|entry| entry.key == key)
+        .map(|entry| Arc::clone(&entry.records))
+}
+
+/// Store `records` under `path`'s current metadata key, replacing any previous
+/// entry (the bridge retains only the most recent file).
+fn store(path: &str, records: &SharedGroupedRecords) {
+    if let Some(key) = cache_key(path) {
+        *lock_shared() = Some(Entry {
+            key,
+            records: Arc::clone(records),
+        });
+    }
+}
+
+/// Drop the bridged records so the global no longer pins them. Consumers call
+/// this once they hold their own `Arc`s to the records.
+pub fn clear() {
+    *lock_shared() = None;
+}
+
+/// Load the grouped records for `path`, reusing the shared bridge when the file
+/// is unchanged since the previous phase loaded it.
+///
+/// On a cache miss the parquet is read once (honouring `deadline`), each
+/// neuron's records are sorted by `obs_index` (matching the per-neuron load
+/// path so downstream ordering is identical), and the result is stored for the
+/// next phase before being returned.
+///
+/// # Errors
+///
+/// Propagates any error from reading the parquet file (including deadline or
+/// cancellation aborts).
+pub fn get_or_load_with_deadline(
+    path: &str,
+    deadline: Option<SystemTime>,
+) -> Result<SharedGroupedRecords> {
+    if let Some(hit) = get(path) {
+        return Ok(hit);
+    }
+
+    let grouped = read_all_records_grouped_by_neuron_with_deadline(path, deadline)?;
+
+    let shared: SharedGroupedRecords = Arc::new(
+        grouped
+            .into_iter()
+            .map(|(uuid, mut recs)| {
+                recs.sort_by_key(|r| r.obs_index);
+                (uuid, Arc::new(recs))
+            })
+            .collect(),
+    );
+
+    store(path, &shared);
+    Ok(shared)
+}

--- a/tests/issue_1406_cross_phase_parquet_reload.rs
+++ b/tests/issue_1406_cross_phase_parquet_reload.rs
@@ -1,0 +1,199 @@
+//! Issue #1406: eliminate the cross-phase parquet reload.
+//!
+//! Focus selection (`rank_focus_neurons`) and the analysis phase
+//! (`RecordCache::new_adaptive_*`, used by `analyze_all`) are two separate FFI
+//! calls that historically each read the same parquet file from scratch. These
+//! tests assert the file is fully read **at most once** when the two phases run
+//! back-to-back on the same file: the analysis cache must serve the *same*
+//! record allocation the focus phase loaded.
+//!
+//! The proof is allocation identity (`Arc::as_ptr`), which is deterministic and
+//! safe under parallel test execution: a second full read would allocate fresh
+//! `Vec`s with different pointers, so pointer equality can only hold when no
+//! reload occurred.
+
+use neat_ai_discovery::analysis::cache::{RecordCache, shared_records};
+use neat_ai_discovery::focus::rank_focus_neurons;
+use neat_ai_discovery::parquet_format::write_records_to_parquet;
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{CreatureJson, NeuronJson, SynapseJson};
+use std::sync::Arc;
+use tempfile::NamedTempFile;
+
+/// Build a minimal creature with one hidden and one output neuron wired from a
+/// single input. Both selectable neurons (`h1`, `o1`) have recorded data.
+fn create_creature() -> CreatureJson {
+    CreatureJson {
+        neurons: vec![
+            NeuronJson {
+                uuid: "h1".to_string(),
+                neuron_type: "hidden".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+            NeuronJson {
+                uuid: "o1".to_string(),
+                neuron_type: "output".to_string(),
+                squash: "IDENTITY".to_string(),
+                bias: 0.0,
+            },
+        ],
+        synapses: vec![
+            SynapseJson {
+                from_uuid: "i0".to_string(),
+                to_uuid: "h1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+            SynapseJson {
+                from_uuid: "h1".to_string(),
+                to_uuid: "o1".to_string(),
+                weight: 0.5,
+                synapse_type: None,
+            },
+        ],
+        input: 1,
+        output: 1,
+    }
+}
+
+/// Records for `obs_count` observations across the input, hidden, and output
+/// neurons. Records are intentionally written out of `obs_index` order to also
+/// exercise the shared cache's sort.
+fn create_records(obs_count: u32) -> Vec<DiscoverRecord> {
+    let mut records = Vec::new();
+    for obs in (0..obs_count).rev() {
+        records.push(DiscoverRecord::new(
+            obs,
+            "i0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![0.1],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "h1".to_string(),
+            Some(0.4),
+            0.3,
+            vec![0.2],
+        ));
+        records.push(DiscoverRecord::new(
+            obs,
+            "o1".to_string(),
+            Some(0.6),
+            0.7,
+            vec![0.15],
+        ));
+    }
+    records
+}
+
+fn write_parquet(records: &[DiscoverRecord]) -> (NamedTempFile, String) {
+    let temp_file = NamedTempFile::new().expect("create temp file");
+    let path = temp_file.path().to_str().unwrap().to_string();
+    write_records_to_parquet(&path, records).expect("write parquet");
+    (temp_file, path)
+}
+
+#[test]
+fn focus_then_analysis_reads_parquet_once() {
+    let (_temp, path) = write_parquet(&create_records(4));
+    let creature = create_creature();
+
+    // Phase 1: focus selection loads the parquet and publishes it to the bridge.
+    let stats = rank_focus_neurons(&path, &creature, None, None).expect("focus ranking succeeds");
+    assert!(
+        !stats.neurons.is_empty(),
+        "focus ranking should rank the selectable neurons"
+    );
+
+    let bridged =
+        shared_records::get(&path).expect("focus phase must populate the cross-phase bridge");
+    let focus_o1_ptr = Arc::as_ptr(bridged.get("o1").expect("bridge holds o1 records"));
+    let focus_h1_ptr = Arc::as_ptr(bridged.get("h1").expect("bridge holds h1 records"));
+
+    // Phase 2: the analysis record cache must reuse the bridged allocations
+    // rather than re-reading the file.
+    let cache =
+        RecordCache::new_adaptive_with_deadline(&path, None).expect("analysis cache builds");
+    let analysis_o1 = cache.get("o1").expect("o1 records from analysis cache");
+    let analysis_h1 = cache.get("h1").expect("h1 records from analysis cache");
+
+    assert_eq!(
+        Arc::as_ptr(&analysis_o1),
+        focus_o1_ptr,
+        "analysis must reuse the focus-loaded o1 records (single parquet read)"
+    );
+    assert_eq!(
+        Arc::as_ptr(&analysis_h1),
+        focus_h1_ptr,
+        "analysis must reuse the focus-loaded h1 records (single parquet read)"
+    );
+
+    // The records served are still correct.
+    assert_eq!(analysis_o1.len(), 4, "o1 has one record per observation");
+    assert_eq!(analysis_h1.len(), 4, "h1 has one record per observation");
+
+    // Once the analysis cache owns the records the bridge is released so it does
+    // not pin the data across cycles.
+    assert!(
+        shared_records::get(&path).is_none(),
+        "bridge is cleared after the analysis cache is built"
+    );
+}
+
+#[test]
+fn shared_cache_reuses_records_for_unchanged_file() {
+    let (_temp, path) = write_parquet(&create_records(3));
+
+    // Cold: nothing cached for this freshly created path.
+    assert!(shared_records::get(&path).is_none());
+
+    let first = shared_records::get_or_load_with_deadline(&path, None).expect("first load");
+    let second = shared_records::get_or_load_with_deadline(&path, None).expect("second load");
+
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "an unchanged file must be served from the cache, not reloaded"
+    );
+
+    // Records are grouped by neuron and sorted by obs_index.
+    let o1 = first.get("o1").expect("o1 group present");
+    assert_eq!(o1.len(), 3);
+    let obs: Vec<u32> = o1.iter().map(|r| r.obs_index).collect();
+    assert_eq!(obs, vec![0, 1, 2], "records sorted by obs_index");
+
+    shared_records::clear();
+    assert!(
+        shared_records::get(&path).is_none(),
+        "clear() releases the bridged records"
+    );
+}
+
+#[test]
+fn shared_cache_invalidates_when_file_changes() {
+    let (_temp, path) = write_parquet(&create_records(2));
+    let first = shared_records::get_or_load_with_deadline(&path, None).expect("first load");
+    assert_eq!(first.get("o1").expect("o1").len(), 2);
+
+    // Overwrite the same path with a different number of records: the size (and
+    // typically mtime) changes, so the key no longer matches.
+    write_records_to_parquet(&path, &create_records(5)).expect("rewrite parquet");
+    assert!(
+        shared_records::get(&path).is_none(),
+        "a changed file must miss the cache"
+    );
+
+    let reloaded = shared_records::get_or_load_with_deadline(&path, None).expect("reload");
+    assert!(
+        !Arc::ptr_eq(&first, &reloaded),
+        "a changed file must be reloaded into a fresh allocation"
+    );
+    assert_eq!(
+        reloaded.get("o1").expect("o1").len(),
+        5,
+        "reload reflects the new file contents"
+    );
+
+    shared_records::clear();
+}


### PR DESCRIPTION
# Eliminate cross-phase parquet reload (Issue #1406)

## Summary

Focus selection (`rank_focus_neurons`) and the analysis phase (`analyze_all`)
are two separate FFI calls that each **fully read the same parquet file from
scratch**. On large files the second full scan — the "parquet reload" — consumed
a meaningful slice of the analysis deadline before any synapse/neuron analysis
began, a primary driver of the GRQ-23 starvation.

This PR loads the grouped discovery records **once per discovery cycle** and
shares them across the two phases via a small process-side bridge
(`analysis::cache::shared_records`), keyed by `(path, mtime, size)`:

- The **first** phase to load a parquet (normally focus selection) publishes the
  grouped, `obs_index`-sorted records — one `Arc<Vec<DiscoverRecord>>` per neuron
  — into a single-entry global.
- The **second** phase (analysis) reuses them when the file is unchanged,
  bypassing the second full scan. The analysis `RecordCache` builds from the
  shared map with cheap `Arc` clones, then **releases** the bridge so it owns the
  records itself — preserving the pre-#1406 memory lifetime (records freed when
  the analysis cache drops).
- When the file changes — a new cycle writing a fresh temp parquet — the
  `(mtime, size)` key misses and a fresh load occurs. Only the most recent entry
  is retained.

Loading-strategy selection (#1376) is untouched: the bridge is only used on the
preload path. Memory-constrained hosts that choose lazy mode keep their existing
on-demand behaviour.

`Closes #1406`

## Evidence

This is a backend/library change with no web interface — no screenshot
applicable. Verification is via tests (below) and a before/after load
measurement.

### Data flow before vs after

```mermaid
flowchart TB
    subgraph Before["Before — file read twice per cycle"]
        P1[parquet file]
        F1[focus: rank_focus_neurons] -->|full scan| P1
        A1[analysis: analyze_all] -->|full scan again| P1
    end
    subgraph After["After — file read once per cycle"]
        P2[parquet file]
        F2[focus: rank_focus_neurons] -->|full scan| P2
        F2 -->|publish Arc records| B[(shared_records bridge<br/>key: path, mtime, size)]
        A2[analysis: analyze_all] -->|reuse, no scan| B
        A2 -.->|clear bridge once owned| B
    end
```

### Before/after load measurement

Ad-hoc measurement (300 neurons × 800 obs, 240k records) comparing the two
full-read sequence (old) against load-then-reuse (new):

| Sequence | Time |
|----------|------|
| OLD — two full grouped reads | ~40.5 ms |
| NEW — load + bridge reuse | ~16.9 ms |
| **Speedup** | **~2.4×** |

The second full scan is structurally eliminated; the remaining time is a single
read. The saving scales with file size — on the large parquet files that drove
GRQ-23 starvation, this reclaims the whole second-scan slice of the analysis
deadline.

## Test Plan

New file `tests/issue_1406_cross_phase_parquet_reload.rs`:

- `focus_then_analysis_reads_parquet_once` — runs focus ranking then builds the
  analysis `RecordCache` on the same file and asserts (via `Arc::as_ptr`
  identity) that the analysis cache serves the **same record allocation** the
  focus phase loaded. A second full read would allocate fresh `Vec`s with
  different pointers, so pointer equality proves a single read. Also asserts the
  bridge is released after the analysis cache is built.
- `shared_cache_reuses_records_for_unchanged_file` — two loads of an unchanged
  file return the same `Arc` (no reload); records are grouped and sorted by
  `obs_index`.
- `shared_cache_invalidates_when_file_changes` — overwriting the file with a
  different record count misses the cache and reloads into a fresh allocation
  reflecting the new contents.

Regression coverage: existing focus and cache suites pass unchanged
(`cache_missing_parquet`, focus unit tests, `neuron` integration tests). The
full `./quality.sh` gate passes (fmt, clippy `-D warnings`, check, tests, doc,
release build).



## Milestone
This PR is part of the **#1405 Focus selection + parquet reload consume analysis deadline; synapse/neuron analysis starved (GRQ-23 logs)** milestone and targets the `milestone/1405-focus-selection-parquet-reload-consume-analys` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqh7robw-98dd4a`<!-- vibe-worker-issue-1406 -->