### PR TITLE
Rank over-threshold hygiene neurons with honest gain (Issue #1519)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-1519.md
+++ b/docs/archive/pr-summaries/pr-summary-1519.md
@@ -1,0 +1,90 @@
+## Summary
+
+Rank over-threshold hygiene neurons with an **honest** gain while keeping them
+removal-eligible. Closes #1519.
+
+Over-threshold "broken" neurons (baseline squash error `> 1e10`) still need to
+be removed because they break WASM compilation of the exported network — the
+NEAT-AI `#2483` hygiene guarantee must not regress. But they were ranked with a
+fabricated `[0.1, 0.5]` floor gain that crowded out realistic (~`1e-4`)
+improvement candidates.
+
+This change adds a small decoupled model on top of the Issue #1518
+propagation-aware estimator so the two concerns are independent:
+
+- **Removal-eligibility** is derived from the hygiene threshold
+  (`MAX_REASONABLE_SQUASH_ERROR = 1e10`) — a broken neuron is removed regardless
+  of its estimated gain.
+- **Ranking value** is the honest, propagation-aware
+  `estimate_remove_neuron_gain` estimate (≈0 or negative), never the retired
+  synthetic floor — so broken neurons no longer displace genuine `~1e-4`
+  candidates.
+
+### Changes
+
+- `src/analysis/remove_neuron_gain.rs`
+  - New `pub const MAX_REASONABLE_SQUASH_ERROR: f64 = 1e10` — mirrors the
+    Deno-side threshold so both sides of the FFI boundary agree.
+  - New `RemoveNeuronAssessment { removal_eligible, gain }` value type.
+  - New `assess_remove_neuron(creature, neuron_uuid, squash_error)` — returns the
+    hygiene eligibility (from the threshold) and the honest gain (from the
+    estimator), fully decoupled. Returns `None` for output / absent neurons
+    (never removal candidates).
+- `src/analysis/mod.rs` — re-export the new constant, type, and function.
+
+The Deno side already keeps the over-threshold promotion (`#2483`) and delegates
+the gain to the injected estimator (`#1520`); this change makes the Rust engine
+the single source of truth for "is this over threshold?" plus "what is the
+honest gain?", and guards the decoupling with tests.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot. Verified via the
+new unit tests plus the existing remove-neuron suites (all green):
+
+```
+tests/hygiene_removal.rs ... ok (5 tests)
+tests/remove_neuron_gain.rs ... ok (5 tests)
+tests/remove_neuron_propagation.rs ... ok (2 tests)
+```
+
+### Decoupling at a glance
+
+```mermaid
+flowchart LR
+    N[Neuron: squash_error, topology] --> E{squash_error > 1e10?}
+    E -- yes --> R[removal_eligible = true]
+    E -- no --> R2[removal_eligible = false]
+    N --> G[estimate_remove_neuron_gain<br/>propagation-aware, ≈0 or negative]
+    G --> V[gain = honest estimate]
+    R --> A[RemoveNeuronAssessment]
+    R2 --> A
+    V --> A
+    A --> S[Ranking sorts on honest gain<br/>genuine ~1e-4 candidates rank above broken neurons]
+```
+
+## Test Plan
+
+Added `tests/hygiene_removal.rs`:
+
+- `over_threshold_neuron_removed_despite_nonpositive_gain` — a neuron with squash
+  error `> 1e10` and a non-positive honest gain stays `removal_eligible`
+  (hygiene / `#2483` guarantee).
+- `over_threshold_gain_is_honest_not_floored` — the reported gain equals the
+  propagation-aware estimate, is outside the retired `[0.1, 0.5]` floor, and a
+  genuine `~1e-4` candidate ranks above it (no crowd-out).
+- `below_threshold_neuron_is_not_hygiene_eligible` — proves eligibility is driven
+  by the threshold, not the gain (decoupling in the other direction).
+- `output_and_unknown_neurons_yield_no_assessment` — outputs / unknown UUIDs are
+  never removal candidates.
+- `assessment_fields_are_decoupled_values` — the assessment carries the two
+  independent fields.
+
+## Notes
+
+- The quality gate's `cargo upgrade --incompatible` step attempted a `wgpu`
+  `29 → 30` (and `naga` `29 → 30`) major bump, which introduces a breaking
+  `BufferView`/`MapRangeError` API change requiring a separate GPU-code
+  migration — out of scope for this issue. That bump was reverted; the remaining
+  gate steps (fmt, clippy `-D warnings`, check, tests, doc, release build) pass
+  on the committed dependency set.

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -107,6 +107,12 @@ pub use analysis_outcome::{AnalysisOutcome, EnvironmentalDisableReason, PassOutc
 // fabricated floor-at-0.1 placeholder).
 pub use remove_neuron_gain::estimate_remove_neuron_gain;
 
+// Issue #1519: decoupled hygiene removal-eligibility (squash-error threshold)
+// from the honest ranking gain.
+pub use remove_neuron_gain::{
+    MAX_REASONABLE_SQUASH_ERROR, RemoveNeuronAssessment, assess_remove_neuron,
+};
+
 // Core public API entry points
 pub use gpu::GpuAnalyzer;
 pub use gpu::supports_unified_memory;

--- a/src/analysis/remove_neuron_gain.rs
+++ b/src/analysis/remove_neuron_gain.rs
@@ -43,6 +43,70 @@
 use crate::CreatureJson;
 use crate::focus::compute_impacts_public;
 
+/// Squash-error magnitude above which a neuron is treated as "broken" for
+/// hygiene purposes (Issue #1519).
+///
+/// A neuron whose baseline squash error exceeds this bound is producing
+/// astronomically large activation errors that break WASM compilation of the
+/// exported network downstream. It must be removed regardless of its estimated
+/// gain — the NEAT-AI `#2483` hygiene guarantee. This mirrors the Deno-side
+/// `MAX_REASONABLE_SQUASH_ERROR` so the removal-eligibility decision uses the
+/// same threshold on both sides of the FFI boundary.
+pub const MAX_REASONABLE_SQUASH_ERROR: f64 = 1e10;
+
+/// Decoupled remove-neuron assessment (Issue #1519).
+///
+/// Separates hygiene **removal-eligibility** from the **ranking value** so an
+/// over-threshold broken neuron is removed regardless of its gain, while its
+/// reported gain stays honest and never crowds out realistic (~`1e-4`)
+/// candidates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RemoveNeuronAssessment {
+    /// `true` when the neuron must be removed on hygiene grounds — its squash
+    /// error exceeds [`MAX_REASONABLE_SQUASH_ERROR`]. Derived purely from the
+    /// hygiene threshold, never from [`gain`](Self::gain).
+    pub removal_eligible: bool,
+    /// The honest, propagation-aware gain used purely for ranking. Always the
+    /// [`estimate_remove_neuron_gain`] value (≈0 or negative for a broken
+    /// neuron), never the retired synthetic `[0.1, 0.5]` floor.
+    pub gain: f64,
+}
+
+/// Assess a remove-neuron candidate, decoupling hygiene removal-eligibility
+/// from the honest ranking gain (Issue #1519).
+///
+/// Removal-eligibility is driven solely by `squash_error` against
+/// [`MAX_REASONABLE_SQUASH_ERROR`]; the gain is the honest, propagation-aware
+/// [`estimate_remove_neuron_gain`] estimate. The two are independent: a broken
+/// (over-threshold) neuron stays removal-eligible even when its honest gain is
+/// ≈0 or negative, and that honest gain — not a fabricated floor — is what the
+/// downstream ranking sorts on.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_uuid` - UUID of the neuron whose removal is being assessed.
+/// * `squash_error` - The neuron's baseline squash error, used only for the
+///   hygiene removal-eligibility decision.
+///
+/// # Returns
+/// `Some(assessment)` for a hidden neuron present in the topology, or `None`
+/// when the neuron is absent or is an output neuron (outputs are never removal
+/// candidates).
+#[must_use]
+pub fn assess_remove_neuron(
+    creature: &CreatureJson,
+    neuron_uuid: &str,
+    squash_error: f64,
+) -> Option<RemoveNeuronAssessment> {
+    // The honest gain also gates candidacy: `None` here means the neuron is an
+    // output or not present, so it is never a removal candidate.
+    let gain = estimate_remove_neuron_gain(creature, neuron_uuid)?;
+    Some(RemoveNeuronAssessment {
+        removal_eligible: squash_error > MAX_REASONABLE_SQUASH_ERROR,
+        gain,
+    })
+}
+
 /// Estimate the honest, propagation-aware creature-score gain from removing a
 /// neuron.
 ///

--- a/tests/hygiene_removal.rs
+++ b/tests/hygiene_removal.rs
@@ -1,0 +1,167 @@
+//! Hygiene removal-eligibility, ranked with an honest gain (Issue #1519).
+//!
+//! Over-threshold "broken" neurons (squash error > [`MAX_REASONABLE_SQUASH_ERROR`])
+//! must stay **removal-eligible** — they break downstream WASM compilation of the
+//! exported network, so the NEAT-AI `#2483` hygiene guarantee must not regress.
+//! But they must no longer be ranked with the fabricated `[0.1, 0.5]` floor gain
+//! that crowds out realistic (~`1e-4`) improvement candidates.
+//!
+//! [`assess_remove_neuron`] decouples the two concerns:
+//! - **Removal-eligibility** comes from the hygiene threshold (squash error), so
+//!   a broken neuron is removed regardless of its honest gain.
+//! - **Ranking value** is the honest, propagation-aware
+//!   [`estimate_remove_neuron_gain`] estimate (≈0 or negative), never the
+//!   synthetic floor.
+
+use neat_ai_discovery::CreatureJson;
+use neat_ai_discovery::analysis::{
+    MAX_REASONABLE_SQUASH_ERROR, RemoveNeuronAssessment, assess_remove_neuron,
+    estimate_remove_neuron_gain,
+};
+
+/// Build a `CreatureJson` from a compact JSON description.
+fn creature(json: &str) -> CreatureJson {
+    serde_json::from_str(json).expect("valid creature JSON")
+}
+
+/// A creature whose hidden neuron `broken` sits behind a heavily-shared output
+/// inbound budget (weight 1 of 20), so its propagation-aware influence — and
+/// hence its honest remove gain magnitude — is a small `0.05`, well below the
+/// retired `[0.1, 0.5]` floor. The neuron is genuinely connected (it carries
+/// real, if small, downstream influence) so its honest gain is non-positive.
+fn creature_with_deep_neuron() -> CreatureJson {
+    creature(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "broken", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "sib", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "broken", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "sib", "weight": 1.0},
+                {"fromUUID": "broken", "toUUID": "out-0", "weight": 1.0},
+                {"fromUUID": "sib", "toUUID": "out-0", "weight": 19.0}
+            ]
+        }"#,
+    )
+}
+
+/// Hygiene guarantee (#2483 must not regress): an over-threshold neuron stays
+/// removal-eligible even when its honest gain is ≈0 or negative — the property
+/// that would otherwise exclude it from the gain-driven removal path.
+#[test]
+fn over_threshold_neuron_removed_despite_nonpositive_gain() {
+    let c = creature_with_deep_neuron();
+
+    // Squash error well above the hygiene threshold — the neuron is "broken".
+    let squash_error = MAX_REASONABLE_SQUASH_ERROR * 10.0;
+
+    let assessment = assess_remove_neuron(&c, "broken", squash_error)
+        .expect("hidden neuron must yield an assessment");
+
+    // Its honest gain is non-positive (removal cannot fabricate a win) — exactly
+    // the case that would normally keep it out of the removal set.
+    assert!(
+        assessment.gain <= 0.0,
+        "honest gain should be non-positive, got {}",
+        assessment.gain
+    );
+
+    // ...yet hygiene keeps it removal-eligible regardless of that gain.
+    assert!(
+        assessment.removal_eligible,
+        "over-threshold broken neuron must remain removal-eligible (hygiene, #2483)"
+    );
+}
+
+/// Fabricated-gain guarantee: the reported gain equals the honest
+/// propagation-aware estimate (≈0 or negative), is NOT inside the retired
+/// `[0.1, 0.5]` synthetic floor, and ranks below a genuine ~`1e-4` candidate so
+/// it no longer crowds real improvements out of the top of the list.
+#[test]
+fn over_threshold_gain_is_honest_not_floored() {
+    let c = creature_with_deep_neuron();
+    let squash_error = MAX_REASONABLE_SQUASH_ERROR * 10.0;
+
+    let assessment = assess_remove_neuron(&c, "broken", squash_error)
+        .expect("hidden neuron must yield an assessment");
+
+    // The reported gain IS the honest estimate — not synthesised from the error.
+    let honest = estimate_remove_neuron_gain(&c, "broken").expect("estimator gain");
+    assert!(
+        (assessment.gain - honest).abs() < 1e-12,
+        "reported gain {} must equal the honest estimate {honest}",
+        assessment.gain
+    );
+
+    // It must NOT sit in the retired fabricated floor range [0.1, 0.5].
+    assert!(
+        !(0.1..=0.5).contains(&assessment.gain.abs()),
+        "gain {} landed in the retired synthetic floor range [0.1, 0.5]",
+        assessment.gain
+    );
+
+    // A genuine ~1e-4 improvement candidate ranks strictly above the broken
+    // neuron — no crowd-out. (Ranking is by gain, descending.)
+    let genuine_candidate_gain = 1e-4_f64;
+    assert!(
+        genuine_candidate_gain > assessment.gain,
+        "a genuine {genuine_candidate_gain} candidate must outrank the broken neuron's honest gain {}",
+        assessment.gain
+    );
+}
+
+/// Decoupling in the other direction: a neuron whose squash error is *below* the
+/// hygiene threshold is NOT made removal-eligible by this hygiene path — its
+/// eligibility is left to the ordinary gain-driven removal logic. This proves
+/// removal-eligibility is driven by the threshold, not by the gain value (which
+/// is identical to the over-threshold case).
+#[test]
+fn below_threshold_neuron_is_not_hygiene_eligible() {
+    let c = creature_with_deep_neuron();
+
+    // Just under the threshold — a normal, non-broken neuron.
+    let squash_error = MAX_REASONABLE_SQUASH_ERROR * 0.5;
+
+    let assessment = assess_remove_neuron(&c, "broken", squash_error)
+        .expect("hidden neuron must yield an assessment");
+
+    assert!(
+        !assessment.removal_eligible,
+        "a below-threshold neuron must not be forced removal-eligible by the hygiene path"
+    );
+    // The honest gain is reported regardless of eligibility (decoupled).
+    let honest = estimate_remove_neuron_gain(&c, "broken").expect("estimator gain");
+    assert!((assessment.gain - honest).abs() < 1e-12);
+}
+
+/// Output and unknown neurons are never removal candidates, so no assessment is
+/// produced even at an over-threshold error.
+#[test]
+fn output_and_unknown_neurons_yield_no_assessment() {
+    let c = creature_with_deep_neuron();
+    let squash_error = MAX_REASONABLE_SQUASH_ERROR * 10.0;
+
+    assert!(
+        assess_remove_neuron(&c, "out-0", squash_error).is_none(),
+        "output neurons are never remove candidates"
+    );
+    assert!(
+        assess_remove_neuron(&c, "does-not-exist", squash_error).is_none(),
+        "unknown neurons yield no assessment"
+    );
+}
+
+/// The assessment is a plain value type carrying the two decoupled fields.
+#[test]
+fn assessment_fields_are_decoupled_values() {
+    let a = RemoveNeuronAssessment {
+        removal_eligible: true,
+        gain: -0.05,
+    };
+    assert!(a.removal_eligible);
+    assert!((a.gain - -0.05).abs() < 1e-12);
+}


### PR DESCRIPTION
## Summary

Rank over-threshold hygiene neurons with an **honest** gain while keeping them
removal-eligible. Closes #1519.

Over-threshold "broken" neurons (baseline squash error `> 1e10`) still need to
be removed because they break WASM compilation of the exported network — the
NEAT-AI `#2483` hygiene guarantee must not regress. But they were ranked with a
fabricated `[0.1, 0.5]` floor gain that crowded out realistic (~`1e-4`)
improvement candidates.

This change adds a small decoupled model on top of the Issue #1518
propagation-aware estimator so the two concerns are independent:

- **Removal-eligibility** is derived from the hygiene threshold
  (`MAX_REASONABLE_SQUASH_ERROR = 1e10`) — a broken neuron is removed regardless
  of its estimated gain.
- **Ranking value** is the honest, propagation-aware
  `estimate_remove_neuron_gain` estimate (≈0 or negative), never the retired
  synthetic floor — so broken neurons no longer displace genuine `~1e-4`
  candidates.

### Changes

- `src/analysis/remove_neuron_gain.rs`
  - New `pub const MAX_REASONABLE_SQUASH_ERROR: f64 = 1e10` — mirrors the
    Deno-side threshold so both sides of the FFI boundary agree.
  - New `RemoveNeuronAssessment { removal_eligible, gain }` value type.
  - New `assess_remove_neuron(creature, neuron_uuid, squash_error)` — returns the
    hygiene eligibility (from the threshold) and the honest gain (from the
    estimator), fully decoupled. Returns `None` for output / absent neurons
    (never removal candidates).
- `src/analysis/mod.rs` — re-export the new constant, type, and function.

The Deno side already keeps the over-threshold promotion (`#2483`) and delegates
the gain to the injected estimator (`#1520`); this change makes the Rust engine
the single source of truth for "is this over threshold?" plus "what is the
honest gain?", and guards the decoupling with tests.

## Evidence

Backend/library change only — no web interface to screenshot. Verified via the
new unit tests plus the existing remove-neuron suites (all green):

```
tests/hygiene_removal.rs ... ok (5 tests)
tests/remove_neuron_gain.rs ... ok (5 tests)
tests/remove_neuron_propagation.rs ... ok (2 tests)
```

### Decoupling at a glance

```mermaid
flowchart LR
    N[Neuron: squash_error, topology] --> E{squash_error > 1e10?}
    E -- yes --> R[removal_eligible = true]
    E -- no --> R2[removal_eligible = false]
    N --> G[estimate_remove_neuron_gain<br/>propagation-aware, ≈0 or negative]
    G --> V[gain = honest estimate]
    R --> A[RemoveNeuronAssessment]
    R2 --> A
    V --> A
    A --> S[Ranking sorts on honest gain<br/>genuine ~1e-4 candidates rank above broken neurons]
```

## Test Plan

Added `tests/hygiene_removal.rs`:

- `over_threshold_neuron_removed_despite_nonpositive_gain` — a neuron with squash
  error `> 1e10` and a non-positive honest gain stays `removal_eligible`
  (hygiene / `#2483` guarantee).
- `over_threshold_gain_is_honest_not_floored` — the reported gain equals the
  propagation-aware estimate, is outside the retired `[0.1, 0.5]` floor, and a
  genuine `~1e-4` candidate ranks above it (no crowd-out).
- `below_threshold_neuron_is_not_hygiene_eligible` — proves eligibility is driven
  by the threshold, not the gain (decoupling in the other direction).
- `output_and_unknown_neurons_yield_no_assessment` — outputs / unknown UUIDs are
  never removal candidates.
- `assessment_fields_are_decoupled_values` — the assessment carries the two
  independent fields.

## Notes

- The quality gate's `cargo upgrade --incompatible` step attempted a `wgpu`
  `29 → 30` (and `naga` `29 → 30`) major bump, which introduces a breaking
  `BufferView`/`MapRangeError` API change requiring a separate GPU-code
  migration — out of scope for this issue. That bump was reverted; the remaining
  gate steps (fmt, clippy `-D warnings`, check, tests, doc, release build) pass
  on the committed dependency set.



## Milestone
This PR is part of the **#1516 Remove-neuron expected gain is a placeholder, ~1000x off actual; no successes** milestone and targets the `milestone/1516-remove-neuron-expected-gain-is-a-placeholder` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mral4amm-fde42f`<!-- vibe-worker-issue-1519 -->