### PR TITLE
🟢 Tautological constant-equals-literal tests across config and GPU modules (Issue #1469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.107"
+version = "0.74.108"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.107"
+version = "0.74.108"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1469.md
+++ b/docs/archive/pr-summaries/pr-summary-1469.md
@@ -1,0 +1,64 @@
+## Summary
+
+Removed the recurring **tautological "constant equals its own literal"** test
+pattern flagged across the config and GPU modules. Each removed assertion (e.g.
+`assert_eq!(WORKGROUP_SIZE, 256)`) was circular — it passed if and only if the
+source literal was unchanged, so it could never catch a bug, only flag a
+deliberate retune and force a meaningless paired edit. Where a constant has a
+runtime getter, the pin was rewritten as a behavioural WHAT-test; where a
+behavioural companion (or compile-time guard) already existed, the redundant pin
+was deleted. Both resolutions are explicitly endorsed by the issue.
+
+Note: a pure `MIN <= DEFAULT <= MAX` assertion on `const` operands is itself
+rejected by Clippy's `assertions_on_constants` lint (the comparison is a
+compile-time constant), so a meaningful runtime test must exercise a
+getter/function rather than the bare constants — reinforcing why the pins added
+no value.
+
+Closes #1469.
+
+### Changes per call site
+
+| File | Test | Resolution |
+|------|------|------------|
+| `src/config/mod.rs` | `block_size_defaults` | Rewritten → `block_size_getter_returns_value_within_bounds` (exercises the `block_size()` clamp; no prior companion) |
+| `src/config/mod.rs` | `session_ttl_default_values` | Deleted — `session_ttl_returns_valid_value` is the behavioural companion |
+| `src/config/mod.rs` | `wall_clock_minutes_default_values` | Deleted — `wall_clock_minutes_returns_valid_value` is the behavioural companion |
+| `src/config/mod.rs` | `drought_log_threshold_default_is_five` | Rewritten → `drought_log_threshold_unset_resolves_to_default` (exercises the parser's fallback branch) |
+| `src/analysis/gpu/analyzer.rs` | `test_workgroup_size_constant`, `test_min_neuron_sample_count`, `test_gpu_max_batch_alloc_bytes` | Deleted — `WORKGROUP_SIZE` invariants already guarded at compile time in `shaders.rs`; tiering behaviour covered by `test_batch_size_for_tier`. Unused import removed. |
+| `src/analysis/gpu/queue/recovery.rs` | `test_default_retry_limit`, `test_default_backoff_constants`, `test_minimum_gpu_batch_size_constant` | Deleted — backoff behaviour covered by `test_backoff_delay_with_default_constants`; retry-limit parsing covered via `gpu_retry_limit()` |
+| `src/analysis/utils/lock_contention.rs` | `default_threshold_is_100ms` | Deleted — covered behaviourally by the `traced_lock_default` tests |
+
+Each deletion leaves an in-place comment recording the removal and its
+behavioural/compile-time companion, per the "document any removed test"
+requirement.
+
+## Evidence
+
+Backend/Rust change only — no web interface to screenshot. Verified via the
+test suite and full quality gate.
+
+The two rewritten tests pass and exercise real runtime code paths:
+
+```
+test config::tests::block_size_getter_returns_value_within_bounds ... ok
+test config::tests::drought_log_threshold_unset_resolves_to_default ... ok
+```
+
+```mermaid
+flowchart LR
+    A["assert_eq!(CONST, literal)<br/>(tautology — cannot fail)"] --> B{Runtime getter exists?}
+    B -->|Yes| C["WHAT-test the getter<br/>(survives retuning)"]
+    B -->|No, companion exists| D["Delete redundant pin<br/>(documented in place)"]
+```
+
+## Test Plan
+
+- Rewrote `block_size_getter_returns_value_within_bounds` — asserts `block_size()`
+  returns a value within `[MIN_BLOCK_SIZE, MAX_BLOCK_SIZE]`.
+- Rewrote `drought_log_threshold_unset_resolves_to_default` — asserts the parser
+  falls back to `DEFAULT_DROUGHT_LOG_THRESHOLD` when nothing is supplied.
+- Deleted the redundant tautological pin tests listed above; each has a
+  documented behavioural or compile-time companion that retains the coverage.
+- Ran `./quality.sh` (fmt, Clippy `-D warnings`, check, lib/integration tests,
+  doc build, release build) until clean.

--- a/docs/archive/pr-summaries/pr-summary-1469.md
+++ b/docs/archive/pr-summaries/pr-summary-1469.md
@@ -13,7 +13,7 @@ Note: a pure `MIN <= DEFAULT <= MAX` assertion on `const` operands is itself
 rejected by Clippy's `assertions_on_constants` lint (the comparison is a
 compile-time constant), so a meaningful runtime test must exercise a
 getter/function rather than the bare constants — reinforcing why the pins added
-no value.
+no value
 
 Closes #1469.
 

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -478,22 +478,14 @@ impl GpuAnalyzer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analysis::gpu::shaders::{MIN_NEURON_SAMPLE_COUNT, WORKGROUP_SIZE};
 
-    #[test]
-    fn test_workgroup_size_constant() {
-        assert_eq!(WORKGROUP_SIZE, 256);
-    }
-
-    #[test]
-    fn test_min_neuron_sample_count() {
-        assert_eq!(MIN_NEURON_SAMPLE_COUNT, 10);
-    }
-
-    #[test]
-    fn test_gpu_max_batch_alloc_bytes() {
-        assert_eq!(GPU_MAX_BATCH_ALLOC_BYTES, 256 * 1024 * 1024);
-    }
+    // Tautological constant-pin tests removed (Issue #1469):
+    // `test_workgroup_size_constant`, `test_min_neuron_sample_count` and
+    // `test_gpu_max_batch_alloc_bytes` only re-asserted each constant's own
+    // literal — they could never catch a bug, only flag a deliberate retune.
+    // The WORKGROUP_SIZE invariants (power-of-two, within hardware limits) are
+    // already guarded at compile time in `shaders.rs`; the batch-size tiering
+    // behaviour is covered by `test_batch_size_for_tier` below.
 
     #[test]
     fn test_batch_size_for_tier() {

--- a/src/analysis/gpu/queue/recovery.rs
+++ b/src/analysis/gpu/queue/recovery.rs
@@ -85,10 +85,9 @@ pub fn is_memory_exhaustion_error(error: &anyhow::Error) -> bool {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_default_retry_limit() {
-        assert_eq!(DEFAULT_GPU_RETRY_LIMIT, 3);
-    }
+    // Tautological `test_default_retry_limit` pin removed (Issue #1469): it only
+    // re-asserted the constant's own literal. The retry-limit parsing behaviour
+    // is exercised through `gpu_retry_limit()` in the config module.
 
     #[test]
     fn test_retry_limit_env_var_name() {
@@ -202,16 +201,10 @@ mod tests {
         assert_eq!(result, 1_000);
     }
 
-    #[test]
-    fn test_default_backoff_constants() {
-        assert_eq!(DEFAULT_BACKOFF_INITIAL_MS, 10);
-        assert_eq!(DEFAULT_BACKOFF_MAX_MS, 1_000);
-    }
-
-    #[test]
-    fn test_minimum_gpu_batch_size_constant() {
-        assert_eq!(MINIMUM_GPU_BATCH_SIZE, 64);
-    }
+    // Tautological `test_default_backoff_constants` and
+    // `test_minimum_gpu_batch_size_constant` pins removed (Issue #1469): they
+    // only re-asserted each constant's literal. The backoff behaviour using
+    // these defaults is covered by `test_backoff_delay_with_default_constants`.
 
     #[test]
     fn test_is_memory_exhaustion_error_detects_oom() {

--- a/src/analysis/utils/lock_contention.rs
+++ b/src/analysis/utils/lock_contention.rs
@@ -105,8 +105,8 @@ mod tests {
         assert_eq!(*guard, 0);
     }
 
-    #[test]
-    fn default_threshold_is_100ms() {
-        assert_eq!(DEFAULT_LOCK_WAIT_THRESHOLD, Duration::from_millis(100));
-    }
+    // Tautological `default_threshold_is_100ms` pin removed (Issue #1469): it
+    // only re-asserted the constant's own literal. The default threshold is
+    // exercised behaviourally by `traced_lock_default_acquires_lock` and the
+    // other `traced_lock_default` tests above.
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -140,10 +140,12 @@ mod tests {
     }
 
     #[test]
-    fn block_size_defaults() {
-        assert_eq!(DEFAULT_BLOCK_SIZE, 10_000);
-        assert_eq!(MIN_BLOCK_SIZE, 10);
-        assert_eq!(MAX_BLOCK_SIZE, 100_000);
+    fn block_size_getter_returns_value_within_bounds() {
+        // WHAT-test: the configured block-size getter must always return a value
+        // within its [MIN, MAX] range, whatever the literals are tuned to. This
+        // exercises the clamp in block_size() rather than pinning the constants.
+        let result = block_size();
+        assert!((MIN_BLOCK_SIZE..=MAX_BLOCK_SIZE).contains(&result));
     }
 
     #[test]
@@ -154,12 +156,9 @@ mod tests {
         assert!(result > 0 && result < 100);
     }
 
-    #[test]
-    fn session_ttl_default_values() {
-        assert_eq!(DEFAULT_SESSION_TTL_SECS, 3600);
-        assert_eq!(MIN_SESSION_TTL_SECS, 60);
-        assert_eq!(MAX_SESSION_TTL_SECS, 86400);
-    }
+    // Tautological `session_ttl_default_values` pin test removed (Issue #1469):
+    // `session_ttl_returns_valid_value` below is the behavioural companion that
+    // asserts the getter stays within [MIN, MAX], making the pin redundant.
 
     #[test]
     fn session_ttl_returns_valid_value() {
@@ -222,12 +221,9 @@ mod tests {
         assert!(delay.as_secs() >= 1);
     }
 
-    #[test]
-    fn wall_clock_minutes_default_values() {
-        assert_eq!(DEFAULT_MAX_WALL_CLOCK_MINUTES, 20);
-        assert_eq!(MIN_WALL_CLOCK_MINUTES, 1);
-        assert_eq!(MAX_WALL_CLOCK_MINUTES, 120);
-    }
+    // Tautological `wall_clock_minutes_default_values` pin test removed (Issue
+    // #1469): `wall_clock_minutes_returns_valid_value` below is the behavioural
+    // companion that asserts the getter stays within [MIN, MAX].
 
     #[test]
     fn wall_clock_minutes_returns_valid_value() {
@@ -249,10 +245,11 @@ mod tests {
     }
 
     #[test]
-    fn drought_log_threshold_default_is_five() {
-        assert_eq!(DEFAULT_DROUGHT_LOG_THRESHOLD, 5);
-        // Nothing supplied → default.
-        assert_eq!(parse_drought_threshold(None), 5);
+    fn drought_log_threshold_unset_resolves_to_default() {
+        // WHAT-test: with nothing supplied the parser must fall back to the
+        // default. Exercises the parser's fallback branch rather than pinning
+        // the default's literal value.
+        assert_eq!(parse_drought_threshold(None), DEFAULT_DROUGHT_LOG_THRESHOLD);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removed the recurring **tautological "constant equals its own literal"** test
pattern flagged across the config and GPU modules. Each removed assertion (e.g.
`assert_eq!(WORKGROUP_SIZE, 256)`) was circular — it passed if and only if the
source literal was unchanged, so it could never catch a bug, only flag a
deliberate retune and force a meaningless paired edit. Where a constant has a
runtime getter, the pin was rewritten as a behavioural WHAT-test; where a
behavioural companion (or compile-time guard) already existed, the redundant pin
was deleted. Both resolutions are explicitly endorsed by the issue.

Note: a pure `MIN <= DEFAULT <= MAX` assertion on `const` operands is itself
rejected by Clippy's `assertions_on_constants` lint (the comparison is a
compile-time constant), so a meaningful runtime test must exercise a
getter/function rather than the bare constants — reinforcing why the pins added
no value.

Closes #1469.

### Changes per call site

| File | Test | Resolution |
|------|------|------------|
| `src/config/mod.rs` | `block_size_defaults` | Rewritten → `block_size_getter_returns_value_within_bounds` (exercises the `block_size()` clamp; no prior companion) |
| `src/config/mod.rs` | `session_ttl_default_values` | Deleted — `session_ttl_returns_valid_value` is the behavioural companion |
| `src/config/mod.rs` | `wall_clock_minutes_default_values` | Deleted — `wall_clock_minutes_returns_valid_value` is the behavioural companion |
| `src/config/mod.rs` | `drought_log_threshold_default_is_five` | Rewritten → `drought_log_threshold_unset_resolves_to_default` (exercises the parser's fallback branch) |
| `src/analysis/gpu/analyzer.rs` | `test_workgroup_size_constant`, `test_min_neuron_sample_count`, `test_gpu_max_batch_alloc_bytes` | Deleted — `WORKGROUP_SIZE` invariants already guarded at compile time in `shaders.rs`; tiering behaviour covered by `test_batch_size_for_tier`. Unused import removed. |
| `src/analysis/gpu/queue/recovery.rs` | `test_default_retry_limit`, `test_default_backoff_constants`, `test_minimum_gpu_batch_size_constant` | Deleted — backoff behaviour covered by `test_backoff_delay_with_default_constants`; retry-limit parsing covered via `gpu_retry_limit()` |
| `src/analysis/utils/lock_contention.rs` | `default_threshold_is_100ms` | Deleted — covered behaviourally by the `traced_lock_default` tests |

Each deletion leaves an in-place comment recording the removal and its
behavioural/compile-time companion, per the "document any removed test"
requirement.

## Evidence

Backend/Rust change only — no web interface to screenshot. Verified via the
test suite and full quality gate.

The two rewritten tests pass and exercise real runtime code paths:

```
test config::tests::block_size_getter_returns_value_within_bounds ... ok
test config::tests::drought_log_threshold_unset_resolves_to_default ... ok
```

```mermaid
flowchart LR
    A["assert_eq!(CONST, literal)<br/>(tautology — cannot fail)"] --> B{Runtime getter exists?}
    B -->|Yes| C["WHAT-test the getter<br/>(survives retuning)"]
    B -->|No, companion exists| D["Delete redundant pin<br/>(documented in place)"]
```

## Test Plan

- Rewrote `block_size_getter_returns_value_within_bounds` — asserts `block_size()`
  returns a value within `[MIN_BLOCK_SIZE, MAX_BLOCK_SIZE]`.
- Rewrote `drought_log_threshold_unset_resolves_to_default` — asserts the parser
  falls back to `DEFAULT_DROUGHT_LOG_THRESHOLD` when nothing is supplied.
- Deleted the redundant tautological pin tests listed above; each has a
  documented behavioural or compile-time companion that retains the coverage.
- Ran `./quality.sh` (fmt, Clippy `-D warnings`, check, lib/integration tests,
  doc build, release build) until clean.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqobmtl5-2f55d5`<!-- vibe-worker-issue-1469 -->