### PR TITLE
Use into_owned() instead of to_string() on Cow in cache deserialisation (Issue #1456)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.102"
+version = "0.74.103"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.102"
+version = "0.74.103"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1456.md
+++ b/docs/archive/pr-summaries/pr-summary-1456.md
@@ -1,0 +1,42 @@
+## Summary
+
+Replaced `.to_string()` with `.into_owned()` on the `Cow<str>` returned by
+`String::from_utf8_lossy` in `src/analysis/cache/serialisation.rs`
+(`deserialise_records`). `into_owned()` is the idiomatic way to take ownership
+of a `Cow`: it returns the existing `String` unchanged when the value is already
+`Cow::Owned` (the invalid-UTF-8 path) and only allocates when it is
+`Cow::Borrowed`. `.to_string()` always allocates a fresh buffer and copies,
+throwing away the buffer the `Cow` just produced on the owned path. This runs
+once per cached record on every cache load, so it avoids an allocation-and-copy
+on the invalid-UTF-8 path while being never worse on the valid path. Behaviour is
+unchanged.
+
+Closes #1456.
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable.
+
+The change is behaviour-preserving; the new regression test exercises the
+invalid-UTF-8 (`Cow::Owned`) branch and asserts the deserialised `neuron_uuid`
+matches the lossy-decoded value (with the Unicode replacement character),
+confirming `into_owned()` produces the same result as the previous
+`.to_string()`.
+
+```
+test analysis::cache::serialisation::tests::deserialise_records_invalid_utf8_uuid_uses_lossy_replacement ... ok
+```
+
+All 14 `serialisation` module tests pass, and `./quality.sh` passes cleanly
+(fmt, clippy `-D warnings`, check, tests, doc build, release build).
+
+## Test Plan
+
+- Added `src/analysis/cache/serialisation.rs::tests::deserialise_records_invalid_utf8_uuid_uses_lossy_replacement`
+  — builds a serialised record whose UUID field carries invalid UTF-8 bytes
+  (driving `from_utf8_lossy` into the `Cow::Owned` branch) and asserts the
+  decoded `neuron_uuid` equals `String::from_utf8_lossy(..)` and contains the
+  replacement character. This pins the ownership-idiom change to observable
+  behaviour rather than implementation detail.
+- Existing `deserialise_records_round_trip` and the truncation tests continue to
+  pass, covering the normal valid-UTF-8 (`Cow::Borrowed`) path.

--- a/src/analysis/cache/serialisation.rs
+++ b/src/analysis/cache/serialisation.rs
@@ -102,7 +102,7 @@ pub(crate) fn deserialise_records(data: &[u8]) -> Result<Vec<DiscoverRecord>> {
         if pos + uuid_len > data.len() {
             bail!("Cache truncated at offset {pos}: expected {uuid_len} bytes for UUID");
         }
-        let neuron_uuid = String::from_utf8_lossy(&data[pos..pos + uuid_len]).to_string();
+        let neuron_uuid = String::from_utf8_lossy(&data[pos..pos + uuid_len]).into_owned();
         pos += uuid_len;
 
         // has_value: u8 (1 byte)
@@ -251,6 +251,31 @@ mod tests {
         assert_eq!(deserialized[0].errors, vec![0.1, 0.2]);
         assert_eq!(deserialized[1].value, None);
         assert_eq!(deserialized[2].errors.len(), 3);
+    }
+
+    #[test]
+    fn deserialise_records_invalid_utf8_uuid_uses_lossy_replacement() {
+        // Issue #1456: a UUID field carrying invalid UTF-8 bytes drives
+        // String::from_utf8_lossy into the Cow::Owned branch. into_owned()
+        // must yield the same lossy-decoded value as before.
+        let invalid_uuid = [0x66, 0x6f, 0x6f, 0xff, 0x62, 0x61, 0x72]; // "foo\u{FFFD}bar"
+        let mut data = Vec::new();
+        data.extend_from_slice(&7u32.to_le_bytes()); // obs_index
+        data.extend_from_slice(&(invalid_uuid.len() as u16).to_le_bytes()); // uuid_len
+        data.extend_from_slice(&invalid_uuid); // uuid (invalid UTF-8)
+        data.push(0); // has_value = false
+        data.extend_from_slice(&0.5f32.to_le_bytes()); // activation
+        data.extend_from_slice(&0u16.to_le_bytes()); // errors_len = 0
+
+        let result = deserialise_records(&data).expect("invalid UTF-8 UUID should still decode");
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].neuron_uuid,
+            String::from_utf8_lossy(&invalid_uuid),
+            "neuron_uuid should match the lossy-decoded UUID with the replacement character"
+        );
+        assert!(result[0].neuron_uuid.contains('\u{FFFD}'));
+        assert_eq!(result[0].obs_index, 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaced `.to_string()` with `.into_owned()` on the `Cow<str>` returned by
`String::from_utf8_lossy` in `src/analysis/cache/serialisation.rs`
(`deserialise_records`). `into_owned()` is the idiomatic way to take ownership
of a `Cow`: it returns the existing `String` unchanged when the value is already
`Cow::Owned` (the invalid-UTF-8 path) and only allocates when it is
`Cow::Borrowed`. `.to_string()` always allocates a fresh buffer and copies,
throwing away the buffer the `Cow` just produced on the owned path. This runs
once per cached record on every cache load, so it avoids an allocation-and-copy
on the invalid-UTF-8 path while being never worse on the valid path. Behaviour is
unchanged.

Closes #1456.

## Evidence

Backend/CLI change with no web interface — no screenshot applicable.

The change is behaviour-preserving; the new regression test exercises the
invalid-UTF-8 (`Cow::Owned`) branch and asserts the deserialised `neuron_uuid`
matches the lossy-decoded value (with the Unicode replacement character),
confirming `into_owned()` produces the same result as the previous
`.to_string()`.

```
test analysis::cache::serialisation::tests::deserialise_records_invalid_utf8_uuid_uses_lossy_replacement ... ok
```

All 14 `serialisation` module tests pass, and `./quality.sh` passes cleanly
(fmt, clippy `-D warnings`, check, tests, doc build, release build).

## Test Plan

- Added `src/analysis/cache/serialisation.rs::tests::deserialise_records_invalid_utf8_uuid_uses_lossy_replacement`
  — builds a serialised record whose UUID field carries invalid UTF-8 bytes
  (driving `from_utf8_lossy` into the `Cow::Owned` branch) and asserts the
  decoded `neuron_uuid` equals `String::from_utf8_lossy(..)` and contains the
  replacement character. This pins the ownership-idiom change to observable
  behaviour rather than implementation detail.
- Existing `deserialise_records_round_trip` and the truncation tests continue to
  pass, covering the normal valid-UTF-8 (`Cow::Borrowed`) path.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqlig4y6-9076b5`<!-- vibe-worker-issue-1456 -->