### PR TITLE
Expose structured GPU capability verdict from check_gpu_available (Issue #1419)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.89"
+version = "0.74.90"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.89"
+version = "0.74.90"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/README.md
+++ b/README.md
@@ -120,8 +120,13 @@ discovery phase. This is by design:
 | **GPU** | Metal (macOS) or Vulkan (Linux) | Required for compute shaders |
 
 When requirements aren't met, `check_gpu_available()` returns `gpuAvailable: false`
-with a descriptive reason. NEAT-AI's evolution process continues normally — only
-the discovery optimisation is skipped.
+with a descriptive `reason` plus a structured capability verdict — `errorKind`
+(`gpu_permanent`, `gpu_transient`, or `memory_exhausted`) and `retryable` — so the
+caller can branch on a permanent skip versus a transient retry **before** starting
+a pass (Issue #1419). NEAT-AI's evolution process continues normally — only the
+discovery optimisation is skipped. There is no CPU fallback: callers must not
+advertise one, since a GPU-less host would otherwise run every pass to a
+guaranteed `0 candidates` result indistinguishable from genuine search exhaustion.
 
 For GPU performance tuning, troubleshooting, and debugging, see
 [docs/GPU_GUIDE.md](docs/GPU_GUIDE.md).

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -240,18 +240,34 @@ suitable GPU, controllers must disable discovery entirely.
   }
   ```
 
-  When GPU is unavailable:
+  When GPU is unavailable (Issue #1419):
 
   ```json
   {
     "success": true,
     "gpuAvailable": false,
-    "reason": "No GPU adapter found. Discovery disabled on this machine..."
+    "reason": "No GPU adapter found. Discovery disabled on this machine...",
+    "errorKind": "gpu_permanent",
+    "retryable": false
   }
   ```
 
 - When `"gpuAvailable"` is `false`, controllers should treat discovery as disabled.
+  Discovery hard-requires a GPU — running a pass on a GPU-less host produces a
+  guaranteed `0 candidates` result that is indistinguishable from genuine search
+  exhaustion, so controllers must branch on this verdict **before** scheduling a
+  pass. There is no CPU fallback; do not advertise one.
 - When `"gpuAvailable"` is `true`, controllers may safely schedule discovery jobs.
+- **Capability verdict (Issue #1419)**: when `"gpuAvailable"` is `false`, the
+  response also carries a structured `errorKind`/`retryable` pair so controllers
+  can distinguish a permanent skip from a transient retry without scraping the
+  `reason` text:
+  - `"errorKind": "gpu_permanent"`, `"retryable": false` — no usable GPU on this
+    host. Skip discovery cleanly with a logged reason; do not retry.
+  - `"errorKind": "gpu_transient"`, `"retryable": true` — a transient GPU failure
+    (device lost, creation failure). Retrying may succeed.
+  - `"errorKind": "memory_exhausted"`, `"retryable": true` — minimum system
+    memory was not met; retry after freeing resources.
 
 ### 🌏 Platform-specific GPU behaviour
 

--- a/docs/archive/pr-summaries/pr-summary-1419.md
+++ b/docs/archive/pr-summaries/pr-summary-1419.md
@@ -1,0 +1,97 @@
+## Summary
+
+On a host with no usable GPU, discovery hard-requires a GPU for synapse/neuron
+analysis, so every pass completed with `0 candidates` — indistinguishable from
+genuine search exhaustion. The crate already fails `analyze_parallel` fast with a
+structured `GpuUnavailable` error, but the **pre-pass capability probe**
+(`check_gpu_available()`) only returned `gpuAvailable: false` plus a free-text
+`reason` on the graceful-disable path. The caller had no programmatic way to tell
+a permanent "discovery-unsupported-on-host" skip from a transient, retryable
+error *before* starting a pass.
+
+This change (Option A — honest gate) makes `check_gpu_available()` emit a
+**distinct, structured capability verdict**: when no usable GPU is present, the
+response now carries `errorKind` (`gpu_permanent` / `gpu_transient` /
+`memory_exhausted`) and `retryable` alongside the existing `gpuAvailable` and
+`reason`. Callers branch on this verdict to skip discovery cleanly (permanent) or
+retry (transient) — never running a guaranteed 0-candidate pass.
+
+No "CPU fallback" claim exists anywhere in the Rust source (confirmed by grep);
+the false message is emitted by the out-of-scope calling layer. Docs were updated
+to state plainly there is no CPU fallback and that callers must branch on the
+verdict before scheduling a pass.
+
+Closes #1419.
+
+## Changes
+
+- `src/ffi_internal/gpu.rs` — extracted a pure, testable `build_check_gpu_output()`
+  that maps a `GpuAvailabilityResult` into `CheckGpuOutput`. The GPU-less path now
+  classifies the unavailability `reason` into a structured `errorKind`/`retryable`
+  pair (defaulting to non-retryable `gpu_permanent` when the reason is unknown or
+  absent — a host with no usable GPU is unsupported, not worth retrying).
+- `docs/FFI_API.md`, `README.md` — documented the structured verdict and
+  reaffirmed there is no CPU fallback.
+- `Cargo.toml` — version bump `0.74.89` → `0.74.90`.
+
+## Capability verdict flow
+
+```mermaid
+flowchart TD
+    A[check_gpu_available] --> B{usable GPU?}
+    B -- yes --> C[success: true, gpuAvailable: true]
+    B -- no, probe ok --> D{classify reason}
+    D -- no GPU / unknown --> E[gpuAvailable: false<br/>errorKind: gpu_permanent<br/>retryable: false → skip cleanly]
+    D -- device lost --> F[gpuAvailable: false<br/>errorKind: gpu_transient<br/>retryable: true → retry]
+    D -- low memory --> G[gpuAvailable: false<br/>errorKind: memory_exhausted<br/>retryable: true → retry]
+    B -- hard error / macOS --> H[success: false<br/>errorKind: gpu_permanent]
+```
+
+## Evidence
+
+Backend/CLI change with no web interface — verified via unit tests rather than a
+screenshot.
+
+```
+running 5 tests
+test ffi_internal::gpu::tests::available_gpu_yields_clean_success ... ok
+test ffi_internal::gpu::tests::hard_error_reports_unsuccessful_permanent_verdict ... ok
+test ffi_internal::gpu::tests::gpu_less_host_yields_distinct_permanent_verdict ... ok
+test ffi_internal::gpu::tests::missing_reason_defaults_to_permanent ... ok
+test ffi_internal::gpu::tests::transient_gpu_failure_is_retryable ... ok
+
+test result: ok. 5 passed; 0 failed
+```
+
+`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, full test suite,
+doc build, release build).
+
+## Test Plan
+
+New unit tests in `src/ffi_internal/gpu.rs` exercise `build_check_gpu_output()`
+against simulated `GpuAvailabilityResult` inputs (the no-GPU environment the issue
+requires):
+
+- `gpu_less_host_yields_distinct_permanent_verdict` — a GPU-less host yields the
+  distinct verdict (`gpuAvailable: false`, `gpu_permanent`, `retryable: false`),
+  never a silent "available" answer.
+- `transient_gpu_failure_is_retryable` — device-lost/creation-failure classifies
+  as `gpu_transient` and `retryable: true`.
+- `hard_error_reports_unsuccessful_permanent_verdict` — macOS-style hard error
+  keeps `success: false` with a permanent classification and an error message.
+- `available_gpu_yields_clean_success` — a usable GPU yields a clean success with
+  no error classification.
+- `missing_reason_defaults_to_permanent` — an unexplained no-GPU host defaults to
+  the non-retryable permanent verdict.
+
+## Acceptance criteria
+
+- [x] A GPU-less host cleanly receives a distinct, logged verdict (Option A);
+  the existing `analyze_parallel` fail-fast (`GpuUnavailable`, `gpu_permanent`)
+  is retained.
+- [x] No log path claims a "CPU fallback" — confirmed absent from the Rust source.
+- [x] The crate exposes a programmatic capability verdict (usable-GPU: yes/no,
+  with reason **and** structured `errorKind`/`retryable`) the caller can branch
+  on before starting a pass.
+- [x] Test: a simulated no-GPU environment yields the distinct verdict, never a
+  silent `found 0 candidates`.

--- a/src/ffi_internal/gpu.rs
+++ b/src/ffi_internal/gpu.rs
@@ -3,14 +3,36 @@
 use anyhow::Result;
 
 use crate::analysis;
+use crate::analysis::gpu::GpuAvailabilityResult;
 use crate::ffi_types::*;
 
 pub fn check_gpu_available_internal() -> Result<String> {
     let result = analysis::GpuAnalyzer::check_gpu_availability();
+    let output = build_check_gpu_output(result);
+    Ok(serde_json::to_string(&output)?)
+}
 
-    // On macOS, missing GPU is an error (Metal should always work).
-    // On Linux, missing GPU gracefully disables discovery (common on headless servers).
-    let output = if result.is_error {
+/// Build the FFI capability verdict from a GPU availability probe result.
+///
+/// Issue #1419: a GPU-less host must receive a *distinct, structured*
+/// verdict it can branch on **before** starting a discovery pass. The crate
+/// hard-requires a GPU for synapse/neuron analysis, so without this verdict a
+/// GPU-less host runs every pass to a guaranteed `0 candidates` result that is
+/// indistinguishable from genuine search exhaustion.
+///
+/// The mapping covers three cases:
+/// - **Hard error** (`is_error`, e.g. macOS where Metal should always work):
+///   `success = false` with a `GpuUnavailable` error and `gpu_permanent` kind.
+/// - **GPU-less host** (probe succeeded, no usable GPU — common on headless
+///   Linux): `success = true`, `gpuAvailable = false`, with the unavailability
+///   reason *classified* into a structured `error_kind`/`retryable` pair so the
+///   caller can tell a permanent "discovery-unsupported-on-host" skip from a
+///   transient error worth retrying.
+/// - **GPU available**: `success = true`, `gpuAvailable = true`, no error
+///   classification.
+pub(crate) fn build_check_gpu_output(result: GpuAvailabilityResult) -> CheckGpuOutput {
+    if result.is_error {
+        // On macOS, missing GPU is an error (Metal should always work).
         let typed = DiscoveryError::GpuUnavailable {
             reason: "GPU required but not available".to_string(),
         };
@@ -23,18 +45,46 @@ pub fn check_gpu_available_internal() -> Result<String> {
             error_kind: Some(kind),
             retryable: Some(kind.is_retryable()),
         }
+    } else if !result.available {
+        // GPU-less host (common on headless Linux servers). The probe itself
+        // succeeded, but discovery is unsupported here. Classify the reason so
+        // the caller can branch on a permanent skip vs a transient retry
+        // instead of running a guaranteed 0-candidate pass (Issue #1419).
+        let kind = classify_gpu_unavailable_reason(result.reason.as_deref());
+        CheckGpuOutput {
+            success: true,
+            gpu_available: false,
+            reason: result.reason,
+            error: None,
+            error_kind: Some(kind),
+            retryable: Some(kind.is_retryable()),
+        }
     } else {
         let (error_kind, retryable) = no_error_fields();
         CheckGpuOutput {
             success: true,
-            gpu_available: result.available,
+            gpu_available: true,
             reason: result.reason,
             error: None,
             error_kind,
             retryable,
         }
-    };
-    Ok(serde_json::to_string(&output)?)
+    }
+}
+
+/// Classify *why* a GPU is unavailable into a structured [`DiscoveryErrorKind`].
+///
+/// Defaults to [`DiscoveryErrorKind::GpuPermanent`] when the reason does not
+/// match a more specific transient (device lost) or memory pattern — a host
+/// with no usable GPU is unsupported, not worth retrying.
+fn classify_gpu_unavailable_reason(reason: Option<&str>) -> DiscoveryErrorKind {
+    match reason {
+        Some(text) => match classify_error(text) {
+            DiscoveryErrorKind::Unknown => DiscoveryErrorKind::GpuPermanent,
+            kind => kind,
+        },
+        None => DiscoveryErrorKind::GpuPermanent,
+    }
 }
 
 pub fn get_library_version_internal() -> Result<String> {
@@ -48,4 +98,114 @@ pub fn get_library_version_internal() -> Result<String> {
         retryable,
     };
     Ok(serde_json::to_string(&output)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A GPU-less host (graceful disable, no hard error) must yield a distinct
+    /// structured verdict — `gpuAvailable = false` with a non-retryable
+    /// `gpu_permanent` classification — never a silent "available" answer that
+    /// would let the caller run a guaranteed 0-candidate pass (Issue #1419).
+    #[test]
+    fn gpu_less_host_yields_distinct_permanent_verdict() {
+        let result = GpuAvailabilityResult {
+            available: false,
+            reason: Some("No GPU adapter found. Discovery disabled on this machine.".to_string()),
+            is_error: false,
+        };
+
+        let output = build_check_gpu_output(result);
+
+        assert!(
+            output.success,
+            "probe itself succeeded — only the GPU is missing"
+        );
+        assert!(!output.gpu_available, "no usable GPU on this host");
+        assert_eq!(
+            output.error_kind,
+            Some(DiscoveryErrorKind::GpuPermanent),
+            "a GPU-less host is a permanent, non-retryable verdict"
+        );
+        assert_eq!(output.retryable, Some(false));
+        assert!(
+            output.reason.is_some(),
+            "the verdict must carry a human-readable reason"
+        );
+    }
+
+    /// A transient GPU failure (device lost / creation failure) must classify
+    /// as retryable so the caller retries rather than skipping the host.
+    #[test]
+    fn transient_gpu_failure_is_retryable() {
+        let result = GpuAvailabilityResult {
+            available: false,
+            reason: Some("GPU device creation failed: device was lost".to_string()),
+            is_error: false,
+        };
+
+        let output = build_check_gpu_output(result);
+
+        assert!(!output.gpu_available);
+        assert_eq!(output.error_kind, Some(DiscoveryErrorKind::GpuTransient));
+        assert_eq!(output.retryable, Some(true));
+    }
+
+    /// A hard error (e.g. macOS where Metal should always work) keeps the
+    /// `success = false` error verdict with a permanent classification.
+    #[test]
+    fn hard_error_reports_unsuccessful_permanent_verdict() {
+        let result = GpuAvailabilityResult {
+            available: false,
+            reason: Some("Metal should always be available".to_string()),
+            is_error: true,
+        };
+
+        let output = build_check_gpu_output(result);
+
+        assert!(!output.success);
+        assert!(!output.gpu_available);
+        assert_eq!(output.error_kind, Some(DiscoveryErrorKind::GpuPermanent));
+        assert_eq!(output.retryable, Some(false));
+        assert!(
+            output.error.is_some(),
+            "hard error must carry an error message"
+        );
+    }
+
+    /// When a usable GPU is present, the verdict is a clean success with no
+    /// error classification.
+    #[test]
+    fn available_gpu_yields_clean_success() {
+        let result = GpuAvailabilityResult {
+            available: true,
+            reason: None,
+            is_error: false,
+        };
+
+        let output = build_check_gpu_output(result);
+
+        assert!(output.success);
+        assert!(output.gpu_available);
+        assert!(output.error_kind.is_none());
+        assert!(output.retryable.is_none());
+        assert!(output.error.is_none());
+    }
+
+    /// A missing reason still produces a permanent (non-retryable) verdict so
+    /// the caller never treats an unexplained no-GPU host as retryable.
+    #[test]
+    fn missing_reason_defaults_to_permanent() {
+        let result = GpuAvailabilityResult {
+            available: false,
+            reason: None,
+            is_error: false,
+        };
+
+        let output = build_check_gpu_output(result);
+
+        assert_eq!(output.error_kind, Some(DiscoveryErrorKind::GpuPermanent));
+        assert_eq!(output.retryable, Some(false));
+    }
 }


### PR DESCRIPTION
## Summary

On a host with no usable GPU, discovery hard-requires a GPU for synapse/neuron
analysis, so every pass completed with `0 candidates` — indistinguishable from
genuine search exhaustion. The crate already fails `analyze_parallel` fast with a
structured `GpuUnavailable` error, but the **pre-pass capability probe**
(`check_gpu_available()`) only returned `gpuAvailable: false` plus a free-text
`reason` on the graceful-disable path. The caller had no programmatic way to tell
a permanent "discovery-unsupported-on-host" skip from a transient, retryable
error *before* starting a pass.

This change (Option A — honest gate) makes `check_gpu_available()` emit a
**distinct, structured capability verdict**: when no usable GPU is present, the
response now carries `errorKind` (`gpu_permanent` / `gpu_transient` /
`memory_exhausted`) and `retryable` alongside the existing `gpuAvailable` and
`reason`. Callers branch on this verdict to skip discovery cleanly (permanent) or
retry (transient) — never running a guaranteed 0-candidate pass.

No "CPU fallback" claim exists anywhere in the Rust source (confirmed by grep);
the false message is emitted by the out-of-scope calling layer. Docs were updated
to state plainly there is no CPU fallback and that callers must branch on the
verdict before scheduling a pass.

Closes #1419.

## Changes

- `src/ffi_internal/gpu.rs` — extracted a pure, testable `build_check_gpu_output()`
  that maps a `GpuAvailabilityResult` into `CheckGpuOutput`. The GPU-less path now
  classifies the unavailability `reason` into a structured `errorKind`/`retryable`
  pair (defaulting to non-retryable `gpu_permanent` when the reason is unknown or
  absent — a host with no usable GPU is unsupported, not worth retrying).
- `docs/FFI_API.md`, `README.md` — documented the structured verdict and
  reaffirmed there is no CPU fallback.
- `Cargo.toml` — version bump `0.74.89` → `0.74.90`.

## Capability verdict flow

```mermaid
flowchart TD
    A[check_gpu_available] --> B{usable GPU?}
    B -- yes --> C[success: true, gpuAvailable: true]
    B -- no, probe ok --> D{classify reason}
    D -- no GPU / unknown --> E[gpuAvailable: false<br/>errorKind: gpu_permanent<br/>retryable: false → skip cleanly]
    D -- device lost --> F[gpuAvailable: false<br/>errorKind: gpu_transient<br/>retryable: true → retry]
    D -- low memory --> G[gpuAvailable: false<br/>errorKind: memory_exhausted<br/>retryable: true → retry]
    B -- hard error / macOS --> H[success: false<br/>errorKind: gpu_permanent]
```

## Evidence

Backend/CLI change with no web interface — verified via unit tests rather than a
screenshot.

```
running 5 tests
test ffi_internal::gpu::tests::available_gpu_yields_clean_success ... ok
test ffi_internal::gpu::tests::hard_error_reports_unsuccessful_permanent_verdict ... ok
test ffi_internal::gpu::tests::gpu_less_host_yields_distinct_permanent_verdict ... ok
test ffi_internal::gpu::tests::missing_reason_defaults_to_permanent ... ok
test ffi_internal::gpu::tests::transient_gpu_failure_is_retryable ... ok

test result: ok. 5 passed; 0 failed
```

`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, full test suite,
doc build, release build).

## Test Plan

New unit tests in `src/ffi_internal/gpu.rs` exercise `build_check_gpu_output()`
against simulated `GpuAvailabilityResult` inputs (the no-GPU environment the issue
requires):

- `gpu_less_host_yields_distinct_permanent_verdict` — a GPU-less host yields the
  distinct verdict (`gpuAvailable: false`, `gpu_permanent`, `retryable: false`),
  never a silent "available" answer.
- `transient_gpu_failure_is_retryable` — device-lost/creation-failure classifies
  as `gpu_transient` and `retryable: true`.
- `hard_error_reports_unsuccessful_permanent_verdict` — macOS-style hard error
  keeps `success: false` with a permanent classification and an error message.
- `available_gpu_yields_clean_success` — a usable GPU yields a clean success with
  no error classification.
- `missing_reason_defaults_to_permanent` — an unexplained no-GPU host defaults to
  the non-retryable permanent verdict.

## Acceptance criteria

- [x] A GPU-less host cleanly receives a distinct, logged verdict (Option A);
  the existing `analyze_parallel` fail-fast (`GpuUnavailable`, `gpu_permanent`)
  is retained.
- [x] No log path claims a "CPU fallback" — confirmed absent from the Rust source.
- [x] The crate exposes a programmatic capability verdict (usable-GPU: yes/no,
  with reason **and** structured `errorKind`/`retryable`) the caller can branch
  on before starting a pass.
- [x] Test: a simulated no-GPU environment yields the distinct verdict, never a
  silent `found 0 candidates`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqhuddgi-9c87e6`<!-- vibe-worker-issue-1419 -->