### PR TITLE
Unify focus selection under the shared analysis deadline (Issue #1407)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.88"
+version = "0.74.89"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.88"
+version = "0.74.89"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -81,6 +81,36 @@ found so far. Coverage improves over repeated runs.
 - **Default**: no deadline
 - **Behaviour**: deadline is passed to the record cache and detection dispatch
 
+#### Shared across focus selection (Issue #1407)
+
+Focus selection (`rank_focus_neurons`) runs as a **separate** FFI call before
+`analyze_parallel`. To stop the two phases opening independent time windows,
+`rank_focus_neurons` now also accepts `analysisDeadlineMs` — pass the **same
+absolute** discovery deadline (ms-since-epoch) to both calls. Focus selection
+then bills against that one deadline and aborts at whichever is sooner: the
+shared deadline or the `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` wall-clock
+budget.
+
+Because the deadline is absolute, time consumed by focus selection (plus its
+parquet load) naturally shrinks the window left for synapse/neuron analysis —
+the later phase sees the remaining budget, not a fresh full window. When
+`analysisDeadlineMs` is omitted from the focus call, the legacy budget-only
+behaviour applies (backwards compatible).
+
+```mermaid
+sequenceDiagram
+    participant Host as NEAT-AI (caller)
+    participant Focus as rank_focus_neurons
+    participant Analysis as analyze_parallel
+    Note over Host: compute ONE absolute deadline D (ms-since-epoch)
+    Host->>Focus: analysisDeadlineMs = D
+    Note over Focus: abort at min(D, focus budget)
+    Focus-->>Host: ranked focus neurons
+    Host->>Analysis: analysisDeadlineMs = D
+    Note over Analysis: remaining window = D − now (already reduced by focus)
+    Analysis-->>Host: candidates
+```
+
 ### Wall-Clock Cap (`maxDiscoveryWallClockMinutes`) — Issue #1098
 
 Caps the total elapsed time from discovery start (recording + analysis),

--- a/docs/archive/pr-summaries/pr-summary-1407.md
+++ b/docs/archive/pr-summaries/pr-summary-1407.md
@@ -1,0 +1,112 @@
+# Unify focus selection under the shared analysis deadline (Issue #1407)
+
+## Summary
+
+Focus selection (`rank_focus_neurons`) ran as a separate FFI call **before**
+`analyze_parallel` and enforced its **own** wall-clock budget
+(`focus_ranking_budget_ms`) derived from a fresh `Instant::now()`. That budget
+was independent of the analysis deadline, so the time focus selection (plus its
+parquet load) consumed was never billed against the discovery budget — synapse
+/neuron analysis could begin with far less wall-clock than the configured
+budget implied.
+
+This change extends the absolute-deadline model from #1097 across the
+focus→analysis boundary so both phases bill against **one** budget:
+
+- `rank_focus_neurons` now accepts the same absolute discovery deadline
+  (`analysisDeadlineMs`, ms-since-epoch) that `analyze_parallel` already
+  enforces. The caller computes the deadline once and passes it to both FFI
+  calls.
+- `FocusDeadline` derives its expiry from that shared absolute deadline rather
+  than a fresh per-call relative window. Focus selection aborts at whichever is
+  **sooner**: the shared deadline or the
+  `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` wall-clock budget (now a safety
+  net, not an independent window).
+- A new shared accounting primitive `remaining_ms_until` lives alongside
+  `build_deadline` / `deadline_to_absolute_ms` in `analysis/utils/deadline.rs`,
+  applying the same year-2000 epoch heuristic so both phases interpret the
+  deadline identically.
+
+Because the deadline is absolute, time spent in focus selection naturally
+shrinks the window left for analysis — the later phase sees the remainder, not
+a fresh full window. When `analysisDeadlineMs` is omitted from the focus call,
+the legacy budget-only behaviour applies (backwards compatible).
+
+Closes #1407.
+
+## Evidence
+
+This is a backend/FFI change with no web interface to screenshot. Verified via
+unit and integration tests (`./quality.sh` passes cleanly).
+
+### Data flow
+
+```mermaid
+sequenceDiagram
+    participant Host as NEAT-AI (caller)
+    participant Focus as rank_focus_neurons
+    participant Analysis as analyze_parallel
+    Note over Host: compute ONE absolute deadline D (ms-since-epoch)
+    Host->>Focus: analysisDeadlineMs = D
+    Note over Focus: FocusDeadline = min(D, focus budget)
+    Focus-->>Host: ranked focus neurons (D − focus_cost remaining)
+    Host->>Analysis: analysisDeadlineMs = D
+    Note over Analysis: remaining window = D − now (already reduced by focus)
+    Analysis-->>Host: candidates
+```
+
+### Acceptance criteria
+
+- **Aggregate cannot exceed the discovery budget** — both phases abort at the
+  same absolute deadline; focus is additionally capped by its budget+grace.
+  Covered by `resolve_uses_shared_deadline_when_sooner_than_budget` and
+  `resolve_uses_budget_when_shared_deadline_is_distant`.
+- **Focus time reduces the analysis window** — proven deterministically by
+  `shared_absolute_deadline_reduces_remaining_window_for_later_phase`: an 80s
+  focus cost against a 100s shared budget leaves analysis exactly 20s, not a
+  fresh 100s.
+- **`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` reconciled & documented** —
+  doc comment in `config/user_facing.rs` and `docs/FFI_API.md` now describe it
+  as a safety-net cap on the shared deadline, no longer an independent window.
+- **A passed shared deadline aborts focus immediately** —
+  `resolve_with_passed_deadline_aborts_immediately`.
+
+## Test Plan
+
+New tests (all calling real functions and asserting on results — no source
+grepping):
+
+- `src/analysis/utils/deadline_tests.rs`
+  - `remaining_ms_until_passes_through_relative_durations`
+  - `remaining_ms_until_subtracts_now_for_absolute_timestamps`
+  - `remaining_ms_until_saturates_to_zero_when_deadline_passed`
+  - `remaining_ms_until_none_without_deadline`
+  - `shared_absolute_deadline_reduces_remaining_window_for_later_phase`
+    (the core acceptance-criterion test)
+- `src/focus/ranking/mod.rs` (inline — `FocusDeadline` and `resolve` are
+  private)
+  - `resolve_uses_shared_deadline_when_sooner_than_budget`
+  - `resolve_uses_budget_when_shared_deadline_is_distant`
+  - `resolve_with_passed_deadline_aborts_immediately`
+- `tests/ffi/issue_1407_focus_shared_deadline.rs` (FFI deserialisation contract)
+  - `rank_focus_input_omits_analysis_deadline_to_none`
+  - `rank_focus_input_supplied_analysis_deadline_round_trips`
+  - `rank_focus_input_accepts_relative_deadline_duration`
+
+`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, tests, doc,
+release build).
+
+## Files Changed
+
+- `src/analysis/utils/deadline.rs` — new `remaining_ms_until` shared primitive.
+- `src/analysis/utils/mod.rs` — re-export `remaining_ms_until`.
+- `src/focus/ranking/mod.rs` — `FocusDeadline::resolve` / `from_shared_deadline`
+  (replacing `from_config`); new `rank_focus_neurons_with_descriptor_and_deadline`
+  entry point; `shared_deadline_ms` threaded through `RankCoreArgs`.
+- `src/focus/mod.rs` — re-export the new entry point.
+- `src/ffi_types/requests.rs` — `analysisDeadlineMs` field on
+  `RankFocusNeuronsInput`.
+- `src/ffi_internal/analysis.rs` — wire `analysisDeadlineMs` into the focus call.
+- `src/config/user_facing.rs` — document the budget/shared-deadline reconciliation.
+- `docs/FFI_API.md` — document the shared deadline across focus selection.
+- `Cargo.toml` — version bump `0.74.88` → `0.74.89`.

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -125,6 +125,36 @@ pub fn build_deadline(deadline_ms: Option<u64>) -> Option<SystemTime> {
         .and_then(|validated_ms| SystemTime::now().checked_add(Duration::from_millis(validated_ms)))
 }
 
+/// Remaining milliseconds from `now_ms` until a discovery deadline (Issue #1407).
+///
+/// Interprets `deadline_ms` with the same epoch heuristic as
+/// [`calculate_effective_timeout_ms`]: values at or above [`YEAR_2000_MS`] are
+/// absolute timestamps (milliseconds since the UNIX epoch); smaller values are
+/// relative durations measured from `now_ms`.
+///
+/// This is the shared accounting primitive that lets focus selection and
+/// synapse/neuron analysis bill against ONE absolute discovery deadline instead
+/// of two independent windows. Because an absolute deadline is fixed, a later
+/// phase naturally sees a smaller remainder — time consumed by an earlier phase
+/// is not handed back as a fresh full window.
+///
+/// Returns:
+/// - `None` when no deadline is supplied.
+/// - `Some(0)` when an absolute deadline has already passed (saturating).
+/// - `Some(remaining_ms)` otherwise.
+#[must_use]
+pub fn remaining_ms_until(deadline_ms: Option<u64>, now_ms: u64) -> Option<u64> {
+    let target_ms = deadline_ms?;
+    if target_ms < YEAR_2000_MS {
+        // Relative duration — already expressed as "from now".
+        Some(target_ms)
+    } else {
+        // Absolute timestamp — remaining time is the target minus now (saturating
+        // so a passed deadline yields zero rather than wrapping).
+        Some(target_ms.saturating_sub(now_ms))
+    }
+}
+
 /// Convert a `SystemTime` deadline to an absolute millisecond timestamp (Issue #1097).
 ///
 /// This is the inverse of `build_deadline`: given a `SystemTime`, return the

--- a/src/analysis/utils/deadline_tests.rs
+++ b/src/analysis/utils/deadline_tests.rs
@@ -316,6 +316,71 @@ fn calculate_effective_timeout_ms_matches_build_deadline_logic() {
 }
 
 // ============================================================================
+// remaining_ms_until tests (Issue #1407)
+// ============================================================================
+
+#[test]
+fn remaining_ms_until_passes_through_relative_durations() {
+    // Values below the year-2000 threshold are relative durations and are
+    // returned unchanged regardless of `now_ms`.
+    assert_eq!(remaining_ms_until(Some(120_000), 999_999), Some(120_000));
+    assert_eq!(remaining_ms_until(Some(0), 42), Some(0));
+}
+
+#[test]
+fn remaining_ms_until_subtracts_now_for_absolute_timestamps() {
+    let now = YEAR_2000_MS + 1_000_000;
+    let deadline = now + 30_000; // 30s in the future
+    assert_eq!(remaining_ms_until(Some(deadline), now), Some(30_000));
+}
+
+#[test]
+fn remaining_ms_until_saturates_to_zero_when_deadline_passed() {
+    let now = YEAR_2000_MS + 1_000_000;
+    let deadline = now - 5_000; // already passed
+    assert_eq!(remaining_ms_until(Some(deadline), now), Some(0));
+}
+
+#[test]
+fn remaining_ms_until_none_without_deadline() {
+    assert_eq!(remaining_ms_until(None, 123), None);
+}
+
+/// Issue #1407 acceptance criterion: focus selection and analysis bill against
+/// ONE shared absolute deadline. Time spent in focus selection must reduce the
+/// window left for analysis — it must NOT receive a fresh full window.
+#[test]
+fn shared_absolute_deadline_reduces_remaining_window_for_later_phase() {
+    let discovery_start_ms = YEAR_2000_MS + 10_000_000;
+    let budget_ms = 100_000; // 100s total discovery budget
+    let shared_deadline = Some(discovery_start_ms + budget_ms);
+
+    // Focus selection starts at the beginning of the cycle — it sees the full
+    // budget.
+    let focus_window =
+        remaining_ms_until(shared_deadline, discovery_start_ms).expect("shared deadline present");
+    assert_eq!(
+        focus_window, budget_ms,
+        "focus should see the full budget at the start of the cycle"
+    );
+
+    // Focus selection (plus its parquet load) consumes 80s of wall clock.
+    let focus_cost_ms = 80_000;
+    let analysis_start_ms = discovery_start_ms + focus_cost_ms;
+    let analysis_window =
+        remaining_ms_until(shared_deadline, analysis_start_ms).expect("shared deadline present");
+
+    // Analysis must get only the remainder (20s), not a fresh 100s window.
+    assert_eq!(analysis_window, budget_ms - focus_cost_ms);
+    assert!(
+        analysis_window < focus_window,
+        "time spent in focus must shrink the analysis window"
+    );
+    // The phases are coordinated under one budget: focus_cost + remainder == budget.
+    assert_eq!(focus_cost_ms + analysis_window, budget_ms);
+}
+
+// ============================================================================
 // parse_input_index tests
 // ============================================================================
 

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -64,7 +64,7 @@ pub use deadline::{
     calculate_gpu_batch_timeout, cap_deadline_to_wall_clock, deadline_passed,
     deadline_to_absolute_ms, derive_seed, focus_unused_observations_from_env, log_analysis_start,
     log_analysis_timeout, order_eligible_sources, order_focus_targets, parse_input_index,
-    shuffle_slice, shuffle_within_top_k, source_input_index_bias_from_env,
+    remaining_ms_until, shuffle_slice, shuffle_within_top_k, source_input_index_bias_from_env,
 };
 
 // Re-export deadline override for tests

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -452,6 +452,17 @@ pub const FOCUS_RANKING_BUDGET_GRACE_MS: u64 = 1_000;
 ///   `[FOCUS_RANKING_BUDGET_MIN_MS, FOCUS_RANKING_BUDGET_MAX_MS]` (Issue #1385).
 ///
 /// Returns `None` only when the budget is explicitly disabled with `0`.
+///
+/// ## Relationship to the shared discovery deadline (Issue #1407)
+///
+/// This budget is no longer an *independent* window. When the caller supplies
+/// the shared absolute discovery deadline (`analysisDeadlineMs`) to
+/// `rank_focus_neurons`, focus selection aborts at whichever is **sooner**: the
+/// shared deadline or this wall-clock budget. The budget therefore acts purely
+/// as a safety net that caps a pathological ranking run; it cannot extend focus
+/// selection past the shared discovery deadline that the synapse/neuron
+/// analysis phase also bills against. When no shared deadline is supplied, the
+/// budget behaves exactly as before.
 pub fn focus_ranking_budget_ms() -> Option<u64> {
     let Ok(raw) = std::env::var("NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS") else {
         return Some(DEFAULT_FOCUS_RANKING_BUDGET_MS);

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -332,12 +332,16 @@ pub fn rank_focus_neurons_internal(input_json: &str) -> Result<String> {
     // topologies activate margin-aware focus ranking. Other topologies
     // (Independent / Simplex / Unknown / OTHER) and `None` get the existing
     // unweighted ranking.
-    let rank_result = focus::rank_focus_neurons_with_descriptor(
+    // Issue #1407: thread the shared absolute discovery deadline so focus
+    // selection bills against the same budget as the analysis phase rather
+    // than opening a fresh independent window.
+    let rank_result = focus::rank_focus_neurons_with_descriptor_and_deadline(
         &input.parquet_file,
         &input.creature,
         input.max_results,
         input.cost_of_growth,
         input.task_descriptor.as_ref(),
+        input.analysis_deadline_ms,
     );
 
     match rank_result {

--- a/src/ffi_types/requests.rs
+++ b/src/ffi_types/requests.rs
@@ -362,6 +362,18 @@ pub struct RankFocusNeuronsInput {
     /// back to neutral rather than failing the whole request (Issue #1402).
     #[serde(default, deserialize_with = "deserialize_permissive_task_descriptor")]
     pub task_descriptor: Option<TaskDescriptor>,
+    /// Shared absolute discovery deadline in milliseconds (Issue #1407).
+    ///
+    /// When provided, focus selection bills against the **same** deadline as
+    /// the subsequent synapse/neuron analysis phase rather than opening a fresh
+    /// independent window. Focus ranking aborts at whichever is sooner: this
+    /// deadline or the `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` wall-clock
+    /// budget. Interpreted with the same heuristic as `analysisDeadlineMs` on
+    /// `analyzeParallel`: values at or above year-2000-in-ms are absolute
+    /// timestamps; smaller values are relative durations. When absent, the
+    /// legacy budget-only behaviour applies (backwards compatible).
+    #[serde(default)]
+    pub analysis_deadline_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/focus/mod.rs
+++ b/src/focus/mod.rs
@@ -51,5 +51,6 @@ pub use ranking::{
     RemovalCandidate, SelectionStats, SynapseCounts, calculate_removal_savings,
     decide_loading_mode_for_available_memory, decide_loading_mode_for_budget,
     lazy_pass_exceeds_perf_cliff, rank_focus_neurons, rank_focus_neurons_with_descriptor,
-    rank_focus_neurons_with_history, rank_focus_neurons_with_history_and_descriptor,
+    rank_focus_neurons_with_descriptor_and_deadline, rank_focus_neurons_with_history,
+    rank_focus_neurons_with_history_and_descriptor,
 };

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -43,7 +43,7 @@ use super::impact::{
 use crate::analysis::task_descriptor::{TargetTopology, TaskDescriptor};
 use crate::analysis::utils::{
     bytes_to_mb_ceil, estimate_parquet_in_memory_bytes, get_memory_info,
-    parquet_preload_fits_available, verbose_enabled,
+    parquet_preload_fits_available, remaining_ms_until, verbose_enabled,
 };
 use crate::config::{
     FOCUS_RANKING_BUDGET_GRACE_MS, focus_ranking_budget_ms, focus_ranking_memory_budget_mb,
@@ -58,7 +58,7 @@ use anyhow::{Context, Result};
 use rayon::prelude::*;
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 /// Loading mode chosen by [`rank_focus_neurons`] for accessing recorded
 /// discovery data (Issue #1172).
@@ -178,11 +178,56 @@ impl FocusDeadline {
         }
     }
 
-    /// Resolve the optional deadline for a run starting at `start` from the
-    /// configured budget. Returns `None` when the budget is disabled
-    /// (`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS=0`).
-    fn from_config(start: Instant) -> Option<Self> {
-        focus_ranking_budget_ms().map(|budget_ms| Self::new(start, budget_ms))
+    /// Resolve the optional focus-ranking deadline for a run starting at
+    /// `start` (Issue #1407).
+    ///
+    /// Two budgets bound focus ranking and the **earlier** wins:
+    /// 1. The shared **absolute** discovery deadline (`shared_deadline_ms`,
+    ///    ms-since-epoch) that the synapse/neuron analysis phase also bills
+    ///    against. Threading the same deadline through both phases means time
+    ///    spent selecting focus neurons reduces the window left for analysis
+    ///    instead of each phase opening a fresh independent window.
+    /// 2. Focus ranking's own wall-clock safety net
+    ///    (`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS`, default
+    ///    [`crate::config::DEFAULT_FOCUS_RANKING_BUDGET_MS`]) which still guards
+    ///    a pathological ranking run even when no shared deadline is supplied.
+    ///
+    /// Returns `None` only when both bounds are absent — no shared deadline AND
+    /// the focus budget explicitly disabled with `0`.
+    fn resolve(start: Instant, shared_deadline_ms: Option<u64>) -> Option<Self> {
+        let budget_deadline =
+            focus_ranking_budget_ms().map(|budget_ms| Self::new(start, budget_ms));
+        let shared_deadline = Self::from_shared_deadline(start, shared_deadline_ms);
+
+        match (budget_deadline, shared_deadline) {
+            (Some(budget), Some(shared)) => Some(if shared.expires_at <= budget.expires_at {
+                shared
+            } else {
+                budget
+            }),
+            (Some(budget), None) => Some(budget),
+            (None, Some(shared)) => Some(shared),
+            (None, None) => None,
+        }
+    }
+
+    /// Build a focus deadline anchored on `start` from the shared absolute
+    /// discovery deadline (Issue #1407).
+    ///
+    /// The shared deadline is the same value the analysis phase enforces, so no
+    /// focus-ranking grace is added here — the budget path keeps its own grace.
+    /// Returns `None` when no shared deadline is supplied or the system clock is
+    /// before the UNIX epoch.
+    fn from_shared_deadline(start: Instant, shared_deadline_ms: Option<u64>) -> Option<Self> {
+        let now_ms = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()?
+            .as_millis() as u64;
+        let remaining_ms = remaining_ms_until(shared_deadline_ms, now_ms)?;
+        Some(Self {
+            expires_at: start + Duration::from_millis(remaining_ms),
+            budget_ms: remaining_ms,
+        })
     }
 
     /// Abort with a structured timeout error if the deadline has passed.
@@ -708,6 +753,41 @@ pub fn rank_focus_neurons_with_descriptor(
         cost_of_growth,
         descriptor,
         history: None,
+        shared_deadline_ms: None,
+    })
+}
+
+/// Focus-ranking entry point that bills against the shared discovery deadline
+/// (Issue #1407).
+///
+/// Identical to [`rank_focus_neurons_with_descriptor`] but additionally accepts
+/// the absolute discovery deadline (`analysis_deadline_ms`, ms-since-epoch) that
+/// the subsequent synapse/neuron analysis phase also enforces. Focus selection
+/// aborts at whichever is sooner: this shared deadline or the focus-ranking
+/// wall-clock budget. Passing `None` reproduces the budget-only behaviour, so
+/// the two phases no longer open independent time windows.
+///
+/// # Errors
+///
+/// Returns an error if the underlying record provider or impact computation
+/// fails, or a [`DiscoveryError::Timeout`] if the shared deadline (or focus
+/// budget) is exceeded mid-run.
+pub fn rank_focus_neurons_with_descriptor_and_deadline(
+    parquet_file: &str,
+    creature: &CreatureJson,
+    max_results: Option<usize>,
+    cost_of_growth: Option<f32>,
+    descriptor: Option<&TaskDescriptor>,
+    analysis_deadline_ms: Option<u64>,
+) -> Result<RankFocusStats> {
+    rank_focus_core(&RankCoreArgs {
+        parquet_file,
+        creature,
+        max_results,
+        cost_of_growth,
+        descriptor,
+        history: None,
+        shared_deadline_ms: analysis_deadline_ms,
     })
 }
 
@@ -724,6 +804,10 @@ struct RankCoreArgs<'a> {
     cost_of_growth: Option<f32>,
     descriptor: Option<&'a TaskDescriptor>,
     history: Option<&'a DiscoveryHistory>,
+    /// Shared absolute discovery deadline (ms-since-epoch) billed against by
+    /// both focus selection and analysis (Issue #1407). `None` keeps the
+    /// budget-only behaviour.
+    shared_deadline_ms: Option<u64>,
 }
 
 /// Shared focus-ranking core (Issue #1375).
@@ -734,7 +818,7 @@ struct RankCoreArgs<'a> {
 /// the creature has no selectable neurons.
 fn rank_focus_core(args: &RankCoreArgs<'_>) -> Result<RankFocusStats> {
     let start = Instant::now();
-    let deadline = FocusDeadline::from_config(start);
+    let deadline = FocusDeadline::resolve(start, args.shared_deadline_ms);
 
     let selectable: Vec<&NeuronJson> = args
         .creature
@@ -1099,6 +1183,7 @@ pub fn rank_focus_neurons_with_history_and_descriptor(
         cost_of_growth,
         descriptor,
         history,
+        shared_deadline_ms: None,
     })
 }
 
@@ -1135,6 +1220,7 @@ pub(in crate::focus) fn rank_with_provider_for_tests(
         cost_of_growth: None,
         descriptor: None,
         history: None,
+        shared_deadline_ms: None,
     };
     rank_selectable(&args, &selectable, provider, meta, deadline, start)
 }
@@ -1142,3 +1228,75 @@ pub(in crate::focus) fn rank_with_provider_for_tests(
 // NOTE: Tests for focus module have been moved to tests/focus.rs
 // following the testing philosophy documented in README.md
 // (prefer tests/ over inline unit tests for tests that use public APIs).
+//
+// The tests below stay inline because `FocusDeadline` and its `resolve`
+// constructor are private to this module and cannot be reached from `tests/`.
+
+#[cfg(test)]
+mod focus_deadline_tests {
+    //! Issue #1407: `FocusDeadline::resolve` must bound focus selection by the
+    //! shared absolute discovery deadline, capped by the focus-ranking budget.
+    use super::FocusDeadline;
+    use std::time::{Duration, Instant, SystemTime};
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock after UNIX epoch")
+            .as_millis() as u64
+    }
+
+    fn abs_diff(a: Instant, b: Instant) -> Duration {
+        if a > b { a - b } else { b - a }
+    }
+
+    #[test]
+    fn resolve_uses_shared_deadline_when_sooner_than_budget() {
+        let start = Instant::now();
+        // Absolute deadline 5s out — well inside the default 120s focus budget.
+        let shared = Some(now_ms() + 5_000);
+        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
+        let budget_only = FocusDeadline::resolve(start, None).expect("budget present");
+
+        // The shared deadline (5s) bounds the run more tightly than the budget,
+        // so it must win — this is the unification the issue requires.
+        assert!(
+            resolved.expires_at < budget_only.expires_at,
+            "shared deadline should expire before the focus budget window",
+        );
+        // Expiry sits roughly 5s from start (tolerant of scheduling jitter).
+        assert!(
+            abs_diff(resolved.expires_at, start + Duration::from_millis(5_000))
+                < Duration::from_millis(1_000),
+            "expiry should track the shared deadline",
+        );
+    }
+
+    #[test]
+    fn resolve_uses_budget_when_shared_deadline_is_distant() {
+        let start = Instant::now();
+        // Absolute deadline far beyond the focus budget (50 minutes out).
+        let shared = Some(now_ms() + 3_000_000);
+        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
+        let budget_only = FocusDeadline::resolve(start, None).expect("budget present");
+
+        // The nearer focus budget caps the distant deadline, so both expire at
+        // effectively the same point.
+        assert!(
+            abs_diff(resolved.expires_at, budget_only.expires_at) < Duration::from_millis(50),
+            "the focus budget should cap a distant shared deadline",
+        );
+    }
+
+    #[test]
+    fn resolve_with_passed_deadline_aborts_immediately() {
+        let start = Instant::now();
+        // An absolute deadline already in the past saturates to zero remaining.
+        let shared = Some(now_ms().saturating_sub(10_000));
+        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
+        assert!(
+            resolved.check("test").is_err(),
+            "a passed shared deadline must abort focus ranking immediately",
+        );
+    }
+}

--- a/tests/ffi/issue_1407_focus_shared_deadline.rs
+++ b/tests/ffi/issue_1407_focus_shared_deadline.rs
@@ -1,0 +1,58 @@
+//! Tests for Issue #1407: focus selection bills against the shared discovery
+//! deadline instead of opening a fresh independent window.
+//!
+//! The FFI contract change is the new optional `analysisDeadlineMs` field on
+//! [`RankFocusNeuronsInput`] — the same absolute discovery deadline already
+//! accepted by `analyzeParallel`. These tests guard the deserialisation
+//! contract:
+//!
+//! - An omitted `analysisDeadlineMs` deserialises to `None` (backwards
+//!   compatible — legacy budget-only behaviour).
+//! - A supplied `analysisDeadlineMs` round-trips verbatim so the Rust layer can
+//!   thread it into `FocusDeadline`.
+
+use neat_ai_discovery::RankFocusNeuronsInput;
+
+#[test]
+fn rank_focus_input_omits_analysis_deadline_to_none() {
+    // RankFocusNeuronsInput uses camelCase field names.
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0}
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    assert!(
+        parsed.analysis_deadline_ms.is_none(),
+        "absent analysisDeadlineMs must deserialise to None (budget-only behaviour)",
+    );
+}
+
+#[test]
+fn rank_focus_input_supplied_analysis_deadline_round_trips() {
+    // An absolute ms-since-epoch deadline well above the year-2000 threshold.
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "analysisDeadlineMs": 1893456000000
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    assert_eq!(
+        parsed.analysis_deadline_ms,
+        Some(1_893_456_000_000),
+        "analysisDeadlineMs must round-trip so it can be shared with analysis",
+    );
+}
+
+#[test]
+fn rank_focus_input_accepts_relative_deadline_duration() {
+    // A small value (below year-2000-in-ms) is a relative duration; the field
+    // still round-trips and the Rust layer interprets it via the shared epoch
+    // heuristic.
+    let payload = r#"{
+        "parquetFile": "/tmp/x.parquet",
+        "creature": {"neurons": [], "synapses": [], "input": 0, "output": 0},
+        "analysisDeadlineMs": 120000
+    }"#;
+    let parsed: RankFocusNeuronsInput = serde_json::from_str(payload).expect("parse");
+    assert_eq!(parsed.analysis_deadline_ms, Some(120_000));
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -9,6 +9,7 @@ mod issue_1184_recurrent_synapse_rejection;
 mod issue_1188_grq3_strip_pattern_rejection;
 mod issue_1314_task_descriptor_plumbing;
 mod issue_1402_lowercase_task_descriptor_regression;
+mod issue_1407_focus_shared_deadline;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
# Unify focus selection under the shared analysis deadline (Issue #1407)

## Summary

Focus selection (`rank_focus_neurons`) ran as a separate FFI call **before**
`analyze_parallel` and enforced its **own** wall-clock budget
(`focus_ranking_budget_ms`) derived from a fresh `Instant::now()`. That budget
was independent of the analysis deadline, so the time focus selection (plus its
parquet load) consumed was never billed against the discovery budget — synapse
/neuron analysis could begin with far less wall-clock than the configured
budget implied.

This change extends the absolute-deadline model from #1097 across the
focus→analysis boundary so both phases bill against **one** budget:

- `rank_focus_neurons` now accepts the same absolute discovery deadline
  (`analysisDeadlineMs`, ms-since-epoch) that `analyze_parallel` already
  enforces. The caller computes the deadline once and passes it to both FFI
  calls.
- `FocusDeadline` derives its expiry from that shared absolute deadline rather
  than a fresh per-call relative window. Focus selection aborts at whichever is
  **sooner**: the shared deadline or the
  `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` wall-clock budget (now a safety
  net, not an independent window).
- A new shared accounting primitive `remaining_ms_until` lives alongside
  `build_deadline` / `deadline_to_absolute_ms` in `analysis/utils/deadline.rs`,
  applying the same year-2000 epoch heuristic so both phases interpret the
  deadline identically.

Because the deadline is absolute, time spent in focus selection naturally
shrinks the window left for analysis — the later phase sees the remainder, not
a fresh full window. When `analysisDeadlineMs` is omitted from the focus call,
the legacy budget-only behaviour applies (backwards compatible).

Closes #1407.

## Evidence

This is a backend/FFI change with no web interface to screenshot. Verified via
unit and integration tests (`./quality.sh` passes cleanly).

### Data flow

```mermaid
sequenceDiagram
    participant Host as NEAT-AI (caller)
    participant Focus as rank_focus_neurons
    participant Analysis as analyze_parallel
    Note over Host: compute ONE absolute deadline D (ms-since-epoch)
    Host->>Focus: analysisDeadlineMs = D
    Note over Focus: FocusDeadline = min(D, focus budget)
    Focus-->>Host: ranked focus neurons (D − focus_cost remaining)
    Host->>Analysis: analysisDeadlineMs = D
    Note over Analysis: remaining window = D − now (already reduced by focus)
    Analysis-->>Host: candidates
```

### Acceptance criteria

- **Aggregate cannot exceed the discovery budget** — both phases abort at the
  same absolute deadline; focus is additionally capped by its budget+grace.
  Covered by `resolve_uses_shared_deadline_when_sooner_than_budget` and
  `resolve_uses_budget_when_shared_deadline_is_distant`.
- **Focus time reduces the analysis window** — proven deterministically by
  `shared_absolute_deadline_reduces_remaining_window_for_later_phase`: an 80s
  focus cost against a 100s shared budget leaves analysis exactly 20s, not a
  fresh 100s.
- **`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` reconciled & documented** —
  doc comment in `config/user_facing.rs` and `docs/FFI_API.md` now describe it
  as a safety-net cap on the shared deadline, no longer an independent window.
- **A passed shared deadline aborts focus immediately** —
  `resolve_with_passed_deadline_aborts_immediately`.

## Test Plan

New tests (all calling real functions and asserting on results — no source
grepping):

- `src/analysis/utils/deadline_tests.rs`
  - `remaining_ms_until_passes_through_relative_durations`
  - `remaining_ms_until_subtracts_now_for_absolute_timestamps`
  - `remaining_ms_until_saturates_to_zero_when_deadline_passed`
  - `remaining_ms_until_none_without_deadline`
  - `shared_absolute_deadline_reduces_remaining_window_for_later_phase`
    (the core acceptance-criterion test)
- `src/focus/ranking/mod.rs` (inline — `FocusDeadline` and `resolve` are
  private)
  - `resolve_uses_shared_deadline_when_sooner_than_budget`
  - `resolve_uses_budget_when_shared_deadline_is_distant`
  - `resolve_with_passed_deadline_aborts_immediately`
- `tests/ffi/issue_1407_focus_shared_deadline.rs` (FFI deserialisation contract)
  - `rank_focus_input_omits_analysis_deadline_to_none`
  - `rank_focus_input_supplied_analysis_deadline_round_trips`
  - `rank_focus_input_accepts_relative_deadline_duration`

`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, tests, doc,
release build).

## Files Changed

- `src/analysis/utils/deadline.rs` — new `remaining_ms_until` shared primitive.
- `src/analysis/utils/mod.rs` — re-export `remaining_ms_until`.
- `src/focus/ranking/mod.rs` — `FocusDeadline::resolve` / `from_shared_deadline`
  (replacing `from_config`); new `rank_focus_neurons_with_descriptor_and_deadline`
  entry point; `shared_deadline_ms` threaded through `RankCoreArgs`.
- `src/focus/mod.rs` — re-export the new entry point.
- `src/ffi_types/requests.rs` — `analysisDeadlineMs` field on
  `RankFocusNeuronsInput`.
- `src/ffi_internal/analysis.rs` — wire `analysisDeadlineMs` into the focus call.
- `src/config/user_facing.rs` — document the budget/shared-deadline reconciliation.
- `docs/FFI_API.md` — document the shared deadline across focus selection.
- `Cargo.toml` — version bump `0.74.88` → `0.74.89`.



## Milestone
This PR is part of the **#1405 Focus selection + parquet reload consume analysis deadline; synapse/neuron analysis starved (GRQ-23 logs)** milestone and targets the `milestone/1405-focus-selection-parquet-reload-consume-analys` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqha0pea-f4821d`<!-- vibe-worker-issue-1407 -->