### PR TITLE
Correct macOS reclaimable available-memory accounting for focus-ranking eager/lazy decision (GRQ #3173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.118"
+version = "0.74.119"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.118"
+version = "0.74.119"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/src/analysis/utils/memory.rs
+++ b/src/analysis/utils/memory.rs
@@ -138,38 +138,96 @@ pub fn get_memory_info() -> (u64, u64) {
         })
         .unwrap_or(8 * 1024 * 1024 * 1024); // Default 8GB
 
-    // Get page size and free/inactive pages from vm_stat
+    // Reclaimable available memory is parsed from vm_stat (Issue #3173).
     let vm_stat = Command::new("vm_stat").output().ok();
     let available = vm_stat.map_or(total / 2, |o| {
         let output = String::from_utf8_lossy(&o.stdout);
-        // Parse page size from vm_stat header - handles both Apple Silicon (16KB)
-        // and Intel Macs (4KB) correctly
-        let page_size = parse_vm_stat_page_size(&output);
-
-        let mut free_pages: u64 = 0;
-        let mut inactive_pages: u64 = 0;
-        let mut purgeable_pages: u64 = 0;
-
-        for line in output.lines() {
-            if line.starts_with("Pages free:") {
-                free_pages = parse_vm_stat_line(line);
-            } else if line.starts_with("Pages inactive:") {
-                inactive_pages = parse_vm_stat_line(line);
-            } else if line.starts_with("Pages purgeable:") {
-                purgeable_pages = parse_vm_stat_line(line);
-            }
-        }
-
-        // Available = free + inactive + purgeable (memory that can be reclaimed)
-        (free_pages + inactive_pages + purgeable_pages) * page_size
-    }); // Default to half of total
+        parse_macos_available_bytes(&output, total)
+    }); // Default to half of total when vm_stat is unavailable
 
     (available, total)
 }
 
+/// Compute reclaimable available memory (bytes) from raw `vm_stat` output and
+/// the total physical memory (Issue #3173).
+///
+/// macOS keeps a large share of RAM as reclaimable file-cache, purgeable and
+/// free pages. The previous `free + inactive + purgeable` figure undercounted
+/// true headroom: file-backed cache sitting in the **active** list was treated
+/// as unavailable, so a ~14.3 GB pre-load projection on a 24 GB host was forced
+/// onto the slow lazy path despite the machine being able to run eager. This
+/// counts every genuinely-reclaimable page class:
+///
+/// - **Pages free** — unused RAM,
+/// - **File-backed pages** — clean file cache (active **and** inactive), which
+///   the kernel drops on demand without I/O,
+/// - **Pages purgeable** — caches the kernel may discard on demand.
+///
+/// Wired, compressed and dirty anonymous (app) pages are deliberately excluded:
+/// reclaiming them needs swap / compression — the very memory pressure the
+/// pre-load margin guards against, so counting them would risk the OOM the
+/// margin exists to prevent.
+///
+/// Falls back to `total_bytes / 2` when no reclaimable field can be parsed (an
+/// unexpected `vm_stat` format) so the whole machine is never reported as
+/// available, and the result is clamped to `total_bytes`.
+#[cfg(any(target_os = "macos", test))]
+#[must_use]
+pub fn parse_macos_available_bytes(vm_stat_output: &str, total_bytes: u64) -> u64 {
+    // Parse page size from the header - handles both Apple Silicon (16KB) and
+    // Intel Macs (4KB) correctly.
+    let page_size = parse_vm_stat_page_size(vm_stat_output);
+
+    let mut free_pages: u64 = 0;
+    let mut file_backed_pages: u64 = 0;
+    let mut purgeable_pages: u64 = 0;
+    let mut parsed_any = false;
+
+    for line in vm_stat_output.lines() {
+        if line.starts_with("Pages free:") {
+            free_pages = parse_vm_stat_line(line);
+            parsed_any = true;
+        } else if line.starts_with("File-backed pages:") {
+            file_backed_pages = parse_vm_stat_line(line);
+            parsed_any = true;
+        } else if line.starts_with("Pages purgeable:") {
+            purgeable_pages = parse_vm_stat_line(line);
+            parsed_any = true;
+        }
+    }
+
+    if !parsed_any {
+        // Unexpected format — be conservative rather than reporting the whole
+        // machine as available.
+        return total_bytes / 2;
+    }
+
+    macos_reclaimable_available_bytes(page_size, free_pages, file_backed_pages, purgeable_pages)
+        .min(total_bytes)
+}
+
+/// Sum the reclaimable macOS page classes and convert to bytes (Issue #3173).
+///
+/// Pure arithmetic split out from [`parse_macos_available_bytes`] so the
+/// reclaimable-memory accounting can be unit-tested against fixed page counts.
+/// Uses saturating arithmetic so implausibly large counts cannot overflow.
+#[cfg(any(target_os = "macos", test))]
+#[must_use]
+pub const fn macos_reclaimable_available_bytes(
+    page_size: u64,
+    free_pages: u64,
+    file_backed_pages: u64,
+    purgeable_pages: u64,
+) -> u64 {
+    free_pages
+        .saturating_add(file_backed_pages)
+        .saturating_add(purgeable_pages)
+        .saturating_mul(page_size)
+}
+
 /// Parse a page count from a `vm_stat` output line.
 /// Example: "Pages free:                              123456." -> 123456
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 pub fn parse_vm_stat_line(line: &str) -> u64 {
     line.split(':')
         .nth(1)
@@ -183,7 +241,7 @@ pub fn parse_vm_stat_line(line: &str) -> u64 {
 ///
 /// Apple Silicon uses 16KB pages, Intel Macs use 4KB pages.
 /// Parsing dynamically ensures correct memory calculations on both.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 pub fn parse_vm_stat_page_size(output: &str) -> u64 {
     // Default page sizes by architecture
     // Apple Silicon (ARM64): 16384 bytes (16KB)

--- a/src/analysis/utils/memory_tests.rs
+++ b/src/analysis/utils/memory_tests.rs
@@ -126,6 +126,111 @@ fn test_preload_zero_margin_uses_full_available() {
 }
 
 // =============================================================================
+// macOS reclaimable available-memory accounting (Issue #3173)
+// =============================================================================
+
+/// `vm_stat` output for a mostly-idle 24 GB Apple Silicon host. Most RAM sits
+/// in reclaimable file-backed cache (much of it in the *active* list, which the
+/// old free+inactive accounting missed), so a ~14.3 GB pre-load must fit.
+const IDLE_24GB_VM_STAT: &str = "\
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              200000.
+Pages active:                            300000.
+Pages inactive:                          150000.
+Pages speculative:                        20000.
+Pages throttled:                              0.
+Pages wired down:                        200000.
+Pages purgeable:                           4000.
+File-backed pages:                       820000.
+Anonymous pages:                         250000.
+Pages stored in compressor:              500000.
+Pages occupied by compressor:            120000.
+";
+
+/// `vm_stat` output for a genuinely constrained 24 GB host: little free RAM,
+/// little file cache, and most memory tied up in dirty anonymous / compressed
+/// app pages that are NOT cheaply reclaimable.
+const CONSTRAINED_24GB_VM_STAT: &str = "\
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               20000.
+Pages active:                            900000.
+Pages inactive:                          400000.
+Pages wired down:                        300000.
+Pages purgeable:                              0.
+File-backed pages:                       100000.
+Anonymous pages:                        1200000.
+Pages occupied by compressor:            300000.
+";
+
+#[test]
+fn macos_available_counts_file_backed_cache_not_just_free_inactive() {
+    const TOTAL: u64 = 24 * 1024 * MB; // 24 GB
+    let available = parse_macos_available_bytes(IDLE_24GB_VM_STAT, TOTAL);
+    // free 200000 + file-backed 820000 + purgeable 4000 = 1_024_000 pages
+    // × 16384 bytes = 16_000 MB reclaimable.
+    assert_eq!(available, 16_000 * MB);
+    // The old free+inactive+purgeable figure would have been only
+    // (200000 + 150000 + 4000) × 16384 ≈ 5.5 GB — far too low, forcing lazy.
+    assert!(available > 15_000 * MB);
+}
+
+#[test]
+fn macos_idle_host_selects_eager_for_14gb_projection() {
+    const TOTAL: u64 = 24 * 1024 * MB;
+    let available = parse_macos_available_bytes(IDLE_24GB_VM_STAT, TOTAL);
+    let projected = 14_297 * MB; // ~14.3 GB pre-load projection
+    let margin = 1024 * MB;
+    assert!(
+        parquet_preload_fits_available(projected, available, margin),
+        "corrected accounting must fit the 14.3 GB projection → eager",
+    );
+}
+
+#[test]
+fn macos_constrained_host_still_selects_lazy() {
+    const TOTAL: u64 = 24 * 1024 * MB;
+    let available = parse_macos_available_bytes(CONSTRAINED_24GB_VM_STAT, TOTAL);
+    // free 20000 + file-backed 100000 + purgeable 0 = 120000 pages
+    // × 16384 bytes = 1_875 MB reclaimable.
+    assert_eq!(available, 1_875 * MB);
+    let projected = 14_297 * MB;
+    let margin = 1024 * MB;
+    assert!(
+        !parquet_preload_fits_available(projected, available, margin),
+        "a genuinely constrained host must stay on the lazy path",
+    );
+}
+
+#[test]
+fn macos_reclaimable_helper_sums_classes_times_page_size() {
+    // (1 + 2 + 3) pages × 4096 bytes = 24576 bytes.
+    assert_eq!(macos_reclaimable_available_bytes(4096, 1, 2, 3), 24_576);
+    // Saturating arithmetic: implausible counts clamp instead of overflowing.
+    assert_eq!(
+        macos_reclaimable_available_bytes(u64::MAX, u64::MAX, 0, 0),
+        u64::MAX
+    );
+}
+
+#[test]
+fn macos_available_falls_back_to_half_total_on_unparseable_output() {
+    const TOTAL: u64 = 16 * 1024 * MB;
+    let available = parse_macos_available_bytes("garbage output\nno fields here", TOTAL);
+    assert_eq!(available, TOTAL / 2);
+}
+
+#[test]
+fn macos_available_never_exceeds_total() {
+    // Absurdly large page counts must clamp to total, never over-report.
+    let output = "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n\
+                  Pages free:                          99999999.\n\
+                  File-backed pages:                   99999999.\n\
+                  Pages purgeable:                            0.\n";
+    const TOTAL: u64 = 8 * 1024 * MB;
+    assert_eq!(parse_macos_available_bytes(output, TOTAL), TOTAL);
+}
+
+// =============================================================================
 // Parquet Memory Check Tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes the macOS available-memory accounting used by the focus-ranking
auto-detect (no explicit `budget_mb`) eager-vs-lazy decision in
`src/focus/ranking/mod.rs` (via `get_memory_info` in
`src/analysis/utils/memory.rs`).

Previously `get_memory_info()` summed only `free + inactive + purgeable`
pages. On macOS a large share of RAM is reclaimable **file-backed cache**,
much of it in the *active* list — which that formula treated as unavailable.
On the 24 GB Apple Silicon exemplar host this reported only ~11 GB available,
so a ~14.3 GB projection + 1 GB margin exceeded it and the ranker dropped to
**lazy** (`reason="memory_pressure"`) even though the host could run **eager**.

### Fix

Compute available memory as the genuinely-reclaimable page classes:

- **Pages free** — unused RAM
- **File-backed pages** — clean file cache (active **and** inactive), dropped on demand without I/O
- **Pages purgeable** — caches the kernel discards on demand

Wired, compressed and dirty anonymous (app) pages are deliberately excluded:
reclaiming them requires swap/compression — the very pressure the pre-load
margin guards against, so counting them would risk the OOM the margin prevents.

Parsing falls back to `total / 2` on unexpected `vm_stat` output and clamps the
result to total, so the machine is never over-reported.

The accounting is extracted into pure, cross-platform-testable helpers
`parse_macos_available_bytes` and `macos_reclaimable_available_bytes`.

### Behaviour

```mermaid
flowchart TD
    A[vm_stat output] --> B[parse free + File-backed + purgeable]
    B --> C[available = reclaimable pages x page_size, clamped to total]
    C --> D{projected + margin <= available?}
    D -- yes --> E[eager pre-load]
    D -- no --> F[lazy + memory_pressure WARN]
```

## Acceptance

- 24 GB idle exemplar, ~14.3 GB projection → corrected accounting reports enough available memory → **eager** (no `memory_pressure` WARN). Covered by `macos_idle_host_selects_eager_for_14gb_projection`.
- `available_mb` now reflects reclaimable memory, not free-only. Covered by `macos_available_counts_file_backed_cache_not_just_free_inactive`.
- Genuinely constrained host still selects **lazy**. Covered by `macos_constrained_host_still_selects_lazy`.
- Non-macOS (Linux/other) accounting unchanged.

## Test Plan

New cross-platform unit tests in `src/analysis/utils/memory_tests.rs`:
`macos_available_counts_file_backed_cache_not_just_free_inactive`,
`macos_idle_host_selects_eager_for_14gb_projection`,
`macos_constrained_host_still_selects_lazy`,
`macos_reclaimable_helper_sums_classes_times_page_size`,
`macos_available_falls_back_to_half_total_on_unparseable_output`,
`macos_available_never_exceeds_total`.

`cargo test --lib memory` (51 passed) and `cargo clippy --lib --all-features`
(clean) both green.

Tracked in GRQ as stSoftwareAU/GRQ#3173 (per GRQ #3170).