### PR TITLE
Wire propagation-aware remove-neuron estimator through dispatch (Issue #1530)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
+checksum = "b952ca5a8046ad741b60f142d6eca4aeebcad615694202bc64c5341f23e32c5b"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
+checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
 dependencies = [
  "bytes",
  "half",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
+checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ee4d470eab1a021bc4b63fa2b2c15d572892bf227b0a982d3b755a6c662b5"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
+checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
+checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -241,15 +241,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
 
 [[package]]
 name = "arrow-select"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
+checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "59.0.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970dff83e97d953c827ae8176f6bf4e9f77bf62daacc01ec5df348ec5eacd913"
+checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/docs/archive/pr-summaries/pr-summary-1530.md
+++ b/docs/archive/pr-summaries/pr-summary-1530.md
@@ -1,0 +1,92 @@
+# Wire propagation-aware remove-neuron estimator through the dispatch (Issue #1530)
+
+## Summary
+
+Milestone #1516 merged the propagation-aware remove-neuron estimator
+`estimate_remove_neuron_gain` (PR #1523), but **nothing in the live pipeline
+invoked it**. The production remove-neuron path still reported the fabricated
+NEAT-AI `#2483` placeholder gain — on GRQ-Discovery commit `2596f073`
+(Discovery `v0.74.120`) the remove-neuron `expected` reproduced the placeholder
+exactly (`+0.17879` vs a measured `actual` of `−0.00032` on creature
+`45a04ef1`). So the #1516 fix was merged but **not live end-to-end**.
+
+This change wires the estimator through `discovery_dispatch.rs` and the
+`analyze_all` orchestration so Discovery becomes the **source of truth** for the
+remove-neuron gain:
+
+- New dispatch seam `apply_honest_remove_neuron_gain(creature, &mut candidates)`
+  in `src/analysis/discovery_dispatch.rs`. For every coordinated candidate whose
+  **sole** operation is a `RemoveNeuron`, it replaces the reported
+  `expected_creature_score_gain` with the honest, propagation-aware estimate for
+  that neuron. Multi-op groups and non-`RemoveNeuron` candidates are left
+  untouched; an output/absent neuron (estimator returns `None`) is left
+  untouched.
+- The orchestration calls this seam on the assembled coordinated candidates
+  **before** the search-exhaustion drought demotion (#1448) and the final gain
+  floor, so all downstream scoring, sorting, and filtering operate on the honest
+  value rather than the placeholder.
+
+Net effect: a deep neuron that still carries downstream influence is corrected
+from the fabricated `+0.17879` to a small negative gain that tracks the measured
+actual in sign and magnitude — the large positive placeholder can no longer
+crowd out realistic (~`1e-4`) candidates.
+
+Closes #1530.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    D[Detection modules<br/>emit RemoveNeuron<br/>candidates w/ fabricated gain] --> M[merge_discovery_module_results]
+    M --> H["apply_honest_remove_neuron_gain<br/>(Issue #1530)"]
+    H -->|gain = estimate_remove_neuron_gain| DR[Drought demotion #1448]
+    DR --> F[Final gain floor]
+    F --> R[FFI response]
+    E[[compute_impacts_public<br/>propagation-aware influence]] -.-> H
+```
+
+## Evidence
+
+Backend/FFI change — no web interface to screenshot. Verified via tests.
+
+- **Dispatch-path integration test** (`tests/ffi/issue_1530_dispatch_honest_remove_neuron_gain.rs`,
+  registered in `tests/ffi/main.rs`):
+  - `dispatch_replaces_request_supplied_gain_with_honest_estimate` — drives the
+    dispatch seam with a deliberately wrong request-supplied gain (`0.5`) and
+    asserts the returned gain equals `estimate_remove_neuron_gain` and does
+    **not** echo the supplied value.
+  - `dispatch_tracks_measured_actual_at_production_depth` — reproduces the
+    `45a04ef1` case end-to-end on the committed production topology fixture: the
+    deep neuron's placeholder gain (`+0.17879`) is corrected to an estimate that
+    is >100× smaller and shares the measured actual's negative sign, within one
+    order of magnitude of `−0.000194`.
+- **Dispatch unit tests** (`src/analysis/discovery_dispatch_tests.rs`):
+  `honest_gain_overrides_fabricated_remove_neuron_gain`,
+  `multi_op_candidate_gain_is_not_overridden`,
+  `non_remove_neuron_candidate_is_not_overridden`,
+  `output_and_absent_neuron_candidates_are_not_overridden`.
+- Existing estimator suites (`tests/remove_neuron_gain.rs`,
+  `tests/remove_neuron_propagation.rs`, `tests/hygiene_removal.rs`) continue to
+  pass and guard the estimator itself.
+
+Full `cargo test --lib --tests` run: `1240+` tests pass. The only failure
+observed was `focus::tests::focus_ranking_aborts_when_budget_exceeded`, a
+pre-existing wall-clock timing flake (budget+grace `1125ms`, took `1191ms`)
+unrelated to this change — it passes in isolation on an idle machine and this
+change does not touch focus ranking.
+
+## Cross-repo coordination
+
+This closes the loop opened by the still-open **stSoftwareAU/NEAT-AI PR #3245**,
+which stops the Deno side from fabricating the remove-neuron gain. With this
+change Discovery is the source of truth for the estimate; the Deno-supplied
+`expectedErrorReduction` is no longer honoured for the remove-neuron path.
+
+## Test Plan
+
+- `cargo test --test ffi issue_1530` — new dispatch-path integration tests.
+- `cargo test --lib discovery_dispatch::tests` — new override unit tests.
+- `cargo test --test remove_neuron_gain --test remove_neuron_propagation --test hygiene_removal`
+  — estimator-level regression guards still green.
+- `cargo clippy --all-targets --all-features -- -D warnings` and
+  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.

--- a/src/analysis/discovery_dispatch.rs
+++ b/src/analysis/discovery_dispatch.rs
@@ -19,8 +19,11 @@ use std::time::SystemTime;
 
 use crate::CoordinatedStructuralCandidateJson;
 use crate::CoordinatedStructuralOpJson;
+use crate::CreatureJson;
 use crate::observability::PhaseTimer;
 use rayon::prelude::*;
+
+use super::remove_neuron_gain::estimate_remove_neuron_gain;
 
 use super::constants::{
     COORDINATED_MIN_EXPECTED_GAIN, MODULE_GATE_THRESHOLD, QUALITY_SKIP_GAIN_THRESHOLD,
@@ -103,6 +106,52 @@ fn apply_coordinated_per_target_cap(
         }
     });
     original_len - candidates.len()
+}
+
+/// Override the reported gain of every single-op `RemoveNeuron` coordinated
+/// candidate with the honest, propagation-aware estimate (Issue #1530).
+///
+/// Milestone #1516 merged [`estimate_remove_neuron_gain`] (PR #1523) but nothing
+/// in the live pipeline invoked it, so the emitted remove-neuron gain stayed the
+/// fabricated NEAT-AI `#2483` placeholder (`+0.17879` on creature `45a04ef1`,
+/// versus a measured `−0.00032`). This makes Discovery the source of truth: for
+/// each candidate whose **sole** operation is a `RemoveNeuron`, the reported
+/// `expected_creature_score_gain` is replaced with the propagation-aware
+/// estimate for that neuron, which attenuates a deep neuron's influence all the
+/// way to the output(s) and is signed (non-positive) — no fabricated large
+/// positive gain survives to crowd out realistic candidates.
+///
+/// Multi-operation coordinated candidates are left untouched: their gain
+/// reflects the combined effect of the whole atomic group, not a bare neuron
+/// removal. Candidates whose neuron is absent or is an output (the estimator
+/// returns `None`) are also left untouched.
+///
+/// Returns the number of candidates whose gain was overridden, for diagnostics.
+// The estimator works in f64; the candidate carries f32. The gain is a small
+// value in `[-1, 0]`, well within f32 range, so the narrowing is intentional
+// precision loss, not overflow (Issue #873).
+#[allow(clippy::cast_possible_truncation)]
+pub fn apply_honest_remove_neuron_gain(
+    creature: &CreatureJson,
+    candidates: &mut [CoordinatedStructuralCandidateJson],
+) -> usize {
+    let mut overridden = 0;
+    for candidate in candidates.iter_mut() {
+        // A lone RemoveNeuron op is the only bare neuron removal; anything else
+        // (multi-op group, or a different single op) is not this estimator's
+        // concern.
+        let [CoordinatedStructuralOpJson::RemoveNeuron { neuron_uuid }] =
+            candidate.operations.as_slice()
+        else {
+            continue;
+        };
+
+        if let Some(gain) = estimate_remove_neuron_gain(creature, neuron_uuid) {
+            candidate.expected_creature_score_gain = gain as f32;
+            overridden += 1;
+        }
+    }
+    overridden
 }
 
 /// Result of a discovery module's detection phase.

--- a/src/analysis/discovery_dispatch_tests.rs
+++ b/src/analysis/discovery_dispatch_tests.rs
@@ -626,3 +626,132 @@ fn coordinated_per_target_cap_env_override() {
         crate::analysis::constants::MAX_COORDINATED_PER_TARGET_OUTPUT,
     );
 }
+
+// =============================================================================
+// Issue #1530: honest propagation-aware remove-neuron gain override
+// =============================================================================
+
+use super::apply_honest_remove_neuron_gain;
+use crate::CreatureJson;
+
+/// A creature whose hidden neuron `deep` sits behind a heavily-shared output
+/// inbound budget (weight 1 of 20), so its propagation-aware influence — and
+/// hence its honest remove-gain magnitude — is a small `0.05`, well below the
+/// retired `[0.1, 0.5]` placeholder floor. `deep` carries real, if small,
+/// downstream influence, so its honest gain is strictly negative.
+fn creature_with_deep_neuron() -> CreatureJson {
+    serde_json::from_str(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "deep", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "sib", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "deep", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "sib", "weight": 1.0},
+                {"fromUUID": "deep", "toUUID": "out-0", "weight": 1.0},
+                {"fromUUID": "sib", "toUUID": "out-0", "weight": 19.0}
+            ]
+        }"#,
+    )
+    .expect("valid creature JSON")
+}
+
+fn remove_neuron_candidate(uuid: &str, gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+            neuron_uuid: uuid.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some("fabricated placeholder gain".to_string()),
+    }
+}
+
+/// The core wiring: a single-op `RemoveNeuron` candidate carrying a fabricated
+/// placeholder gain is overwritten with the honest, propagation-aware estimate
+/// (which is non-positive), not left echoing the supplied value.
+#[test]
+fn honest_gain_overrides_fabricated_remove_neuron_gain() {
+    let creature = creature_with_deep_neuron();
+    // Deliberately wrong, fabricated placeholder-range gain.
+    let mut candidates = vec![remove_neuron_candidate("deep", 0.17879)];
+
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(
+        overridden, 1,
+        "the single RemoveNeuron candidate is overridden"
+    );
+
+    let honest = crate::analysis::estimate_remove_neuron_gain(&creature, "deep")
+        .expect("estimator gain for the hidden neuron");
+    let reported = f64::from(candidates[0].expected_creature_score_gain);
+    assert!(
+        (reported - honest).abs() < 1e-6,
+        "reported gain {reported} must equal the honest estimate {honest}, not the placeholder"
+    );
+    assert!(
+        reported <= 0.0,
+        "honest remove-neuron gain must be non-positive, got {reported}"
+    );
+    assert!(
+        !(0.1..=0.5).contains(&reported.abs()),
+        "gain {reported} must not land in the retired fabricated floor range [0.1, 0.5]"
+    );
+}
+
+/// Multi-operation coordinated candidates reflect the whole atomic group's
+/// effect, so their gain is left untouched by the bare-removal estimator.
+#[test]
+fn multi_op_candidate_gain_is_not_overridden() {
+    let creature = creature_with_deep_neuron();
+    let mut candidates = vec![CoordinatedStructuralCandidateJson {
+        operations: vec![
+            CoordinatedStructuralOpJson::RemoveSynapse {
+                from_neuron_uuid: "input-0".to_string(),
+                to_neuron_uuid: "deep".to_string(),
+            },
+            CoordinatedStructuralOpJson::RemoveNeuron {
+                neuron_uuid: "deep".to_string(),
+            },
+        ],
+        expected_creature_score_gain: 0.05,
+        comment: None,
+    }];
+
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(overridden, 0, "multi-op candidates are not touched");
+    assert!(
+        (candidates[0].expected_creature_score_gain - 0.05).abs() < f32::EPSILON,
+        "multi-op gain must be preserved"
+    );
+}
+
+/// Non-RemoveNeuron single-op candidates are left untouched.
+#[test]
+fn non_remove_neuron_candidate_is_not_overridden() {
+    let creature = creature_with_deep_neuron();
+    let mut candidates = vec![make_candidate(0.42)]; // a RemoveSynapse candidate
+
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(overridden, 0, "non-RemoveNeuron candidates are not touched");
+    assert!((candidates[0].expected_creature_score_gain - 0.42).abs() < f32::EPSILON);
+}
+
+/// A `RemoveNeuron` candidate targeting an output or an absent neuron yields no
+/// estimate (`None`), so its gain is left untouched rather than being zeroed.
+#[test]
+fn output_and_absent_neuron_candidates_are_not_overridden() {
+    let creature = creature_with_deep_neuron();
+    let mut candidates = vec![
+        remove_neuron_candidate("out-0", 0.9),
+        remove_neuron_candidate("does-not-exist", 0.8),
+    ];
+
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(overridden, 0, "output/absent neurons yield no estimate");
+    assert!((candidates[0].expected_creature_score_gain - 0.9).abs() < f32::EPSILON);
+    assert!((candidates[1].expected_creature_score_gain - 0.8).abs() < f32::EPSILON);
+}

--- a/src/analysis/orchestration.rs
+++ b/src/analysis/orchestration.rs
@@ -978,6 +978,29 @@ pub fn analyze_all(input: &AnalyzeAllInput) -> Result<AnalyzeAllResult> {
         }
     } // end if !memory_budget_exceeded (Issue #1028)
 
+    // Issue #1530: Make the propagation-aware remove-neuron estimator the source
+    // of truth for the emitted gain. Milestone #1516 merged
+    // `estimate_remove_neuron_gain` (PR #1523) but nothing in the live pipeline
+    // invoked it, so the reported remove-neuron gain was still the fabricated
+    // NEAT-AI #2483 placeholder (+0.17879 on creature 45a04ef1, versus a
+    // measured -0.00032). Override every single-op RemoveNeuron candidate's gain
+    // with the honest, propagation-aware estimate before the drought demotion
+    // and final gain floor act on it, so downstream scoring, sorting, and
+    // filtering all operate on the honest value rather than the placeholder.
+    if let Some(syn) = synapse_result.as_mut() {
+        let overridden = super::discovery_dispatch::apply_honest_remove_neuron_gain(
+            &input.creature,
+            &mut syn.coordinated_structural_candidates,
+        );
+        if overridden > 0 {
+            tracing::debug!(
+                overridden,
+                "Issue #1530: replaced {overridden} remove-neuron candidate gain(s) with the \
+                 propagation-aware estimate"
+            );
+        }
+    }
+
     // Issue #1448: Deprioritise destructive remove-neuron candidates during a
     // search-exhaustion drought. On a plateaued dense creature the remove-neuron
     // path dominates the failure cache (bucket `247b83ab`) with low-impact

--- a/tests/ffi/issue_1530_dispatch_honest_remove_neuron_gain.rs
+++ b/tests/ffi/issue_1530_dispatch_honest_remove_neuron_gain.rs
@@ -1,0 +1,168 @@
+//! Dispatch-path wiring for the propagation-aware remove-neuron estimator
+//! (Issue #1530) — make milestone #1516 live end-to-end.
+//!
+//! Milestone #1516 merged [`estimate_remove_neuron_gain`] (PR #1523), but
+//! nothing in `src/ffi/` or `discovery_dispatch.rs` invoked it, so the live
+//! remove-neuron path still reported the fabricated NEAT-AI `#2483` placeholder
+//! gain (`+0.17879` on creature `45a04ef1`, versus a measured `−0.00032`).
+//!
+//! [`apply_honest_remove_neuron_gain`] is the dispatch seam the orchestration
+//! calls on the assembled coordinated candidates before the drought demotion
+//! and final gain floor. These tests drive that seam with a deliberately wrong
+//! request-supplied gain and assert the returned gain comes from the honest,
+//! propagation-aware estimator — it does **not** echo the supplied value.
+//!
+//! The `production_depth` test reproduces the `45a04ef1` failure end-to-end on
+//! the committed production topology fixture: a deep neuron carrying the
+//! placeholder gain is corrected to an estimate that tracks the measured actual
+//! effect in sign and magnitude rather than the `+0.17879` placeholder.
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts (Issue #873)
+
+use std::path::{Path, PathBuf};
+
+use neat_ai_discovery::analysis::discovery_dispatch::apply_honest_remove_neuron_gain;
+use neat_ai_discovery::analysis::estimate_remove_neuron_gain;
+use neat_ai_discovery::{
+    CoordinatedStructuralCandidateJson, CoordinatedStructuralOpJson, CreatureJson,
+};
+
+/// The fabricated placeholder gain (`expectedCreatureScoreGain`) recorded for
+/// the failure example — reproduced exactly by the NEAT-AI `#2483`
+/// over-threshold sink `0.1 + (log10(err) − 10)/10 × 0.4`.
+const PLACEHOLDER_GAIN: f32 = 0.178_829_21;
+
+/// The empirically measured effect of the removal on the output
+/// (`actualErrorReduction`, ~69k samples). Negative: removal made the network
+/// slightly worse — the opposite of the placeholder's sign.
+const MEASURED_ACTUAL: f64 = -0.000_194_478_429_877_298_35;
+
+/// The target neuron, sitting many layers from the single output.
+const TARGET_NEURON: &str = "neuron-1802938338";
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/remove_neuron_propagation")
+}
+
+/// Load the production creature topology from the committed fixture.
+fn load_network() -> CreatureJson {
+    let path = fixture_dir().join("network.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read network fixture {}: {e}", path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("failed to parse network fixture {}: {e}", path.display()))
+}
+
+fn remove_neuron_candidate(uuid: &str, gain: f32) -> CoordinatedStructuralCandidateJson {
+    CoordinatedStructuralCandidateJson {
+        operations: vec![CoordinatedStructuralOpJson::RemoveNeuron {
+            neuron_uuid: uuid.to_string(),
+        }],
+        expected_creature_score_gain: gain,
+        comment: Some("request-supplied placeholder gain".to_string()),
+    }
+}
+
+/// Ratio of two magnitudes, guarding against a zero denominator.
+fn magnitude_ratio(a: f64, b: f64) -> f64 {
+    let denom = b.abs();
+    assert!(denom > 0.0, "magnitude_ratio: zero denominator");
+    a.abs() / denom
+}
+
+/// A small synthetic creature with a hidden neuron that carries genuine (if
+/// small) downstream influence, so its honest remove-gain is strictly negative.
+fn creature_with_deep_neuron() -> CreatureJson {
+    serde_json::from_str(
+        r#"{
+            "input": 1, "output": 1,
+            "neurons": [
+                {"uuid": "input-0", "type": "constant"},
+                {"uuid": "deep", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "sib", "type": "hidden", "squash": "IDENTITY"},
+                {"uuid": "out-0", "type": "output", "squash": "IDENTITY"}
+            ],
+            "synapses": [
+                {"fromUUID": "input-0", "toUUID": "deep", "weight": 1.0},
+                {"fromUUID": "input-0", "toUUID": "sib", "weight": 1.0},
+                {"fromUUID": "deep", "toUUID": "out-0", "weight": 1.0},
+                {"fromUUID": "sib", "toUUID": "out-0", "weight": 19.0}
+            ]
+        }"#,
+    )
+    .expect("valid creature JSON")
+}
+
+/// The dispatch seam replaces the request-supplied remove-neuron gain with the
+/// honest, propagation-aware estimate — the returned gain does not echo the
+/// deliberately wrong supplied value.
+#[test]
+fn dispatch_replaces_request_supplied_gain_with_honest_estimate() {
+    let creature = creature_with_deep_neuron();
+
+    // Drive the dispatch path with a deliberately wrong request-supplied gain.
+    let mut candidates = vec![remove_neuron_candidate("deep", 0.5)];
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(
+        overridden, 1,
+        "the single RemoveNeuron candidate is overridden"
+    );
+
+    let honest = estimate_remove_neuron_gain(&creature, "deep").expect("estimator gain");
+    let reported = f64::from(candidates[0].expected_creature_score_gain);
+
+    assert!(
+        (reported - honest).abs() < 1e-6,
+        "dispatch must report the honest estimate {honest}, not the supplied 0.5 (got {reported})"
+    );
+    assert!(
+        (reported - 0.5).abs() > 1e-6,
+        "dispatch must NOT echo the request-supplied gain 0.5 (got {reported})"
+    );
+    assert!(
+        reported < 0.0,
+        "a genuinely-connected neuron's honest remove gain is negative, got {reported}"
+    );
+}
+
+/// End-to-end reproduction of the `45a04ef1` failure on the committed
+/// production topology: the deep neuron's request-supplied placeholder gain
+/// (`+0.17879`) is corrected to an estimate that tracks the measured actual
+/// effect (`−0.000194`) in sign and magnitude.
+#[test]
+fn dispatch_tracks_measured_actual_at_production_depth() {
+    let creature = load_network();
+
+    // The request supplies the known-bad placeholder gain for the deep neuron.
+    let mut candidates = vec![remove_neuron_candidate(TARGET_NEURON, PLACEHOLDER_GAIN)];
+    let overridden = apply_honest_remove_neuron_gain(&creature, &mut candidates);
+    assert_eq!(
+        overridden, 1,
+        "the production-depth candidate is overridden"
+    );
+
+    let reported = f64::from(candidates[0].expected_creature_score_gain);
+
+    // No longer the placeholder fingerprint (large positive ~0.17879).
+    assert!(
+        !(0.1..=0.5).contains(&reported.abs()),
+        "reported gain {reported} still sits in the retired placeholder floor range [0.1, 0.5]"
+    );
+    assert!(
+        magnitude_ratio(f64::from(PLACEHOLDER_GAIN), reported) > 100.0,
+        "the placeholder {PLACEHOLDER_GAIN} should dwarf the honest gain {reported} (>100×)"
+    );
+
+    // The honest gain tracks the measured actual's sign and magnitude: removing
+    // a neuron that still carries downstream influence is a small net loss.
+    assert!(
+        reported < 0.0 && reported.signum() == MEASURED_ACTUAL.signum(),
+        "honest gain {reported} must share the measured actual's negative sign"
+    );
+    let ratio = magnitude_ratio(reported, MEASURED_ACTUAL);
+    assert!(
+        (0.1..=10.0).contains(&ratio),
+        "honest gain {reported} must be within one order of magnitude of the measured actual \
+         {MEASURED_ACTUAL} (ratio {ratio})"
+    );
+}

--- a/tests/ffi/main.rs
+++ b/tests/ffi/main.rs
@@ -11,6 +11,7 @@ mod issue_1314_task_descriptor_plumbing;
 mod issue_1402_lowercase_task_descriptor_regression;
 mod issue_1407_focus_shared_deadline;
 mod issue_1445_focus_selection_diversity;
+mod issue_1530_dispatch_honest_remove_neuron_gain;
 mod issue_574_ffi_json_fuzz_edge_cases;
 mod issue_711_ffi_safety_unsafe_markers;
 mod issue_950_numeric_neuron_ids;


### PR DESCRIPTION
# Wire propagation-aware remove-neuron estimator through the dispatch (Issue #1530)

## Summary

Milestone #1516 merged the propagation-aware remove-neuron estimator
`estimate_remove_neuron_gain` (PR #1523), but **nothing in the live pipeline
invoked it**. The production remove-neuron path still reported the fabricated
NEAT-AI `#2483` placeholder gain — on GRQ-Discovery commit `2596f073`
(Discovery `v0.74.120`) the remove-neuron `expected` reproduced the placeholder
exactly (`+0.17879` vs a measured `actual` of `−0.00032` on creature
`45a04ef1`). So the #1516 fix was merged but **not live end-to-end**.

This change wires the estimator through `discovery_dispatch.rs` and the
`analyze_all` orchestration so Discovery becomes the **source of truth** for the
remove-neuron gain:

- New dispatch seam `apply_honest_remove_neuron_gain(creature, &mut candidates)`
  in `src/analysis/discovery_dispatch.rs`. For every coordinated candidate whose
  **sole** operation is a `RemoveNeuron`, it replaces the reported
  `expected_creature_score_gain` with the honest, propagation-aware estimate for
  that neuron. Multi-op groups and non-`RemoveNeuron` candidates are left
  untouched; an output/absent neuron (estimator returns `None`) is left
  untouched.
- The orchestration calls this seam on the assembled coordinated candidates
  **before** the search-exhaustion drought demotion (#1448) and the final gain
  floor, so all downstream scoring, sorting, and filtering operate on the honest
  value rather than the placeholder.

Net effect: a deep neuron that still carries downstream influence is corrected
from the fabricated `+0.17879` to a small negative gain that tracks the measured
actual in sign and magnitude — the large positive placeholder can no longer
crowd out realistic (~`1e-4`) candidates.

Closes #1530.

## Data flow

```mermaid
flowchart LR
    D[Detection modules<br/>emit RemoveNeuron<br/>candidates w/ fabricated gain] --> M[merge_discovery_module_results]
    M --> H["apply_honest_remove_neuron_gain<br/>(Issue #1530)"]
    H -->|gain = estimate_remove_neuron_gain| DR[Drought demotion #1448]
    DR --> F[Final gain floor]
    F --> R[FFI response]
    E[[compute_impacts_public<br/>propagation-aware influence]] -.-> H
```

## Evidence

Backend/FFI change — no web interface to screenshot. Verified via tests.

- **Dispatch-path integration test** (`tests/ffi/issue_1530_dispatch_honest_remove_neuron_gain.rs`,
  registered in `tests/ffi/main.rs`):
  - `dispatch_replaces_request_supplied_gain_with_honest_estimate` — drives the
    dispatch seam with a deliberately wrong request-supplied gain (`0.5`) and
    asserts the returned gain equals `estimate_remove_neuron_gain` and does
    **not** echo the supplied value.
  - `dispatch_tracks_measured_actual_at_production_depth` — reproduces the
    `45a04ef1` case end-to-end on the committed production topology fixture: the
    deep neuron's placeholder gain (`+0.17879`) is corrected to an estimate that
    is >100× smaller and shares the measured actual's negative sign, within one
    order of magnitude of `−0.000194`.
- **Dispatch unit tests** (`src/analysis/discovery_dispatch_tests.rs`):
  `honest_gain_overrides_fabricated_remove_neuron_gain`,
  `multi_op_candidate_gain_is_not_overridden`,
  `non_remove_neuron_candidate_is_not_overridden`,
  `output_and_absent_neuron_candidates_are_not_overridden`.
- Existing estimator suites (`tests/remove_neuron_gain.rs`,
  `tests/remove_neuron_propagation.rs`, `tests/hygiene_removal.rs`) continue to
  pass and guard the estimator itself.

Full `cargo test --lib --tests` run: `1240+` tests pass. The only failure
observed was `focus::tests::focus_ranking_aborts_when_budget_exceeded`, a
pre-existing wall-clock timing flake (budget+grace `1125ms`, took `1191ms`)
unrelated to this change — it passes in isolation on an idle machine and this
change does not touch focus ranking.

## Cross-repo coordination

This closes the loop opened by the still-open **stSoftwareAU/NEAT-AI PR #3245**,
which stops the Deno side from fabricating the remove-neuron gain. With this
change Discovery is the source of truth for the estimate; the Deno-supplied
`expectedErrorReduction` is no longer honoured for the remove-neuron path.

## Test Plan

- `cargo test --test ffi issue_1530` — new dispatch-path integration tests.
- `cargo test --lib discovery_dispatch::tests` — new override unit tests.
- `cargo test --test remove_neuron_gain --test remove_neuron_propagation --test hygiene_removal`
  — estimator-level regression guards still green.
- `cargo clippy --all-targets --all-features -- -D warnings` and
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.



## Milestone
This PR is part of the **#1529 Prove error-reduction estimates are accurate for production-scale creatures** milestone and targets the `milestone/1529-prove-error-reduction-estimates-are-accurate` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrbv4a15-cccce4`<!-- vibe-worker-issue-1530 -->