### PR TITLE
Replace WGSL source-grep HOW-tests with naga behaviour tests (Issue #1467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "arrow"
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
@@ -1262,6 +1262,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "lz4_flex",
+ "naga",
  "parking_lot",
  "parquet",
  "pollster",
@@ -2636,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.105"
+version = "0.74.106"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tempfile = "3.27"
 serial_test = "3.5"
 criterion = { version = "0.8", default-features = false, features = ["rayon", "cargo_bench_support"] }
 proptest = "1.11"  # Property-based testing for mathematical functions (Issue #573)
+naga = { version = "29", features = ["wgsl-in"] }  # WGSL parse/validate for shader behaviour tests (Issue #1467)
 
 [[bench]]
 name = "synapse_counts"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.105"
+version = "0.74.106"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1467.md
+++ b/docs/archive/pr-summaries/pr-summary-1467.md
@@ -1,0 +1,78 @@
+## Summary
+
+Replaced the HOW-tests in `src/analysis/gpu/shaders.rs` that grepped the embedded
+WGSL shader **source text** with genuine WHAT-tests that assert on behaviour.
+The old tests asserted on internal helper names, WGSL keywords, and source
+formatting — so a behaviour-preserving shader refactor (renaming a helper,
+reformatting `@workgroup_size( 256 )`, or switching the reduction memory
+strategy) would break the suite even though the GPU output a caller observes is
+unchanged. They also gave false confidence: a shader containing `fn add_contributions`
+only in a comment would pass. Closes #1467.
+
+The four affected tests are resolved as follows:
+
+| Old test (HOW) | Resolution |
+|----------------|------------|
+| `test_shader_sources_contain_workgroup_size` | Replaced by `test_compute_entry_points_declare_workgroup_size` — parses each shader with `naga` (the front-end wgpu uses) and asserts the validated compute entry point's **structured** `workgroup_size` equals `WORKGROUP_SIZE`. Immune to whitespace/formatting. |
+| `test_shader_wgsl_syntax_basics` | Replaced by `test_shaders_are_valid_wgsl` — parses **and validates** each shader and asserts it exposes a `@compute` entry point. Unlike a `contains("fn ")` grep, this actually fails on malformed WGSL. |
+| `test_reduction_shaders_contain_required_functions` | Removed — asserted internal helper names (`add_contributions`, `zero_contribution`, ...). Pure implementation detail. |
+| `test_reduction_shaders_use_shared_memory` | Removed — asserted the `var<workgroup>` memory strategy. Pure implementation detail. |
+
+### Why removal of the two reduce-shader tests is safe
+
+The observable behaviour they stood in for — the reduce shaders produce correct
+aggregated statistics — is already verified end-to-end by
+`tests/gpu/gpu_workgroup_reduction.rs` (`test_helpful_reduction_correctness`,
+`test_harmful_reduction_correctness`, `test_reduction_numerical_stability`, ...).
+The reduce shaders' WGSL validity and workgroup size are additionally covered by
+the two new naga tests, which run on CPU (no GPU required). A `// NOTE (Issue #1467)`
+in the test module documents the removal and its replacement coverage.
+
+### Approach
+
+`naga = "29"` (matching wgpu 29, already a transitive dependency at 29.0.3) is
+added as a dev-dependency with the `wgsl-in` feature. A `validate_wgsl` test
+helper parses and validates a shader, panicking with a descriptive message on
+failure; an `ALL_SHADERS` constant lists every embedded shader once (DRY).
+
+```mermaid
+flowchart LR
+    A["WGSL source<br/>(embedded const)"] --> B["naga::front::wgsl::parse_str"]
+    B --> C["naga::valid::Validator::validate"]
+    C --> D{"compute entry point?"}
+    D -->|yes| E["assert workgroup_size == 256"]
+    D -->|no| F["test fails"]
+```
+
+## Evidence
+
+Backend/library change with no web interface — no screenshot applicable.
+
+Test run (`cargo test --lib --all-features shaders::tests`):
+
+```
+running 7 tests
+test analysis::gpu::shaders::tests::test_gpu_reduction_threshold_is_valid ... ok
+test analysis::gpu::shaders::tests::test_gpu_timeouts_are_valid ... ok
+test analysis::gpu::shaders::tests::test_min_neuron_sample_count_is_valid ... ok
+test analysis::gpu::shaders::tests::test_shader_sources_are_not_empty ... ok
+test analysis::gpu::shaders::tests::test_shaders_are_valid_wgsl ... ok
+test analysis::gpu::shaders::tests::test_compute_entry_points_declare_workgroup_size ... ok
+test analysis::gpu::shaders::tests::test_workgroup_size_is_valid ... ok
+
+test result: ok. 7 passed; 0 failed; ...
+```
+
+`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, tests, doc, release build).
+
+## Test Plan
+
+- Added `test_compute_entry_points_declare_workgroup_size` — validates every
+  shader with naga and asserts each compute entry point declares
+  `workgroup_size == [256, 1, 1]`. Survives reformatting; fails on a wrong size.
+- Added `test_shaders_are_valid_wgsl` — validates every shader compiles as WGSL
+  and exposes a `@compute` entry point. Fails on malformed WGSL (a real signal
+  the substring grep could not provide).
+- Removed `test_reduction_shaders_contain_required_functions` and
+  `test_reduction_shaders_use_shared_memory` (HOW-tests); reduction correctness
+  remains covered by `tests/gpu/gpu_workgroup_reduction.rs`.

--- a/src/analysis/gpu/shaders.rs
+++ b/src/analysis/gpu/shaders.rs
@@ -202,6 +202,36 @@ pub const GPU_REDUCTION_THRESHOLD: usize = 10_000;
 mod tests {
     use super::*;
 
+    /// Every embedded shader, paired with a human-readable name for assertions.
+    const ALL_SHADERS: &[(&str, &str)] = &[
+        ("helpful", HELPFUL_SHADER),
+        ("harmful", HARMFUL_SHADER),
+        ("relu", RELU_SHADER),
+        ("activation", ACTIVATION_SHADER),
+        ("bias", BIAS_SHADER),
+        ("helpful_reduce", HELPFUL_REDUCE_SHADER),
+        ("harmful_reduce", HARMFUL_REDUCE_SHADER),
+        ("relu_reduce", RELU_REDUCE_SHADER),
+        ("activation_reduce", ACTIVATION_REDUCE_SHADER),
+    ];
+
+    /// Parse and validate a WGSL shader with naga, returning the compiled
+    /// module. Panics with a descriptive message if the shader does not parse
+    /// or fails validation — this "does it compile" property is behavioural
+    /// (a caller observes a broken shader as a failed pipeline), unlike a
+    /// substring grep of the source text.
+    fn validate_wgsl(name: &str, source: &str) -> naga::Module {
+        let module = naga::front::wgsl::parse_str(source)
+            .unwrap_or_else(|e| panic!("{name} shader is not valid WGSL: {e}"));
+        naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .unwrap_or_else(|e| panic!("{name} shader failed WGSL validation: {e:?}"));
+        module
+    }
+
     #[test]
     fn test_shader_sources_are_not_empty() {
         // Verify all shaders have content
@@ -247,46 +277,33 @@ mod tests {
     }
 
     #[test]
-    fn test_shader_sources_contain_workgroup_size() {
-        // Verify shaders declare the correct workgroup size
-        let expected_workgroup = format!("@workgroup_size({WORKGROUP_SIZE})");
-
-        assert!(
-            HELPFUL_SHADER.contains(&expected_workgroup),
-            "HELPFUL_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            HARMFUL_SHADER.contains(&expected_workgroup),
-            "HARMFUL_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            RELU_SHADER.contains(&expected_workgroup),
-            "RELU_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            ACTIVATION_SHADER.contains(&expected_workgroup),
-            "ACTIVATION_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            BIAS_SHADER.contains(&expected_workgroup),
-            "BIAS_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            HELPFUL_REDUCE_SHADER.contains(&expected_workgroup),
-            "HELPFUL_REDUCE_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            HARMFUL_REDUCE_SHADER.contains(&expected_workgroup),
-            "HARMFUL_REDUCE_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            RELU_REDUCE_SHADER.contains(&expected_workgroup),
-            "RELU_REDUCE_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
-        assert!(
-            ACTIVATION_REDUCE_SHADER.contains(&expected_workgroup),
-            "ACTIVATION_REDUCE_SHADER should declare @workgroup_size({WORKGROUP_SIZE})"
-        );
+    fn test_compute_entry_points_declare_workgroup_size() {
+        // WHAT-test: every compute entry point must declare the configured
+        // workgroup size. Reads the validated module's structured
+        // `workgroup_size` instead of grepping for the formatted
+        // "@workgroup_size(N)" text, so it is immune to whitespace and
+        // formatting changes (e.g. "@workgroup_size( 256 )") yet still fails
+        // if a shader genuinely declares the wrong size.
+        for (name, shader) in ALL_SHADERS {
+            let module = validate_wgsl(name, shader);
+            let compute_points: Vec<_> = module
+                .entry_points
+                .iter()
+                .filter(|ep| ep.stage == naga::ShaderStage::Compute)
+                .collect();
+            assert!(
+                !compute_points.is_empty(),
+                "{name} shader should expose a @compute entry point"
+            );
+            for ep in compute_points {
+                assert_eq!(
+                    ep.workgroup_size,
+                    [WORKGROUP_SIZE, 1, 1],
+                    "{name} entry point '{}' should declare workgroup size {WORKGROUP_SIZE}",
+                    ep.name
+                );
+            }
+        }
     }
 
     #[test]
@@ -325,26 +342,21 @@ mod tests {
     }
 
     #[test]
-    fn test_shader_wgsl_syntax_basics() {
-        // Basic syntax verification - shaders should have struct and fn declarations
-        for (name, shader) in [
-            ("helpful", HELPFUL_SHADER),
-            ("harmful", HARMFUL_SHADER),
-            ("relu", RELU_SHADER),
-            ("activation", ACTIVATION_SHADER),
-            ("bias", BIAS_SHADER),
-            ("helpful_reduce", HELPFUL_REDUCE_SHADER),
-            ("harmful_reduce", HARMFUL_REDUCE_SHADER),
-            ("relu_reduce", RELU_REDUCE_SHADER),
-            ("activation_reduce", ACTIVATION_REDUCE_SHADER),
-        ] {
+    fn test_shaders_are_valid_wgsl() {
+        // WHAT-test: each shader must parse and validate as WGSL via naga (the
+        // same front-end wgpu uses) and expose at least one @compute entry
+        // point. Unlike a substring grep for "fn " or "struct", this actually
+        // fails when a shader is malformed, and it survives any internal
+        // rename, reformat, or rewrite that keeps the shader compilable.
+        for (name, shader) in ALL_SHADERS {
+            let module = validate_wgsl(name, shader);
+            let has_compute = module
+                .entry_points
+                .iter()
+                .any(|ep| ep.stage == naga::ShaderStage::Compute);
             assert!(
-                shader.contains("struct") || shader.contains("fn "),
-                "{name} shader should contain struct or fn declarations"
-            );
-            assert!(
-                shader.contains("@compute"),
-                "{name} shader should contain @compute decorator"
+                has_compute,
+                "{name} shader should expose a @compute entry point"
             );
         }
     }
@@ -363,61 +375,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_reduction_shaders_contain_required_functions() {
-        // Verify reduction shaders have the required add_contributions and zero_contribution functions
-        assert!(
-            HELPFUL_REDUCE_SHADER.contains("fn add_contributions"),
-            "HELPFUL_REDUCE_SHADER should contain add_contributions function"
-        );
-        assert!(
-            HELPFUL_REDUCE_SHADER.contains("fn zero_contribution"),
-            "HELPFUL_REDUCE_SHADER should contain zero_contribution function"
-        );
-        assert!(
-            HARMFUL_REDUCE_SHADER.contains("fn add_contributions"),
-            "HARMFUL_REDUCE_SHADER should contain add_contributions function"
-        );
-        assert!(
-            HARMFUL_REDUCE_SHADER.contains("fn zero_contribution"),
-            "HARMFUL_REDUCE_SHADER should contain zero_contribution function"
-        );
-        assert!(
-            RELU_REDUCE_SHADER.contains("fn add_contributions"),
-            "RELU_REDUCE_SHADER should contain add_contributions function"
-        );
-        assert!(
-            RELU_REDUCE_SHADER.contains("fn zero_contribution"),
-            "RELU_REDUCE_SHADER should contain zero_contribution function"
-        );
-        assert!(
-            ACTIVATION_REDUCE_SHADER.contains("fn add_outputs"),
-            "ACTIVATION_REDUCE_SHADER should contain add_outputs function"
-        );
-        assert!(
-            ACTIVATION_REDUCE_SHADER.contains("fn zero_output"),
-            "ACTIVATION_REDUCE_SHADER should contain zero_output function"
-        );
-    }
-
-    #[test]
-    fn test_reduction_shaders_use_shared_memory() {
-        // Verify reduction shaders use workgroup shared memory
-        assert!(
-            HELPFUL_REDUCE_SHADER.contains("var<workgroup>"),
-            "HELPFUL_REDUCE_SHADER should use workgroup shared memory"
-        );
-        assert!(
-            HARMFUL_REDUCE_SHADER.contains("var<workgroup>"),
-            "HARMFUL_REDUCE_SHADER should use workgroup shared memory"
-        );
-        assert!(
-            RELU_REDUCE_SHADER.contains("var<workgroup>"),
-            "RELU_REDUCE_SHADER should use workgroup shared memory"
-        );
-        assert!(
-            ACTIVATION_REDUCE_SHADER.contains("var<workgroup>"),
-            "ACTIVATION_REDUCE_SHADER should use workgroup shared memory"
-        );
-    }
+    // NOTE (Issue #1467): the former HOW-tests
+    // `test_reduction_shaders_contain_required_functions` and
+    // `test_reduction_shaders_use_shared_memory` were removed. They grepped the
+    // reduce shaders' source for internal helper names (`add_contributions`,
+    // `zero_contribution`, ...) and the `var<workgroup>` memory strategy —
+    // implementation details that a behaviour-preserving refactor (renaming a
+    // helper, switching reduction strategy) would break for no reason. The
+    // observable behaviour they were standing in for — that the reduce shaders
+    // produce correct aggregated statistics — is verified end-to-end by
+    // `tests/gpu/gpu_workgroup_reduction.rs` (`test_helpful_reduction_correctness`,
+    // `test_harmful_reduction_correctness`, etc.), and the reduce shaders'
+    // WGSL validity plus workgroup size are now covered by
+    // `test_shaders_are_valid_wgsl` and
+    // `test_compute_entry_points_declare_workgroup_size` above.
 }


### PR DESCRIPTION
## Summary

Replaced the HOW-tests in `src/analysis/gpu/shaders.rs` that grepped the embedded
WGSL shader **source text** with genuine WHAT-tests that assert on behaviour.
The old tests asserted on internal helper names, WGSL keywords, and source
formatting — so a behaviour-preserving shader refactor (renaming a helper,
reformatting `@workgroup_size( 256 )`, or switching the reduction memory
strategy) would break the suite even though the GPU output a caller observes is
unchanged. They also gave false confidence: a shader containing `fn add_contributions`
only in a comment would pass. Closes #1467.

The four affected tests are resolved as follows:

| Old test (HOW) | Resolution |
|----------------|------------|
| `test_shader_sources_contain_workgroup_size` | Replaced by `test_compute_entry_points_declare_workgroup_size` — parses each shader with `naga` (the front-end wgpu uses) and asserts the validated compute entry point's **structured** `workgroup_size` equals `WORKGROUP_SIZE`. Immune to whitespace/formatting. |
| `test_shader_wgsl_syntax_basics` | Replaced by `test_shaders_are_valid_wgsl` — parses **and validates** each shader and asserts it exposes a `@compute` entry point. Unlike a `contains("fn ")` grep, this actually fails on malformed WGSL. |
| `test_reduction_shaders_contain_required_functions` | Removed — asserted internal helper names (`add_contributions`, `zero_contribution`, ...). Pure implementation detail. |
| `test_reduction_shaders_use_shared_memory` | Removed — asserted the `var<workgroup>` memory strategy. Pure implementation detail. |

### Why removal of the two reduce-shader tests is safe

The observable behaviour they stood in for — the reduce shaders produce correct
aggregated statistics — is already verified end-to-end by
`tests/gpu/gpu_workgroup_reduction.rs` (`test_helpful_reduction_correctness`,
`test_harmful_reduction_correctness`, `test_reduction_numerical_stability`, ...).
The reduce shaders' WGSL validity and workgroup size are additionally covered by
the two new naga tests, which run on CPU (no GPU required). A `// NOTE (Issue #1467)`
in the test module documents the removal and its replacement coverage.

### Approach

`naga = "29"` (matching wgpu 29, already a transitive dependency at 29.0.3) is
added as a dev-dependency with the `wgsl-in` feature. A `validate_wgsl` test
helper parses and validates a shader, panicking with a descriptive message on
failure; an `ALL_SHADERS` constant lists every embedded shader once (DRY).

```mermaid
flowchart LR
    A["WGSL source<br/>(embedded const)"] --> B["naga::front::wgsl::parse_str"]
    B --> C["naga::valid::Validator::validate"]
    C --> D{"compute entry point?"}
    D -->|yes| E["assert workgroup_size == 256"]
    D -->|no| F["test fails"]
```

## Evidence

Backend/library change with no web interface — no screenshot applicable.

Test run (`cargo test --lib --all-features shaders::tests`):

```
running 7 tests
test analysis::gpu::shaders::tests::test_gpu_reduction_threshold_is_valid ... ok
test analysis::gpu::shaders::tests::test_gpu_timeouts_are_valid ... ok
test analysis::gpu::shaders::tests::test_min_neuron_sample_count_is_valid ... ok
test analysis::gpu::shaders::tests::test_shader_sources_are_not_empty ... ok
test analysis::gpu::shaders::tests::test_shaders_are_valid_wgsl ... ok
test analysis::gpu::shaders::tests::test_compute_entry_points_declare_workgroup_size ... ok
test analysis::gpu::shaders::tests::test_workgroup_size_is_valid ... ok

test result: ok. 7 passed; 0 failed; ...
```

`./quality.sh` passes cleanly (fmt, clippy `-D warnings`, check, tests, doc, release build).

## Test Plan

- Added `test_compute_entry_points_declare_workgroup_size` — validates every
  shader with naga and asserts each compute entry point declares
  `workgroup_size == [256, 1, 1]`. Survives reformatting; fails on a wrong size.
- Added `test_shaders_are_valid_wgsl` — validates every shader compiles as WGSL
  and exposes a `@compute` entry point. Fails on malformed WGSL (a real signal
  the substring grep could not provide).
- Removed `test_reduction_shaders_contain_required_functions` and
  `test_reduction_shaders_use_shared_memory` (HOW-tests); reduction correctness
  remains covered by `tests/gpu/gpu_workgroup_reduction.rs`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqo4y5od-e0b242`<!-- vibe-worker-issue-1467 -->