### PR TITLE
Surface synapse/neuron starvation + per-cycle deadline breakdown (Issue #1409)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ env knobs — is documented end-to-end in
 | **GPU not available** | Check system meets minimum requirements; on Linux check `/dev/dri` permissions |
 | **Out of memory (exit 137)** | Reduce `--max-old-space-size`; see [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) |
 | **Analysis timeout** | Expected under deadlines; coverage improves over repeated runs |
+| **Synapse/neuron starvation** | Grep logs for `GRQ-23` to see the per-cycle deadline-consumption breakdown, and `STARVED` for the curtailed-phase warning with skipped/total counts; the `starved` flag on `synapseMetadata`/`neuronMetadata` exposes the same signal programmatically |
 | **GPU timeout errors** | Reduce `NEAT_AI_DISCOVERY_GPU_BATCH_SIZE`; restart if GPU driver hung |
 | **Low GPU utilisation** | Often CPU-bound sample building; see [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) |
 | **Deadlock or stuck** | Send `kill -USR1 <pid>` for thread dump; see [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md) |

--- a/docs/archive/pr-summaries/pr-summary-1409.md
+++ b/docs/archive/pr-summaries/pr-summary-1409.md
@@ -1,0 +1,97 @@
+## Summary
+
+Surfaces synapse/neuron **starvation** and a consolidated **per-cycle
+deadline-consumption breakdown** so the GRQ-23 logs can attribute *where* the
+analysis deadline went and show *that* synapse/neuron analysis was curtailed.
+This is **observability only** — no analysis math changed. Closes #1409.
+
+The data needed to diagnose #1405 already existed but was scattered: per-phase
+timings lived in `ProfileData`, while the starvation signals (`timed_out`,
+`completed_focus_neurons`, `total_focus_neurons`) lived on the per-phase
+metadata and were never emitted as an explicit, greppable warning. This PR
+consolidates them.
+
+### What changed
+
+- **New `analysis::deadline_breakdown` module** — a small, pure
+  `DeadlineConsumptionBreakdown` (+ `PhaseCompletion`) that:
+  - renders one greppable summary line (stable `GRQ-23` marker) attributing ms
+    to parquet reload, synapse analysis, neuron analysis, and total analysis,
+    plus `completed/total` focus-neuron ratios per phase;
+  - emits an explicit `STARVED` `warn!` with skipped/total counts when a phase
+    timed out **and** left focus neurons unanalysed.
+- **`analysis::orchestration`** — `dispatch_analyses` now returns per-phase
+  wall-clock durations; `analyze_all` captures the parquet-reload and total
+  durations and emits the breakdown once per invocation, just before returning.
+- **FFI metadata** — added a `starved` boolean to both
+  `synapseMetadata` and `neuronMetadata` so the TypeScript / GRQ layer can
+  detect starvation programmatically without recomputing
+  `timedOut && completedFocusNeurons < totalFocusNeurons`. The completion
+  ratios themselves were already present.
+- **README** — added a troubleshooting row pointing at the `GRQ-23` /
+  `STARVED` log markers and the `starved` flag.
+
+The focus phase (parquet load + focus ranking) runs in the separate
+`rank_focus_neurons` FFI call; its mode + elapsed are surfaced there
+(Issue #1377) and combined by the GRQ layer. Per-phase ms for disabled phases
+render as `n/a` rather than fabricated zeroes.
+
+### Out of scope
+
+Fixing the underlying consumption (reload-dedup, budget-unification,
+reserved-floor) — those are the sibling sub-issues. This PR only makes the
+problem measurable.
+
+## Evidence
+
+Backend/CLI library change — no web interface to screenshot. Verified via the
+new unit/integration tests (`cargo test --test deadline_breakdown_test`, 8
+passing) plus `cargo clippy`, `cargo check`, `cargo doc`, and the release build,
+all clean for the changed code.
+
+```mermaid
+flowchart TD
+    A[analyze_all] --> B[parquet reload<br/>capture ms]
+    B --> C[dispatch_analyses]
+    C --> D[synapse analysis<br/>capture ms]
+    C --> E[neuron analysis<br/>capture ms]
+    D --> F[build DeadlineConsumptionBreakdown]
+    E --> F
+    B --> F
+    F --> G["info: GRQ-23 deadline consumption (ms): ..."]
+    F --> H{timed_out && completed &lt; total?}
+    H -- yes --> I["warn: STARVED — skipped M/N targets"]
+    H -- no --> J[no warning]
+    F --> K["FFI: synapseMetadata.starved / neuronMetadata.starved"]
+```
+
+## Test Plan
+
+New integration test `tests/deadline_breakdown_test.rs` (8 cases), covering the
+observable behaviour (not implementation):
+
+- `phase_completion_starved_when_timed_out_with_remaining` /
+  `phase_completion_not_starved_when_all_completed` /
+  `phase_completion_not_starved_without_timeout` — the starvation predicate.
+- `simulated_timeout_emits_starved_warning_with_counts` — a simulated timeout
+  produces the `STARVED` warning naming skipped/total per phase, and `emit()`
+  does not panic.
+- `starved_warning_only_names_curtailed_phase` — only the curtailed phase is
+  named.
+- `completed_run_has_no_starvation_warning` — no warning on a clean run.
+- `summary_line_attributes_all_phases` /
+  `summary_line_marks_disabled_phases_as_not_applicable` — the consolidated,
+  greppable summary line.
+
+## Pre-existing unrelated breakage (not introduced here)
+
+The milestone branch already fails to compile the test crate
+`tests/issue_1406_cross_phase_parquet_reload.rs`: it imports
+`analysis::cache::shared_records`, but Issue #1406's cross-phase bridge module
+is present yet never declared in `cache/mod.rs`, and its production integration
+(focus phase populating the bridge) is unimplemented. This is sibling Issue
+#1406's work — explicitly out of scope for #1409 — so this PR deliberately does
+not touch it. As a result `./quality.sh`'s aggregate `cargo test --lib --tests`
+cannot go green on this branch until #1406 lands. All other gates (clippy,
+check, doc, release build, and this PR's new tests) pass cleanly. Verified the
+failure pre-exists this PR via `git stash`.

--- a/src/analysis/deadline_breakdown.rs
+++ b/src/analysis/deadline_breakdown.rs
@@ -1,0 +1,156 @@
+//! Consolidated per-cycle deadline-consumption breakdown (Issue #1409 / GRQ-23).
+//!
+//! The data needed to diagnose where the analysis deadline went is scattered:
+//! per-phase timings live in `ProfileData`, while synapse/neuron starvation
+//! signals (`timed_out`, `completed_focus_neurons`, `total_focus_neurons`) live
+//! on the per-phase metadata. This module consolidates them into a single,
+//! greppable summary emitted once per `analyze_all` invocation so operators can
+//! attribute deadline consumption across phases and see, explicitly, when
+//! synapse/neuron analysis was starved by the deadline.
+//!
+//! # Emission
+//!
+//! [`DeadlineConsumptionBreakdown::emit`] logs one structured `tracing::info!`
+//! summary line. When either phase was curtailed by the deadline it also logs a
+//! `tracing::warn!` carrying the `STARVED` marker and the skipped/total counts.
+//!
+//! This is **observability only** — it never changes analysis math.
+
+/// Completion accounting for one analysis phase (synapse or neuron).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhaseCompletion {
+    /// Whether this phase hit its deadline and returned partial results.
+    pub timed_out: bool,
+    /// Focus neurons completed before the phase returned.
+    pub completed_focus_neurons: usize,
+    /// Focus neurons requested for the phase.
+    pub total_focus_neurons: usize,
+}
+
+impl PhaseCompletion {
+    /// Number of focus neurons the phase did not reach (saturating).
+    #[must_use]
+    pub fn skipped(&self) -> usize {
+        self.total_focus_neurons
+            .saturating_sub(self.completed_focus_neurons)
+    }
+
+    /// True when the deadline curtailed this phase: it timed out **and** left at
+    /// least one focus neuron unanalysed.
+    #[must_use]
+    pub fn is_starved(&self) -> bool {
+        self.timed_out && self.completed_focus_neurons < self.total_focus_neurons
+    }
+}
+
+/// Per-phase millisecond breakdown of where the analysis deadline was consumed,
+/// plus synapse/neuron completion ratios, for a single discovery cycle.
+///
+/// `synapse`/`neuron` are `None` when the corresponding analysis was disabled
+/// for the run. The focus phase (parquet load + focus ranking) runs in a
+/// separate FFI call (`rank_focus_neurons`); its timings are surfaced there
+/// (Issue #1377) and combined by the GRQ layer.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DeadlineConsumptionBreakdown {
+    /// Milliseconds spent re-loading the Parquet record cache for the analysis
+    /// phase.
+    pub parquet_reload_ms: u64,
+    /// Wall-clock milliseconds spent in synapse analysis (`None` when disabled).
+    pub synapse_analysis_ms: Option<u64>,
+    /// Wall-clock milliseconds spent in neuron analysis (`None` when disabled).
+    pub neuron_analysis_ms: Option<u64>,
+    /// Total wall-clock milliseconds for the whole analysis invocation.
+    pub total_analysis_ms: u64,
+    /// Synapse completion accounting (`None` when synapse analysis disabled).
+    pub synapse: Option<PhaseCompletion>,
+    /// Neuron completion accounting (`None` when neuron analysis disabled).
+    pub neuron: Option<PhaseCompletion>,
+}
+
+impl DeadlineConsumptionBreakdown {
+    /// True when either phase was curtailed by the deadline.
+    #[must_use]
+    pub fn is_starved(&self) -> bool {
+        self.synapse.is_some_and(|s| s.is_starved()) || self.neuron.is_some_and(|n| n.is_starved())
+    }
+
+    /// One greppable line attributing deadline consumption across all phases
+    /// owned by the analysis call.
+    #[must_use]
+    pub fn summary_line(&self) -> String {
+        fn ms(value: Option<u64>) -> String {
+            value.map_or_else(|| "n/a".to_string(), |v| v.to_string())
+        }
+        fn ratio(phase: Option<PhaseCompletion>) -> String {
+            phase.map_or_else(
+                || "n/a".to_string(),
+                |p| format!("{}/{}", p.completed_focus_neurons, p.total_focus_neurons),
+            )
+        }
+
+        format!(
+            "GRQ-23 deadline consumption (ms): parquet_reload={} synapse_analysis={} \
+             neuron_analysis={} total_analysis={}; focus completed synapse={} neuron={}",
+            self.parquet_reload_ms,
+            ms(self.synapse_analysis_ms),
+            ms(self.neuron_analysis_ms),
+            self.total_analysis_ms,
+            ratio(self.synapse),
+            ratio(self.neuron),
+        )
+    }
+
+    /// The `STARVED` warning message when the deadline curtailed analysis,
+    /// otherwise `None`.
+    ///
+    /// Names which phase(s) were skipped and by how much, so the warning is
+    /// actionable without re-running analysis.
+    #[must_use]
+    pub fn starvation_warning(&self) -> Option<String> {
+        let mut parts = Vec::new();
+        if let Some(syn) = self.synapse.filter(PhaseCompletion::is_starved) {
+            parts.push(format!(
+                "synapse analysis skipped {}/{} targets",
+                syn.skipped(),
+                syn.total_focus_neurons
+            ));
+        }
+        if let Some(neu) = self.neuron.filter(PhaseCompletion::is_starved) {
+            parts.push(format!(
+                "neuron analysis skipped {}/{} targets",
+                neu.skipped(),
+                neu.total_focus_neurons
+            ));
+        }
+
+        if parts.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "STARVED: {} — deadline exhausted by focus+parquet before analysis could finish",
+            parts.join("; ")
+        ))
+    }
+
+    /// Emit the consolidated breakdown: one structured `info` summary line, plus
+    /// a `warn` carrying the `STARVED` marker when analysis was curtailed.
+    pub fn emit(&self) {
+        tracing::info!(
+            marker = "GRQ-23",
+            parquet_reload_ms = self.parquet_reload_ms,
+            synapse_analysis_ms = self.synapse_analysis_ms.unwrap_or(0),
+            neuron_analysis_ms = self.neuron_analysis_ms.unwrap_or(0),
+            total_analysis_ms = self.total_analysis_ms,
+            synapse_completed = self.synapse.map_or(0, |s| s.completed_focus_neurons),
+            synapse_total = self.synapse.map_or(0, |s| s.total_focus_neurons),
+            neuron_completed = self.neuron.map_or(0, |n| n.completed_focus_neurons),
+            neuron_total = self.neuron.map_or(0, |n| n.total_focus_neurons),
+            "{}",
+            self.summary_line()
+        );
+
+        if let Some(warning) = self.starvation_warning() {
+            tracing::warn!(marker = "GRQ-23", "{warning}");
+        }
+    }
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -39,6 +39,7 @@ pub mod candidate_compression;
 pub mod candidate_diversity;
 pub mod constants;
 pub mod cost_function_hint;
+pub mod deadline_breakdown;
 pub mod diagnostics;
 pub mod discovery_dispatch;
 pub mod discovery_mode;

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -119,16 +119,35 @@ pub(crate) fn run_optional_analysis<T>(
     }
 }
 
+/// Wall-clock milliseconds spent in each analysis phase (Issue #1409).
+///
+/// `None` when the corresponding analysis was disabled for the run. Feeds the
+/// consolidated per-cycle deadline-consumption breakdown.
+#[derive(Debug, Clone, Copy, Default)]
+struct DispatchDurations {
+    synapse_ms: Option<u64>,
+    neuron_ms: Option<u64>,
+}
+
 /// Run synapse and neuron analyses concurrently when both are enabled (Issue #1002).
 ///
 /// Uses `rayon::join` to run both analyses in parallel with a shared GPU queue,
 /// reducing wall-clock time. When only one analysis is enabled, it runs alone.
+///
+/// Also returns the per-phase wall-clock durations (Issue #1409) so the
+/// orchestrator can attribute deadline consumption.
 fn dispatch_analyses(
     synapse_input: Option<AnalyzeSynapsesInput>,
     neuron_input: Option<AnalyzeNeuronsInput>,
     shared_cache: &Arc<cache::RecordCache>,
     shared_gpu_queue: &Arc<super::gpu::GpuWorkQueue>,
-) -> Result<(Option<AnalyzeSynapsesResult>, Option<AnalyzeNeuronsResult>)> {
+) -> Result<(
+    Option<AnalyzeSynapsesResult>,
+    Option<AnalyzeNeuronsResult>,
+    DispatchDurations,
+)> {
+    use std::time::Instant;
+
     let both_enabled = synapse_input.is_some() && neuron_input.is_some();
 
     if both_enabled {
@@ -144,9 +163,11 @@ fn dispatch_analyses(
 
         // Issue #1087: Wrap each rayon::join branch with catch_unwind so a
         // panic in one analysis does not corrupt results from the other.
-        let (syn_result, neu_result) = rayon::join(
+        // Issue #1409: Each branch also returns its wall-clock duration.
+        let ((syn_result, syn_ms), (neu_result, neu_ms)) = rayon::join(
             || {
-                std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let started = Instant::now();
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     run_optional_analysis(
                         true,
                         "analysis::analyze_all → synapse analysis starting",
@@ -170,10 +191,12 @@ fn dispatch_analyses(
                         "Synapse analysis panicked — caught and converted to error (Issue #1087)"
                     );
                     Err(anyhow::anyhow!("synapse analysis module panicked: {msg}"))
-                })
+                });
+                (result, started.elapsed().as_millis() as u64)
             },
             || {
-                std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let started = Instant::now();
+                let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
                     run_optional_analysis(
                         true,
                         "analysis::analyze_all → neuron analysis starting",
@@ -197,17 +220,24 @@ fn dispatch_analyses(
                         "Neuron analysis panicked — caught and converted to error (Issue #1087)"
                     );
                     Err(anyhow::anyhow!("neuron analysis module panicked: {msg}"))
-                })
+                });
+                (result, started.elapsed().as_millis() as u64)
             },
         );
         Ok((
             syn_result.context("failed during synapse analysis phase")?,
             neu_result.context("failed during neuron analysis phase")?,
+            DispatchDurations {
+                synapse_ms: Some(syn_ms),
+                neuron_ms: Some(neu_ms),
+            },
         ))
     } else {
         // Only one (or neither) analysis is enabled — run sequentially.
+        let synapse_enabled = synapse_input.is_some();
+        let synapse_started = Instant::now();
         let synapse_result = run_optional_analysis(
-            synapse_input.is_some(),
+            synapse_enabled,
             "analysis::analyze_all → synapse analysis starting",
             "analysis::analyze_all → synapse analysis finished",
             "analysis::analyze_all → synapse analysis skipped",
@@ -221,9 +251,12 @@ fn dispatch_analyses(
                 )
             },
         )?;
+        let synapse_ms = synapse_enabled.then(|| synapse_started.elapsed().as_millis() as u64);
 
+        let neuron_enabled = neuron_input.is_some();
+        let neuron_started = Instant::now();
         let neuron_result = run_optional_analysis(
-            neuron_input.is_some(),
+            neuron_enabled,
             "analysis::analyze_all → neuron analysis starting",
             "analysis::analyze_all → neuron analysis finished",
             "analysis::analyze_all → neuron analysis skipped",
@@ -237,8 +270,16 @@ fn dispatch_analyses(
                 )
             },
         )?;
+        let neuron_ms = neuron_enabled.then(|| neuron_started.elapsed().as_millis() as u64);
 
-        Ok((synapse_result, neuron_result))
+        Ok((
+            synapse_result,
+            neuron_result,
+            DispatchDurations {
+                synapse_ms,
+                neuron_ms,
+            },
+        ))
     }
 }
 
@@ -256,8 +297,9 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
     // so that a prior SIGTERM does not immediately abort this invocation.
     crate::cancellation::reset_cancellation();
 
-    // Phase timer for total analysis (Issue #214)
-    let _total_timer = PhaseTimer::new("total_analysis");
+    // Phase timer for total analysis (Issue #214). Also drives the consolidated
+    // per-cycle deadline-consumption breakdown total (Issue #1409).
+    let total_timer = PhaseTimer::new("total_analysis");
 
     // Profile data collection (when NEAT_AI_DISCOVERY_PROFILE=json)
     let mut profile = ProfileData::new();
@@ -488,10 +530,10 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
         Err(e) => return Err(e).context("failed to load parquet record cache for analysis"),
     };
-    profile.record_phase(
-        "parquet_loading",
-        parquet_loading_start.elapsed().as_millis() as u64,
-    );
+    // Issue #1409: capture the parquet reload duration for the consolidated
+    // per-cycle deadline-consumption breakdown.
+    let parquet_reload_ms = parquet_loading_start.elapsed().as_millis() as u64;
+    profile.record_phase("parquet_loading", parquet_reload_ms);
     crate::watchdog::beat("analysis::analyze_all → parquet cache loaded");
 
     // Issue #1028: Check memory budget after parquet loading (often the largest
@@ -594,7 +636,7 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
 
     // Issue #1047: If analysis was cancelled during dispatch, return a clean
     // partial result rather than propagating the error.
-    let (synapse_result, neuron_result) = match dispatch_result {
+    let (synapse_result, neuron_result, dispatch_durations) = match dispatch_result {
         Ok(results) => results,
         Err(_) if crate::cancellation::is_cancelled() => {
             tracing::info!("analysis dispatch cancelled by host — returning empty result");
@@ -1075,6 +1117,30 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
             super::drought_reset::rearm_drought_reset(None, Some(&mut *guard));
         }
     }
+
+    // Issue #1409 (GRQ-23): Emit one consolidated, greppable summary attributing
+    // deadline consumption across the analysis phases, plus an explicit STARVED
+    // warning when synapse/neuron analysis was curtailed by the deadline. The
+    // focus phase (parquet load + focus ranking) runs in the separate
+    // rank_focus_neurons call and is surfaced there (Issue #1377).
+    use super::deadline_breakdown::{DeadlineConsumptionBreakdown, PhaseCompletion};
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms,
+        synapse_analysis_ms: dispatch_durations.synapse_ms,
+        neuron_analysis_ms: dispatch_durations.neuron_ms,
+        total_analysis_ms: total_timer.elapsed_ms(),
+        synapse: synapse_result.as_ref().map(|s| PhaseCompletion {
+            timed_out: s.metadata.timed_out,
+            completed_focus_neurons: s.metadata.completed_focus_neurons,
+            total_focus_neurons: s.metadata.total_focus_neurons,
+        }),
+        neuron: neuron_result.as_ref().map(|n| PhaseCompletion {
+            timed_out: n.metadata.timed_out,
+            completed_focus_neurons: n.metadata.completed_focus_neurons,
+            total_focus_neurons: n.metadata.total_focus_neurons,
+        }),
+    };
+    breakdown.emit();
 
     Ok(AnalyzeAllResult {
         synapse: synapse_result,

--- a/src/ffi_internal/analysis.rs
+++ b/src/ffi_internal/analysis.rs
@@ -143,6 +143,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     timed_out: s.metadata.timed_out,
                     completed_focus_neurons: s.metadata.completed_focus_neurons,
                     total_focus_neurons: s.metadata.total_focus_neurons,
+                    // Issue #1409: explicit starvation flag for the GRQ layer.
+                    starved: s.metadata.timed_out
+                        && s.metadata.completed_focus_neurons < s.metadata.total_focus_neurons,
                     input_index_min_seen_with_records: s.metadata.input_index_min_seen_with_records,
                     input_index_max_seen_with_records: s.metadata.input_index_max_seen_with_records,
                     timing: s.metadata.timing.as_ref().map(timing_to_json),
@@ -170,6 +173,9 @@ pub fn analyze_parallel_internal(input_json: &str) -> Result<String> {
                     timed_out: n.metadata.timed_out,
                     completed_focus_neurons: n.metadata.completed_focus_neurons,
                     total_focus_neurons: n.metadata.total_focus_neurons,
+                    // Issue #1409: explicit starvation flag for the GRQ layer.
+                    starved: n.metadata.timed_out
+                        && n.metadata.completed_focus_neurons < n.metadata.total_focus_neurons,
                     timing: n.metadata.timing.as_ref().map(timing_to_json),
                     gpu_info: n.metadata.gpu_info.as_ref().map(gpu_info_to_json),
                     rejection_breakdown: n.metadata.rejection_breakdown.counts().clone(),

--- a/src/ffi_types/responses/analysis.rs
+++ b/src/ffi_types/responses/analysis.rs
@@ -128,6 +128,12 @@ pub struct SynapseAnalysisMetadataJson {
     pub completed_focus_neurons: usize,
     /// Total focus neurons requested for this analysis invocation.
     pub total_focus_neurons: usize,
+    /// True when synapse analysis was curtailed by the deadline: it timed out
+    /// **and** left at least one focus neuron unanalysed (Issue #1409).
+    ///
+    /// Lets the GRQ layer detect synapse starvation programmatically without
+    /// recomputing `timedOut && completedFocusNeurons < totalFocusNeurons`.
+    pub starved: bool,
     /// Minimum input index observed with non-empty records (eg 0).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_index_min_seen_with_records: Option<usize>,
@@ -285,6 +291,12 @@ pub struct NeuronAnalysisMetadataJson {
     pub completed_focus_neurons: usize,
     /// Total focus neurons requested for this analysis invocation.
     pub total_focus_neurons: usize,
+    /// True when neuron analysis was curtailed by the deadline: it timed out
+    /// **and** left at least one focus neuron unanalysed (Issue #1409).
+    ///
+    /// Lets the GRQ layer detect neuron starvation programmatically without
+    /// recomputing `timedOut && completedFocusNeurons < totalFocusNeurons`.
+    pub starved: bool,
     /// GPU timing data for performance diagnostics (Issue #195).
     /// Only present when `NEAT_AI_DISCOVERY_GPU_TIMING=1` is set.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/deadline_breakdown_test.rs
+++ b/tests/deadline_breakdown_test.rs
@@ -1,0 +1,198 @@
+//! Tests for the consolidated per-cycle deadline-consumption breakdown
+//! (Issue #1409 / GRQ-23).
+//!
+//! These verify the observable behaviour of the breakdown: the greppable
+//! summary line, the explicit `STARVED` warning emitted when synapse/neuron
+//! analysis is curtailed by the deadline, and the starvation predicate that the
+//! structured analysis result surfaces to the GRQ layer.
+
+use neat_ai_discovery::analysis::deadline_breakdown::{
+    DeadlineConsumptionBreakdown, PhaseCompletion,
+};
+
+/// A phase that finished all its focus neurons is never starved, even if the
+/// `timed_out` flag was set after the last neuron completed.
+#[test]
+fn phase_completion_not_starved_when_all_completed() {
+    let phase = PhaseCompletion {
+        timed_out: true,
+        completed_focus_neurons: 8,
+        total_focus_neurons: 8,
+    };
+    assert!(!phase.is_starved());
+    assert_eq!(phase.skipped(), 0);
+}
+
+/// A phase that timed out before reaching every focus neuron is starved.
+#[test]
+fn phase_completion_starved_when_timed_out_with_remaining() {
+    let phase = PhaseCompletion {
+        timed_out: true,
+        completed_focus_neurons: 3,
+        total_focus_neurons: 10,
+    };
+    assert!(phase.is_starved());
+    assert_eq!(phase.skipped(), 7);
+}
+
+/// Partial completion without a timeout is not starvation — the phase simply
+/// found nothing more to do.
+#[test]
+fn phase_completion_not_starved_without_timeout() {
+    let phase = PhaseCompletion {
+        timed_out: false,
+        completed_focus_neurons: 3,
+        total_focus_neurons: 10,
+    };
+    assert!(!phase.is_starved());
+}
+
+/// On a simulated timeout the breakdown reports starvation and the warning
+/// names the skipped/total counts for each curtailed phase.
+#[test]
+fn simulated_timeout_emits_starved_warning_with_counts() {
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms: 4200,
+        synapse_analysis_ms: Some(1200),
+        neuron_analysis_ms: Some(900),
+        total_analysis_ms: 6300,
+        synapse: Some(PhaseCompletion {
+            timed_out: true,
+            completed_focus_neurons: 2,
+            total_focus_neurons: 12,
+        }),
+        neuron: Some(PhaseCompletion {
+            timed_out: true,
+            completed_focus_neurons: 1,
+            total_focus_neurons: 12,
+        }),
+    };
+
+    assert!(breakdown.is_starved());
+
+    let warning = breakdown
+        .starvation_warning()
+        .expect("a curtailed run must produce a STARVED warning");
+    assert!(warning.contains("STARVED"), "warning: {warning}");
+    assert!(
+        warning.contains("synapse analysis skipped 10/12 targets"),
+        "warning: {warning}"
+    );
+    assert!(
+        warning.contains("neuron analysis skipped 11/12 targets"),
+        "warning: {warning}"
+    );
+
+    // Emission must not panic.
+    breakdown.emit();
+}
+
+/// Only the curtailed phase is named when the other phase completed in time.
+#[test]
+fn starved_warning_only_names_curtailed_phase() {
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms: 100,
+        synapse_analysis_ms: Some(50),
+        neuron_analysis_ms: Some(50),
+        total_analysis_ms: 200,
+        synapse: Some(PhaseCompletion {
+            timed_out: true,
+            completed_focus_neurons: 4,
+            total_focus_neurons: 9,
+        }),
+        neuron: Some(PhaseCompletion {
+            timed_out: false,
+            completed_focus_neurons: 9,
+            total_focus_neurons: 9,
+        }),
+    };
+
+    let warning = breakdown
+        .starvation_warning()
+        .expect("synapse was curtailed");
+    assert!(warning.contains("synapse analysis skipped 5/9 targets"));
+    assert!(
+        !warning.contains("neuron analysis skipped"),
+        "neuron completed in time: {warning}"
+    );
+}
+
+/// A run that completes within the deadline produces no warning.
+#[test]
+fn completed_run_has_no_starvation_warning() {
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms: 300,
+        synapse_analysis_ms: Some(800),
+        neuron_analysis_ms: Some(700),
+        total_analysis_ms: 1800,
+        synapse: Some(PhaseCompletion {
+            timed_out: false,
+            completed_focus_neurons: 16,
+            total_focus_neurons: 16,
+        }),
+        neuron: Some(PhaseCompletion {
+            timed_out: false,
+            completed_focus_neurons: 16,
+            total_focus_neurons: 16,
+        }),
+    };
+
+    assert!(!breakdown.is_starved());
+    assert!(breakdown.starvation_warning().is_none());
+    breakdown.emit();
+}
+
+/// The consolidated summary line spans every phase the analysis call owns and
+/// stays greppable via the stable `GRQ-23` marker.
+#[test]
+fn summary_line_attributes_all_phases() {
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms: 4200,
+        synapse_analysis_ms: Some(1200),
+        neuron_analysis_ms: Some(900),
+        total_analysis_ms: 6300,
+        synapse: Some(PhaseCompletion {
+            timed_out: true,
+            completed_focus_neurons: 2,
+            total_focus_neurons: 12,
+        }),
+        neuron: Some(PhaseCompletion {
+            timed_out: true,
+            completed_focus_neurons: 1,
+            total_focus_neurons: 12,
+        }),
+    };
+
+    let line = breakdown.summary_line();
+    assert!(line.contains("GRQ-23"), "line: {line}");
+    assert!(line.contains("parquet_reload=4200"), "line: {line}");
+    assert!(line.contains("synapse_analysis=1200"), "line: {line}");
+    assert!(line.contains("neuron_analysis=900"), "line: {line}");
+    assert!(line.contains("total_analysis=6300"), "line: {line}");
+    assert!(line.contains("synapse=2/12"), "line: {line}");
+    assert!(line.contains("neuron=1/12"), "line: {line}");
+}
+
+/// Disabled phases render as `n/a` rather than fabricated zeroes, so the
+/// breakdown does not imply a phase ran when it was switched off.
+#[test]
+fn summary_line_marks_disabled_phases_as_not_applicable() {
+    let breakdown = DeadlineConsumptionBreakdown {
+        parquet_reload_ms: 500,
+        synapse_analysis_ms: Some(1000),
+        neuron_analysis_ms: None,
+        total_analysis_ms: 1600,
+        synapse: Some(PhaseCompletion {
+            timed_out: false,
+            completed_focus_neurons: 5,
+            total_focus_neurons: 5,
+        }),
+        neuron: None,
+    };
+
+    let line = breakdown.summary_line();
+    assert!(line.contains("neuron_analysis=n/a"), "line: {line}");
+    assert!(line.contains("neuron=n/a"), "line: {line}");
+    assert!(!breakdown.is_starved());
+    assert!(breakdown.starvation_warning().is_none());
+}


### PR DESCRIPTION
## Summary

Surfaces synapse/neuron **starvation** and a consolidated **per-cycle
deadline-consumption breakdown** so the GRQ-23 logs can attribute *where* the
analysis deadline went and show *that* synapse/neuron analysis was curtailed.
This is **observability only** — no analysis math changed. Closes #1409.

The data needed to diagnose #1405 already existed but was scattered: per-phase
timings lived in `ProfileData`, while the starvation signals (`timed_out`,
`completed_focus_neurons`, `total_focus_neurons`) lived on the per-phase
metadata and were never emitted as an explicit, greppable warning. This PR
consolidates them.

### What changed

- **New `analysis::deadline_breakdown` module** — a small, pure
  `DeadlineConsumptionBreakdown` (+ `PhaseCompletion`) that:
  - renders one greppable summary line (stable `GRQ-23` marker) attributing ms
    to parquet reload, synapse analysis, neuron analysis, and total analysis,
    plus `completed/total` focus-neuron ratios per phase;
  - emits an explicit `STARVED` `warn!` with skipped/total counts when a phase
    timed out **and** left focus neurons unanalysed.
- **`analysis::orchestration`** — `dispatch_analyses` now returns per-phase
  wall-clock durations; `analyze_all` captures the parquet-reload and total
  durations and emits the breakdown once per invocation, just before returning.
- **FFI metadata** — added a `starved` boolean to both
  `synapseMetadata` and `neuronMetadata` so the TypeScript / GRQ layer can
  detect starvation programmatically without recomputing
  `timedOut && completedFocusNeurons < totalFocusNeurons`. The completion
  ratios themselves were already present.
- **README** — added a troubleshooting row pointing at the `GRQ-23` /
  `STARVED` log markers and the `starved` flag.

The focus phase (parquet load + focus ranking) runs in the separate
`rank_focus_neurons` FFI call; its mode + elapsed are surfaced there
(Issue #1377) and combined by the GRQ layer. Per-phase ms for disabled phases
render as `n/a` rather than fabricated zeroes.

### Out of scope

Fixing the underlying consumption (reload-dedup, budget-unification,
reserved-floor) — those are the sibling sub-issues. This PR only makes the
problem measurable.

## Evidence

Backend/CLI library change — no web interface to screenshot. Verified via the
new unit/integration tests (`cargo test --test deadline_breakdown_test`, 8
passing) plus `cargo clippy`, `cargo check`, `cargo doc`, and the release build,
all clean for the changed code.

```mermaid
flowchart TD
    A[analyze_all] --> B[parquet reload<br/>capture ms]
    B --> C[dispatch_analyses]
    C --> D[synapse analysis<br/>capture ms]
    C --> E[neuron analysis<br/>capture ms]
    D --> F[build DeadlineConsumptionBreakdown]
    E --> F
    B --> F
    F --> G["info: GRQ-23 deadline consumption (ms): ..."]
    F --> H{timed_out && completed &lt; total?}
    H -- yes --> I["warn: STARVED — skipped M/N targets"]
    H -- no --> J[no warning]
    F --> K["FFI: synapseMetadata.starved / neuronMetadata.starved"]
```

## Test Plan

New integration test `tests/deadline_breakdown_test.rs` (8 cases), covering the
observable behaviour (not implementation):

- `phase_completion_starved_when_timed_out_with_remaining` /
  `phase_completion_not_starved_when_all_completed` /
  `phase_completion_not_starved_without_timeout` — the starvation predicate.
- `simulated_timeout_emits_starved_warning_with_counts` — a simulated timeout
  produces the `STARVED` warning naming skipped/total per phase, and `emit()`
  does not panic.
- `starved_warning_only_names_curtailed_phase` — only the curtailed phase is
  named.
- `completed_run_has_no_starvation_warning` — no warning on a clean run.
- `summary_line_attributes_all_phases` /
  `summary_line_marks_disabled_phases_as_not_applicable` — the consolidated,
  greppable summary line.

## Pre-existing unrelated breakage (not introduced here)

The milestone branch already fails to compile the test crate
`tests/issue_1406_cross_phase_parquet_reload.rs`: it imports
`analysis::cache::shared_records`, but Issue #1406's cross-phase bridge module
is present yet never declared in `cache/mod.rs`, and its production integration
(focus phase populating the bridge) is unimplemented. This is sibling Issue
#1406's work — explicitly out of scope for #1409 — so this PR deliberately does
not touch it. As a result `./quality.sh`'s aggregate `cargo test --lib --tests`
cannot go green on this branch until #1406 lands. All other gates (clippy,
check, doc, release build, and this PR's new tests) pass cleanly. Verified the
failure pre-exists this PR via `git stash`.



## Milestone
This PR is part of the **#1405 Focus selection + parquet reload consume analysis deadline; synapse/neuron analysis starved (GRQ-23 logs)** milestone and targets the `milestone/1405-focus-selection-parquet-reload-consume-analys` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqhcjdw2-3ebc84`<!-- vibe-worker-issue-1409 -->