### PR TITLE
Propagation-aware remove-neuron gain estimate (Issue #1518)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1518.md
+++ b/docs/archive/pr-summaries/pr-summary-1518.md
@@ -1,0 +1,82 @@
+## Summary
+
+Replaced the fabricated floor-at-`0.1` placeholder remove-neuron gain with a
+**propagation-aware estimator** in NEAT-AI-Discovery (Rust). The old NEAT-AI
+(Deno) `#2483` sink turned a large squash error into a large positive "gain"
+(`0.1 + (log10(err) − 10)/10 × 0.4`, clamped `[0.1, 0.5]`) regardless of
+topology. For a neuron many layers from the output(s), the activation is
+attenuated / squashed repeatedly on the way to the output, so the true effect of
+removal is tiny — the placeholder claimed `+0.17882921` for `neuron-1802938338`
+while the measured effect was only `-0.000194` (~920× too large and opposite in
+sign).
+
+The new `estimate_remove_neuron_gain(creature, neuron_uuid)` reuses the existing
+propagation-aware impact machinery (`compute_impacts_public`, which walks every
+downstream edge weight and squash bound to the output) and turns the unsigned
+influence fraction into a signed honest gain:
+
+- **Magnitude** = the neuron's propagation-aware influence on the output(s).
+  Deep neurons attenuate to ~`1e-4`, not the fabricated `0.1+`.
+- **Sign** = non-positive. Removing a neuron that still carries genuine
+  downstream influence removes that contribution, so the trained network's score
+  is expected to drop by roughly its influence. A neuron with no downstream
+  influence attenuates to ~`0`.
+
+This keeps over-threshold "harmful" neurons removal-eligible (their honest gain
+is ≈0 or slightly negative) without a fabricated large positive gain crowding
+out realistic (~`1e-4`) candidates.
+
+Closes #1518.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the committed
+production-depth fixture (`neuron-1802938338` in the GRQ-cluster creature) and
+synthetic-topology unit tests.
+
+Data flow of the estimator:
+
+```mermaid
+flowchart LR
+    A[Remove-neuron candidate<br/>neuron_uuid] --> B[compute_impacts_public]
+    B --> C[Walk downstream edges:<br/>weight × squash bound<br/>to output(s)]
+    C --> D[Influence fraction I in 0..1<br/>deep neuron → tiny]
+    D --> E[Signed honest gain = −I]
+    E --> F{Within one order of<br/>measured actual<br/>& correct sign?}
+    F -->|yes| G[Regression gate green]
+```
+
+Estimator result on the recorded failure fixture:
+
+| Quantity | Value |
+|----------|-------|
+| Old placeholder gain | `+0.17882921` |
+| Measured actual effect | `-0.000194` |
+| Propagation-aware estimate | small **negative** value within one order of magnitude of `-1.9e-4` |
+
+## Test Plan
+
+- `tests/remove_neuron_propagation.rs`
+  - `remove_neuron_effect_at_production_depth` — **`#[ignore]` removed**; now the
+    permanent regression gate. Asserts `estimate_remove_neuron_gain` matches the
+    measured actual (`-0.000194`) within one order of magnitude and in sign on
+    the committed fixtures.
+  - `placeholder_gain_is_wrong_at_depth` — **inverted** (per #1516/#1517 done-check):
+    now asserts the estimator does **not** emit a value in the retired
+    `[0.1, 0.5]` placeholder floor range for the deep neuron, so an accidental
+    resurfacing of the placeholder path turns CI red.
+- `tests/remove_neuron_gain.rs` (new) — synthetic-topology unit tests:
+  - `shallow_hidden_neuron_has_small_negative_gain` — 1-of-2 inbound neuron → `~-0.5`.
+  - `deeper_neuron_attenuates_below_shallower_neuron` — deeper neuron attenuates
+    below a shallower one (propagation behaviour the placeholder lacked).
+  - `output_neuron_returns_none`, `unknown_neuron_returns_none` — edge cases.
+  - `disconnected_neuron_has_zero_gain` — no downstream path → `~0` gain.
+
+### Note on dependency upgrade
+
+`quality.sh`'s `cargo upgrade --incompatible` step bumps `wgpu`/`naga` from
+`29 → 30`, a major version with breaking API changes (`BufferView` /
+`MapRangeError`) that does not compile. That bump is out of scope for this issue
+and was reverted so this PR stays isolated; the `wgpu 30` migration is a
+separate piece of work. All other quality checks (fmt, clippy `-D warnings`,
+check, doc, tests) pass at the pinned `wgpu 29`.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -61,6 +61,7 @@ pub mod one_hot_class_allocation;
 pub mod quantised_error;
 pub mod recent_failure_window;
 pub mod remove_neuron_drought;
+pub mod remove_neuron_gain;
 pub mod samples;
 pub mod scale_outcomes;
 pub mod shared;
@@ -101,6 +102,10 @@ pub(crate) use orchestration::run_optional_analysis;
 // Issue #1421: outcome classification distinguishing environmentally-disabled
 // passes from genuine search exhaustion.
 pub use analysis_outcome::{AnalysisOutcome, EnvironmentalDisableReason, PassOutcomeCounts};
+
+// Issue #1518: propagation-aware remove-neuron gain estimator (replaces the
+// fabricated floor-at-0.1 placeholder).
+pub use remove_neuron_gain::estimate_remove_neuron_gain;
 
 // Core public API entry points
 pub use gpu::GpuAnalyzer;

--- a/src/analysis/remove_neuron_gain.rs
+++ b/src/analysis/remove_neuron_gain.rs
@@ -1,0 +1,85 @@
+//! Propagation-aware remove-neuron gain estimation (Issue #1518).
+//!
+//! Replaces the fabricated floor-at-`0.1` placeholder gain (the NEAT-AI Deno
+//! `#2483` over-threshold sink `0.1 + (log10(err) − 10)/10 × 0.4`, clamped to
+//! `[0.1, 0.5]`) with a **propagation-aware** estimate of the effect on the
+//! network output(s) of removing a neuron.
+//!
+//! ## Why the placeholder was wrong
+//!
+//! The placeholder ignored topology entirely: it turned a large squash error
+//! into a large positive "gain" regardless of where the neuron sat in the
+//! network. For a neuron many layers from the output(s), the activation is
+//! attenuated / squashed repeatedly on the way to the output, so the true
+//! effect of removing it is tiny. For the recorded failure example
+//! (`neuron-1802938338`) the placeholder claimed `+0.17882921` while the
+//! empirically measured effect was only `-0.000194` — ~920× too large and
+//! opposite in sign.
+//!
+//! ## The propagation-aware estimate
+//!
+//! [`compute_impacts_public`] already
+//! walks every downstream connection, applying each edge weight and the local
+//! squash bound / derivative, accumulating the fraction of the output(s)'
+//! sensitivity that flows through each neuron. For a deep neuron this
+//! attenuates to a tiny value — exactly the propagation the placeholder
+//! ignored.
+//!
+//! We reuse that machinery (DRY) and turn the unsigned influence fraction into
+//! a **signed honest gain**:
+//!
+//! - **Magnitude** = the neuron's propagation-aware influence on the output(s).
+//!   Deep neurons attenuate to ~`1e-4`, not the fabricated `0.1+`.
+//! - **Sign** = negative. Removing a neuron that still carries genuine
+//!   downstream influence removes that contribution, so the trained network's
+//!   score is expected to *drop* by roughly its influence. A neuron with no
+//!   downstream influence (dead / disconnected) attenuates to ~`0`, so its
+//!   honest gain is ~`0` — neither a fabricated win nor a large loss.
+//!
+//! This keeps over-threshold "harmful" neurons removal-eligible (their honest
+//! gain is ≈0 or slightly negative) without letting a fabricated large positive
+//! gain crowd out realistic (~`1e-4`) candidates.
+
+use crate::CreatureJson;
+use crate::focus::compute_impacts_public;
+
+/// Estimate the honest, propagation-aware creature-score gain from removing a
+/// neuron.
+///
+/// The returned value is signed:
+/// - Its **magnitude** is the neuron's propagation-aware influence on the
+///   output(s) — the squash-bounded product of downstream edge weights
+///   accumulated all the way to the output(s). Neurons many layers from the
+///   output attenuate to a tiny value.
+/// - Its **sign** is negative (or zero): removing a neuron that still carries
+///   downstream influence is expected to *reduce* the trained network's score
+///   by roughly its influence, so the honest "gain" from removal is
+///   non-positive.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_uuid` - UUID of the neuron whose removal is being estimated.
+///
+/// # Returns
+/// `Some(gain)` where `gain <= 0.0`, or `None` when the neuron is not present
+/// in the topology or is an output neuron (outputs are not removal candidates).
+#[must_use]
+pub fn estimate_remove_neuron_gain(creature: &CreatureJson, neuron_uuid: &str) -> Option<f64> {
+    // Output neurons are never remove-neuron candidates.
+    if creature
+        .neurons
+        .iter()
+        .any(|n| n.uuid == neuron_uuid && n.neuron_type == "output")
+    {
+        return None;
+    }
+
+    let impacts = compute_impacts_public(creature);
+    let influence = impacts.get(neuron_uuid).copied()?;
+
+    // Honest gain: removing a contributing neuron costs its downstream
+    // influence, so the score is expected to fall by roughly that amount.
+    // Guard against any negative/NaN influence leaking through.
+    let magnitude = f64::from(influence).max(0.0);
+    Some(-magnitude)
+}

--- a/tests/fixtures/remove_neuron_propagation/README.md
+++ b/tests/fixtures/remove_neuron_propagation/README.md
@@ -12,10 +12,12 @@ repositories at runtime.
 ## Why these values matter
 
 The placeholder gain is ~920× larger than — and opposite in sign to — the
-measured actual effect. A propagation-aware estimate of the target neuron's
-influence on the output is `~2.1e-5` (structural impact), within an order of
-magnitude of the measured `~1.9e-4` and thousands of times below the
-placeholder. See Issue #1516 for the root-cause analysis.
+measured actual effect. The propagation-aware estimator
+(`estimate_remove_neuron_gain`, Issue #1518) attenuates the target neuron's
+contribution through downstream weights and squash bounds to the output; its
+signed estimate is a small negative value within an order of magnitude of the
+measured `~1.9e-4` and thousands of times below the placeholder. See Issue
+#1516 for the root-cause analysis and #1518 for the estimator.
 
 Do not edit these fixtures by hand. If either upstream source changes, refresh
 the file and re-validate `placeholder_gain_is_wrong_at_depth`.

--- a/tests/remove_neuron_gain.rs
+++ b/tests/remove_neuron_gain.rs
@@ -1,0 +1,157 @@
+//! Unit tests for the propagation-aware remove-neuron gain estimator
+//! (Issue #1518).
+//!
+//! These exercise the estimator on small synthetic topologies where the
+//! expected attenuation is easy to reason about, complementing the
+//! production-depth fixture spec in `remove_neuron_propagation.rs`.
+
+use neat_ai_discovery::CreatureJson;
+use neat_ai_discovery::analysis::estimate_remove_neuron_gain;
+
+/// Build a `CreatureJson` from a compact JSON description.
+fn creature(json: &str) -> CreatureJson {
+    serde_json::from_str(json).expect("valid creature JSON")
+}
+
+/// A hidden neuron one hop from the output, sharing the output's inbound weight
+/// budget with another hidden neuron, has a bounded (< 1.0) but non-trivial
+/// influence — so removing it yields a small negative honest gain.
+#[test]
+fn shallow_hidden_neuron_has_small_negative_gain() {
+    let c = creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "h1", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "h2", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "h1", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "h2", "weight": 1.0},
+                {"fromUUID": "h1", "toUUID": "out-0", "weight": 1.0},
+                {"fromUUID": "h2", "toUUID": "out-0", "weight": 1.0}
+            ]
+        }"#,
+    );
+
+    let gain = estimate_remove_neuron_gain(&c, "h1").expect("gain for hidden neuron");
+    // Honest gain is non-positive (removal cannot fabricate a win).
+    assert!(gain <= 0.0, "expected non-positive gain, got {gain}");
+    // h1 carries half the output's inbound weight, so |gain| ≈ 0.5.
+    assert!(
+        (gain - -0.5).abs() < 1e-6,
+        "expected ~-0.5 for a 1-of-2 inbound neuron, got {gain}"
+    );
+}
+
+/// A neuron deeper in the network — sharing its inbound weight budget with a
+/// sibling at each layer on the way to the output — attenuates further, so its
+/// honest gain magnitude is smaller than a shallower neuron's. This is the
+/// propagation-aware behaviour the placeholder lacked.
+///
+/// Topology (all IDENTITY, all weight 1):
+/// `deep`/`other` → `mid`; `mid`/`shallow` → `out`.
+/// - `shallow` shares the output's inbound budget once → influence 0.5.
+/// - `deep` shares `mid`'s budget (0.5) and `mid` shares the output's (0.5) →
+///   influence 0.25.
+#[test]
+fn deeper_neuron_attenuates_below_shallower_neuron() {
+    let c = creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "deep", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "other", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "mid", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "shallow", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "deep", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "other", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "shallow", "weight": 1.0},
+                {"fromUUID": "deep", "toUUID": "mid", "weight": 1.0},
+                {"fromUUID": "other", "toUUID": "mid", "weight": 1.0},
+                {"fromUUID": "mid", "toUUID": "out-0", "weight": 1.0},
+                {"fromUUID": "shallow", "toUUID": "out-0", "weight": 1.0}
+            ]
+        }"#,
+    );
+
+    let deep = estimate_remove_neuron_gain(&c, "deep").expect("deep gain");
+    let shallow = estimate_remove_neuron_gain(&c, "shallow").expect("shallow gain");
+
+    assert!(deep <= 0.0 && shallow <= 0.0);
+    assert!(
+        deep.abs() < shallow.abs(),
+        "deep neuron {deep} should attenuate below shallow neuron {shallow}"
+    );
+}
+
+/// Output neurons are never remove-neuron candidates.
+#[test]
+fn output_neuron_returns_none() {
+    let c = creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "h1", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "h1", "weight": 1.0},
+                {"fromUUID": "h1", "toUUID": "out-0", "weight": 1.0}
+            ]
+        }"#,
+    );
+
+    assert!(estimate_remove_neuron_gain(&c, "out-0").is_none());
+}
+
+/// An unknown neuron UUID yields `None` rather than a fabricated value.
+#[test]
+fn unknown_neuron_returns_none() {
+    let c = creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "out-0", "weight": 1.0}
+            ]
+        }"#,
+    );
+
+    assert!(estimate_remove_neuron_gain(&c, "does-not-exist").is_none());
+}
+
+/// A hidden neuron with no downstream path to the output has zero influence, so
+/// its honest gain is ~0 — neither a fabricated win nor a large loss.
+#[test]
+fn disconnected_neuron_has_zero_gain() {
+    let c = creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "orphan", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "out-0", "weight": 1.0}
+            ]
+        }"#,
+    );
+
+    let gain = estimate_remove_neuron_gain(&c, "orphan").expect("gain for orphan");
+    assert!(
+        gain.abs() < 1e-9,
+        "disconnected neuron should have ~0 gain, got {gain}"
+    );
+}

--- a/tests/remove_neuron_propagation.rs
+++ b/tests/remove_neuron_propagation.rs
@@ -16,19 +16,20 @@
 //!   failure, carrying the placeholder gain and the measured actual effect.
 //!
 //! This file ships two tests:
-//! - [`placeholder_gain_is_wrong_at_depth`] (runnable) — the red-state guard.
-//!   It proves the recorded placeholder gain differs from the measured actual by
-//!   more than an order of magnitude, and fails if the placeholder silently
-//!   changes.
-//! - [`remove_neuron_effect_at_production_depth`] (`#[ignore]`) — the estimator
-//!   spec. It is red until the #1516 propagation-aware estimator lands: the
-//!   "current estimate" (the recorded placeholder) does not yet match the
-//!   measured actual. The propagation reference corroborates that the true
-//!   effect really is tiny.
+//! - [`placeholder_gain_is_wrong_at_depth`] (runnable) — since #1518 landed the
+//!   propagation-aware estimator, this is inverted into a regression guard: it
+//!   asserts the estimator no longer emits the floor-clamped `[0.1, 0.5]`
+//!   placeholder range for this deep neuron. If the placeholder path is ever
+//!   accidentally reinstated (e.g. a fallback branch resurfaces), it fails.
+//! - [`remove_neuron_effect_at_production_depth`] — the estimator spec. Now that
+//!   the #1516/#1518 propagation-aware estimator lands, the `#[ignore]` is
+//!   removed and this is the permanent regression gate: the estimate must match
+//!   the measured actual within one order of magnitude and in sign.
 
 #![allow(clippy::cast_precision_loss)] // Intentional numeric casts (Issue #873)
 
 use neat_ai_discovery::CreatureJson;
+use neat_ai_discovery::analysis::estimate_remove_neuron_gain;
 use neat_ai_discovery::focus::compute_impacts_public;
 use std::path::{Path, PathBuf};
 
@@ -109,13 +110,19 @@ fn propagation_aware_impact(creature: &CreatureJson, neuron_uuid: &str) -> f64 {
     f64::from(impact)
 }
 
-/// Red-state guard (runnable in CI). Proves the recorded placeholder gain is
-/// wrong at depth: it differs from the measured actual by more than an order of
-/// magnitude. If the placeholder is ever silently changed, this test turns CI
-/// red at that commit so the fixture / spec can be re-validated.
+/// Regression guard (runnable in CI). Inverted by #1518: the propagation-aware
+/// estimator has replaced the placeholder, so this now asserts that the
+/// estimator no longer emits the floor-clamped `[0.1, 0.5]` placeholder range
+/// for this deep neuron. If the placeholder path is ever accidentally
+/// reinstated (e.g. a fallback branch resurfaces and clamps the gain back up),
+/// this test turns CI red at that commit.
+///
+/// It still pins the recorded fixture values so drift in the known-bad
+/// placeholder / measured-actual constants is caught in the same run.
 #[test]
 fn placeholder_gain_is_wrong_at_depth() {
     let (recorded_gain, recorded_actual, uuid) = load_failure_fixture();
+    let creature = load_network();
 
     // The fixture still encodes the known-bad placeholder and measured actual.
     // Drift in either value flips this guard red.
@@ -131,39 +138,33 @@ fn placeholder_gain_is_wrong_at_depth() {
     );
     assert_eq!(uuid, TARGET_NEURON, "fixture target neuron changed");
 
-    // Core red-state fact: the placeholder is more than an order of magnitude
-    // larger than the measured actual (it is ~920×).
-    let ratio = magnitude_ratio(recorded_gain, recorded_actual);
+    // Inverted guard: the estimator must NOT emit the floor-clamped
+    // `[0.1, 0.5]` placeholder range for this deep neuron. The honest gain is a
+    // tiny (~1e-4) value, far below the fabricated floor of 0.1.
+    let estimate = estimate_remove_neuron_gain(&creature, &uuid)
+        .expect("estimator must return a gain for the target hidden neuron");
     assert!(
-        ratio > 10.0,
-        "placeholder gain must differ from the measured actual by > 1 order of magnitude, \
-         got ratio {ratio:.1}"
-    );
-
-    // ...and it points the wrong way (positive vs the measured negative effect).
-    assert!(
-        recorded_gain.signum() != recorded_actual.signum(),
-        "placeholder gain should be opposite in sign to the measured actual"
+        !(0.1..=0.5).contains(&estimate.abs()),
+        "estimator emitted a value {estimate} inside the retired placeholder floor range \
+         [0.1, 0.5]; the fabricated floor-clamped placeholder path has resurfaced"
     );
 }
 
-/// Estimator spec — red until the #1516 propagation-aware estimator lands.
+/// Estimator spec — the permanent regression gate (#1516/#1518).
 ///
-/// The "current estimate" is the recorded placeholder gain (there is no
-/// propagation-aware estimator to call yet). This case asserts the estimate
-/// matches the measured actual within tolerance — which FAILS today (hence
-/// `#[ignore]`). Once #1516 replaces the placeholder with a propagation-aware
-/// estimate, remove the `#[ignore]` and this becomes the permanent regression
-/// gate on the committed fixtures.
+/// The propagation-aware estimator ([`estimate_remove_neuron_gain`]) replaces
+/// the fabricated placeholder. This case asserts the estimate matches the
+/// measured actual within one order of magnitude AND in sign on the committed
+/// fixtures. Any future estimator change that breaks the scale or sign fidelity
+/// fails `cargo test` in CI before merge.
 ///
 /// The propagation reference (computed live from the committed topology)
 /// corroborates that the true effect at production depth really is tiny —
 /// within an order of magnitude of the measured actual and thousands of times
-/// below the placeholder.
+/// below the retired placeholder.
 #[test]
-#[ignore = "red until #1516 estimator lands"]
 fn remove_neuron_effect_at_production_depth() {
-    let (current_estimate, measured_actual, uuid) = load_failure_fixture();
+    let (placeholder_gain, measured_actual, uuid) = load_failure_fixture();
     let creature = load_network();
 
     // Reference computation: propagate the neuron's contribution through all
@@ -180,18 +181,18 @@ fn remove_neuron_effect_at_production_depth() {
 
     // ...and thousands of times below the fabricated placeholder.
     assert!(
-        magnitude_ratio(current_estimate, reference) > 100.0,
-        "placeholder {current_estimate} should dwarf the propagation reference {reference:e}"
+        magnitude_ratio(placeholder_gain, reference) > 100.0,
+        "placeholder {placeholder_gain} should dwarf the propagation reference {reference:e}"
     );
 
-    // The executable specification: a correct estimator matches the measured
-    // actual within one order of magnitude AND in sign. TODO(#1516): replace
-    // `current_estimate` with a call to the propagation-aware estimator. Until
-    // then this uses the recorded placeholder and is RED.
+    // The executable specification: the propagation-aware estimator matches the
+    // measured actual within one order of magnitude AND in sign.
+    let estimate = estimate_remove_neuron_gain(&creature, &uuid)
+        .expect("estimator must return a gain for the target hidden neuron");
     assert!(
-        within_one_order(current_estimate, measured_actual)
-            && current_estimate.signum() == measured_actual.signum(),
-        "estimate {current_estimate} must match the measured actual {measured_actual:e} \
+        within_one_order(estimate, measured_actual)
+            && estimate.signum() == measured_actual.signum(),
+        "estimate {estimate:e} must match the measured actual {measured_actual:e} \
          within one order of magnitude and in sign"
     );
 }


### PR DESCRIPTION
## Summary

Replaced the fabricated floor-at-`0.1` placeholder remove-neuron gain with a
**propagation-aware estimator** in NEAT-AI-Discovery (Rust). The old NEAT-AI
(Deno) `#2483` sink turned a large squash error into a large positive "gain"
(`0.1 + (log10(err) − 10)/10 × 0.4`, clamped `[0.1, 0.5]`) regardless of
topology. For a neuron many layers from the output(s), the activation is
attenuated / squashed repeatedly on the way to the output, so the true effect of
removal is tiny — the placeholder claimed `+0.17882921` for `neuron-1802938338`
while the measured effect was only `-0.000194` (~920× too large and opposite in
sign).

The new `estimate_remove_neuron_gain(creature, neuron_uuid)` reuses the existing
propagation-aware impact machinery (`compute_impacts_public`, which walks every
downstream edge weight and squash bound to the output) and turns the unsigned
influence fraction into a signed honest gain:

- **Magnitude** = the neuron's propagation-aware influence on the output(s).
  Deep neurons attenuate to ~`1e-4`, not the fabricated `0.1+`.
- **Sign** = non-positive. Removing a neuron that still carries genuine
  downstream influence removes that contribution, so the trained network's score
  is expected to drop by roughly its influence. A neuron with no downstream
  influence attenuates to ~`0`.

This keeps over-threshold "harmful" neurons removal-eligible (their honest gain
is ≈0 or slightly negative) without a fabricated large positive gain crowding
out realistic (~`1e-4`) candidates.

Closes #1518.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the committed
production-depth fixture (`neuron-1802938338` in the GRQ-cluster creature) and
synthetic-topology unit tests.

Data flow of the estimator:

```mermaid
flowchart LR
    A[Remove-neuron candidate<br/>neuron_uuid] --> B[compute_impacts_public]
    B --> C[Walk downstream edges:<br/>weight × squash bound<br/>to output(s)]
    C --> D[Influence fraction I in 0..1<br/>deep neuron → tiny]
    D --> E[Signed honest gain = −I]
    E --> F{Within one order of<br/>measured actual<br/>& correct sign?}
    F -->|yes| G[Regression gate green]
```

Estimator result on the recorded failure fixture:

| Quantity | Value |
|----------|-------|
| Old placeholder gain | `+0.17882921` |
| Measured actual effect | `-0.000194` |
| Propagation-aware estimate | small **negative** value within one order of magnitude of `-1.9e-4` |

## Test Plan

- `tests/remove_neuron_propagation.rs`
  - `remove_neuron_effect_at_production_depth` — **`#[ignore]` removed**; now the
    permanent regression gate. Asserts `estimate_remove_neuron_gain` matches the
    measured actual (`-0.000194`) within one order of magnitude and in sign on
    the committed fixtures.
  - `placeholder_gain_is_wrong_at_depth` — **inverted** (per #1516/#1517 done-check):
    now asserts the estimator does **not** emit a value in the retired
    `[0.1, 0.5]` placeholder floor range for the deep neuron, so an accidental
    resurfacing of the placeholder path turns CI red.
- `tests/remove_neuron_gain.rs` (new) — synthetic-topology unit tests:
  - `shallow_hidden_neuron_has_small_negative_gain` — 1-of-2 inbound neuron → `~-0.5`.
  - `deeper_neuron_attenuates_below_shallower_neuron` — deeper neuron attenuates
    below a shallower one (propagation behaviour the placeholder lacked).
  - `output_neuron_returns_none`, `unknown_neuron_returns_none` — edge cases.
  - `disconnected_neuron_has_zero_gain` — no downstream path → `~0` gain.

### Note on dependency upgrade

`quality.sh`'s `cargo upgrade --incompatible` step bumps `wgpu`/`naga` from
`29 → 30`, a major version with breaking API changes (`BufferView` /
`MapRangeError`) that does not compile. That bump is out of scope for this issue
and was reverted so this PR stays isolated; the `wgpu 30` migration is a
separate piece of work. All other quality checks (fmt, clippy `-D warnings`,
check, doc, tests) pass at the pinned `wgpu 29`.



## Milestone
This PR is part of the **#1516 Remove-neuron expected gain is a placeholder, ~1000x off actual; no successes** milestone and targets the `milestone/1516-remove-neuron-expected-gain-is-a-placeholder` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mragm9wd-291d04`<!-- vibe-worker-issue-1518 -->