### PR TITLE
Document 5 undocumented public FFI entry points (Issue #1506)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.116"
+version = "0.74.117"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.116"
+version = "0.74.117"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ The library exposes a Deno FFI-friendly symbol set. The authoritative list lives
 | **Recording (streaming)** | `start_discovery_session`, `append_discovery_records`, `finish_discovery_session`, `cancel_discovery_session` |
 | **Recording (single-call)** | `record_discovery` (avoid for large runs) |
 | **Analysis** | `rank_focus_neurons`, `analyze_parallel` |
+| **Cancellation** | `cancel_analysis`, `cancel_analysis_memory_pressure` (CRITICAL memory pressure), `reset_cancellation`, `is_analysis_active` |
 | **Utilities** | `merge_discovery_parquet`, `read_discovery_records_ffi`, `export_visualisation_snapshot` |
+| **Calibration** | `get_calibration_summary` |
+| **Lifecycle / cleanup** | `cleanup_discovery_lib` (call before process exit), `cleanup_discovery_dir`, `clean_orphaned_discovery_dirs` |
 | **Memory usage** | `discovery_memory_usage_bytes` |
 | **Memory management** | `free_discovery_result` |
 

--- a/docs/FFI_API.md
+++ b/docs/FFI_API.md
@@ -18,8 +18,10 @@ The most commonly used entry points are:
 - **Recording**:
   - Streaming: `start_discovery_session`, `append_discovery_records`, `finish_discovery_session`, `cancel_discovery_session`
   - Single-call: `record_discovery` (avoid for large runs; prefer streaming to prevent JS/V8 string limits)
-- **Analysis**: `rank_focus_neurons`, `analyze_parallel`, `cancel_analysis`, `reset_cancellation`, `is_analysis_active`
+- **Analysis**: `rank_focus_neurons`, `analyze_parallel`, `cancel_analysis`, `cancel_analysis_memory_pressure`, `reset_cancellation`, `is_analysis_active`
 - **Utilities**: `merge_discovery_parquet`, `read_discovery_records_ffi`, `export_visualisation_snapshot`
+- **Calibration**: `get_calibration_summary` (returns JSON)
+- **Lifecycle / cleanup**: `cleanup_discovery_lib` (call before process exit), `cleanup_discovery_dir`, `clean_orphaned_discovery_dirs`
 - **Memory usage**: `discovery_memory_usage_bytes()` (returns `u64`)
 - **Memory management**: `free_discovery_result`
 
@@ -190,6 +192,17 @@ Allows the host process to request graceful shutdown of in-flight analysis
   - **Input**: no arguments
   - **Output**: no return value
   - **Thread safety**: safe to call from any thread at any time
+- **Symbol**: `cancel_analysis_memory_pressure` — cancel due to CRITICAL memory
+  pressure (Issue #1099)
+  - **Input**: no arguments
+  - **Output**: no return value
+  - **Behaviour**: sets **both** the general cancellation flag and a
+    memory-pressure-specific flag, so the pipeline can report the specific
+    reason (`environmentalGates.memoryPressureCancelled: true`) and the host can
+    take additional recovery actions (e.g. clearing WASM caches, evicting
+    discovery buffers). Call this instead of `cancel_analysis` when the memory
+    monitor detects CRITICAL pressure (e.g. ≥85% heap usage).
+  - **Thread safety**: safe to call from any thread at any time
 - **Symbol**: `reset_cancellation` — clears the flag before a new analysis run
   - Called automatically at the start of `analyze_all`, but can also be
     called explicitly by the host
@@ -220,6 +233,103 @@ still reading from it.
   `CompressedLruRecordCache` hold an open file handle to the parquet file.
   On Unix, this keeps the inode alive even if the path is unlinked, so
   in-flight reads succeed even under a race condition.
+
+---
+
+## 📈 Calibration Summary (Issue #605)
+
+Query the per-module prediction-calibration summary accumulated in a
+`DiscoveryHistory`. Controllers use it to inspect how well each module's
+predicted gains have matched observed outcomes.
+
+- **Symbol**: `get_calibration_summary`
+- **Input**: JSON string carrying the serialised discovery history:
+
+  ```json
+  {
+    "discoveryHistory": "<serialised DiscoveryHistory JSON string>"
+  }
+  ```
+
+- **Output**: JSON string:
+
+  ```json
+  {
+    "success": true,
+    "calibrationSummary": [
+      {
+        "moduleName": "saturation",
+        "candidateType": "addSynapse",
+        "sampleCount": 10,
+        "meanAbsoluteError": 0.02,
+        "bias": 0.01,
+        "calibrationFactor": 0.95
+      }
+    ]
+  }
+  ```
+
+- **Errors**: on failure, `success` is `false`, `calibrationSummary` is empty,
+  and `error` / `errorKind` / `retryable` describe the failure.
+- **Memory**: the returned pointer **must** be freed with `free_discovery_result`.
+
+---
+
+## 🧹 Library Lifecycle & Directory Cleanup
+
+### Library Shutdown (`cleanup_discovery_lib`, Issue #994)
+
+Shut down the background threads (deadlock-detector and signal-handler) spawned
+by the library. **The host must call this before process exit** — without it,
+those threads may keep the host process alive after all FFI work has finished.
+
+- **Symbol**: `cleanup_discovery_lib`
+- **Input**: no arguments
+- **Output**: no return value
+- **Idempotent**: safe to call multiple times and from any thread.
+
+### Discovery Directory Cleanup (`cleanup_discovery_dir`, Issue #1100)
+
+Atomically remove a single discovery temp directory tree in one recursive call,
+so the lock file is never absent while the directory still exists.
+
+- **Symbol**: `cleanup_discovery_dir`
+- **Input**: JSON string:
+
+  ```json
+  { "tempDir": "/path/to/.discovery/abc123" }
+  ```
+
+- **Output**: JSON string. When another actor already removed the directory,
+  `alreadyGone` is `true` with `success: true` (no error):
+
+  ```json
+  { "success": true, "alreadyGone": false }
+  ```
+
+- **Memory**: the returned pointer **must** be freed with `free_discovery_result`.
+
+### Orphaned Directory Sweep (`clean_orphaned_discovery_dirs`, Issue #1100)
+
+Scan a base directory for orphaned discovery directories (subdirectories with no
+`discovery.lock` file) and remove them. `NotFound` races are suppressed because
+the async cleanup actor may have removed a directory between the orphan check and
+the removal call.
+
+- **Symbol**: `clean_orphaned_discovery_dirs`
+- **Input**: JSON string:
+
+  ```json
+  { "baseDir": "/path/to/.discovery" }
+  ```
+
+- **Output**: JSON string:
+
+  ```json
+  { "success": true, "removed": 2, "alreadyGone": 0, "removalErrors": [] }
+  ```
+
+- **Memory**: the returned pointer **must** be freed with `free_discovery_result`.
 
 ---
 

--- a/docs/archive/pr-summaries/pr-summary-1506.md
+++ b/docs/archive/pr-summaries/pr-summary-1506.md
@@ -1,0 +1,73 @@
+## Summary
+
+Documentation-only change closing the README ↔ `docs/FFI_API.md` coverage gap
+identified by the Documentation Posture Audit (finding `BP-3be62eced7f5`). Five
+public `pub extern "C"` FFI entry points exported by the `neat_ai_discovery`
+cdylib were absent from **both** the README's `## 🔌 FFI API Summary` table and
+the authoritative interface spec (`docs/FFI_API.md`), leaving them
+undiscoverable through the documented consumer path (README summary →
+`docs/FFI_API.md`). Closes #1506.
+
+The five newly-documented entry points:
+
+| Entry point | Declared at | Purpose |
+|-------------|-------------|---------|
+| `get_calibration_summary` | `src/ffi/utilities.rs` | Per-module prediction-calibration summary from discovery history |
+| `cleanup_discovery_lib` | `src/ffi/utilities.rs` | Shut down background threads — **must** be called before process exit |
+| `cleanup_discovery_dir` | `src/ffi/utilities.rs` | Atomically remove a single discovery temp directory |
+| `clean_orphaned_discovery_dirs` | `src/ffi/utilities.rs` | Sweep and remove orphaned discovery directories |
+| `cancel_analysis_memory_pressure` | `src/ffi/analysis.rs` | Cancel in-flight analysis under CRITICAL memory pressure |
+
+### Changes
+
+- **README.md** — extended the `## 🔌 FFI API Summary` table with new
+  **Cancellation**, **Calibration**, and **Lifecycle / cleanup** rows so every
+  exported symbol is represented, flagging `cleanup_discovery_lib` as
+  "call before process exit".
+- **docs/FFI_API.md** —
+  - added the missing symbols to the Exported Symbols list;
+  - documented `cancel_analysis_memory_pressure` in the Cancellation Signal
+    section (behaviour + `memoryPressureCancelled` output);
+  - added a **Calibration Summary** section with input/output JSON contract;
+  - added a **Library Lifecycle & Directory Cleanup** section documenting
+    `cleanup_discovery_lib`, `cleanup_discovery_dir`, and
+    `clean_orphaned_discovery_dirs` with their JSON contracts.
+
+No source/behaviour change — documentation only.
+
+## Evidence
+
+Backend/documentation change; no web UI to screenshot. Verified via the new
+regression test suite, which fails against the pre-change docs and passes after.
+
+```mermaid
+flowchart LR
+    C[Consumer] --> R[README FFI API Summary]
+    R --> F[docs/FFI_API.md]
+    F --> S[All pub extern C symbols]
+    style S fill:#c8e6c9
+```
+
+Before this change the five symbols terminated the discovery path at `README`
+with no onward reference; now every exported symbol is reachable through the
+documented path.
+
+## Test Plan
+
+Added `tests/issue_1506_ffi_doc_coverage.rs` (TDD — failed before the doc edits,
+passes after):
+
+- `readme_documents_all_previously_missing_ffi_entry_points` — asserts README
+  mentions each of the five symbols.
+- `ffi_api_doc_documents_all_previously_missing_ffi_entry_points` — asserts
+  `docs/FFI_API.md` mentions each of the five symbols.
+- `readme_flags_cleanup_before_exit` — asserts the README flags
+  `cleanup_discovery_lib` as a before-process-exit call (the most material
+  omission per the finding).
+- `documented_cleanup_symbol_is_a_real_ffi_entry_point` — calls
+  `cleanup_discovery_lib()` (idempotent, no args) to prove the documented symbol
+  is a genuine, callable FFI entry point rather than a phantom reference.
+- `documented_memory_pressure_symbol_is_a_real_ffi_entry_point` — binds
+  `cancel_analysis_memory_pressure` as an `extern "C" fn()` pointer to prove it
+  resolves with the correct signature, without mutating global cancellation
+  state from a parallel test.

--- a/tests/issue_1506_ffi_doc_coverage.rs
+++ b/tests/issue_1506_ffi_doc_coverage.rs
@@ -1,0 +1,78 @@
+//! Issue #1506 — DOC-README-API-GAP: verify every public FFI entry point is
+//! documented in both the README FFI API Summary and `docs/FFI_API.md`.
+//!
+//! `neat_ai_discovery` is consumed exclusively across its FFI boundary, so the
+//! `pub extern "C"` symbol set *is* the public surface. A consumer following
+//! the documented discovery path (README summary → `docs/FFI_API.md`) must be
+//! able to learn that each entry point exists. These tests assert the five
+//! previously-undocumented symbols are present in both documents, and that they
+//! are genuine, callable FFI entry points (not stale doc references).
+
+/// The FFI entry points that Issue #1506 identified as undocumented in both the
+/// README and `docs/FFI_API.md`.
+const NEWLY_DOCUMENTED_SYMBOLS: &[&str] = &[
+    "get_calibration_summary",
+    "cleanup_discovery_lib",
+    "cleanup_discovery_dir",
+    "clean_orphaned_discovery_dirs",
+    "cancel_analysis_memory_pressure",
+];
+
+const README: &str = include_str!("../README.md");
+const FFI_API: &str = include_str!("../docs/FFI_API.md");
+
+#[test]
+fn readme_documents_all_previously_missing_ffi_entry_points() {
+    for symbol in NEWLY_DOCUMENTED_SYMBOLS {
+        assert!(
+            README.contains(symbol),
+            "README.md must document the `{symbol}` FFI entry point (Issue #1506)"
+        );
+    }
+}
+
+#[test]
+fn ffi_api_doc_documents_all_previously_missing_ffi_entry_points() {
+    for symbol in NEWLY_DOCUMENTED_SYMBOLS {
+        assert!(
+            FFI_API.contains(symbol),
+            "docs/FFI_API.md must document the `{symbol}` FFI entry point (Issue #1506)"
+        );
+    }
+}
+
+/// The most material omission called out in the issue: `cleanup_discovery_lib`
+/// is a correctness-relevant call a host must make before process exit. Ensure
+/// the README flags it as such rather than merely naming it.
+#[test]
+fn readme_flags_cleanup_before_exit() {
+    assert!(
+        README.contains("cleanup_discovery_lib"),
+        "README.md must name `cleanup_discovery_lib` (Issue #1506)"
+    );
+    assert!(
+        README.to_lowercase().contains("before process exit"),
+        "README.md must flag that cleanup is called before process exit (Issue #1506)"
+    );
+}
+
+/// `cleanup_discovery_lib` takes no arguments and is safe to call multiple times
+/// from any thread, so calling it here proves the documented symbol is a real,
+/// callable FFI entry point — the docs are not referencing a phantom function.
+#[test]
+fn documented_cleanup_symbol_is_a_real_ffi_entry_point() {
+    neat_ai_discovery::ffi::cleanup_discovery_lib();
+    // Idempotent: a second call must also succeed without panicking.
+    neat_ai_discovery::ffi::cleanup_discovery_lib();
+}
+
+/// `cancel_analysis_memory_pressure` mutates global cancellation state, so we
+/// must not call it from a parallel test. Binding it as a function pointer with
+/// its exact `extern "C"` signature still proves the documented symbol resolves
+/// to a genuine, correctly-typed FFI entry point without touching that state.
+#[test]
+fn documented_memory_pressure_symbol_is_a_real_ffi_entry_point() {
+    let symbol: extern "C" fn() = neat_ai_discovery::ffi::cancel_analysis_memory_pressure;
+    // Reference the pointer so the binding is genuinely used.
+    assert!(symbol as usize != 0);
+}


### PR DESCRIPTION
## Summary

Documentation-only change closing the README ↔ `docs/FFI_API.md` coverage gap
identified by the Documentation Posture Audit (finding `BP-3be62eced7f5`). Five
public `pub extern "C"` FFI entry points exported by the `neat_ai_discovery`
cdylib were absent from **both** the README's `## 🔌 FFI API Summary` table and
the authoritative interface spec (`docs/FFI_API.md`), leaving them
undiscoverable through the documented consumer path (README summary →
`docs/FFI_API.md`). Closes #1506.

The five newly-documented entry points:

| Entry point | Declared at | Purpose |
|-------------|-------------|---------|
| `get_calibration_summary` | `src/ffi/utilities.rs` | Per-module prediction-calibration summary from discovery history |
| `cleanup_discovery_lib` | `src/ffi/utilities.rs` | Shut down background threads — **must** be called before process exit |
| `cleanup_discovery_dir` | `src/ffi/utilities.rs` | Atomically remove a single discovery temp directory |
| `clean_orphaned_discovery_dirs` | `src/ffi/utilities.rs` | Sweep and remove orphaned discovery directories |
| `cancel_analysis_memory_pressure` | `src/ffi/analysis.rs` | Cancel in-flight analysis under CRITICAL memory pressure |

### Changes

- **README.md** — extended the `## 🔌 FFI API Summary` table with new
  **Cancellation**, **Calibration**, and **Lifecycle / cleanup** rows so every
  exported symbol is represented, flagging `cleanup_discovery_lib` as
  "call before process exit".
- **docs/FFI_API.md** —
  - added the missing symbols to the Exported Symbols list;
  - documented `cancel_analysis_memory_pressure` in the Cancellation Signal
    section (behaviour + `memoryPressureCancelled` output);
  - added a **Calibration Summary** section with input/output JSON contract;
  - added a **Library Lifecycle & Directory Cleanup** section documenting
    `cleanup_discovery_lib`, `cleanup_discovery_dir`, and
    `clean_orphaned_discovery_dirs` with their JSON contracts.

No source/behaviour change — documentation only.

## Evidence

Backend/documentation change; no web UI to screenshot. Verified via the new
regression test suite, which fails against the pre-change docs and passes after.

```mermaid
flowchart LR
    C[Consumer] --> R[README FFI API Summary]
    R --> F[docs/FFI_API.md]
    F --> S[All pub extern C symbols]
    style S fill:#c8e6c9
```

Before this change the five symbols terminated the discovery path at `README`
with no onward reference; now every exported symbol is reachable through the
documented path.

## Test Plan

Added `tests/issue_1506_ffi_doc_coverage.rs` (TDD — failed before the doc edits,
passes after):

- `readme_documents_all_previously_missing_ffi_entry_points` — asserts README
  mentions each of the five symbols.
- `ffi_api_doc_documents_all_previously_missing_ffi_entry_points` — asserts
  `docs/FFI_API.md` mentions each of the five symbols.
- `readme_flags_cleanup_before_exit` — asserts the README flags
  `cleanup_discovery_lib` as a before-process-exit call (the most material
  omission per the finding).
- `documented_cleanup_symbol_is_a_real_ffi_entry_point` — calls
  `cleanup_discovery_lib()` (idempotent, no args) to prove the documented symbol
  is a genuine, callable FFI entry point rather than a phantom reference.
- `documented_memory_pressure_symbol_is_a_real_ffi_entry_point` — binds
  `cancel_analysis_memory_pressure` as an `extern "C" fn()` pointer to prove it
  resolves with the correct signature, without mutating global cancellation
  state from a parallel test.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mr643bf6-3b7321`<!-- vibe-worker-issue-1506 -->