### PR TITLE
Investigate thin failure cache calibration; add regression guard (Issue #1521)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1521.md
+++ b/docs/archive/pr-summaries/pr-summary-1521.md
@@ -1,0 +1,97 @@
+# PR Summary — Issue #1521
+
+## Summary
+
+Investigation of low remove-neuron candidate throughput and whether the thin
+(2-entry) failure cache for creature `247b83ab` starves the #1131/#1162
+calibration EWMA into suppressing candidate suggestion. **Closes #1521.**
+
+**Finding (negative result on the "starvation" hypothesis).** The thin failure
+cache does **not** starve the per-change-type calibration EWMA into collapsing
+the remove-neuron candidate stream. Two existing safeguards in
+`src/analysis/scoring/calibration_correction.rs` make a thin cache safe:
+
+1. **Correction floor / clamp.** `CalibrationCorrection::from_failure_cache`
+   clamps every per-`change_type` EWMA to
+   `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]` = `[0.001, 1.0]`. Even two
+   ~800× over-predictions (the `247b83ab` shape: predicted ≈ 0.166, actual
+   ≈ −0.0002) produce a correction of `0.001` — heavily discounted but strictly
+   non-zero. `apply_prediction_calibration` is a plain multiply
+   (`gain * factor`), so the corrected candidate gain stays strictly positive
+   and the stream is never zeroed by this layer.
+2. **Graceful fallback below the specific-sample threshold.** The per-
+   `(change_type, target_squash)` specific layer requires
+   `MIN_SPECIFIC_TARGET_SQUASH_SAMPLES` (= 3) usable entries. With only 2 the
+   specific layer stays empty and `correction_for` falls back to the
+   per-`change_type` EWMA (populated by any single usable entry) rather than
+   leaving the correction undefined.
+
+Low candidate throughput was therefore driven by the **placeholder gain**
+(parent #1516) — the ~920× fabricated remove-neuron gain — which is addressed by
+the propagation-aware estimate landed in #1517/#1518, **not** by the thin
+failure cache. This is the "negative result … resolved by the estimator
+sub-issues" outcome the issue explicitly allows.
+
+**Remedy shipped.** Per the issue's failure-detection requirement, this PR ships
+the regression test `tests/issue_1521_thin_failure_cache_calibration.rs` that
+codifies the cold-start / warm-up fallback guarantee, plus a documentation note
+in the calibration module. No behavioural code change was required — the floor
+*is* the existing cold-start handling. The test prevents a future regression
+(removing the floor, or gating corrections behind a minimum entry count) from
+re-suppressing candidates.
+
+## Evidence
+
+Backend/Rust change only — no web interface to screenshot. Evidence is the test
+suite: the new regression test passes and the existing calibration/drought
+guards (`tests/analysis/issue_1425_remove_neuron_calibration.rs`,
+`tests/issue_1448_remove_neuron_drought.rs`) remain green.
+
+Calibration flow for a thin remove-neuron failure cache:
+
+```mermaid
+flowchart TD
+    A["2-entry failure cache<br/>(247b83ab: pred≈0.166, actual≈-0.0002)"] --> B{"expected == 0<br/>or ratio non-finite?"}
+    B -- yes --> S["skip entry"]
+    B -- no --> C["ratio = actual / expected ≈ -0.00125"]
+    C --> D["per-change_type EWMA"]
+    C --> E{"specific (change_type, squash)<br/>>= 3 samples?"}
+    E -- "no (only 2)" --> D
+    E -- yes --> F["specific EWMA"]
+    D --> G["clamp to [0.001, 1.0] → 0.001 (floor)"]
+    F --> G
+    G --> H["gain * COORDINATED_PREDICTION_CALIBRATION * 0.001"]
+    H --> I["corrected gain > 0<br/>(non-zero candidate stream)"]
+```
+
+## Test Plan
+
+Added `tests/issue_1521_thin_failure_cache_calibration.rs` (5 tests):
+
+- `thin_two_entry_cache_yields_non_zero_floored_correction` — a 2-entry cache
+  still populates the per-change-type correction with a strictly-positive,
+  floored (`0.001`) value; the EWMA is not starved into silence.
+- `thin_cache_corrected_gain_is_non_zero` — applying the correction to the
+  fabricated gain yields a strictly-positive corrected gain (non-zero stream)
+  that is still far below the raw gain.
+- `thin_cache_falls_back_to_change_type_not_neutral` — with 2 squash-tagged
+  entries the specific layer stays empty and lookup falls back to the non-zero
+  per-change-type EWMA (not neutral 1.0).
+- `thin_cache_ewma_reflects_observed_ratio` — two mild (ratio 0.5) entries yield
+  ≈ 0.5, proving the EWMA tracks the data with only 2 samples.
+- `thin_cache_matches_long_uniform_cache` — the 2-entry correction equals the
+  20-entry uniform correction; the thin cache is not "under-warmed".
+
+Also added a "Thin failure cache is safe (Issue #1521)" note to the module docs
+in `src/analysis/scoring/calibration_correction.rs`.
+
+Validation: `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`,
+`cargo check --all-targets --all-features`,
+`cargo test --lib --tests --all-features -- --test-threads=2` (all green,
+including the existing #1425 / #1448 guards), and `cargo doc` all pass.
+
+> Note: `quality.sh` runs `cargo upgrade --incompatible`, which pulls an
+> incompatible `wgpu`/`naga` 29→30 major bump that breaks unrelated GPU code
+> (`bytemuck::cast_slice` / `MapRangeError` API changes). That migration is out
+> of scope for this investigation, so the dependency bump was reverted and the
+> quality steps were run against the pinned dependencies.

--- a/src/analysis/scoring/calibration_correction.rs
+++ b/src/analysis/scoring/calibration_correction.rs
@@ -53,6 +53,30 @@
 //! over as it does for every other squash. Non-risky squashes (`ReLU` family,
 //! Sigmoid, Tanh, …) keep the existing 1.0 cold-start default.
 //!
+//! ## Thin failure cache is safe (Issue #1521)
+//!
+//! A creature whose failure cache holds only a couple of entries (the parent
+//! milestone #1516 observed just 2 for creature `247b83ab`) does **not** starve
+//! this EWMA into suppressing candidate suggestion. Two safeguards make a thin
+//! cache safe:
+//!
+//! - Every per-`change_type` EWMA is clamped to
+//!   `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]` (= `[0.001, 1.0]`), so
+//!   even two ~800× over-predictions produce a correction of `0.001` — heavily
+//!   discounted but strictly non-zero. The correction is applied by a plain
+//!   multiply, so the corrected candidate gain stays strictly positive and the
+//!   candidate stream is never collapsed to zero by this layer.
+//! - The per-`(change_type, target_squash)` specific layer requires
+//!   [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] entries; below that threshold
+//!   [`CalibrationCorrection::correction_for`] falls back to the per-`change_type`
+//!   EWMA (populated by any single usable entry) rather than leaving the
+//!   correction undefined.
+//!
+//! The floor is therefore the cold-start / warm-up handling for a thin cache.
+//! `tests/issue_1521_thin_failure_cache_calibration.rs` locks in this
+//! behaviour so a future change cannot re-suppress candidates by starving the
+//! EWMA.
+//!
 //! # Formula
 //!
 //! Given failure cache entries with `expected_error_reduction` and

--- a/tests/issue_1521_thin_failure_cache_calibration.rs
+++ b/tests/issue_1521_thin_failure_cache_calibration.rs
@@ -1,0 +1,206 @@
+//! Issue #1521 — a thin (2-entry) failure cache must NOT starve the
+//! #1131/#1162 calibration EWMA into suppressing the remove-neuron candidate
+//! stream.
+//!
+//! ## Investigation summary (negative result on the "starvation" hypothesis)
+//!
+//! The parent milestone (#1516) observed that the failure cache for creature
+//! `247b83ab` holds only 2 entries and hypothesised that this thin cache
+//! starves the per-change-type calibration EWMA, suppressing remove-neuron
+//! candidate suggestion. This investigation shows the thin cache does **not**
+//! starve the EWMA, because two existing design safeguards in
+//! `src/analysis/scoring/calibration_correction.rs` make a thin cache safe:
+//!
+//! 1. **Correction floor / clamp.** [`CalibrationCorrection::from_failure_cache`]
+//!    clamps every per-change-type EWMA to
+//!    `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]` = `[0.001, 1.0]`. Even a
+//!    2-entry cache dominated by ~800× over-predictions produces a correction of
+//!    `0.001` — heavily discounted but strictly non-zero. Because
+//!    `apply_prediction_calibration` is a plain multiply, the corrected gain
+//!    stays strictly positive, so the candidate stream is never collapsed to
+//!    zero by the calibration layer.
+//!
+//! 2. **Graceful fallback below the specific-sample threshold.** The per-
+//!    `(change_type, target_squash)` specific layer requires
+//!    [`MIN_SPECIFIC_TARGET_SQUASH_SAMPLES`] (= 3) entries. With only 2 the
+//!    specific layer stays empty and [`CalibrationCorrection::correction_for`]
+//!    falls back to the per-`change_type` EWMA, which any single usable entry
+//!    already populates. A thin cache therefore degrades gracefully rather than
+//!    leaving the correction undefined.
+//!
+//! Low candidate throughput was driven by the **placeholder gain** (parent
+//! #1516), addressed by the propagation-aware estimate in #1517/#1518 — not by
+//! the thin failure cache. These tests are the documented warm-up fallback the
+//! issue calls for: they lock in that a 2-entry remove-neuron cache still yields
+//! a non-zero, floored correction and a strictly-positive corrected candidate
+//! stream, so a future regression (removing the floor, or gating corrections
+//! behind a minimum entry count) that re-suppresses candidates fails here.
+
+#![allow(clippy::cast_precision_loss)]
+
+use neat_ai_discovery::analysis::constants::COORDINATED_PREDICTION_CALIBRATION;
+use neat_ai_discovery::analysis::scoring::calibration_correction::{
+    CHANGE_TYPE_REMOVE_NEURON, CalibrationCorrection, FailureCacheEntry,
+    MIN_CALIBRATION_CORRECTION, MIN_SPECIFIC_TARGET_SQUASH_SAMPLES, NEUTRAL_CORRECTION,
+};
+
+/// A single failure-cache entry mirroring the `247b83ab` evidence shape:
+/// predicted ≈ 0.166, actual ≈ 0 (slightly negative) — a ~800× over-prediction.
+fn remove_neuron_failure() -> FailureCacheEntry {
+    FailureCacheEntry {
+        change_type: CHANGE_TYPE_REMOVE_NEURON.to_string(),
+        expected_error_reduction: 0.165_710_48,
+        actual_error_reduction: -0.000_207_19,
+        target_squash: None,
+        variant_key: None,
+        target_uuid: None,
+        improved_count: None,
+        total_count: None,
+    }
+}
+
+/// Build the thin, 2-entry failure cache described in the parent issue.
+fn thin_two_entry_cache() -> Vec<FailureCacheEntry> {
+    vec![remove_neuron_failure(), remove_neuron_failure()]
+}
+
+/// Core guarantee: a 2-entry remove-neuron failure cache still populates the
+/// per-change-type correction with a strictly-positive, floored value — the
+/// EWMA is not starved into silence by the thin cache.
+#[test]
+fn thin_two_entry_cache_yields_non_zero_floored_correction() {
+    let cache = thin_two_entry_cache();
+    assert_eq!(
+        cache.len(),
+        2,
+        "guard: this exercises the thin 2-entry cache"
+    );
+
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+
+    // The per-change-type layer IS populated from just 2 entries.
+    assert!(
+        !correction.is_empty(),
+        "a 2-entry cache must still populate the per-change-type correction"
+    );
+
+    let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    assert!(
+        learned.is_finite() && learned > 0.0,
+        "correction must be finite and strictly positive, got {learned}"
+    );
+    // ~800× over-prediction with only 2 entries clamps to the floor, not zero.
+    assert!(
+        (learned - MIN_CALIBRATION_CORRECTION).abs() < 1e-6,
+        "expected the correction floored at {MIN_CALIBRATION_CORRECTION}, got {learned}"
+    );
+}
+
+/// The corrected candidate gain stays strictly positive: the calibration layer
+/// discounts the fabricated gain but never collapses the stream to zero.
+#[test]
+fn thin_cache_corrected_gain_is_non_zero() {
+    let correction = CalibrationCorrection::from_failure_cache(&thin_two_entry_cache());
+    let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+
+    let raw_gain = 0.165_710_48_f32;
+    let corrected = raw_gain * COORDINATED_PREDICTION_CALIBRATION * learned;
+
+    assert!(
+        corrected > 0.0,
+        "corrected gain must remain strictly positive (non-zero candidate stream), got {corrected}"
+    );
+    // The correction still does its job: the fabricated gain is heavily shrunk.
+    assert!(
+        corrected < raw_gain * 0.05,
+        "corrected gain ({corrected}) must be far below the raw gain ({raw_gain})"
+    );
+}
+
+/// Below the per-squash sample threshold the specific layer stays empty and the
+/// lookup falls back to the (non-zero) per-change-type EWMA — a thin cache does
+/// not leave the correction undefined or neutral.
+#[test]
+fn thin_cache_falls_back_to_change_type_not_neutral() {
+    // Two entries carrying a target squash — still one short of the specific
+    // threshold, so the specific bucket must not be retained.
+    const _: () = assert!(MIN_SPECIFIC_TARGET_SQUASH_SAMPLES > 2);
+    let cache: Vec<FailureCacheEntry> = (0..2)
+        .map(|_| {
+            let mut e = remove_neuron_failure();
+            e.target_squash = Some("SELU".to_string());
+            e
+        })
+        .collect();
+
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+    assert!(
+        correction.specific_as_map().is_empty(),
+        "2 entries is below MIN_SPECIFIC_TARGET_SQUASH_SAMPLES; specific layer must stay empty"
+    );
+
+    let with_squash = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, Some("SELU"));
+    let fallback = correction.get_correction(CHANGE_TYPE_REMOVE_NEURON);
+    assert!(
+        (with_squash - fallback).abs() < 1e-9,
+        "specific lookup must fall back to the per-change-type EWMA ({fallback}), got {with_squash}"
+    );
+    // The fallback is the floored, non-zero correction — not the neutral 1.0
+    // that would leave the fabricated gain undiscounted.
+    assert!(
+        with_squash < NEUTRAL_CORRECTION && with_squash > 0.0,
+        "fallback must be a discounting, non-zero correction, got {with_squash}"
+    );
+}
+
+/// Two entries are enough for the EWMA to reflect the observed ratio: a cache of
+/// two mild (ratio ≈ 0.5) outcomes yields ≈ 0.5, proving the EWMA is not starved
+/// into a degenerate value by the small sample count.
+#[test]
+fn thin_cache_ewma_reflects_observed_ratio() {
+    let cache = vec![
+        FailureCacheEntry {
+            change_type: CHANGE_TYPE_REMOVE_NEURON.to_string(),
+            expected_error_reduction: 1.0,
+            actual_error_reduction: 0.5,
+            target_squash: None,
+            variant_key: None,
+            target_uuid: None,
+            improved_count: None,
+            total_count: None,
+        },
+        FailureCacheEntry {
+            change_type: CHANGE_TYPE_REMOVE_NEURON.to_string(),
+            expected_error_reduction: 1.0,
+            actual_error_reduction: 0.5,
+            target_squash: None,
+            variant_key: None,
+            target_uuid: None,
+            improved_count: None,
+            total_count: None,
+        },
+    ];
+    let correction = CalibrationCorrection::from_failure_cache(&cache);
+    let learned = correction.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    assert!(
+        (learned - 0.5).abs() < 1e-6,
+        "EWMA of two 0.5 ratios must be 0.5 (not starved to floor/neutral), got {learned}"
+    );
+}
+
+/// The 2-entry correction matches a many-entry uniform cache: the EWMA of a
+/// constant sequence is that constant, so two entries produce the same
+/// calibration a long history would. The thin cache is not "under-warmed".
+#[test]
+fn thin_cache_matches_long_uniform_cache() {
+    let thin = CalibrationCorrection::from_failure_cache(&thin_two_entry_cache());
+    let long: Vec<FailureCacheEntry> = (0..20).map(|_| remove_neuron_failure()).collect();
+    let long = CalibrationCorrection::from_failure_cache(&long);
+
+    let thin_value = thin.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    let long_value = long.correction_for(CHANGE_TYPE_REMOVE_NEURON, None);
+    assert!(
+        (thin_value - long_value).abs() < 1e-6,
+        "2-entry correction ({thin_value}) must match the 20-entry correction ({long_value})"
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1521

## Summary

Investigation of low remove-neuron candidate throughput and whether the thin
(2-entry) failure cache for creature `247b83ab` starves the #1131/#1162
calibration EWMA into suppressing candidate suggestion. **Closes #1521.**

**Finding (negative result on the "starvation" hypothesis).** The thin failure
cache does **not** starve the per-change-type calibration EWMA into collapsing
the remove-neuron candidate stream. Two existing safeguards in
`src/analysis/scoring/calibration_correction.rs` make a thin cache safe:

1. **Correction floor / clamp.** `CalibrationCorrection::from_failure_cache`
   clamps every per-`change_type` EWMA to
   `[MIN_CALIBRATION_CORRECTION, NEUTRAL_CORRECTION]` = `[0.001, 1.0]`. Even two
   ~800× over-predictions (the `247b83ab` shape: predicted ≈ 0.166, actual
   ≈ −0.0002) produce a correction of `0.001` — heavily discounted but strictly
   non-zero. `apply_prediction_calibration` is a plain multiply
   (`gain * factor`), so the corrected candidate gain stays strictly positive
   and the stream is never zeroed by this layer.
2. **Graceful fallback below the specific-sample threshold.** The per-
   `(change_type, target_squash)` specific layer requires
   `MIN_SPECIFIC_TARGET_SQUASH_SAMPLES` (= 3) usable entries. With only 2 the
   specific layer stays empty and `correction_for` falls back to the
   per-`change_type` EWMA (populated by any single usable entry) rather than
   leaving the correction undefined.

Low candidate throughput was therefore driven by the **placeholder gain**
(parent #1516) — the ~920× fabricated remove-neuron gain — which is addressed by
the propagation-aware estimate landed in #1517/#1518, **not** by the thin
failure cache. This is the "negative result … resolved by the estimator
sub-issues" outcome the issue explicitly allows.

**Remedy shipped.** Per the issue's failure-detection requirement, this PR ships
the regression test `tests/issue_1521_thin_failure_cache_calibration.rs` that
codifies the cold-start / warm-up fallback guarantee, plus a documentation note
in the calibration module. No behavioural code change was required — the floor
*is* the existing cold-start handling. The test prevents a future regression
(removing the floor, or gating corrections behind a minimum entry count) from
re-suppressing candidates.

## Evidence

Backend/Rust change only — no web interface to screenshot. Evidence is the test
suite: the new regression test passes and the existing calibration/drought
guards (`tests/analysis/issue_1425_remove_neuron_calibration.rs`,
`tests/issue_1448_remove_neuron_drought.rs`) remain green.

Calibration flow for a thin remove-neuron failure cache:

```mermaid
flowchart TD
    A["2-entry failure cache<br/>(247b83ab: pred≈0.166, actual≈-0.0002)"] --> B{"expected == 0<br/>or ratio non-finite?"}
    B -- yes --> S["skip entry"]
    B -- no --> C["ratio = actual / expected ≈ -0.00125"]
    C --> D["per-change_type EWMA"]
    C --> E{"specific (change_type, squash)<br/>>= 3 samples?"}
    E -- "no (only 2)" --> D
    E -- yes --> F["specific EWMA"]
    D --> G["clamp to [0.001, 1.0] → 0.001 (floor)"]
    F --> G
    G --> H["gain * COORDINATED_PREDICTION_CALIBRATION * 0.001"]
    H --> I["corrected gain > 0<br/>(non-zero candidate stream)"]
```

## Test Plan

Added `tests/issue_1521_thin_failure_cache_calibration.rs` (5 tests):

- `thin_two_entry_cache_yields_non_zero_floored_correction` — a 2-entry cache
  still populates the per-change-type correction with a strictly-positive,
  floored (`0.001`) value; the EWMA is not starved into silence.
- `thin_cache_corrected_gain_is_non_zero` — applying the correction to the
  fabricated gain yields a strictly-positive corrected gain (non-zero stream)
  that is still far below the raw gain.
- `thin_cache_falls_back_to_change_type_not_neutral` — with 2 squash-tagged
  entries the specific layer stays empty and lookup falls back to the non-zero
  per-change-type EWMA (not neutral 1.0).
- `thin_cache_ewma_reflects_observed_ratio` — two mild (ratio 0.5) entries yield
  ≈ 0.5, proving the EWMA tracks the data with only 2 samples.
- `thin_cache_matches_long_uniform_cache` — the 2-entry correction equals the
  20-entry uniform correction; the thin cache is not "under-warmed".

Also added a "Thin failure cache is safe (Issue #1521)" note to the module docs
in `src/analysis/scoring/calibration_correction.rs`.

Validation: `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`,
`cargo check --all-targets --all-features`,
`cargo test --lib --tests --all-features -- --test-threads=2` (all green,
including the existing #1425 / #1448 guards), and `cargo doc` all pass.

> Note: `quality.sh` runs `cargo upgrade --incompatible`, which pulls an
> incompatible `wgpu`/`naga` 29→30 major bump that breaks unrelated GPU code
> (`bytemuck::cast_slice` / `MapRangeError` API changes). That migration is out
> of scope for this investigation, so the dependency bump was reverted and the
> quality steps were run against the pinned dependencies.



## Milestone
This PR is part of the **#1516 Remove-neuron expected gain is a placeholder, ~1000x off actual; no successes** milestone and targets the `milestone/1516-remove-neuron-expected-gain-is-a-placeholder` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mraiuy4r-f045da`<!-- vibe-worker-issue-1521 -->