### PR TITLE
Remove dead uuid dependency from Cargo.toml (Issue #1455)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.101"
+version = "0.74.102"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
- "uuid",
  "wgpu",
 ]
 
@@ -2168,17 +2167,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "uuid"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ pollster = "0.4"
 bytemuck = { version = "1.25", features = ["derive"] }
 rayon = "1.12"
 rand = "0.10"
-uuid = { version = "1.23", features = ["v4"] }  # Session ID generation for streaming API
 
 crossbeam-channel = "0.5"  # Efficient multi-producer work queues for GPU thread
 lz4_flex = "0.13"  # Pure Rust LZ4 compression for memory-constrained cache (Issue #420)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.101"
+version = "0.74.102"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1455.md
+++ b/docs/archive/pr-summaries/pr-summary-1455.md
@@ -1,0 +1,29 @@
+## Summary
+
+Removed the dead `uuid` dependency from `Cargo.toml` and refreshed `Cargo.lock`. Closes #1455.
+
+The `uuid` crate was declared at `Cargo.toml:26` with a stale comment claiming it powered session-ID generation for the streaming API. In reality, `src/streaming.rs` generates session IDs with `rand` (`rand::rng().sample_iter(&Alphanumeric)...`), so the `uuid` crate was unused dead weight — inflating build time and the supply-chain attack surface while misleading maintainers.
+
+A repo-wide search confirmed no `use uuid`, `extern crate uuid`, `uuid::` path, or `Uuid::new_v4()` reference exists in any `*.rs` file. Every remaining `uuid` match is either a struct field name (`uuid:`, `source_uuid`, `from_uuid`), a comment about the neuron-identity *concept* (a `String`), or a benchmark file name (`uuid_hashing`, `impact_uuid_cloning`) — none reference the crate.
+
+## Evidence
+
+This is a backend dependency-removal change with no web interface to screenshot. Verification is compiler-backed:
+
+- `cargo update -p uuid` reported `Removing uuid v1.23.3` and the crate no longer appears in `Cargo.lock` (`grep -c '^name = "uuid"' Cargo.lock` → `0`).
+- `cargo check` succeeds — the compiler confirms nothing references the removed crate (an actually-used dependency would fail to resolve).
+- `./quality.sh` passes cleanly: fmt, clippy (`-D warnings`), check, all 171+ unit/integration tests, doc build, and the optimised release build.
+
+```mermaid
+flowchart LR
+    A[Cargo.toml: uuid declared] -->|grep + cargo check| B{Referenced anywhere?}
+    B -->|No: rand generates session IDs| C[Remove dep + refresh Cargo.lock]
+    C --> D[cargo check + quality.sh pass]
+```
+
+## Test Plan
+
+No new unit test is added: the change removes a dependency, and the correct, compiler-backed verification is that the project still builds and all existing tests pass without `uuid`. A test asserting "uuid is not a dependency" would merely grep `Cargo.toml`, which the project's testing guidelines explicitly forbid (tests must exercise real behaviour, not inspect source text).
+
+- `cargo check` — passes (proves no source references the removed crate).
+- `./quality.sh` — full gate passes: fmt, clippy, check, 171+ tests across the suite, docs, release build.


### PR DESCRIPTION
## Summary

Removed the dead `uuid` dependency from `Cargo.toml` and refreshed `Cargo.lock`. Closes #1455.

The `uuid` crate was declared at `Cargo.toml:26` with a stale comment claiming it powered session-ID generation for the streaming API. In reality, `src/streaming.rs` generates session IDs with `rand` (`rand::rng().sample_iter(&Alphanumeric)...`), so the `uuid` crate was unused dead weight — inflating build time and the supply-chain attack surface while misleading maintainers.

A repo-wide search confirmed no `use uuid`, `extern crate uuid`, `uuid::` path, or `Uuid::new_v4()` reference exists in any `*.rs` file. Every remaining `uuid` match is either a struct field name (`uuid:`, `source_uuid`, `from_uuid`), a comment about the neuron-identity *concept* (a `String`), or a benchmark file name (`uuid_hashing`, `impact_uuid_cloning`) — none reference the crate.

## Evidence

This is a backend dependency-removal change with no web interface to screenshot. Verification is compiler-backed:

- `cargo update -p uuid` reported `Removing uuid v1.23.3` and the crate no longer appears in `Cargo.lock` (`grep -c '^name = "uuid"' Cargo.lock` → `0`).
- `cargo check` succeeds — the compiler confirms nothing references the removed crate (an actually-used dependency would fail to resolve).
- `./quality.sh` passes cleanly: fmt, clippy (`-D warnings`), check, all 171+ unit/integration tests, doc build, and the optimised release build.

```mermaid
flowchart LR
    A[Cargo.toml: uuid declared] -->|grep + cargo check| B{Referenced anywhere?}
    B -->|No: rand generates session IDs| C[Remove dep + refresh Cargo.lock]
    C --> D[cargo check + quality.sh pass]
```

## Test Plan

No new unit test is added: the change removes a dependency, and the correct, compiler-backed verification is that the project still builds and all existing tests pass without `uuid`. A test asserting "uuid is not a dependency" would merely grep `Cargo.toml`, which the project's testing guidelines explicitly forbid (tests must exercise real behaviour, not inspect source text).

- `cargo check` — passes (proves no source references the removed crate).
- `./quality.sh` — full gate passes: fmt, clippy, check, 171+ tests across the suite, docs, release build.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqlgqpd2-afce85`<!-- vibe-worker-issue-1455 -->