### PR TITLE
Scale focus-ranking wall-clock budget with mode + dataset size (GRQ #3172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.117"
+version = "0.74.118"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.117"
+version = "0.74.118"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/FOCUS_SELECTION.md
+++ b/docs/FOCUS_SELECTION.md
@@ -55,7 +55,7 @@ Ranking now runs under a layered performance guard:
 
 | Guard | Mechanism | Issue |
 |-------|-----------|-------|
-| **Wall-clock budget** | `FocusDeadline` checks the deadline between passes and inside the per-neuron loops; on overrun it aborts with a structured retryable `Timeout`. Configured by `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` (default 120 s). | #1375 |
+| **Wall-clock budget** | `FocusDeadline` checks the deadline between passes and inside the per-neuron loops; on overrun it aborts with a structured retryable `Timeout`. Configured by `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` (default 120 s). The default is **scaled by loading mode + dataset size**: an eager run keeps 120 s, while a slower lazy fallback earns `4 × default + 20 ms/projected MB` (clamped to 1 h) so a legitimate lazy run finishes instead of aborting. An explicit env override wins verbatim and is never scaled. | #1375, #3172 |
 | **Single-pass record loading** | Records are loaded once and reused across the ranking passes instead of re-read per neuron. | #1374 |
 | **Eager vs lazy decision** | `decide_loading_mode_for_available_memory` / `decide_loading_mode_for_budget` choose an eager pre-load or a lazy per-neuron loader based on available memory and the projected dataset size (file × 3), capped by `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB`. | #1376, #1172 |
 | **Perf-cliff observability** | A lazy pass at or above `NEAT_AI_DISCOVERY_FOCUS_RANKING_PERF_CLIFF_MS` (default 60 s) emits one explicit perf-cliff `WARN` naming the neuron count and projected dataset size (`lazy_pass_exceeds_perf_cliff`). | #1377 |
@@ -87,7 +87,7 @@ All knobs are defined in the README
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` | `120000` | Wall-clock budget for focus ranking; overrun aborts with a retryable `Timeout`. `0` disables; other values clamp to `[1000, 3600000]` (#1375, #1385). |
+| `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` | `120000` (eager); scaled for lazy | Wall-clock budget for focus ranking; overrun aborts with a retryable `Timeout`. When **unset**, the default is scaled by loading mode + projected dataset size — eager keeps 120 s, lazy earns `4 × 120 s + 20 ms/projected MB` (clamped to `[1000, 3600000]`) so a legitimate lazy fallback finishes (#3172). An explicit value **wins verbatim** (never scaled); `0` disables; other values clamp to `[1000, 3600000]` (#1375, #1385). |
 | `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` | unset | Cap the eager pre-load size; projected size (file × 3) above the cap forces lazy mode with a structured `info` log (#1172). |
 | `NEAT_AI_DISCOVERY_FOCUS_RANKING_PERF_CLIFF_MS` | `60000` | Perf-cliff threshold for a *lazy* pass; at/above it emits one perf-cliff `WARN`. Preload never trips it. `0` disables (#1377). |
 

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -463,13 +463,43 @@ pub const FOCUS_RANKING_BUDGET_GRACE_MS: u64 = 1_000;
 /// selection past the shared discovery deadline that the synapse/neuron
 /// analysis phase also bills against. When no shared deadline is supplied, the
 /// budget behaves exactly as before.
+///
+/// This accessor returns the **unscaled** budget (the default, or an explicit
+/// override). For a run whose loading mode + dataset size are known, prefer
+/// [`effective_focus_ranking_budget_ms`] (Issue #3172), which scales the default
+/// for the slower lazy-loading path.
 pub fn focus_ranking_budget_ms() -> Option<u64> {
+    match focus_ranking_budget_override() {
+        FocusBudgetOverride::Explicit(v) => Some(v),
+        FocusBudgetOverride::Disabled => None,
+        FocusBudgetOverride::Default => Some(DEFAULT_FOCUS_RANKING_BUDGET_MS),
+    }
+}
+
+/// Parsed outcome of the `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` override
+/// (Issue #3172).
+///
+/// Distinguishing an **explicit** operator value from the fall-through default
+/// lets [`effective_focus_ranking_budget_ms`] scale only the default while
+/// honouring an explicit override verbatim.
+enum FocusBudgetOverride {
+    /// Explicit positive value, already clamped to the supported range.
+    Explicit(u64),
+    /// Explicit `0` — the budget is disabled (fully unbounded opt-out).
+    Disabled,
+    /// Unset / empty / invalid — use the (scalable) default budget.
+    Default,
+}
+
+/// Parse the `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` override once, shared by
+/// [`focus_ranking_budget_ms`] and [`effective_focus_ranking_budget_ms`].
+fn focus_ranking_budget_override() -> FocusBudgetOverride {
     let Ok(raw) = std::env::var("NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS") else {
-        return Some(DEFAULT_FOCUS_RANKING_BUDGET_MS);
+        return FocusBudgetOverride::Default;
     };
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Some(DEFAULT_FOCUS_RANKING_BUDGET_MS);
+        return FocusBudgetOverride::Default;
     }
     match trimmed.parse::<u64>() {
         Ok(0) => {
@@ -477,7 +507,7 @@ pub fn focus_ranking_budget_ms() -> Option<u64> {
                 "Focus-ranking wall-clock budget disabled via \
                  NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS=0"
             );
-            None
+            FocusBudgetOverride::Disabled
         }
         Ok(v) => {
             let clamped = v.clamp(FOCUS_RANKING_BUDGET_MIN_MS, FOCUS_RANKING_BUDGET_MAX_MS);
@@ -491,7 +521,7 @@ pub fn focus_ranking_budget_ms() -> Option<u64> {
                      supported range"
                 );
             }
-            Some(clamped)
+            FocusBudgetOverride::Explicit(clamped)
         }
         Err(_) => {
             tracing::debug!(
@@ -499,7 +529,77 @@ pub fn focus_ranking_budget_ms() -> Option<u64> {
                 "Ignoring invalid NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS \
                  (expected a non-negative integer in milliseconds)"
             );
-            Some(DEFAULT_FOCUS_RANKING_BUDGET_MS)
+            FocusBudgetOverride::Default
+        }
+    }
+}
+
+/// Multiplier applied to the **default** focus-ranking wall-clock budget when a
+/// run falls back to lazy-loading mode (Issue #3172).
+///
+/// Lazy mode is chosen only when the host cannot pre-load the dataset, and it is
+/// materially slower by design (records are decoded on demand). The fixed
+/// default budget that comfortably covers a fast eager run is therefore
+/// near-guaranteed to abort a large lazy run into degraded recorded-error
+/// aggregation. A lazy run gets `multiplier ×` the base default before the
+/// per-megabyte term is added.
+pub const FOCUS_RANKING_LAZY_BUDGET_MULTIPLIER: u64 = 4;
+
+/// Extra wall-clock budget (in milliseconds) granted per projected megabyte of
+/// the pre-load dataset when scaling a lazy run's budget (Issue #3172).
+///
+/// A larger dataset takes proportionally longer to scan on the lazy path, so the
+/// budget grows with the projected in-memory size. The #3170 incident projected
+/// ~14 297 MB and aborted at the fixed 120 s; this per-MB term plus the lazy
+/// multiplier lifts such a run well clear of the fixed net (clamped to
+/// [`FOCUS_RANKING_BUDGET_MAX_MS`]).
+pub const FOCUS_RANKING_BUDGET_MS_PER_PROJECTED_MB: u64 = 20;
+
+/// Scale the **default** focus-ranking wall-clock budget for a resolved run
+/// (Issue #3172).
+///
+/// - **Eager** (`is_lazy == false`): returns [`DEFAULT_FOCUS_RANKING_BUDGET_MS`]
+///   unchanged — the fast path keeps its current budget with no regression.
+/// - **Lazy** (`is_lazy == true`): returns `default × lazy_multiplier +
+///   projected_mb × per_mb`, clamped to
+///   `[FOCUS_RANKING_BUDGET_MIN_MS, FOCUS_RANKING_BUDGET_MAX_MS]`, so a
+///   legitimate lazy fallback on a large dataset has enough wall-clock to finish
+///   instead of aborting into recorded-error aggregation. The scaling constants
+///   are [`FOCUS_RANKING_LAZY_BUDGET_MULTIPLIER`] and
+///   [`FOCUS_RANKING_BUDGET_MS_PER_PROJECTED_MB`].
+///
+/// Pure and saturating so it is trivially unit-testable and cannot overflow.
+#[must_use]
+pub fn scale_default_focus_ranking_budget_ms(is_lazy: bool, projected_mb: u64) -> u64 {
+    if !is_lazy {
+        return DEFAULT_FOCUS_RANKING_BUDGET_MS;
+    }
+    let scaled = DEFAULT_FOCUS_RANKING_BUDGET_MS
+        .saturating_mul(FOCUS_RANKING_LAZY_BUDGET_MULTIPLIER)
+        .saturating_add(projected_mb.saturating_mul(FOCUS_RANKING_BUDGET_MS_PER_PROJECTED_MB));
+    scaled.clamp(FOCUS_RANKING_BUDGET_MIN_MS, FOCUS_RANKING_BUDGET_MAX_MS)
+}
+
+/// Effective focus-ranking wall-clock budget for a resolved run, scaled to the
+/// chosen loading mode + dataset size (Issue #3172).
+///
+/// Combines the override precedence of [`focus_ranking_budget_ms`] with
+/// mode/dataset scaling:
+/// - An explicit `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` override **wins**
+///   verbatim (clamped) and is never scaled — the operator's value is
+///   authoritative.
+/// - `0` disables the budget (returns `None`, fully unbounded opt-out).
+/// - Otherwise the default budget is scaled for `is_lazy` + `projected_mb` via
+///   [`scale_default_focus_ranking_budget_ms`].
+///
+/// Returns `None` only when the budget is explicitly disabled with `0`.
+#[must_use]
+pub fn effective_focus_ranking_budget_ms(is_lazy: bool, projected_mb: u64) -> Option<u64> {
+    match focus_ranking_budget_override() {
+        FocusBudgetOverride::Explicit(v) => Some(v),
+        FocusBudgetOverride::Disabled => None,
+        FocusBudgetOverride::Default => {
+            Some(scale_default_focus_ranking_budget_ms(is_lazy, projected_mb))
         }
     }
 }

--- a/src/focus/ranking/mod.rs
+++ b/src/focus/ranking/mod.rs
@@ -46,8 +46,8 @@ use crate::analysis::utils::{
     parquet_preload_fits_available, remaining_ms_until, verbose_enabled,
 };
 use crate::config::{
-    FOCUS_RANKING_BUDGET_GRACE_MS, focus_ranking_budget_ms, focus_ranking_memory_budget_mb,
-    focus_ranking_memory_margin_mb, focus_ranking_perf_cliff_ms,
+    FOCUS_RANKING_BUDGET_GRACE_MS, effective_focus_ranking_budget_ms,
+    focus_ranking_memory_budget_mb, focus_ranking_memory_margin_mb, focus_ranking_perf_cliff_ms,
 };
 use crate::discovery_history::DiscoveryHistory;
 use crate::ffi_types::DiscoveryError;
@@ -193,12 +193,23 @@ impl FocusDeadline {
     ///    (`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS`, default
     ///    [`crate::config::DEFAULT_FOCUS_RANKING_BUDGET_MS`]) which still guards
     ///    a pathological ranking run even when no shared deadline is supplied.
+    ///    Issue #3172: this safety net is **scaled** by the resolved loading
+    ///    `mode` + `projected_mb` — a lazy fallback on a large dataset is
+    ///    materially slower, so it earns a larger budget than the fast eager
+    ///    path, which keeps the unscaled default. An explicit env override still
+    ///    wins verbatim.
     ///
     /// Returns `None` only when both bounds are absent — no shared deadline AND
     /// the focus budget explicitly disabled with `0`.
-    fn resolve(start: Instant, shared_deadline_ms: Option<u64>) -> Option<Self> {
-        let budget_deadline =
-            focus_ranking_budget_ms().map(|budget_ms| Self::new(start, budget_ms));
+    fn resolve(
+        start: Instant,
+        shared_deadline_ms: Option<u64>,
+        mode: FocusLoadingMode,
+        projected_mb: u64,
+    ) -> Option<Self> {
+        let is_lazy = mode == FocusLoadingMode::Lazy;
+        let budget_deadline = effective_focus_ranking_budget_ms(is_lazy, projected_mb)
+            .map(|budget_ms| Self::new(start, budget_ms));
         let shared_deadline = Self::from_shared_deadline(start, shared_deadline_ms);
 
         match (budget_deadline, shared_deadline) {
@@ -277,10 +288,14 @@ const DEFAULT_COST_OF_GROWTH: f32 = 1e-7;
 const IMPACT_EPSILON: f32 = 0.0001;
 const IMPACT_GAMMA: f32 = 0.8;
 
-/// Outcome of choosing eager vs lazy loading for a focus-ranking run
-/// (Issue #1172).
-struct LoadingDecision {
-    provider: Arc<dyn RecordProvider>,
+/// Loading plan: the eager-vs-lazy decision plus its projection, decided
+/// **before** the (possibly expensive) record provider is built (Issue #3172).
+///
+/// Separating the cheap decision from the provider build lets the wall-clock
+/// deadline be scaled to the chosen `mode` + `projected_mb` before the lazy warm
+/// pass (a full parquet decode) starts consuming the budget.
+#[derive(Debug, Clone, Copy)]
+struct LoadingPlan {
     mode: FocusLoadingMode,
     reason: FocusLazyReason,
     budget_mb: Option<u64>,
@@ -354,38 +369,111 @@ pub fn lazy_pass_exceeds_perf_cliff(
     mode == FocusLoadingMode::Lazy && threshold_ms > 0 && elapsed_ms >= u128::from(threshold_ms)
 }
 
-/// Load records provider, taking the optional configurable memory budget into
-/// account.
+/// Decide eager-vs-lazy loading and log the decision, **without** building the
+/// (possibly expensive) record provider (Issue #3172).
+///
+/// This is the cheap half of loading — a parquet-size estimate plus an
+/// OS-memory query — split out so [`FocusDeadline::resolve`] can scale the
+/// wall-clock budget to the chosen `mode` + `projected_mb` before the lazy warm
+/// pass (a full parquet decode) begins consuming that budget.
 ///
 /// Behaviour (Issue #1172):
 /// - When `NEAT_AI_DISCOVERY_FOCUS_RANKING_MEMORY_BUDGET_MB` is set, the
 ///   projected in-memory size (file size × 3) is compared against the budget.
-///   Lazy mode is selected with a structured `info` log when the projection
-///   exceeds the budget.
+///   Lazy mode is selected with a structured `WARN` when the projection exceeds
+///   the budget.
 /// - When the budget is unset, the auto-detect path compares the projection
 ///   against real OS-available memory minus a configurable safety margin
 ///   (Issue #1376). Pre-load is chosen whenever the projection fits, so hosts
 ///   with GBs free stay on the fast path; lazy mode (with a `WARN`) is reserved
 ///   for genuinely memory-constrained hosts.
-fn load_records_provider(
-    parquet_file: &str,
-    selectable: &[&NeuronJson],
-) -> Result<LoadingDecision> {
+fn plan_loading(parquet_file: &str, selectable_len: usize) -> LoadingPlan {
+    const BYTES_PER_MB: u64 = 1024 * 1024;
     let budget_mb = focus_ranking_memory_budget_mb();
     let projected_bytes = estimate_parquet_in_memory_bytes(parquet_file);
     let projected_mb = bytes_to_mb_ceil(projected_bytes);
 
     if let Some(budget) = budget_mb {
-        return decide_with_budget(
-            parquet_file,
-            selectable,
-            budget,
-            projected_bytes,
+        let (mode, reason) = decide_loading_mode_for_budget(projected_bytes, budget);
+        if mode == FocusLoadingMode::Lazy {
+            // Issue #1377: escalate to WARN and record available memory
+            // alongside projected/budget so the eager-vs-lazy trade-off is
+            // visible at the decision point, not split across log lines.
+            let (available_bytes, _total_bytes) = get_memory_info();
+            tracing::warn!(
+                target: "neat_ai_discovery::focus::ranking",
+                mode = FocusLoadingMode::Lazy.as_str(),
+                reason = reason.as_str(),
+                budget_mb = budget,
+                projected_mb,
+                available_mb = bytes_to_mb_ceil(available_bytes),
+                selectable = selectable_len,
+                "focus::ranking selected lazy mode: projected pre-load exceeds configured budget",
+            );
+        }
+        return LoadingPlan {
+            mode,
+            reason,
+            budget_mb: Some(budget),
             projected_mb,
+        };
+    }
+
+    // Issue #1376: base the decision on real OS-available memory minus a safety
+    // margin, rather than the 50%-of-total-RAM cap that dropped mid-sized
+    // parquet files onto the slow lazy path while GBs of RAM were free.
+    let (available_bytes, _total_bytes) = get_memory_info();
+    let margin_mb = focus_ranking_memory_margin_mb();
+    let margin_bytes = margin_mb.saturating_mul(BYTES_PER_MB);
+    let available_mb = bytes_to_mb_ceil(available_bytes);
+    let (mode, reason) =
+        decide_loading_mode_for_available_memory(projected_bytes, available_bytes, margin_bytes);
+
+    if mode == FocusLoadingMode::Lazy {
+        tracing::warn!(
+            target: "neat_ai_discovery::focus::ranking",
+            mode = FocusLoadingMode::Lazy.as_str(),
+            reason = reason.as_str(),
+            projected_mb,
+            available_mb,
+            // Issue #1377: no explicit budget on the auto-detect path; log 0
+            // so the field is uniform with the budget path's lazy log.
+            budget_mb = 0u64,
+            margin_mb,
+            selectable = selectable_len,
+            "Insufficient available memory for full pre-load in focus ranking. \
+             Using lazy-loading mode (slower but memory-efficient).",
         );
     }
 
-    decide_with_auto_detect(parquet_file, selectable, projected_bytes, projected_mb)
+    LoadingPlan {
+        mode,
+        reason,
+        budget_mb: None,
+        projected_mb,
+    }
+}
+
+/// Build the record provider for a resolved [`LoadingPlan`] (Issue #3172).
+///
+/// The expensive half of loading: an eager pre-load decodes the whole parquet
+/// file through the process-shared cache (Issue #1406) so the analysis phase can
+/// reuse it; a lazy plan warms a bounded, working-set-sized cache
+/// ([`build_lazy_provider`]). Kept separate from [`plan_loading`] so this work
+/// runs *after* the wall-clock deadline has been scaled to the plan.
+fn build_provider(
+    parquet_file: &str,
+    selectable: &[&NeuronJson],
+    plan: LoadingPlan,
+) -> Result<Arc<dyn RecordProvider>> {
+    match plan.mode {
+        FocusLoadingMode::Lazy => Ok(build_lazy_provider(parquet_file, selectable)),
+        FocusLoadingMode::Preload => {
+            let shared = load_grouped_records_shared(parquet_file, None)
+                .context("Failed to read discovery records from parquet file")?;
+            Ok(Arc::new(EagerRecordProvider::from_shared(&shared)))
+        }
+    }
 }
 
 /// Build a lazy record provider whose cache is sized to the ranking working set
@@ -426,112 +514,6 @@ fn build_lazy_provider(parquet_file: &str, selectable: &[&NeuronJson]) -> Arc<dy
     }
 
     Arc::new(provider)
-}
-
-fn decide_with_budget(
-    parquet_file: &str,
-    selectable: &[&NeuronJson],
-    budget_mb: u64,
-    projected_bytes: u64,
-    projected_mb: u64,
-) -> Result<LoadingDecision> {
-    let (mode, reason) = decide_loading_mode_for_budget(projected_bytes, budget_mb);
-    match mode {
-        FocusLoadingMode::Lazy => {
-            // Issue #1377: escalate to WARN and record available memory
-            // alongside projected/budget so the eager-vs-lazy trade-off is
-            // visible at the decision point, not split across log lines.
-            let (available_bytes, _total_bytes) = get_memory_info();
-            tracing::warn!(
-                target: "neat_ai_discovery::focus::ranking",
-                mode = FocusLoadingMode::Lazy.as_str(),
-                reason = reason.as_str(),
-                budget_mb,
-                projected_mb,
-                available_mb = bytes_to_mb_ceil(available_bytes),
-                "focus::ranking selected lazy mode: projected pre-load exceeds configured budget",
-            );
-            Ok(LoadingDecision {
-                provider: build_lazy_provider(parquet_file, selectable),
-                mode,
-                reason,
-                budget_mb: Some(budget_mb),
-                projected_mb,
-            })
-        }
-        FocusLoadingMode::Preload => {
-            // Issue #1406: decode through the process-shared cache so the
-            // following analysis phase can reuse this load instead of scanning
-            // the same parquet file a second time.
-            let shared = load_grouped_records_shared(parquet_file, None)
-                .context("Failed to read discovery records from parquet file")?;
-            Ok(LoadingDecision {
-                provider: Arc::new(EagerRecordProvider::from_shared(&shared)),
-                mode,
-                reason,
-                budget_mb: Some(budget_mb),
-                projected_mb,
-            })
-        }
-    }
-}
-
-fn decide_with_auto_detect(
-    parquet_file: &str,
-    selectable: &[&NeuronJson],
-    projected_bytes: u64,
-    projected_mb: u64,
-) -> Result<LoadingDecision> {
-    const BYTES_PER_MB: u64 = 1024 * 1024;
-
-    // Issue #1376: base the decision on real OS-available memory minus a safety
-    // margin, rather than the 50%-of-total-RAM cap that dropped mid-sized
-    // parquet files onto the slow lazy path while GBs of RAM were free.
-    let (available_bytes, _total_bytes) = get_memory_info();
-    let margin_mb = focus_ranking_memory_margin_mb();
-    let margin_bytes = margin_mb.saturating_mul(BYTES_PER_MB);
-    let available_mb = bytes_to_mb_ceil(available_bytes);
-
-    let (mode, reason) =
-        decide_loading_mode_for_available_memory(projected_bytes, available_bytes, margin_bytes);
-
-    match mode {
-        FocusLoadingMode::Preload => {
-            // Issue #1406: decode through the process-shared cache (see the
-            // budget-path branch) so the analysis phase reuses this load.
-            let shared = load_grouped_records_shared(parquet_file, None)
-                .context("Failed to read discovery records from parquet file")?;
-            Ok(LoadingDecision {
-                provider: Arc::new(EagerRecordProvider::from_shared(&shared)),
-                mode,
-                reason,
-                budget_mb: None,
-                projected_mb,
-            })
-        }
-        FocusLoadingMode::Lazy => {
-            tracing::warn!(
-                target: "neat_ai_discovery::focus::ranking",
-                mode = FocusLoadingMode::Lazy.as_str(),
-                reason = reason.as_str(),
-                projected_mb,
-                available_mb,
-                // Issue #1377: no explicit budget on the auto-detect path; log 0
-                // so the field is uniform with the budget path's lazy log.
-                budget_mb = 0u64,
-                margin_mb,
-                "Insufficient available memory for full pre-load in focus ranking. \
-                 Using lazy-loading mode (slower but memory-efficient).",
-            );
-            Ok(LoadingDecision {
-                provider: build_lazy_provider(parquet_file, selectable),
-                mode,
-                reason,
-                budget_mb: None,
-                projected_mb,
-            })
-        }
-    }
 }
 
 /// Emit the structured end-of-pass summary (Issue #1172). Always logged at
@@ -873,7 +855,6 @@ struct RankCoreArgs<'a> {
 /// the creature has no selectable neurons.
 fn rank_focus_core(args: &RankCoreArgs<'_>) -> Result<RankFocusStats> {
     let start = Instant::now();
-    let deadline = FocusDeadline::resolve(start, args.shared_deadline_ms);
 
     let selectable: Vec<&NeuronJson> = args
         .creature
@@ -899,21 +880,43 @@ fn rank_focus_core(args: &RankCoreArgs<'_>) -> Result<RankFocusStats> {
         });
     }
 
-    let LoadingDecision {
-        provider,
-        mode,
-        reason,
-        budget_mb,
-        projected_mb,
-    } = load_records_provider(args.parquet_file, &selectable)?;
+    // Issue #3172: decide the loading mode + projection *first* (cheap), so the
+    // wall-clock deadline can be scaled to the chosen mode and dataset size
+    // before the (possibly expensive) provider build starts spending it. A lazy
+    // fallback on a large dataset thereby earns a larger budget instead of being
+    // set up to abort at the fixed default.
+    let plan = plan_loading(args.parquet_file, selectable.len());
+    let deadline =
+        FocusDeadline::resolve(start, args.shared_deadline_ms, plan.mode, plan.projected_mb);
+    log_effective_budget(plan, deadline);
+
+    let provider = build_provider(args.parquet_file, &selectable, plan)?;
     let meta = LoadingMeta {
-        mode,
-        reason,
-        budget_mb,
-        projected_mb,
+        mode: plan.mode,
+        reason: plan.reason,
+        budget_mb: plan.budget_mb,
+        projected_mb: plan.projected_mb,
     };
 
     rank_selectable(args, &selectable, provider, meta, deadline, start)
+}
+
+/// Log the resolved wall-clock budget for a run so the mode + effective
+/// `budget_ms` are visible for diagnosis (Issue #3172 acceptance criterion).
+///
+/// `budget_enabled == false` marks a run whose budget was explicitly disabled
+/// (`..._BUDGET_MS=0`) and which has no shared discovery deadline either — i.e.
+/// fully unbounded.
+fn log_effective_budget(plan: LoadingPlan, deadline: Option<FocusDeadline>) {
+    let budget_ms = deadline.map(|d| d.budget_ms);
+    tracing::info!(
+        target: "neat_ai_discovery::focus::ranking",
+        mode = plan.mode.as_str(),
+        projected_mb = plan.projected_mb,
+        budget_ms = budget_ms.unwrap_or(0),
+        budget_enabled = budget_ms.is_some(),
+        "focus::ranking wall-clock budget resolved",
+    );
 }
 
 /// Run the ranking passes over an already-loaded record provider (Issue #1375).
@@ -1276,7 +1279,7 @@ pub(in crate::focus) fn rank_with_provider_for_tests(
 mod focus_deadline_tests {
     //! Issue #1407: `FocusDeadline::resolve` must bound focus selection by the
     //! shared absolute discovery deadline, capped by the focus-ranking budget.
-    use super::FocusDeadline;
+    use super::{FocusDeadline, FocusLoadingMode};
     use std::time::{Duration, Instant, SystemTime};
 
     fn now_ms() -> u64 {
@@ -1290,13 +1293,19 @@ mod focus_deadline_tests {
         if a > b { a - b } else { b - a }
     }
 
+    /// Resolve using the eager default budget (no mode/dataset scaling), the
+    /// baseline these #1407 tests were written against.
+    fn resolve_eager(start: Instant, shared: Option<u64>) -> Option<FocusDeadline> {
+        FocusDeadline::resolve(start, shared, FocusLoadingMode::Preload, 0)
+    }
+
     #[test]
     fn resolve_uses_shared_deadline_when_sooner_than_budget() {
         let start = Instant::now();
         // Absolute deadline 5s out — well inside the default 120s focus budget.
         let shared = Some(now_ms() + 5_000);
-        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
-        let budget_only = FocusDeadline::resolve(start, None).expect("budget present");
+        let resolved = resolve_eager(start, shared).expect("deadline present");
+        let budget_only = resolve_eager(start, None).expect("budget present");
 
         // The shared deadline (5s) bounds the run more tightly than the budget,
         // so it must win — this is the unification the issue requires.
@@ -1317,8 +1326,8 @@ mod focus_deadline_tests {
         let start = Instant::now();
         // Absolute deadline far beyond the focus budget (50 minutes out).
         let shared = Some(now_ms() + 3_000_000);
-        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
-        let budget_only = FocusDeadline::resolve(start, None).expect("budget present");
+        let resolved = resolve_eager(start, shared).expect("deadline present");
+        let budget_only = resolve_eager(start, None).expect("budget present");
 
         // The nearer focus budget caps the distant deadline, so both expire at
         // effectively the same point.
@@ -1333,10 +1342,53 @@ mod focus_deadline_tests {
         let start = Instant::now();
         // An absolute deadline already in the past saturates to zero remaining.
         let shared = Some(now_ms().saturating_sub(10_000));
-        let resolved = FocusDeadline::resolve(start, shared).expect("deadline present");
+        let resolved = resolve_eager(start, shared).expect("deadline present");
         assert!(
             resolved.check("test").is_err(),
             "a passed shared deadline must abort focus ranking immediately",
+        );
+    }
+
+    // Issue #3172: the budget-only deadline must scale with the resolved loading
+    // mode + dataset size — a lazy fallback on a large dataset earns a materially
+    // larger window than the fast eager path, which keeps the unscaled default.
+    #[test]
+    fn resolve_scales_lazy_budget_above_eager_default() {
+        let start = Instant::now();
+        // No shared deadline: only the (scaled) focus budget bounds the run.
+        let eager = FocusDeadline::resolve(start, None, FocusLoadingMode::Preload, 0)
+            .expect("eager budget present");
+        let lazy = FocusDeadline::resolve(start, None, FocusLoadingMode::Lazy, 14_297)
+            .expect("lazy budget present");
+
+        assert!(
+            lazy.expires_at > eager.expires_at,
+            "a large lazy run must get a later deadline than the eager default \
+             so it can finish instead of aborting into recorded-error aggregation",
+        );
+        // The eager default stays at the fixed 120s net (no regression).
+        assert_eq!(
+            eager.budget_ms,
+            crate::config::DEFAULT_FOCUS_RANKING_BUDGET_MS,
+            "eager mode must keep the unscaled default budget",
+        );
+        assert!(
+            lazy.budget_ms > crate::config::DEFAULT_FOCUS_RANKING_BUDGET_MS,
+            "lazy mode on a large dataset must exceed the fixed default budget",
+        );
+    }
+
+    // Issue #3172: a bigger projected dataset earns a bigger lazy budget.
+    #[test]
+    fn resolve_lazy_budget_grows_with_projected_size() {
+        let start = Instant::now();
+        let small = FocusDeadline::resolve(start, None, FocusLoadingMode::Lazy, 100)
+            .expect("small lazy budget present");
+        let large = FocusDeadline::resolve(start, None, FocusLoadingMode::Lazy, 20_000)
+            .expect("large lazy budget present");
+        assert!(
+            large.budget_ms >= small.budget_ms,
+            "a larger projected dataset must not shrink the lazy budget",
         );
     }
 }

--- a/tests/issue_3172_focus_ranking_budget_scaling.rs
+++ b/tests/issue_3172_focus_ranking_budget_scaling.rs
@@ -1,0 +1,222 @@
+//! Issue #3172 — scale the focus-ranking wall-clock budget with mode + dataset
+//! size so a legitimate lazy fallback finishes instead of aborting into
+//! degraded recorded-error aggregation.
+//!
+//! Verifies that:
+//! - Eager mode keeps the current fixed default budget (no regression).
+//! - Lazy mode scales the budget above the default, growing with the projected
+//!   dataset size, and is clamped to the supported maximum.
+//! - An explicit `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` override wins
+//!   verbatim for both modes and is never scaled.
+//! - `0` still disables the budget; the unscaled `focus_ranking_budget_ms`
+//!   accessor keeps its prior behaviour (regression guard).
+
+use neat_ai_discovery::config::{
+    DEFAULT_FOCUS_RANKING_BUDGET_MS, FOCUS_RANKING_BUDGET_MAX_MS, FOCUS_RANKING_BUDGET_MIN_MS,
+    FOCUS_RANKING_LAZY_BUDGET_MULTIPLIER, effective_focus_ranking_budget_ms,
+    focus_ranking_budget_ms, scale_default_focus_ranking_budget_ms,
+};
+use serial_test::serial;
+
+const BUDGET_KEY: &str = "NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS";
+
+/// RAII guard that restores an env var on drop so env-mutating tests do not leak
+/// into one another. Tests are `#[serial]` so no concurrent set/unset races.
+struct EnvGuard {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prior }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: tests are marked #[serial] so no concurrent set/unset races.
+        unsafe {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Pure scaling helper (no env) — the core of the fix.
+// =============================================================================
+
+#[test]
+fn eager_scaling_keeps_the_default_budget() {
+    // No regression: eager ignores dataset size and keeps the fixed default.
+    assert_eq!(
+        scale_default_focus_ranking_budget_ms(false, 0),
+        DEFAULT_FOCUS_RANKING_BUDGET_MS
+    );
+    assert_eq!(
+        scale_default_focus_ranking_budget_ms(false, 50_000),
+        DEFAULT_FOCUS_RANKING_BUDGET_MS,
+        "eager mode must not scale with dataset size",
+    );
+}
+
+#[test]
+fn lazy_scaling_exceeds_the_default_budget() {
+    // The #3170 incident: ~14 297 MB projected aborted at the fixed 120 s.
+    let scaled = scale_default_focus_ranking_budget_ms(true, 14_297);
+    assert!(
+        scaled > DEFAULT_FOCUS_RANKING_BUDGET_MS,
+        "a large lazy run must earn more than the fixed default budget \
+         (got {scaled} vs default {DEFAULT_FOCUS_RANKING_BUDGET_MS})",
+    );
+    // At minimum the lazy multiplier is applied before the per-MB term.
+    assert!(
+        scaled >= DEFAULT_FOCUS_RANKING_BUDGET_MS * FOCUS_RANKING_LAZY_BUDGET_MULTIPLIER,
+        "lazy budget must be at least the multiplied default",
+    );
+}
+
+#[test]
+fn lazy_scaling_grows_with_projected_size() {
+    let small = scale_default_focus_ranking_budget_ms(true, 100);
+    let mid = scale_default_focus_ranking_budget_ms(true, 5_000);
+    let large = scale_default_focus_ranking_budget_ms(true, 20_000);
+    assert!(
+        small <= mid && mid <= large,
+        "budget must be monotone in size"
+    );
+    assert!(
+        large > small,
+        "a materially larger dataset must earn a larger budget",
+    );
+}
+
+#[test]
+fn lazy_scaling_is_clamped_to_the_supported_range() {
+    // An enormous projection cannot exceed the one-hour ceiling.
+    let huge = scale_default_focus_ranking_budget_ms(true, u64::MAX);
+    assert_eq!(
+        huge, FOCUS_RANKING_BUDGET_MAX_MS,
+        "lazy budget must clamp to the supported maximum, not overflow",
+    );
+    // Even the smallest lazy run stays within [MIN, MAX].
+    let tiny = scale_default_focus_ranking_budget_ms(true, 0);
+    assert!((FOCUS_RANKING_BUDGET_MIN_MS..=FOCUS_RANKING_BUDGET_MAX_MS).contains(&tiny));
+}
+
+// =============================================================================
+// Effective budget: override precedence + scaling (env).
+// =============================================================================
+
+#[test]
+#[serial]
+fn effective_default_scales_by_mode_when_unset() {
+    let _g = EnvGuard::unset(BUDGET_KEY);
+    let eager = effective_focus_ranking_budget_ms(false, 14_297).expect("eager enabled");
+    let lazy = effective_focus_ranking_budget_ms(true, 14_297).expect("lazy enabled");
+    assert_eq!(
+        eager, DEFAULT_FOCUS_RANKING_BUDGET_MS,
+        "unset + eager must return the unscaled default",
+    );
+    assert!(
+        lazy > eager,
+        "unset + lazy must scale above the eager default (lazy {lazy} vs eager {eager})",
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_override_wins_verbatim_and_is_never_scaled() {
+    let _g = EnvGuard::set(BUDGET_KEY, "90000");
+    // The operator's value is authoritative for BOTH modes — no scaling.
+    assert_eq!(
+        effective_focus_ranking_budget_ms(false, 0),
+        Some(90_000),
+        "explicit override must win for eager",
+    );
+    assert_eq!(
+        effective_focus_ranking_budget_ms(true, 50_000),
+        Some(90_000),
+        "explicit override must win for lazy and must not be scaled by dataset size",
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_override_is_clamped_but_still_not_scaled() {
+    // Above the max → clamped down to the ceiling, still not scaled by mode.
+    let _g = EnvGuard::set(BUDGET_KEY, "999999999");
+    assert_eq!(
+        effective_focus_ranking_budget_ms(true, 20_000),
+        Some(FOCUS_RANKING_BUDGET_MAX_MS),
+    );
+}
+
+#[test]
+#[serial]
+fn explicit_zero_disables_budget_for_both_modes() {
+    let _g = EnvGuard::set(BUDGET_KEY, "0");
+    assert_eq!(effective_focus_ranking_budget_ms(false, 0), None);
+    assert_eq!(
+        effective_focus_ranking_budget_ms(true, 14_297),
+        None,
+        "0 is the deliberate opt-out even for a large lazy run",
+    );
+}
+
+#[test]
+#[serial]
+fn invalid_override_falls_back_to_scaled_default() {
+    let _g = EnvGuard::set(BUDGET_KEY, "not-a-number");
+    // Garbage must not disable or pin the budget — the scaled default applies.
+    let lazy = effective_focus_ranking_budget_ms(true, 14_297).expect("lazy enabled");
+    assert!(
+        lazy > DEFAULT_FOCUS_RANKING_BUDGET_MS,
+        "invalid override must fall back to the scaled default for lazy",
+    );
+    assert_eq!(
+        effective_focus_ranking_budget_ms(false, 0),
+        Some(DEFAULT_FOCUS_RANKING_BUDGET_MS),
+        "invalid override must fall back to the unscaled default for eager",
+    );
+}
+
+// =============================================================================
+// Regression guard: the unscaled accessor keeps its prior behaviour.
+// =============================================================================
+
+#[test]
+#[serial]
+fn unscaled_accessor_unchanged_when_unset() {
+    let _g = EnvGuard::unset(BUDGET_KEY);
+    assert_eq!(
+        focus_ranking_budget_ms(),
+        Some(DEFAULT_FOCUS_RANKING_BUDGET_MS)
+    );
+}
+
+#[test]
+#[serial]
+fn unscaled_accessor_honours_override_and_zero() {
+    {
+        let _g = EnvGuard::set(BUDGET_KEY, "45000");
+        assert_eq!(focus_ranking_budget_ms(), Some(45_000));
+    }
+    {
+        let _g = EnvGuard::set(BUDGET_KEY, "0");
+        assert_eq!(focus_ranking_budget_ms(), None);
+    }
+}


### PR DESCRIPTION
## Summary

Focus ranking's wall-clock safety net (`NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS`, default `120000` ms) was a **fixed constant**. When the memory heuristic forced **lazy-loading** mode (slower by design) on a large dataset, the budget was **not** increased, so the lazy path was near-guaranteed to exceed 120 s and abort in `verify_selectable_records`, degrading focus selection into recorded-error aggregation.

Observed (GRQ #3170, 2026-07-05):

```
WARN focus::ranking: Using lazy-loading mode ... reason="memory_pressure" projected_mb=14297
WARN focus::ranking aborted: wall-clock budget exceeded budget_ms=120000 grace_ms=1000 context="verify_selectable_records"
```

This PR **scales** the wall-clock budget with the selected **mode** and **dataset size** so a legitimate lazy fallback finishes instead of aborting.

## Change

- `scale_default_focus_ranking_budget_ms(is_lazy, projected_mb)` — pure, saturating:
  - **Eager**: returns the fixed `DEFAULT_FOCUS_RANKING_BUDGET_MS` (120 s) unchanged — **no regression**.
  - **Lazy**: `4 × default + 20 ms × projected_mb`, clamped to `[1000, 3600000]` ms.
- `effective_focus_ranking_budget_ms(is_lazy, projected_mb)` — override precedence:
  - An explicit `NEAT_AI_DISCOVERY_FOCUS_RANKING_BUDGET_MS` **wins verbatim** (clamped) and is **never scaled**.
  - `0` still disables the budget.
  - Otherwise the default is scaled by mode + dataset size.
- Loading is split into a cheap **plan** step (mode + projection, no I/O beyond a size estimate) and the expensive **provider build**, so `FocusDeadline::resolve` scales the budget to the chosen mode + `projected_mb` **before** the lazy warm pass (a full parquet decode) starts spending it.
- The resolved effective budget (`mode`, `budget_ms`) is logged for diagnosis.

```mermaid
flowchart LR
    S[start] --> P[plan_loading<br/>mode + projected_mb]
    P --> R{resolve deadline}
    R -->|eager| E[default 120s]
    R -->|lazy| L["4×default + 20ms/MB<br/>clamp 1s–1h"]
    R -->|env override| O[verbatim, clamped]
    E --> B[build_provider]
    L --> B
    O --> B
    B --> K[rank passes<br/>check_deadline]
```

## Acceptance

- ✅ Eager mode keeps the current fast budget (no regression).
- ✅ Lazy mode on a large dataset completes within a scaled budget instead of aborting into recorded-error aggregation.
- ✅ Explicit `..._BUDGET_MS` override still honoured (verbatim, never scaled).
- ✅ Effective budget (mode + `budget_ms`) is logged.

## Test Plan

- `tests/issue_3172_focus_ranking_budget_scaling.rs` — eager keeps default; lazy scales above default and grows with projected size; clamp to max; explicit override wins/clamps but is not scaled; `0` disables; invalid falls back to scaled default; unscaled accessor regression guard.
- Inline `focus_deadline_tests` — `resolve` gives a lazy run a later deadline than eager, and the lazy budget grows with projected size.
- Full suite: `cargo test --lib --tests --all-features -- --test-threads=2` → all pass; `cargo clippy --all-targets -- -D warnings` clean.

Part of stSoftwareAU/GRQ#3170. Tracks stSoftwareAU/GRQ#3172 (GRQ is the tracking home; this is the code PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
