### PR TITLE
Replace flaky wall-clock timing assertion with monotonicity what-test (Issue #1468)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.106"
+version = "0.74.107"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.106"
+version = "0.74.107"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1468.md
+++ b/docs/archive/pr-summaries/pr-summary-1468.md
@@ -1,0 +1,49 @@
+## Summary
+
+Fixed the flaky wall-clock timing assertion in
+`tests/infrastructure/observability.rs` (the `phase_timer_accuracy` test).
+The original test measured host wall-clock time externally and asserted the
+50ms sleep plus all scheduling overhead finished within a 50ms margin. That is
+a "how-fast-is-the-host" assertion, not a behavioural one: thread-scheduling
+jitter on a loaded CI runner or contended ARM box can breach a 50ms margin
+without any regression in `PhaseTimer`. Closes #1468.
+
+The test is now a "what" test (option (a) from the issue): it asserts on the
+duration `PhaseTimer` itself reports via `elapsed_ms()`, keeping only the
+behaviourally meaningful guarantee — monotonicity, i.e. having slept for at
+least the requested duration, the timer must report at least that much. The
+fragile host-speed upper bound is dropped. This aligns with the repository's
+testing philosophy (AGENTS.md §4: test "what", not "how"; no
+`Instant`/`elapsed` pass/fail thresholds in unit tests).
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the test
+suite:
+
+```mermaid
+flowchart LR
+    A["sleep(50ms)"] --> B["timer.elapsed_ms()"]
+    B --> C{"reported >= 50ms?"}
+    C -->|yes| D[pass]
+    C -->|no| E[fail]
+```
+
+- `cargo test --test infrastructure phase_timer` — all 5 phase-timer tests pass.
+- `./quality.sh` — passes cleanly (fmt, Clippy `-D warnings`, check, tests, doc,
+  release build).
+
+The new assertion reads the value the timer *reports* (`elapsed_ms`), not
+externally-measured wall-clock, so it carries a real correctness signal
+(monotonicity) and cannot flip red purely on host load.
+
+## Test Plan
+
+- Modified `tests/infrastructure/observability.rs::phase_timer_accuracy`:
+  replaced the external wall-clock measurement and the flaky `< sleep + 50ms`
+  upper bound with an assertion on `PhaseTimer::elapsed_ms()` reporting at least
+  the slept duration. No existing tests were removed; `phase_timer_respects_env_var`,
+  `phase_timer_nested`, and `phase_timer_repeated_creation_and_drop` continue to
+  cover the other paths.
+- Bumped crate version `0.74.106` → `0.74.107` per the version-increment
+  invariant.

--- a/tests/infrastructure/observability.rs
+++ b/tests/infrastructure/observability.rs
@@ -37,29 +37,30 @@ macro_rules! skip_without_gpu {
 // PhaseTimer Tests
 // =============================================================================
 
-/// Test that `PhaseTimer` records duration accurately (within 10ms tolerance).
+/// Test that `PhaseTimer` reports at least the elapsed sleep duration.
+///
+/// This is a "what" test: it asserts on the value the timer itself reports
+/// (`elapsed_ms`), not on externally-measured host wall-clock. The only
+/// behavioural guarantee is monotonicity — having slept for at least
+/// `sleep_duration`, the timer must report at least that much. A fragile
+/// upper bound on overhead is intentionally omitted: thread-scheduling jitter
+/// on a loaded CI runner can exceed any tight margin without any regression in
+/// `PhaseTimer` itself (Issue #1468).
 #[test]
 fn phase_timer_accuracy() {
-    // Create a timer and sleep for a known duration
-    let phase_name = "test_phase";
     let sleep_duration = Duration::from_millis(50);
 
-    let start = std::time::Instant::now();
-    {
-        let _timer = PhaseTimer::new(phase_name);
-        std::thread::sleep(sleep_duration);
-    }
-    let elapsed = start.elapsed();
+    let timer = PhaseTimer::new("test_phase");
+    std::thread::sleep(sleep_duration);
+    let reported = Duration::from_millis(timer.elapsed_ms());
 
-    // The timer should have recorded approximately the sleep duration
-    // We allow 10ms tolerance for scheduling variance
+    // Monotonicity: the timer reports at least the time we slept. `elapsed_ms`
+    // truncates to whole milliseconds and `thread::sleep` guarantees sleeping
+    // for at least the requested duration, so this holds without a host-speed
+    // assumption.
     assert!(
-        elapsed >= sleep_duration,
-        "Timer should record at least the sleep duration"
-    );
-    assert!(
-        elapsed < sleep_duration + Duration::from_millis(50),
-        "Timer should not have excessive overhead (>50ms)"
+        reported >= sleep_duration,
+        "PhaseTimer should report at least the slept duration ({sleep_duration:?}), got {reported:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixed the flaky wall-clock timing assertion in
`tests/infrastructure/observability.rs` (the `phase_timer_accuracy` test).
The original test measured host wall-clock time externally and asserted the
50ms sleep plus all scheduling overhead finished within a 50ms margin. That is
a "how-fast-is-the-host" assertion, not a behavioural one: thread-scheduling
jitter on a loaded CI runner or contended ARM box can breach a 50ms margin
without any regression in `PhaseTimer`. Closes #1468.

The test is now a "what" test (option (a) from the issue): it asserts on the
duration `PhaseTimer` itself reports via `elapsed_ms()`, keeping only the
behaviourally meaningful guarantee — monotonicity, i.e. having slept for at
least the requested duration, the timer must report at least that much. The
fragile host-speed upper bound is dropped. This aligns with the repository's
testing philosophy (AGENTS.md §4: test "what", not "how"; no
`Instant`/`elapsed` pass/fail thresholds in unit tests).

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the test
suite:

```mermaid
flowchart LR
    A["sleep(50ms)"] --> B["timer.elapsed_ms()"]
    B --> C{"reported >= 50ms?"}
    C -->|yes| D[pass]
    C -->|no| E[fail]
```

- `cargo test --test infrastructure phase_timer` — all 5 phase-timer tests pass.
- `./quality.sh` — passes cleanly (fmt, Clippy `-D warnings`, check, tests, doc,
  release build).

The new assertion reads the value the timer *reports* (`elapsed_ms`), not
externally-measured wall-clock, so it carries a real correctness signal
(monotonicity) and cannot flip red purely on host load.

## Test Plan

- Modified `tests/infrastructure/observability.rs::phase_timer_accuracy`:
  replaced the external wall-clock measurement and the flaky `< sleep + 50ms`
  upper bound with an assertion on `PhaseTimer::elapsed_ms()` reporting at least
  the slept duration. No existing tests were removed; `phase_timer_respects_env_var`,
  `phase_timer_nested`, and `phase_timer_repeated_creation_and_drop` continue to
  cover the other paths.
- Bumped crate version `0.74.106` → `0.74.107` per the version-increment
  invariant.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqo8zng7-2cb1c8`<!-- vibe-worker-issue-1468 -->