### PR TITLE
Replace doc-prose grep with behavioural test (Issue #1503)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.113"
+version = "0.74.114"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.113"
+version = "0.74.114"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1503.md
+++ b/docs/archive/pr-summaries/pr-summary-1503.md
@@ -1,0 +1,44 @@
+## Summary
+
+Replaced the doc-prose grep test `test_activation_recommendation_documented` in
+`tests/recommendation/issue_431_activation_recommendation.rs` with a behavioural
+WHAT-test. The old test read `docs/DISCOVERY_TYPES.md` and asserted only that a
+heading string appeared in the Markdown file — a HOW/editorial check that broke
+on any doc rewording and gave no correctness signal, while a full removal of the
+feature would have left it green as long as the heading survived.
+
+The new test `test_activation_recommendation_produces_change_squash_candidate`
+exercises the public recommender on the documented scenario (a Gaussian-input
+neuron currently using `RELU`) and asserts the behaviour the documentation
+promises: a recommendation is produced, it names a valid squash op distinct from
+the current one, and it converts to the documented `changeSquash` candidate
+operation carrying that op. This survives editorial doc changes and fails if the
+recommendation behaviour regresses.
+
+Closes #1503.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified via the test
+runner:
+
+- New test passes: `cargo test --test recommendation issue_431` → 17 passed, 0
+  failed (including the new behavioural test).
+- Full quality gate `./quality.sh` passes cleanly (fmt, clippy, check, tests,
+  doc build, release build).
+
+```mermaid
+flowchart LR
+    A["Old: grep DISCOVERY_TYPES.md<br/>for heading string"] -->|"breaks on reword,<br/>no behaviour signal"| B[HOW-test]
+    C["New: run recommend_activation_function<br/>on Gaussian neuron"] -->|"assert changeSquash<br/>candidate emitted"| D[WHAT-test]
+```
+
+## Test Plan
+
+- Removed: `test_activation_recommendation_documented` (doc-prose grep).
+- Added: `test_activation_recommendation_produces_change_squash_candidate` —
+  asserts the recommender yields a `changeSquash` candidate naming a valid
+  recommended squash op for a Gaussian-input `RELU` neuron.
+- Ran `cargo test --test recommendation issue_431 -- --test-threads=2` — all 17
+  tests pass.
+- Ran `./quality.sh` — all checks pass.

--- a/tests/recommendation/issue_431_activation_recommendation.rs
+++ b/tests/recommendation/issue_431_activation_recommendation.rs
@@ -501,19 +501,53 @@ fn test_considers_gradient_flow() {
 }
 
 // =============================================================================
-// Test 16: Documentation Consistency
+// Test 16: Documented Behaviour — Activation Recommendation emits changeSquash
 // =============================================================================
 
-/// Test that activation recommendation is documented in `DISCOVERY_TYPES.md`.
+/// Assert the behaviour `DISCOVERY_TYPES.md` promises for activation
+/// recommendation (Issue #1503): the public recommender, run on a neuron whose
+/// input distribution favours a different activation, produces a recommendation
+/// that converts to the documented `changeSquash` candidate operation naming a
+/// valid squash op.
+///
+/// This replaces a former doc-prose grep (which only checked that a heading
+/// string appeared in the Markdown file) with a WHAT-test that exercises the
+/// real recommender output — the behaviour the documentation describes.
 #[test]
-fn test_activation_recommendation_documented() {
-    let doc_content =
-        std::fs::read_to_string("docs/DISCOVERY_TYPES.md").expect("Should read DISCOVERY_TYPES.md");
+fn test_activation_recommendation_produces_change_squash_candidate() {
+    use neat_ai_discovery::analysis::recommendation::activation_recommendation::recommendation_to_coordinated_candidate;
 
+    // Gaussian-like inputs on a neuron currently using RELU: the documented
+    // scenario where a better-matched activation should be recommended.
+    let records: Vec<DiscoverRecord> = (0..100)
+        .map(|i| {
+            let x = (i as f32 - 50.0) / 25.0;
+            record("hidden-doc-behaviour", i, x, Some(x))
+        })
+        .collect();
+
+    let recommendation = recommend_activation_function(&records, "RELU")
+        .expect("activation recommendation should be produced for a Gaussian neuron");
+
+    // The recommendation must name a non-empty squash op distinct from current.
     assert!(
-        doc_content.contains("Activation Recommendation")
-            || doc_content.contains("activation recommendation")
-            || doc_content.contains("Activation Function Recommendation"),
-        "DISCOVERY_TYPES.md should document activation recommendation"
+        !recommendation.recommended_squash.is_empty(),
+        "recommended squash op should be named"
+    );
+    assert_ne!(
+        recommendation.recommended_squash, recommendation.current_squash,
+        "a recommendation should change the activation function"
+    );
+
+    // The documented candidate operation is `changeSquash` (DISCOVERY_TYPES.md).
+    let candidate = recommendation_to_coordinated_candidate(&recommendation);
+    let ops_json = serde_json::to_string(&candidate.operations).unwrap();
+    assert!(
+        ops_json.contains("changeSquash"),
+        "activation recommendation should emit the documented changeSquash operation, got {ops_json}"
+    );
+    assert!(
+        ops_json.contains(&recommendation.recommended_squash),
+        "changeSquash operation should carry the recommended squash op"
     );
 }


### PR DESCRIPTION
## Summary

Replaced the doc-prose grep test `test_activation_recommendation_documented` in
`tests/recommendation/issue_431_activation_recommendation.rs` with a behavioural
WHAT-test. The old test read `docs/DISCOVERY_TYPES.md` and asserted only that a
heading string appeared in the Markdown file — a HOW/editorial check that broke
on any doc rewording and gave no correctness signal, while a full removal of the
feature would have left it green as long as the heading survived.

The new test `test_activation_recommendation_produces_change_squash_candidate`
exercises the public recommender on the documented scenario (a Gaussian-input
neuron currently using `RELU`) and asserts the behaviour the documentation
promises: a recommendation is produced, it names a valid squash op distinct from
the current one, and it converts to the documented `changeSquash` candidate
operation carrying that op. This survives editorial doc changes and fails if the
recommendation behaviour regresses.

Closes #1503.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified via the test
runner:

- New test passes: `cargo test --test recommendation issue_431` → 17 passed, 0
  failed (including the new behavioural test).
- Full quality gate `./quality.sh` passes cleanly (fmt, clippy, check, tests,
  doc build, release build).

```mermaid
flowchart LR
    A["Old: grep DISCOVERY_TYPES.md<br/>for heading string"] -->|"breaks on reword,<br/>no behaviour signal"| B[HOW-test]
    C["New: run recommend_activation_function<br/>on Gaussian neuron"] -->|"assert changeSquash<br/>candidate emitted"| D[WHAT-test]
```

## Test Plan

- Removed: `test_activation_recommendation_documented` (doc-prose grep).
- Added: `test_activation_recommendation_produces_change_squash_candidate` —
  asserts the recommender yields a `changeSquash` candidate naming a valid
  recommended squash op for a Gaussian-input `RELU` neuron.
- Ran `cargo test --test recommendation issue_431 -- --test-threads=2` — all 17
  tests pass.
- Ran `./quality.sh` — all checks pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr5nwtyk-47bd17`<!-- vibe-worker-issue-1503 -->