### PR TITLE
Apply failure-cache calibration correction to harmful-neuron (remove-neuron) path (Issue #1425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+#### Harmful-neuron (remove-neuron) failure-cache calibration correction (Issue #1425)
+
+Harmful-neuron (`remove-neuron`) candidates over-predicted their score gain by
+~800× (failure bucket `247b83ab`): predicted `+0.166` vs actual `≈0`. Because
+`expected_creature_score_gain` is the candidate ranking key, these inflated
+predictions crowded the top of the candidate list every pass, failed scoring,
+and landed in the failure cache only to be regenerated next time — sustaining
+the discovery drought.
+
+The failure-cache calibration correction (`CalibrationCorrection::correction_for`,
+Issues #1131 / #1162) was applied to the add-neuron and add-synapse paths but
+not to the harmful-neuron path.
+
+- A single-op `RemoveNeuron` coordinated candidate is now keyed under the new
+  `remove-neuron` change type (`CHANGE_TYPE_REMOVE_NEURON`) when its predicted
+  gain is calibrated, so repeated remove-neuron over-predictions shrink future
+  remove-neuron predictions via the failure-cache EWMA.
+- Multi-op coordinated candidates and non-removal single ops keep the generic
+  `coordinated-structural` correction — regression preserved.
+
 #### Wall-clock budget on focus ranking with graceful fallback (Issue #1375)
 
 Focus ranking previously had no wall-clock bound. In the #1373 incident it ran

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.95"
+version = "0.74.96"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.95"
+version = "0.74.96"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1425.md
+++ b/docs/archive/pr-summaries/pr-summary-1425.md
@@ -1,0 +1,84 @@
+## Summary
+
+Harmful-neuron (`remove-neuron`) candidates over-predicted their score gain by
+~800× (failure bucket `247b83ab`, GRQ-Discovery): predicted `+0.166` vs actual
+`≈0`. Because `expected_creature_score_gain` is the candidate ranking key
+(`src/analysis/discovery_dispatch.rs`), these inflated predictions crowded the
+top of the candidate list every pass, failed scoring, and landed in the failure
+cache only to be regenerated next pass — directly sustaining the discovery
+drought.
+
+The failure-cache calibration correction (`CalibrationCorrection::correction_for`,
+Issues #1131 / #1162) was applied to the add-neuron and add-synapse paths but
+**not** to the harmful-neuron path, so repeated remove-neuron misses never
+shrank future remove-neuron predictions.
+
+This PR wires the failure-cache correction into the harmful-neuron path:
+
+- Added `CHANGE_TYPE_REMOVE_NEURON = "remove-neuron"`
+  (`src/analysis/scoring/calibration_correction.rs`). The `from_failure_cache`
+  EWMA already groups by `change_type`, so the new constant makes the
+  remove-neuron bucket a first-class, documented key.
+- In `apply_impact_to_coordinated`
+  (`src/analysis/synapse/post_processing.rs`), a single-op `RemoveNeuron`
+  coordinated candidate — functionally a `remove-neuron` change, recorded under
+  that change type in the failure cache — is now calibrated with
+  `correction_for(CHANGE_TYPE_REMOVE_NEURON, …)` instead of the generic
+  `coordinated-structural` correction. Multi-op groups and non-removal single
+  ops keep the `coordinated-structural` key (regression preserved). The
+  corrected gain is used by the existing sort, so re-ranking follows
+  automatically.
+
+With nine cached `remove-neuron` failures replayed, the learnt correction
+collapses to the floor (`≈0.001`), shrinking the predicted gain by ~1000× so
+these doomed removals no longer dominate ranking.
+
+Closes #1425.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by tests and the
+full quality gate (`./quality.sh` → "✅ All quality checks passed!").
+
+```mermaid
+flowchart TD
+    A[Coordinated structural candidate] --> B{single-op RemoveNeuron?}
+    B -- yes --> C[change_type = remove-neuron]
+    B -- no --> D[change_type = coordinated-structural]
+    C --> E["correction_for(change_type, squash)"]
+    D --> E
+    E --> F["gain × COORDINATED_PREDICTION_CALIBRATION × correction"]
+    F --> G[sort by expected_creature_score_gain]
+```
+
+Before: a single-op `RemoveNeuron` used the `coordinated-structural` correction,
+which never learns from `remove-neuron`-keyed failures → gain stayed inflated.
+After: it uses the `remove-neuron` correction, which the nine cached failures
+drive to the floor → gain shrinks toward the observed `≈0`.
+
+## Test Plan
+
+New unit tests — `src/analysis/synapse/post_processing.rs`
+(`remove_neuron_calibration_tests`):
+
+- `single_remove_neuron_is_keyed_as_remove_neuron` — a single-op `RemoveNeuron`
+  is keyed `remove-neuron`; multi-op groups and non-removal single ops stay
+  `coordinated-structural`.
+- `remove_neuron_failures_shrink_predicted_gain` — replaying nine cached
+  remove-neuron failures shrinks a fresh candidate's calibrated gain by >20×
+  versus a neutral cache (criteria 1 & 2).
+- `coordinated_structural_unaffected_by_remove_neuron_failures` — regression
+  guard: remove-neuron failures do not discount coordinated-structural
+  candidates.
+
+New integration tests — `tests/analysis/issue_1425_remove_neuron_calibration.rs`:
+
+- `nine_remove_neuron_failures_drive_correction_to_floor` — `correction_for`
+  for the `remove-neuron` change type collapses toward the floor (criteria 2 & 3).
+- `remove_neuron_and_coordinated_structural_are_independent` — the two change
+  types are tracked independently.
+- `remove_neuron_json_round_trip` — a `remove-neuron` failure-cache JSON entry
+  round-trips and feeds the correction.
+
+All new tests pass; full `./quality.sh` passes (fmt, Clippy `-D warnings`,
+check, lib+integration tests, doc build, release build).

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -142,6 +142,16 @@ pub const CHANGE_TYPE_ADD_SYNAPSES: &str = "add-synapses";
 /// Change-type key for `coordinated-structural` candidates.
 pub const CHANGE_TYPE_COORDINATED_STRUCTURAL: &str = "coordinated-structural";
 
+/// Change-type key for `remove-neuron` (harmful-neuron) candidates (Issue #1425).
+///
+/// A single-op `RemoveNeuron` coordinated candidate is recorded in the failure
+/// cache under this change type. Grouping these failures separately from the
+/// generic `coordinated-structural` bucket lets the failure-cache EWMA learn
+/// the remove-neuron-specific over-prediction (the harmful-neuron path
+/// historically over-predicted gain by ~800×) and feed it back via
+/// [`CalibrationCorrection::correction_for`].
+pub const CHANGE_TYPE_REMOVE_NEURON: &str = "remove-neuron";
+
 // =============================================================================
 // Failure cache entry
 // =============================================================================

--- a/src/analysis/synapse/post_processing.rs
+++ b/src/analysis/synapse/post_processing.rs
@@ -17,7 +17,8 @@ use super::scoring::{
 use crate::analysis::cache::RecordCache;
 use crate::analysis::samples::EPSILON;
 use crate::analysis::scoring::calibration_correction::{
-    CHANGE_TYPE_ADD_SYNAPSES, CHANGE_TYPE_COORDINATED_STRUCTURAL, CalibrationCorrection,
+    CHANGE_TYPE_ADD_SYNAPSES, CHANGE_TYPE_COORDINATED_STRUCTURAL, CHANGE_TYPE_REMOVE_NEURON,
+    CalibrationCorrection,
 };
 
 /// Drop add-synapse candidates whose `expected_creature_score_gain` is below
@@ -332,6 +333,29 @@ fn apply_impact_to_harmful(
 /// The pessimism discount has been folded into the per-op-count empirical factors
 /// applied in `candidate_aggregation::apply_operation_count_discount`. This avoids
 /// the three-layer compound discount that was too aggressive and poorly calibrated.
+/// Determine the failure-cache change-type key for a coordinated candidate
+/// (Issue #1425).
+///
+/// A coordinated candidate consisting of a single `RemoveNeuron` operation is
+/// functionally a `remove-neuron` (harmful-neuron) change and is recorded under
+/// [`CHANGE_TYPE_REMOVE_NEURON`] in the failure cache. Every other coordinated
+/// candidate (multi-op groups, or single ops of other kinds) keeps the generic
+/// [`CHANGE_TYPE_COORDINATED_STRUCTURAL`] key, preserving existing behaviour.
+fn coordinated_candidate_change_type(
+    candidate: &crate::CoordinatedStructuralCandidateJson,
+) -> &'static str {
+    if candidate.operations.len() == 1
+        && matches!(
+            candidate.operations.first(),
+            Some(crate::CoordinatedStructuralOpJson::RemoveNeuron { .. })
+        )
+    {
+        CHANGE_TYPE_REMOVE_NEURON
+    } else {
+        CHANGE_TYPE_COORDINATED_STRUCTURAL
+    }
+}
+
 fn apply_impact_to_coordinated(
     candidate: &mut crate::CoordinatedStructuralCandidateJson,
     impact_scores: &HashMap<String, f32>,
@@ -387,9 +411,18 @@ fn apply_impact_to_coordinated(
     // Issue #1131: Scaled by the per-creature failure-cache correction.
     // Issue #1162: prefer the per-(change_type, target_squash) specific value
     // when the target neuron's squash is known.
+    //
+    // Issue #1425: a single-op `RemoveNeuron` coordinated candidate is
+    // functionally a `remove-neuron` (harmful-neuron) change and is recorded
+    // in the failure cache under that change type. Use the remove-neuron
+    // correction key for it so repeated remove-neuron over-predictions (the
+    // ~800× over-prediction in failure bucket `247b83ab`) shrink future
+    // remove-neuron predictions, rather than the generic coordinated-structural
+    // correction which never learns from remove-neuron-keyed failures.
+    let change_type = coordinated_candidate_change_type(candidate);
     let target_squash = target_squash_map.get(target_uuid).copied();
     let coordinated_calibration = crate::analysis::constants::COORDINATED_PREDICTION_CALIBRATION
-        * calibration_correction.correction_for(CHANGE_TYPE_COORDINATED_STRUCTURAL, target_squash);
+        * calibration_correction.correction_for(change_type, target_squash);
     candidate.expected_creature_score_gain = apply_prediction_calibration(
         candidate.expected_creature_score_gain,
         coordinated_calibration,
@@ -688,5 +721,190 @@ pub(crate) fn build_metadata(
         drought_diagnostic: None,
         // Issue #1424: populated by orchestration on the alarm crossing.
         creature_drought_alarm: None,
+    }
+}
+
+// =============================================================================
+// Tests (Issue #1425) — remove-neuron / harmful-neuron calibration correction
+// =============================================================================
+
+#[cfg(test)]
+mod remove_neuron_calibration_tests {
+    //! Issue #1425: harmful-neuron (`remove-neuron`) candidates must have the
+    //! failure-cache calibration correction applied to their predicted gain.
+    //! A single-op `RemoveNeuron` coordinated candidate is keyed under
+    //! `remove-neuron`, so repeated remove-neuron over-predictions shrink future
+    //! remove-neuron predictions instead of being re-emitted every pass.
+
+    use super::{apply_impact_to_coordinated, coordinated_candidate_change_type};
+    use crate::analysis::scoring::calibration_correction::{
+        CHANGE_TYPE_COORDINATED_STRUCTURAL, CHANGE_TYPE_REMOVE_NEURON, CalibrationCorrection,
+        FailureCacheEntry,
+    };
+    use crate::{CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson};
+    use std::collections::HashMap;
+
+    /// Build a failure-cache entry mirroring the `247b83ab` evidence shape:
+    /// `change_type = remove-neuron`, predicted ≈ 0.166, actual ≈ 0 (slightly
+    /// negative) — a ~800× over-prediction.
+    fn remove_neuron_failure() -> FailureCacheEntry {
+        FailureCacheEntry {
+            change_type: CHANGE_TYPE_REMOVE_NEURON.to_string(),
+            expected_error_reduction: 0.165_710_48,
+            actual_error_reduction: -0.000_207_19,
+            target_squash: None,
+            variant_key: None,
+            target_uuid: None,
+            improved_count: None,
+            total_count: None,
+        }
+    }
+
+    fn single_remove_neuron_candidate(gain: f32) -> CoordinatedStructuralCandidateJson {
+        CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "h-1075292892".to_string(),
+            }],
+            expected_creature_score_gain: gain,
+            comment: None,
+        }
+    }
+
+    /// Apply `apply_impact_to_coordinated` with a fixed impact of 1.0 for the
+    /// target so the calibration factor is the only variable under test.
+    fn calibrated_gain(
+        candidate: &mut CoordinatedStructuralCandidateJson,
+        correction: &CalibrationCorrection,
+    ) -> f32 {
+        let mut impact_scores: HashMap<String, f32> = HashMap::new();
+        impact_scores.insert("h-1075292892".to_string(), 1.0);
+        let neuron_type_map: HashMap<&str, &str> = HashMap::new();
+        let target_squash_map: HashMap<&str, &str> = HashMap::new();
+        apply_impact_to_coordinated(
+            candidate,
+            &impact_scores,
+            &neuron_type_map,
+            &target_squash_map,
+            correction,
+        );
+        candidate.expected_creature_score_gain
+    }
+
+    /// Criterion 3: a single-op `RemoveNeuron` coordinated candidate is keyed
+    /// under the `remove-neuron` change type; everything else stays
+    /// `coordinated-structural`.
+    #[test]
+    fn single_remove_neuron_is_keyed_as_remove_neuron() {
+        let remove = single_remove_neuron_candidate(0.1);
+        assert_eq!(
+            coordinated_candidate_change_type(&remove),
+            CHANGE_TYPE_REMOVE_NEURON
+        );
+
+        // Multi-op group containing a RemoveNeuron stays coordinated-structural.
+        let multi = CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::SetBias {
+                    neuron_uuid: "out-0".to_string(),
+                    bias: 0.1,
+                },
+                CoordinatedStructuralOpJson::RemoveNeuron {
+                    neuron_uuid: "h-1".to_string(),
+                },
+            ],
+            expected_creature_score_gain: 0.1,
+            comment: None,
+        };
+        assert_eq!(
+            coordinated_candidate_change_type(&multi),
+            CHANGE_TYPE_COORDINATED_STRUCTURAL
+        );
+
+        // A non-removal single op stays coordinated-structural too.
+        let add = CoordinatedStructuralCandidateJson {
+            operations: vec![CoordinatedStructuralOpJson::AddSynapse {
+                from_neuron_uuid: "a".to_string(),
+                to_neuron_uuid: "b".to_string(),
+                weight: 0.5,
+            }],
+            expected_creature_score_gain: 0.1,
+            comment: None,
+        };
+        assert_eq!(
+            coordinated_candidate_change_type(&add),
+            CHANGE_TYPE_COORDINATED_STRUCTURAL
+        );
+    }
+
+    /// Criteria 1 & 2: replaying the cached remove-neuron failures shrinks the
+    /// predicted gain of a fresh remove-neuron candidate toward the observed
+    /// ≈ 0 — far below the gain it receives under a neutral (empty) cache.
+    #[test]
+    fn remove_neuron_failures_shrink_predicted_gain() {
+        // Nine cached remove-neuron failures, matching the evidence bucket.
+        let cache: Vec<FailureCacheEntry> = (0..9).map(|_| remove_neuron_failure()).collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+        // The remove-neuron correction must learn the ~800× over-prediction and
+        // collapse to (near) the floor.
+        let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+        assert!(
+            learned <= 0.01,
+            "remove-neuron correction should be near the floor, got {learned}"
+        );
+
+        let raw_gain = 0.165_710_48_f32;
+        let mut with_failures = single_remove_neuron_candidate(raw_gain);
+        let gain_with = calibrated_gain(&mut with_failures, &correction);
+
+        let neutral = CalibrationCorrection::neutral();
+        let mut without = single_remove_neuron_candidate(raw_gain);
+        let gain_without = calibrated_gain(&mut without, &neutral);
+
+        // Both must remain positive (sign preserved) but the learned correction
+        // must shrink the prediction by roughly the over-prediction factor.
+        assert!(gain_with > 0.0 && gain_without > 0.0);
+        assert!(
+            gain_with < gain_without * 0.05,
+            "learned correction must shrink the gain by >20×: with={gain_with}, without={gain_without}"
+        );
+    }
+
+    /// Regression guard: the remove-neuron correction must NOT bleed into a
+    /// coordinated-structural candidate — only remove-neuron-keyed candidates
+    /// are discounted by remove-neuron failures.
+    #[test]
+    fn coordinated_structural_unaffected_by_remove_neuron_failures() {
+        let cache: Vec<FailureCacheEntry> = (0..9).map(|_| remove_neuron_failure()).collect();
+        let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+        let raw_gain = 0.165_710_48_f32;
+        let mut coordinated = CoordinatedStructuralCandidateJson {
+            operations: vec![
+                CoordinatedStructuralOpJson::RemoveSynapse {
+                    from_neuron_uuid: "a".to_string(),
+                    to_neuron_uuid: "h-1075292892".to_string(),
+                },
+                CoordinatedStructuralOpJson::RemoveNeuron {
+                    neuron_uuid: "h-1075292892".to_string(),
+                },
+            ],
+            expected_creature_score_gain: raw_gain,
+            comment: None,
+        };
+        let gain_coord = calibrated_gain(&mut coordinated, &correction);
+
+        let neutral = CalibrationCorrection::neutral();
+        let mut coordinated_neutral = coordinated.clone();
+        coordinated_neutral.expected_creature_score_gain = raw_gain;
+        let gain_neutral = calibrated_gain(&mut coordinated_neutral, &neutral);
+
+        // No coordinated-structural failures recorded, so the correction is
+        // neutral for this candidate — gain is identical with or without the
+        // remove-neuron failures.
+        assert!(
+            (gain_coord - gain_neutral).abs() < f32::EPSILON,
+            "coordinated-structural gain must be unaffected: {gain_coord} vs {gain_neutral}"
+        );
     }
 }

--- a/tests/analysis/issue_1425_remove_neuron_calibration.rs
+++ b/tests/analysis/issue_1425_remove_neuron_calibration.rs
@@ -1,0 +1,97 @@
+//! Integration tests for Issue #1425: failure-cache calibration correction for
+//! harmful-neuron (`remove-neuron`) candidates.
+//!
+//! Harmful-neuron candidates historically over-predicted their score gain by
+//! ~800× (failure bucket `247b83ab`). The failure-cache calibration correction
+//! that learns from exactly these misses was applied to the add-neuron and
+//! add-synapse paths but not to the remove-neuron path. These tests cover the
+//! public surface of [`CalibrationCorrection::correction_for`] for the
+//! `remove-neuron` change type.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_COORDINATED_STRUCTURAL, CHANGE_TYPE_REMOVE_NEURON, CalibrationCorrection,
+    FailureCacheEntry,
+};
+
+/// A failure-cache entry mirroring the `247b83ab` evidence shape: predicted
+/// ≈ 0.166, actual ≈ 0 (slightly negative) — a ~800× over-prediction.
+fn remove_neuron_failure() -> FailureCacheEntry {
+    FailureCacheEntry {
+        change_type: CHANGE_TYPE_REMOVE_NEURON.to_string(),
+        expected_error_reduction: 0.165_710_48,
+        actual_error_reduction: -0.000_207_19,
+        target_squash: None,
+        variant_key: None,
+        target_uuid: None,
+        improved_count: None,
+        total_count: None,
+    }
+}
+
+/// Acceptance criterion 2/3: replaying the 9 cached `remove-neuron` failures
+/// produces a `remove-neuron` correction near the floor, so the predicted gain
+/// is shrunk toward the observed ≈ 0.
+#[test]
+fn nine_remove_neuron_failures_drive_correction_to_floor() {
+    let cache: Vec<FailureCacheEntry> = (0..9).map(|_| remove_neuron_failure()).collect();
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+    let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    assert!(
+        learned <= 0.01,
+        "remove-neuron correction should collapse toward the floor, got {learned}"
+    );
+
+    // Applying the learnt correction to the over-predicted gain shrinks it by
+    // roughly the over-prediction factor.
+    let raw_gain = 0.165_710_48_f32;
+    let corrected = raw_gain * learned;
+    assert!(
+        corrected < raw_gain * 0.05,
+        "corrected gain ({corrected}) must be far below the raw gain ({raw_gain})"
+    );
+}
+
+/// The `remove-neuron` change type is tracked independently from
+/// `coordinated-structural`: remove-neuron failures must not discount
+/// coordinated-structural predictions and vice versa.
+#[test]
+fn remove_neuron_and_coordinated_structural_are_independent() {
+    let cache: Vec<FailureCacheEntry> = (0..9).map(|_| remove_neuron_failure()).collect();
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+    let remove = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    let coordinated = correction.correction_for(CHANGE_TYPE_COORDINATED_STRUCTURAL, None);
+
+    // remove-neuron is heavily discounted; coordinated-structural saw no
+    // failures so it remains neutral (1.0).
+    assert!(remove < coordinated);
+    assert!((coordinated - 1.0).abs() < 1e-9);
+}
+
+/// Acceptance criterion 3: a `remove-neuron` failure-cache JSON entry
+/// round-trips through serde and feeds the correction for that change type.
+#[test]
+fn remove_neuron_json_round_trip() {
+    let cache_json = r#"[
+        {
+            "changeType": "remove-neuron",
+            "expectedErrorReduction": 0.16571048,
+            "actualErrorReduction": -0.00020719
+        }
+    ]"#;
+    let parsed: Vec<FailureCacheEntry> = serde_json::from_str(cache_json).expect("parse");
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].change_type, CHANGE_TYPE_REMOVE_NEURON);
+
+    // A single entry is below the per-squash specific threshold but still feeds
+    // the per-change_type EWMA fallback used by `correction_for`.
+    let correction = CalibrationCorrection::from_failure_cache(&parsed);
+    let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    assert!(
+        learned <= 0.01,
+        "single severe over-prediction should still discount, got {learned}"
+    );
+}

--- a/tests/analysis/main.rs
+++ b/tests/analysis/main.rs
@@ -29,6 +29,7 @@ mod issue_1202_drought_diagnostic;
 mod issue_1204_adaptive_target_cooldown;
 mod issue_1317_cost_identity_wiring;
 mod issue_1408_analysis_reserve;
+mod issue_1425_remove_neuron_calibration;
 mod issue_199_dynamic_constant_source_threshold;
 mod issue_201_batched_activation;
 mod issue_204_activation_frequency_ranking;


### PR DESCRIPTION
## Summary

Harmful-neuron (`remove-neuron`) candidates over-predicted their score gain by
~800× (failure bucket `247b83ab`, GRQ-Discovery): predicted `+0.166` vs actual
`≈0`. Because `expected_creature_score_gain` is the candidate ranking key
(`src/analysis/discovery_dispatch.rs`), these inflated predictions crowded the
top of the candidate list every pass, failed scoring, and landed in the failure
cache only to be regenerated next pass — directly sustaining the discovery
drought.

The failure-cache calibration correction (`CalibrationCorrection::correction_for`,
Issues #1131 / #1162) was applied to the add-neuron and add-synapse paths but
**not** to the harmful-neuron path, so repeated remove-neuron misses never
shrank future remove-neuron predictions.

This PR wires the failure-cache correction into the harmful-neuron path:

- Added `CHANGE_TYPE_REMOVE_NEURON = "remove-neuron"`
  (`src/analysis/scoring/calibration_correction.rs`). The `from_failure_cache`
  EWMA already groups by `change_type`, so the new constant makes the
  remove-neuron bucket a first-class, documented key.
- In `apply_impact_to_coordinated`
  (`src/analysis/synapse/post_processing.rs`), a single-op `RemoveNeuron`
  coordinated candidate — functionally a `remove-neuron` change, recorded under
  that change type in the failure cache — is now calibrated with
  `correction_for(CHANGE_TYPE_REMOVE_NEURON, …)` instead of the generic
  `coordinated-structural` correction. Multi-op groups and non-removal single
  ops keep the `coordinated-structural` key (regression preserved). The
  corrected gain is used by the existing sort, so re-ranking follows
  automatically.

With nine cached `remove-neuron` failures replayed, the learnt correction
collapses to the floor (`≈0.001`), shrinking the predicted gain by ~1000× so
these doomed removals no longer dominate ranking.

Closes #1425.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by tests and the
full quality gate (`./quality.sh` → "✅ All quality checks passed!").

```mermaid
flowchart TD
    A[Coordinated structural candidate] --> B{single-op RemoveNeuron?}
    B -- yes --> C[change_type = remove-neuron]
    B -- no --> D[change_type = coordinated-structural]
    C --> E["correction_for(change_type, squash)"]
    D --> E
    E --> F["gain × COORDINATED_PREDICTION_CALIBRATION × correction"]
    F --> G[sort by expected_creature_score_gain]
```

Before: a single-op `RemoveNeuron` used the `coordinated-structural` correction,
which never learns from `remove-neuron`-keyed failures → gain stayed inflated.
After: it uses the `remove-neuron` correction, which the nine cached failures
drive to the floor → gain shrinks toward the observed `≈0`.

## Test Plan

New unit tests — `src/analysis/synapse/post_processing.rs`
(`remove_neuron_calibration_tests`):

- `single_remove_neuron_is_keyed_as_remove_neuron` — a single-op `RemoveNeuron`
  is keyed `remove-neuron`; multi-op groups and non-removal single ops stay
  `coordinated-structural`.
- `remove_neuron_failures_shrink_predicted_gain` — replaying nine cached
  remove-neuron failures shrinks a fresh candidate's calibrated gain by >20×
  versus a neutral cache (criteria 1 & 2).
- `coordinated_structural_unaffected_by_remove_neuron_failures` — regression
  guard: remove-neuron failures do not discount coordinated-structural
  candidates.

New integration tests — `tests/analysis/issue_1425_remove_neuron_calibration.rs`:

- `nine_remove_neuron_failures_drive_correction_to_floor` — `correction_for`
  for the `remove-neuron` change type collapses toward the floor (criteria 2 & 3).
- `remove_neuron_and_coordinated_structural_are_independent` — the two change
  types are tracked independently.
- `remove_neuron_json_round_trip` — a `remove-neuron` failure-cache JSON entry
  round-trips and feeds the correction.

All new tests pass; full `./quality.sh` passes (fmt, Clippy `-D warnings`,
check, lib+integration tests, doc build, release build).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqi4w3jt-9312b6`<!-- vibe-worker-issue-1425 -->