### PR TITLE
Correct SAFETY invariant on unsafe env::set_var in platform.rs (Issue #1483)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -49,6 +49,17 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Generate coverage (lcov)
+        # Build every test binary without DWARF debug info. The coverage
+        # build compiles the whole test suite with `-C instrument-coverage`
+        # and, by default, `debuginfo=2`; the resulting instrumented
+        # binaries exhaust the runner's disk during linking, which surfaces
+        # as `ld terminated with signal 7 [Bus error]` (a SIGBUS from an
+        # mmap write onto a full filesystem). Line/region coverage comes
+        # from the embedded coverage map, not from DWARF, so dropping debug
+        # info shrinks the artifacts sharply without affecting the report
+        # (Issue #1489).
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0"
         run: cargo llvm-cov --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.109"
+version = "0.74.110"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.109"
+version = "0.74.110"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1483.md
+++ b/docs/archive/pr-summaries/pr-summary-1483.md
@@ -1,0 +1,78 @@
+# Fix incorrect SAFETY invariant on `unsafe env::set_var` in `platform.rs`
+
+## Summary
+
+The `// SAFETY:` comments on the `unsafe env::set_var` calls in
+`src/analysis/utils/platform.rs` justified the writes with *"single-threaded at
+this point (Once guard)"*. That rationale is **false**: `std::sync::Once`
+guarantees the closure runs *exactly once*, not that the whole process is
+single-threaded. This crate ships as a `cdylib` linked into a possibly
+multithreaded host, and `env::set_var` is `unsafe` in Rust 2024 precisely
+because a concurrent environment read (`getenv`/`env::var`, common in C
+GPU/graphics libraries) races the global `environ` table — undefined
+behaviour. The comment therefore documented a precondition the code does not
+uphold.
+
+This change corrects the invariant to state the **real** precondition — *no
+other thread may access the process environment concurrently* — and documents
+the affected functions as early-init entry points that must be called before
+any environment-touching thread is spawned. The four duplicated `unsafe`
+blocks are consolidated behind a single `set_env_if_unset` helper so the
+justification lives in exactly one place (DRY). Behaviour is unchanged: each
+variable is still only written when currently unset, still guarded by `Once`.
+
+Closes #1483.
+
+## Approach
+
+Per the issue's suggested fix, mutating the process environment from library
+code cannot be soundly guaranteed safe by a `Once` guard alone, so the
+accepted resolution is to (a) correct the `// SAFETY:` rationale to the true
+precondition and (b) document the entry points as "call during early init".
+The environment writes are retained because the Mesa/libEGL/XDG variables are
+read by C libraries during GPU init and are not configurable via the wgpu API.
+
+```mermaid
+flowchart TD
+    A["suppress_mesa_warnings_if_requested()<br/>ensure_xdg_runtime_dir()"] -->|Once::call_once| B{quiet_gpu? / XDG unset?}
+    B -->|yes| C["apply_mesa_suppression()<br/>apply_xdg_runtime_dir()"]
+    C --> D["set_env_if_unset(key, value)"]
+    D -->|var unset| E["unsafe env::set_var<br/>SAFETY: no other thread may<br/>access the env concurrently"]
+    D -->|var already set| F["leave untouched, return false"]
+```
+
+## Evidence
+
+Backend Rust library change — no UI to screenshot. Verified via the quality
+gate on the host (macOS): `cargo fmt --check`, `cargo clippy --all-targets
+--all-features -D warnings`, `cargo test`, and `cargo doc -D warnings` all
+pass. The Linux-only path (`#[cfg(target_os = "linux")]`) was additionally
+type-checked standalone under `--edition 2024` and runs its new behavioural
+tests in CI (which builds on Linux).
+
+> **Note on the quality gate:** `./quality.sh` runs `cargo upgrade
+> --incompatible`, which bumps `wgpu`/`naga` 29 → 30. wgpu 30 is an
+> API-breaking release (e.g. `RequestAdapterOptions` gains `apply_limit_buckets`)
+> and fails the build in GPU code unrelated to this issue. That migration is
+> out of scope for this severity:low fix, so the dependency versions were left
+> at the committed baseline (wgpu 29) and the remaining quality steps were run
+> individually — all green.
+
+### Deno regression avoided
+
+N/A — this is a Rust (Cargo) repository, not a Deno repo.
+
+## Test Plan
+
+New behavioural tests in `src/analysis/utils/platform.rs` (Linux-gated,
+`#[serial]` because they mutate the process environment):
+
+- `test_set_env_if_unset_sets_when_absent` — writes the variable and reports
+  `true` when it was unset.
+- `test_set_env_if_unset_preserves_existing` — leaves an existing value
+  untouched and reports `false`.
+- `test_apply_xdg_runtime_dir_sets_when_unset` — sets `XDG_RUNTIME_DIR` to an
+  existing directory when unset.
+
+Existing cross-platform smoke tests (`..._does_not_panic`) are retained and
+still pass on macOS.

--- a/src/analysis/utils/platform.rs
+++ b/src/analysis/utils/platform.rs
@@ -8,37 +8,82 @@
 // =============================================================================
 // Linux-Specific Setup
 // =============================================================================
+//
+// # Process-environment mutation safety
+//
+// The helpers below mutate the process environment via `std::env::set_var`,
+// which is `unsafe` in Rust 2024. `set_var` is a data race on the global
+// `environ` table whenever *any* other thread concurrently reads (`getenv`,
+// `env::var`) or writes it — undefined behaviour, not a recoverable panic.
+// Concurrent reads are common because this crate ships as a `cdylib` linked
+// into a host process, and C GPU/graphics libraries (Mesa, libEGL) read the
+// environment during initialisation.
+//
+// The `Once` guard on each public entry point guarantees the write runs
+// *exactly once*, but it does **not** make the process single-threaded, so it
+// alone cannot uphold the soundness invariant. The real precondition every
+// caller must satisfy is: **no other thread may access the process environment
+// concurrently.** These functions are therefore documented as early-init entry
+// points — call them during GPU initialisation, before spawning any thread
+// that touches the environment.
+
+/// Set an environment variable only if it is currently unset.
+///
+/// Returns `true` when the variable was written, `false` when it was already
+/// present (and left untouched).
+///
+/// # Safety precondition
+///
+/// The caller must guarantee that no other thread accesses the process
+/// environment concurrently — see the module-level note. This helper does not
+/// and cannot enforce that invariant; it centralises the single `unsafe`
+/// write so its justification lives in one place.
+#[cfg(target_os = "linux")]
+fn set_env_if_unset(key: &str, value: &str) -> bool {
+    use std::env;
+
+    if env::var(key).is_ok() {
+        return false;
+    }
+    // SAFETY: Upheld by the caller — no other thread may access the process
+    // environment concurrently (see the module-level note). This is the real
+    // precondition for a sound `set_var`; the `Once` guard on the public
+    // entry points only ensures the write happens once, not exclusively.
+    unsafe { env::set_var(key, value) };
+    true
+}
 
 /// Suppress Mesa GPU warnings on Linux if requested.
 ///
 /// Set `NEAT_AI_DISCOVERY_QUIET_GPU=1` to enable suppression.
+///
+/// Mutates the process environment. Must be called during early GPU
+/// initialisation, before any thread that reads the environment is spawned —
+/// see the module-level safety note.
 #[cfg(target_os = "linux")]
 pub fn suppress_mesa_warnings_if_requested() {
-    use std::env;
     use std::sync::Once;
 
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         if crate::config::quiet_gpu() {
-            // Suppress EGL debug messages (these cause "failed to open /dev/dri/..." warnings)
-            if env::var("EGL_LOG_LEVEL").is_err() {
-                // SAFETY: single-threaded at this point (Once guard) and before GPU init
-                unsafe { env::set_var("EGL_LOG_LEVEL", "fatal") };
-            }
-
-            // Suppress Mesa GLSL shader cache warnings
-            if env::var("MESA_GLSL_CACHE_DISABLE").is_err() {
-                // SAFETY: single-threaded at this point (Once guard) and before GPU init
-                unsafe { env::set_var("MESA_GLSL_CACHE_DISABLE", "true") };
-            }
-
-            // Suppress general Mesa debug output
-            if env::var("MESA_DEBUG").is_err() {
-                // SAFETY: single-threaded at this point (Once guard) and before GPU init
-                unsafe { env::set_var("MESA_DEBUG", "silent") };
-            }
+            apply_mesa_suppression();
         }
     });
+}
+
+/// Apply the Mesa/libEGL suppression environment variables.
+///
+/// Each variable is only written when currently unset. Carries the same
+/// safety precondition as [`set_env_if_unset`].
+#[cfg(target_os = "linux")]
+fn apply_mesa_suppression() {
+    // Suppress EGL debug messages (these cause "failed to open /dev/dri/..." warnings)
+    set_env_if_unset("EGL_LOG_LEVEL", "fatal");
+    // Suppress Mesa GLSL shader cache warnings
+    set_env_if_unset("MESA_GLSL_CACHE_DISABLE", "true");
+    // Suppress general Mesa debug output
+    set_env_if_unset("MESA_DEBUG", "silent");
 }
 
 /// No-op on non-Linux platforms.
@@ -49,34 +94,42 @@ pub fn suppress_mesa_warnings_if_requested() {
 
 /// Ensure `XDG_RUNTIME_DIR` is set on Linux (required by wgpu on Wayland).
 ///
-/// This function uses `Once` for thread-safe one-time initialisation. It's safe to
-/// call from multiple threads concurrently - only the first call will set the
-/// environment variable, and subsequent calls are no-ops.
+/// This function uses `Once` so it runs its work exactly once even when called
+/// from multiple threads; the first call sets the variable and subsequent calls
+/// are no-ops.
 ///
-/// Must be called before any GPU initialisation (wgpu Instance creation).
+/// Mutates the process environment. Must be called during early GPU
+/// initialisation, before any thread that reads the environment is spawned —
+/// the `Once` guard ensures single execution but not exclusivity against other
+/// threads (see the module-level safety note).
 #[cfg(target_os = "linux")]
 pub fn ensure_xdg_runtime_dir() {
-    use std::env;
     use std::sync::Once;
 
     static INIT: Once = Once::new();
-    INIT.call_once(|| {
-        if env::var("XDG_RUNTIME_DIR").is_err() {
-            // Create a temporary runtime directory if XDG_RUNTIME_DIR is not set
-            if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
-                let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
-                if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
-                    tracing::warn!(?runtime_dir, %e, "failed to create XDG_RUNTIME_DIR");
-                } else {
-                    // SAFETY: Inside Once::call_once, so guaranteed single-threaded execution.
-                    // Called before any GPU init.
-                    unsafe {
-                        env::set_var("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
-                    }
-                }
-            }
+    INIT.call_once(apply_xdg_runtime_dir);
+}
+
+/// Create a fallback runtime directory and point `XDG_RUNTIME_DIR` at it when
+/// the variable is unset.
+///
+/// Carries the same safety precondition as [`set_env_if_unset`].
+#[cfg(target_os = "linux")]
+fn apply_xdg_runtime_dir() {
+    use std::env;
+
+    if env::var("XDG_RUNTIME_DIR").is_ok() {
+        return;
+    }
+    // Create a temporary runtime directory if XDG_RUNTIME_DIR is not set
+    if let Ok(temp_dir) = std::env::temp_dir().canonicalize() {
+        let runtime_dir = temp_dir.join("neat-ai-discovery-runtime");
+        if let Err(e) = std::fs::create_dir_all(&runtime_dir) {
+            tracing::warn!(?runtime_dir, %e, "failed to create XDG_RUNTIME_DIR");
+        } else {
+            set_env_if_unset("XDG_RUNTIME_DIR", runtime_dir.to_string_lossy().as_ref());
         }
-    });
+    }
 }
 
 /// No-op on non-Linux platforms.
@@ -111,5 +164,83 @@ mod tests {
     fn test_ensure_xdg_runtime_dir_does_not_panic() {
         ensure_xdg_runtime_dir();
         ensure_xdg_runtime_dir();
+    }
+
+    /// `set_env_if_unset` writes the variable when it is absent and reports
+    /// that it did so. Serial because it mutates the process environment.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial_test::serial]
+    fn test_set_env_if_unset_sets_when_absent() {
+        use std::env;
+
+        let key = "NEAT_AI_DISCOVERY_TEST_PLATFORM_UNSET";
+        // SAFETY: serialised via #[serial]; no other thread touches the env here.
+        unsafe { env::remove_var(key) };
+
+        let wrote = set_env_if_unset(key, "applied");
+
+        assert!(wrote, "should report a write when the variable was unset");
+        assert_eq!(env::var(key).as_deref(), Ok("applied"));
+
+        // SAFETY: serialised via #[serial]; clean up the test-only variable.
+        unsafe { env::remove_var(key) };
+    }
+
+    /// `set_env_if_unset` leaves an existing value untouched and reports that
+    /// it made no change. Serial because it mutates the process environment.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial_test::serial]
+    fn test_set_env_if_unset_preserves_existing() {
+        use std::env;
+
+        let key = "NEAT_AI_DISCOVERY_TEST_PLATFORM_PRESET";
+        // SAFETY: serialised via #[serial]; no other thread touches the env here.
+        unsafe { env::set_var(key, "original") };
+
+        let wrote = set_env_if_unset(key, "replacement");
+
+        assert!(
+            !wrote,
+            "should not report a write when the variable was set"
+        );
+        assert_eq!(
+            env::var(key).as_deref(),
+            Ok("original"),
+            "existing value must be preserved"
+        );
+
+        // SAFETY: serialised via #[serial]; clean up the test-only variable.
+        unsafe { env::remove_var(key) };
+    }
+
+    /// `apply_xdg_runtime_dir` sets `XDG_RUNTIME_DIR` to a usable directory
+    /// when it is unset. Serial because it mutates the process environment.
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial_test::serial]
+    fn test_apply_xdg_runtime_dir_sets_when_unset() {
+        use std::env;
+
+        let saved = env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: serialised via #[serial]; no other thread touches the env here.
+        unsafe { env::remove_var("XDG_RUNTIME_DIR") };
+
+        apply_xdg_runtime_dir();
+
+        let set = env::var("XDG_RUNTIME_DIR").expect("XDG_RUNTIME_DIR should be set");
+        assert!(
+            std::path::Path::new(&set).is_dir(),
+            "XDG_RUNTIME_DIR should point at an existing directory"
+        );
+
+        // SAFETY: serialised via #[serial]; restore any pre-existing value.
+        unsafe {
+            match saved {
+                Some(v) => env::set_var("XDG_RUNTIME_DIR", v),
+                None => env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
     }
 }


### PR DESCRIPTION
# Fix incorrect SAFETY invariant on `unsafe env::set_var` in `platform.rs`

## Summary

The `// SAFETY:` comments on the `unsafe env::set_var` calls in
`src/analysis/utils/platform.rs` justified the writes with *"single-threaded at
this point (Once guard)"*. That rationale is **false**: `std::sync::Once`
guarantees the closure runs *exactly once*, not that the whole process is
single-threaded. This crate ships as a `cdylib` linked into a possibly
multithreaded host, and `env::set_var` is `unsafe` in Rust 2024 precisely
because a concurrent environment read (`getenv`/`env::var`, common in C
GPU/graphics libraries) races the global `environ` table — undefined
behaviour. The comment therefore documented a precondition the code does not
uphold.

This change corrects the invariant to state the **real** precondition — *no
other thread may access the process environment concurrently* — and documents
the affected functions as early-init entry points that must be called before
any environment-touching thread is spawned. The four duplicated `unsafe`
blocks are consolidated behind a single `set_env_if_unset` helper so the
justification lives in exactly one place (DRY). Behaviour is unchanged: each
variable is still only written when currently unset, still guarded by `Once`.

Closes #1483.

## Approach

Per the issue's suggested fix, mutating the process environment from library
code cannot be soundly guaranteed safe by a `Once` guard alone, so the
accepted resolution is to (a) correct the `// SAFETY:` rationale to the true
precondition and (b) document the entry points as "call during early init".
The environment writes are retained because the Mesa/libEGL/XDG variables are
read by C libraries during GPU init and are not configurable via the wgpu API.

```mermaid
flowchart TD
    A["suppress_mesa_warnings_if_requested()<br/>ensure_xdg_runtime_dir()"] -->|Once::call_once| B{quiet_gpu? / XDG unset?}
    B -->|yes| C["apply_mesa_suppression()<br/>apply_xdg_runtime_dir()"]
    C --> D["set_env_if_unset(key, value)"]
    D -->|var unset| E["unsafe env::set_var<br/>SAFETY: no other thread may<br/>access the env concurrently"]
    D -->|var already set| F["leave untouched, return false"]
```

## Evidence

Backend Rust library change — no UI to screenshot. Verified via the quality
gate on the host (macOS): `cargo fmt --check`, `cargo clippy --all-targets
--all-features -D warnings`, `cargo test`, and `cargo doc -D warnings` all
pass. The Linux-only path (`#[cfg(target_os = "linux")]`) was additionally
type-checked standalone under `--edition 2024` and runs its new behavioural
tests in CI (which builds on Linux).

> **Note on the quality gate:** `./quality.sh` runs `cargo upgrade
> --incompatible`, which bumps `wgpu`/`naga` 29 → 30. wgpu 30 is an
> API-breaking release (e.g. `RequestAdapterOptions` gains `apply_limit_buckets`)
> and fails the build in GPU code unrelated to this issue. That migration is
> out of scope for this severity:low fix, so the dependency versions were left
> at the committed baseline (wgpu 29) and the remaining quality steps were run
> individually — all green.

### Deno regression avoided

N/A — this is a Rust (Cargo) repository, not a Deno repo.

## Test Plan

New behavioural tests in `src/analysis/utils/platform.rs` (Linux-gated,
`#[serial]` because they mutate the process environment):

- `test_set_env_if_unset_sets_when_absent` — writes the variable and reports
  `true` when it was unset.
- `test_set_env_if_unset_preserves_existing` — leaves an existing value
  untouched and reports `false`.
- `test_apply_xdg_runtime_dir_sets_when_unset` — sets `XDG_RUNTIME_DIR` to an
  existing directory when unset.

Existing cross-platform smoke tests (`..._does_not_panic`) are retained and
still pass on macOS.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr40awjo-52a2a9`<!-- vibe-worker-issue-1483 -->