### PR TITLE
Remove dead worker/deno Mermaid block from markdown-lint workflow (Issue #1504)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
-    # markdownlint-cli2 + optional Mermaid validation — light job,
-    # 10 minute cap (Issue #1287).
+    # markdownlint-cli2 — light job, 10 minute cap (Issue #1287).
     timeout-minutes: 10
     steps:
       # actions/checkout@v5
@@ -36,21 +35,3 @@ jobs:
         run: npm install -g --ignore-scripts markdownlint-cli2@0.23.0
       - name: Run markdownlint-cli2
         run: markdownlint-cli2
-      # Optional: mirror the local check-mermaid quality gate when Deno
-      # and the worker module are available in the repo (Issue #1683).
-      - name: Detect Deno worker module
-        id: detect-deno
-        run: |
-          if [ -f worker/deno/mod.ts ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
-      # denoland/setup-deno@v2
-      - if: steps.detect-deno.outputs.present == 'true'
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-        with:
-          deno-version: v2.x
-      - if: steps.detect-deno.outputs.present == 'true'
-        name: Validate Mermaid blocks
-        run: deno run --allow-read --allow-env=DEBUG,LOG_LEVEL,CONFIG_PATH,OUTPUT_JSON worker/deno/mod.ts check-mermaid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.114"
+version = "0.74.115"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.114"
+version = "0.74.115"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1504.md
+++ b/docs/archive/pr-summaries/pr-summary-1504.md
@@ -1,0 +1,37 @@
+## Summary
+
+Removed the dead Deno/Mermaid validation block from `.github/workflows/markdown-lint.yml`. This repository is a pure Rust library (`Cargo.toml`, `src/lib.rs`, no `deno.json`/`deno.lock`) with no `worker/` directory, so the three steps that referenced `worker/deno/mod.ts` could never execute here:
+
+- **`Detect Deno worker module`** — `[ -f worker/deno/mod.ts ]` always resolved to `present=false`.
+- **`denoland/setup-deno`** — gated on `present == 'true'`, never ran.
+- **`Validate Mermaid blocks`** — same gate, never ran.
+
+The inert steps carried an ongoing maintenance cost (the `denoland/setup-deno` SHA pin still had to be kept current) and added review noise for a code path that can never run in this repo. Deleting them leaves the `markdownlint-cli2` gate intact and also drops the stale `setup-deno` pin so Renovate/`bump-deps` no longer track it here.
+
+The job-level comment was trimmed to match (`optional Mermaid validation` removed) so the workflow description stays accurate.
+
+Closes #1504.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verification performed:
+
+- `python3 -c "yaml.safe_load(...)"` → **YAML OK** (workflow parses cleanly after the edit).
+- `grep -rn "worker/deno|setup-deno|check-mermaid|detect-deno" .github/` → **no dead references remaining**.
+
+Resulting `markdownlint` job flow:
+
+```mermaid
+flowchart LR
+    A[checkout] --> B[setup-node 22]
+    B --> C[install markdownlint-cli2]
+    C --> D[run markdownlint-cli2]
+```
+
+## Test Plan
+
+This is a GitHub Actions workflow change with no Rust code impact, so the repo's `quality.sh` (fmt/clippy/test/build) gate is not exercised by the change. Validation instead:
+
+- Confirmed the workflow YAML remains valid after removal.
+- Confirmed no `worker/deno`, `setup-deno`, `check-mermaid`, or `detect-deno` references remain under `.github/`.
+- Confirmed the `markdownlint-cli2` install + run steps are unchanged and intact.


### PR DESCRIPTION
## Summary

Removed the dead Deno/Mermaid validation block from `.github/workflows/markdown-lint.yml`. This repository is a pure Rust library (`Cargo.toml`, `src/lib.rs`, no `deno.json`/`deno.lock`) with no `worker/` directory, so the three steps that referenced `worker/deno/mod.ts` could never execute here:

- **`Detect Deno worker module`** — `[ -f worker/deno/mod.ts ]` always resolved to `present=false`.
- **`denoland/setup-deno`** — gated on `present == 'true'`, never ran.
- **`Validate Mermaid blocks`** — same gate, never ran.

The inert steps carried an ongoing maintenance cost (the `denoland/setup-deno` SHA pin still had to be kept current) and added review noise for a code path that can never run in this repo. Deleting them leaves the `markdownlint-cli2` gate intact and also drops the stale `setup-deno` pin so Renovate/`bump-deps` no longer track it here.

The job-level comment was trimmed to match (`optional Mermaid validation` removed) so the workflow description stays accurate.

Closes #1504.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verification performed:

- `python3 -c "yaml.safe_load(...)"` → **YAML OK** (workflow parses cleanly after the edit).
- `grep -rn "worker/deno|setup-deno|check-mermaid|detect-deno" .github/` → **no dead references remaining**.

Resulting `markdownlint` job flow:

```mermaid
flowchart LR
    A[checkout] --> B[setup-node 22]
    B --> C[install markdownlint-cli2]
    C --> D[run markdownlint-cli2]
```

## Test Plan

This is a GitHub Actions workflow change with no Rust code impact, so the repo's `quality.sh` (fmt/clippy/test/build) gate is not exercised by the change. Validation instead:

- Confirmed the workflow YAML remains valid after removal.
- Confirmed no `worker/deno`, `setup-deno`, `check-mermaid`, or `detect-deno` references remain under `.github/`.
- Confirmed the `markdownlint-cli2` install + run steps are unchanged and intact.
