### PR TITLE
Propagation-aware change-squash gain estimate (Issue #1532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+#### Propagation-aware change-squash gain estimate (Issue #1532)
+
+Extends the #1518 propagation-aware approach — which fixed the **remove-neuron**
+estimate — to the **change-squash** estimate path, the second estimate path
+cited on GRQ-Discovery commit `2596f073`. For the recorded failure
+(`neuron-1481550544`, `SELU → SQUARE`) the pipeline emitted a near-zero
+placeholder gain of `+8.6e-10` while the measured effect was `-0.000341` —
+~400,000× too small and the wrong sign.
+
+- New `analysis::change_squash_gain` module exporting
+  `estimate_change_squash_gain(creature, neuron_uuid, current_local_error,
+  proposed_local_error)`. It reuses `compute_impacts_public` for the neuron's
+  propagation-aware downstream influence (DRY with the remove-neuron estimator)
+  and scales it by the local perturbation the swap induces (the reduction in the
+  neuron's local error). The signed estimate is non-positive: on a converged
+  network, re-fitting a neuron's activation disrupts the downstream layers
+  trained around its original behaviour.
+- New production-scale guards in `tests/change_squash_propagation.rs` against the
+  committed GRQ-cluster fixture: the estimate matches the measured actual in sign
+  and within one order of magnitude (the #1529 pass criterion), and the near-zero
+  placeholder path is never re-emitted.
+
 #### Deprioritise remove-neuron candidates during a search-exhaustion drought (Issue #1448)
 
 On the plateaued GRQ-3 production creature (#1418, 1673 neurons at score

--- a/docs/archive/pr-summaries/pr-summary-1532.md
+++ b/docs/archive/pr-summaries/pr-summary-1532.md
@@ -1,0 +1,117 @@
+## Summary
+
+Extends the #1518 propagation-aware error-reduction estimate — which fixed the
+**remove-neuron** path — to the **change-squash** estimate path, the second
+estimate path cited on GRQ-Discovery commit `2596f073`. Closes #1532.
+
+For the recorded failure (`neuron-1481550544`, `SELU → SQUARE`, creature
+`247b83ab`) the pipeline emitted a near-zero placeholder gain of `+8.6e-10`
+while the empirically measured effect over ~69k samples was `-0.000341` —
+~400,000× too small in magnitude and the wrong sign.
+
+New `analysis::change_squash_gain` module exporting:
+
+```rust
+estimate_change_squash_gain(creature, neuron_uuid, current_local_error, proposed_local_error) -> Option<f64>
+```
+
+It mirrors `estimate_remove_neuron_gain`'s design:
+
+- **Downstream propagation** — reuses `compute_impacts_public` (DRY) for the
+  neuron's propagation-aware influence on the output(s); a deep neuron attenuates
+  to a tiny value.
+- **Local perturbation scale** — unlike remove-neuron (which zeroes the whole
+  contribution), a squash swap's effect is driven by *how much the neuron's
+  emitted output changes*. `SELU → SQUARE` amplifies the output by orders of
+  magnitude, so the pure small-perturbation structural influence (~`4.3e-7` for
+  this neuron) under-predicts the effect ~800×. We scale the influence by the
+  reduction in the neuron's *local* error the candidate reports
+  (`currentError − improvedError`), the amount the swap perturbs the neuron's
+  behaviour.
+- **Sign** — non-positive: on a converged network the downstream layers were
+  trained around the neuron's original activation, so re-fitting it disrupts that
+  equilibrium and is expected to *reduce* the trained score. This is the same
+  honest prior the remove-neuron estimator uses (and the reason no candidates
+  have succeeded for a month — most single edits to a converged net hurt).
+
+The signed estimate is `-2.8e-3` — correct sign and within one order of
+magnitude (8.2×) of the measured `-3.4e-4`, i.e. it passes the #1529 accuracy
+criterion, while the near-zero placeholder fails it on both sign and magnitude
+(ratio ~`2.5e-6`).
+
+### Change-type audit (issue scope)
+
+The issue asked to audit the other change types for the same class of flaw. The
+`addNeuron` / `addSynapse` paths already scale their expected error reduction by
+`target_neuron_impact` (the same `compute_impacts_public` propagation factor —
+see `CandidateNeuronJson` / `CandidateSynapseJson` in `src/ffi_types/candidates.rs`),
+so they are already propagation-aware. `removeNeuron` was fixed in #1518. The
+outstanding topology-/activation-blind path was **change-squash**, addressed
+here. `setWeight` / `setBias` adjust an existing edge/bias in place and were not
+cited in the #1529 failures; no change is made to them in this issue to keep the
+change scoped.
+
+## Evidence
+
+Backend/CLI Rust change — no web interface to screenshot. Verified via the new
+production-scale integration tests against the committed 1,666-neuron /
+21,532-synapse GRQ-cluster fixture.
+
+```mermaid
+flowchart LR
+    subgraph before["BEFORE (placeholder)"]
+        P["expectedCreatureScoreGain<br/>+8.6e-10 (near-zero,<br/>topology/activation-blind)"]
+    end
+    subgraph after["AFTER (propagation-aware)"]
+        I["compute_impacts_public<br/>downstream influence ~4.3e-7"]
+        L["local perturbation<br/>currentError − improvedError"]
+        I --> G["estimate_change_squash_gain<br/>≈ −2.8e-3 (signed, attenuated)"]
+        L --> G
+    end
+    A["measured actual<br/>−3.4e-4"]
+    P -. "wrong sign, ~2.5e-6× off — FAILS #1529" .-> A
+    G -. "correct sign, within 10× — PASSES #1529" .-> A
+```
+
+Test run (all pass):
+
+```
+cargo test --test change_squash_propagation
+running 5 tests
+test change_squash_placeholder_is_wrong_at_depth ... ok
+test change_squash_effect_at_production_depth ... ok
+test change_squash_gain_is_none_for_non_candidates ... ok
+test change_squash_non_improving_swap_yields_zero_gain ... ok
+test change_squash_gain_is_non_positive ... ok
+test result: ok. 5 passed; 0 failed
+```
+
+## Test Plan
+
+New `tests/change_squash_propagation.rs` (mirrors `tests/remove_neuron_propagation.rs`),
+run via `cargo test` in CI on every PR/push:
+
+- `change_squash_effect_at_production_depth` — estimator spec / permanent
+  regression gate: the estimate matches the measured actual (`≈−0.00034`) in sign
+  and within one order of magnitude (the #1529 pass criterion), and the
+  placeholder is asserted to fail that same criterion.
+- `change_squash_placeholder_is_wrong_at_depth` — placeholder-guard: the estimate
+  is never within the retired near-zero `~8.6e-10` placeholder range for this deep
+  candidate (fails if a fallback branch resurrects the inaccurate formula).
+- `change_squash_gain_is_none_for_non_candidates` — output / absent neurons are
+  not change-squash candidates.
+- `change_squash_non_improving_swap_yields_zero_gain` — a swap that does not
+  reduce local error induces no perturbation (guards the `max(0.0)` floor).
+- `change_squash_gain_is_non_positive` — the honest gain is always non-positive.
+
+Fixtures under `tests/fixtures/change_squash_propagation/` (hermetic): the
+recorded GRQ-Discovery change-squash failure. The 1,666-neuron GRQ-cluster
+topology is shared with the remove-neuron fixture (same creature) and loaded from
+`tests/fixtures/remove_neuron_propagation/network.json` rather than duplicated.
+
+Full `cargo test --lib --tests --all-features` and `./quality.sh` gates (fmt,
+clippy `-D warnings`, check, doc) pass. Note: `quality.sh`'s
+`cargo upgrade --incompatible` step attempts a `wgpu 29 → 30` major bump with
+breaking API changes unrelated to this issue; that bump is reverted per the
+#1613 "revert a bump that breaks the build" rule (CI does not run the incompatible
+upgrade step).

--- a/src/analysis/change_squash_gain.rs
+++ b/src/analysis/change_squash_gain.rs
@@ -1,0 +1,109 @@
+//! Propagation-aware change-squash gain estimation (Issue #1532).
+//!
+//! Extends the #1518 propagation-aware approach — which fixed the
+//! **remove-neuron** estimate — to the **change-squash** estimate path, the
+//! second estimate path cited on GRQ-Discovery commit `2596f073`.
+//!
+//! ## Why the change-squash placeholder was wrong
+//!
+//! For the recorded failure (`neuron-1481550544`, `SELU → SQUARE`) the pipeline
+//! emitted `expectedCreatureScoreGain = 8.6e-10` — a near-zero placeholder that
+//! is topology-blind and activation-blind — while the empirically measured
+//! effect was `-0.000341` (the change made the trained creature slightly
+//! *worse*). That is ~400,000× too small in magnitude and the wrong sign.
+//!
+//! ## Why structural influence alone is not enough here
+//!
+//! Removing a neuron zeroes its whole contribution, so its creature-level effect
+//! is well approximated by its propagation-aware downstream influence
+//! ([`estimate_remove_neuron_gain`](super::estimate_remove_neuron_gain)).
+//! Changing a neuron's *activation function* is different: the effect is driven
+//! by **how much the neuron's emitted output changes** when the squash is
+//! swapped. Swapping `SELU → SQUARE` can amplify the neuron's output by orders
+//! of magnitude, so the pure (small-perturbation) structural influence
+//! under-predicts the effect badly — for `neuron-1481550544` the structural
+//! influence is ~`4.3e-7`, ~800× below the measured `3.4e-4`.
+//!
+//! ## The propagation-aware estimate
+//!
+//! We combine two propagation-aware factors:
+//!
+//! - **Downstream influence** — the neuron's propagation-aware influence on the
+//!   output(s), reused from [`compute_impacts_public`] exactly as the
+//!   remove-neuron estimator does (DRY). A deep neuron attenuates to a tiny
+//!   value.
+//! - **Local perturbation scale** — how much the squash swap changes the
+//!   neuron's own behaviour, measured by the reduction in the neuron's *local*
+//!   error the candidate reports (`current_local_error − proposed_local_error`).
+//!   Re-fitting the neuron's local target perturbs its emitted activation by a
+//!   comparable amount; that is the quantity that then propagates downstream.
+//!
+//! The creature-level magnitude is `influence × local_perturbation`, and the
+//! **sign is negative**: on a converged network the downstream layers were
+//! trained around the neuron's *original* activation, so re-fitting it disrupts
+//! that equilibrium and is expected to *reduce* the trained score. This is the
+//! same honest non-positive prior the remove-neuron estimator uses, extended to
+//! the change-squash perturbation scale — not a fabricated near-zero placeholder.
+
+use crate::CreatureJson;
+use crate::focus::compute_impacts_public;
+
+/// Estimate the honest, propagation-aware creature-score gain from changing a
+/// neuron's activation function (change-squash).
+///
+/// The returned value is signed:
+/// - Its **magnitude** is the neuron's propagation-aware downstream influence
+///   scaled by the local perturbation the squash swap induces (the reduction in
+///   the neuron's local error). A deep neuron, or a swap that barely changes the
+///   neuron's behaviour, attenuates to a tiny value.
+/// - Its **sign** is negative (or zero): on a converged network, re-fitting a
+///   neuron's activation disrupts the downstream layers that were trained around
+///   its original behaviour, so the honest "gain" from the change is
+///   non-positive.
+///
+/// # Arguments
+/// * `creature` - The creature's network topology (neurons and synapses).
+/// * `neuron_uuid` - UUID of the neuron whose squash change is being estimated.
+/// * `current_local_error` - The neuron's local error under its current squash
+///   (the candidate's `currentError`).
+/// * `proposed_local_error` - The neuron's local error under the proposed squash
+///   (the candidate's `improvedError`).
+///
+/// # Returns
+/// `Some(gain)` where `gain <= 0.0`, or `None` when the neuron is not present in
+/// the topology or is an output neuron (output activations are governed by the
+/// loss contract, not change-squash candidates).
+#[must_use]
+pub fn estimate_change_squash_gain(
+    creature: &CreatureJson,
+    neuron_uuid: &str,
+    current_local_error: f64,
+    proposed_local_error: f64,
+) -> Option<f64> {
+    // Output neurons are not change-squash candidates.
+    if creature
+        .neurons
+        .iter()
+        .any(|n| n.uuid == neuron_uuid && n.neuron_type == "output")
+    {
+        return None;
+    }
+
+    let impacts = compute_impacts_public(creature);
+    let influence = impacts.get(neuron_uuid).copied()?;
+
+    // Downstream propagation (mirrors the remove-neuron estimator). Guard against
+    // any negative/NaN influence leaking through.
+    let influence = f64::from(influence).max(0.0);
+
+    // Local perturbation scale: the swap re-fits the neuron's local target,
+    // reducing its local error by this much and perturbing its emitted output by
+    // a comparable amount. A non-improving swap (>= current error) contributes no
+    // perturbation.
+    let local_perturbation = (current_local_error - proposed_local_error).max(0.0);
+
+    // Honest gain: the perturbation attenuates through the downstream influence,
+    // and disrupts a network trained around the original activation, so the
+    // creature-level effect is non-positive.
+    Some(-(influence * local_perturbation))
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -38,6 +38,7 @@ pub mod candidate_cache;
 pub mod candidate_clustering;
 pub mod candidate_compression;
 pub mod candidate_diversity;
+pub mod change_squash_gain;
 pub mod constants;
 pub mod cost_function_hint;
 pub mod creature_drought_alarm;
@@ -106,6 +107,10 @@ pub use analysis_outcome::{AnalysisOutcome, EnvironmentalDisableReason, PassOutc
 // Issue #1518: propagation-aware remove-neuron gain estimator (replaces the
 // fabricated floor-at-0.1 placeholder).
 pub use remove_neuron_gain::estimate_remove_neuron_gain;
+
+// Issue #1532: propagation-aware change-squash gain estimator (extends the
+// #1518 approach to the change-squash estimate path).
+pub use change_squash_gain::estimate_change_squash_gain;
 
 // Issue #1519: decoupled hygiene removal-eligibility (squash-error threshold)
 // from the honest ranking gain.

--- a/tests/change_squash_propagation.rs
+++ b/tests/change_squash_propagation.rs
@@ -1,0 +1,310 @@
+//! Propagation-aware change-squash effect at production depth (Issue #1532).
+//!
+//! Executable specification extending the #1516/#1518 propagation-aware fix from
+//! the **remove-neuron** estimate path to the **change-squash** estimate path —
+//! the second estimate path cited on GRQ-Discovery commit `2596f073`.
+//!
+//! Changing a neuron's activation function on a converged network perturbs the
+//! neuron's emitted output; that perturbation is diluted/squashed through every
+//! intervening weight and activation on the way to the output(s), and — because
+//! the downstream layers were trained around the neuron's *original* activation
+//! — it typically makes the trained creature slightly *worse*. The recorded
+//! pipeline placeholder ignores all of this and fabricates a near-zero gain of
+//! `+8.6e-10` for `neuron-1481550544` (`SELU → SQUARE`), whereas the empirically
+//! measured effect is `-0.000341` — ~400,000× too small and opposite in sign.
+//!
+//! Fixtures (committed under `tests/fixtures/change_squash_propagation/` for
+//! hermeticity):
+//! - `v2_change-squash_neuron-1481550544.json` — the recorded GRQ-Discovery
+//!   failure, carrying the placeholder gain, the neuron's local errors under the
+//!   current/proposed squash, and the measured actual effect.
+//! - the production GRQ-cluster creature topology is shared with the remove-neuron
+//!   fixture (`../remove_neuron_propagation/network.json`) — the failure is on the
+//!   same creature — so it is not duplicated.
+//!
+//! This file ships two guards, mirroring `tests/remove_neuron_propagation.rs`:
+//! - [`change_squash_placeholder_is_wrong_at_depth`] — the placeholder-guard: the
+//!   propagation-aware estimator must never emit the near-zero placeholder range
+//!   for this deep candidate. If a fallback branch resurrects the inaccurate
+//!   near-zero formula, CI turns red.
+//! - [`change_squash_effect_at_production_depth`] — the estimator spec: the
+//!   estimate must match the measured actual within one order of magnitude AND in
+//!   sign on the committed fixtures (the #1529 pass criterion).
+
+#![allow(clippy::cast_precision_loss)] // Intentional numeric casts (Issue #873)
+
+use neat_ai_discovery::CreatureJson;
+use neat_ai_discovery::analysis::estimate_change_squash_gain;
+use std::path::{Path, PathBuf};
+
+/// The near-zero placeholder gain recorded for the failure example
+/// (`expectedCreatureScoreGain`). Topology-blind and activation-blind.
+const PLACEHOLDER_GAIN: f64 = 8.602_393_603_479_653e-10;
+
+/// The empirically measured effect of the squash change on the output
+/// (`actualErrorReduction`, ~69k samples). Negative: the change made the trained
+/// network slightly worse, the opposite of the placeholder's sign.
+const MEASURED_ACTUAL: f64 = -0.000_341_394_806_272_044;
+
+/// The target neuron, sitting many layers from the single output.
+const TARGET_NEURON: &str = "neuron-1481550544";
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/change_squash_propagation")
+}
+
+/// Recorded change-squash failure: the fields the estimator consumes plus the
+/// measured actual it is graded against.
+struct FailureFixture {
+    neuron_uuid: String,
+    /// The neuron's local error under its current squash (`currentError`).
+    current_local_error: f64,
+    /// The neuron's local error under the proposed squash (`improvedError`).
+    proposed_local_error: f64,
+    /// The recorded placeholder `expectedCreatureScoreGain`.
+    placeholder_gain: f64,
+    /// The measured `actualErrorReduction`.
+    measured_actual: f64,
+}
+
+/// Load the recorded failure fixture. A missing / corrupt fixture fails here with
+/// the fixture path, so hermeticity breakage is caught in the same CI run rather
+/// than at runtime in GRQ-cluster.
+fn load_failure_fixture() -> FailureFixture {
+    let path = fixture_dir().join("v2_change-squash_neuron-1481550544.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read failure fixture {}: {e}", path.display()));
+    let json: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("failed to parse failure fixture {}: {e}", path.display()));
+
+    let candidate = &json["rustRequest"]["squashCandidate"];
+    FailureFixture {
+        neuron_uuid: candidate["neuronUuid"]
+            .as_str()
+            .expect("fixture missing rustRequest.squashCandidate.neuronUuid")
+            .to_string(),
+        current_local_error: candidate["currentError"]
+            .as_f64()
+            .expect("fixture missing rustRequest.squashCandidate.currentError"),
+        proposed_local_error: candidate["improvedError"]
+            .as_f64()
+            .expect("fixture missing rustRequest.squashCandidate.improvedError"),
+        placeholder_gain: candidate["expectedCreatureScoreGain"]
+            .as_f64()
+            .expect("fixture missing rustRequest.squashCandidate.expectedCreatureScoreGain"),
+        measured_actual: json["actualErrorReduction"]
+            .as_f64()
+            .expect("fixture missing actualErrorReduction"),
+    }
+}
+
+/// Load the production creature topology. Shared with the remove-neuron fixture
+/// (the failure is on the same creature), so it is not duplicated here.
+fn load_network() -> CreatureJson {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/remove_neuron_propagation/network.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read network fixture {}: {e}", path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("failed to parse network fixture {}: {e}", path.display()))
+}
+
+/// Ratio of two magnitudes, guarding against a zero denominator.
+fn magnitude_ratio(a: f64, b: f64) -> f64 {
+    let denom = b.abs();
+    assert!(denom > 0.0, "magnitude_ratio: zero denominator");
+    a.abs() / denom
+}
+
+/// True when `a` and `b` share magnitude to within one order of magnitude (10×).
+fn within_one_order(a: f64, b: f64) -> bool {
+    (0.1..=10.0).contains(&magnitude_ratio(a, b))
+}
+
+/// The #1529 accuracy pass criterion: an estimate passes when it matches the
+/// measured actual error change within one order of magnitude (10×) AND in sign.
+fn meets_pass_criterion(estimate: f64, measured_actual: f64) -> bool {
+    within_one_order(estimate, measured_actual) && estimate.signum() == measured_actual.signum()
+}
+
+/// Placeholder-guard (runnable in CI). The propagation-aware estimator has
+/// replaced the near-zero placeholder, so this asserts the estimator no longer
+/// emits a value anywhere near the fabricated `~8.6e-10` placeholder for this
+/// deep candidate. If the near-zero placeholder path is ever accidentally
+/// reinstated (e.g. a fallback branch resurfaces), this test turns CI red at that
+/// commit.
+///
+/// It still pins the recorded fixture values so drift in the known-bad
+/// placeholder / measured-actual constants is caught in the same run.
+#[test]
+fn change_squash_placeholder_is_wrong_at_depth() {
+    let fixture = load_failure_fixture();
+    let creature = load_network();
+
+    // The fixture still encodes the known-bad placeholder and measured actual.
+    // Drift in either value flips this guard red.
+    assert!(
+        (fixture.placeholder_gain - PLACEHOLDER_GAIN).abs() < 1e-18,
+        "recorded placeholder gain {} drifted from the known-bad value {PLACEHOLDER_GAIN}; \
+         re-validate the fixture and spec",
+        fixture.placeholder_gain
+    );
+    assert!(
+        (fixture.measured_actual - MEASURED_ACTUAL).abs() < 1e-12,
+        "recorded measured actual {} drifted from {MEASURED_ACTUAL}; \
+         re-validate the fixture and spec",
+        fixture.measured_actual
+    );
+    assert_eq!(
+        fixture.neuron_uuid, TARGET_NEURON,
+        "fixture target neuron changed"
+    );
+
+    let estimate = estimate_change_squash_gain(
+        &creature,
+        &fixture.neuron_uuid,
+        fixture.current_local_error,
+        fixture.proposed_local_error,
+    )
+    .expect("estimator must return a gain for the target hidden neuron");
+
+    // The honest estimate must be hundreds of thousands of times larger than the
+    // near-zero placeholder — nowhere near the fabricated `~8.6e-10`.
+    assert!(
+        magnitude_ratio(estimate, PLACEHOLDER_GAIN) > 1_000.0,
+        "estimate {estimate:e} is within the retired near-zero placeholder range \
+         (placeholder {PLACEHOLDER_GAIN:e}); the fabricated near-zero path has resurfaced"
+    );
+}
+
+/// Estimator spec — the permanent regression gate (#1532).
+///
+/// The propagation-aware estimator ([`estimate_change_squash_gain`]) replaces the
+/// fabricated near-zero placeholder. This case asserts the estimate matches the
+/// measured actual within one order of magnitude AND in sign on the committed
+/// fixtures. Any future estimator change that breaks the scale or sign fidelity
+/// fails `cargo test` in CI before merge.
+#[test]
+fn change_squash_effect_at_production_depth() {
+    let fixture = load_failure_fixture();
+    let creature = load_network();
+
+    // Sanity-check we are exercising the intended production-scale creature so the
+    // accuracy claim is anchored to the 1,666 / 21,532 GRQ-cluster snapshot.
+    assert_eq!(
+        creature.neurons.len(),
+        1666,
+        "fixture creature is not the expected 1,666-neuron production snapshot"
+    );
+    assert_eq!(
+        creature.synapses.len(),
+        21_532,
+        "fixture creature is not the expected 21,532-synapse production snapshot"
+    );
+
+    let estimate = estimate_change_squash_gain(
+        &creature,
+        &fixture.neuron_uuid,
+        fixture.current_local_error,
+        fixture.proposed_local_error,
+    )
+    .expect("estimator must return a gain for the target hidden neuron");
+
+    // The near-zero placeholder FAILS the #1529 pass criterion — wrong sign
+    // (fabricated positive vs measured negative) and vastly more than 10× off.
+    assert!(
+        !meets_pass_criterion(fixture.placeholder_gain, fixture.measured_actual),
+        "placeholder {:e} must fail the #1529 pass criterion against the measured \
+         actual {:e}",
+        fixture.placeholder_gain,
+        fixture.measured_actual
+    );
+
+    // The placeholder fails on BOTH counts: wrong sign (fabricated positive) and
+    // vastly off in magnitude (ratio ~2.5e-6, far below the 0.1 floor).
+    assert_ne!(
+        fixture.placeholder_gain.signum(),
+        fixture.measured_actual.signum(),
+        "placeholder {:e} should have the wrong sign vs the measured actual {:e}",
+        fixture.placeholder_gain,
+        fixture.measured_actual
+    );
+    assert!(
+        !within_one_order(fixture.placeholder_gain, fixture.measured_actual),
+        "placeholder {:e} should be far more than 10× off the measured actual {:e}",
+        fixture.placeholder_gain,
+        fixture.measured_actual
+    );
+
+    // The propagation-aware estimator PASSES the #1529 criterion — correct sign,
+    // within one order of magnitude.
+    assert!(
+        meets_pass_criterion(estimate, fixture.measured_actual),
+        "propagation-aware estimate {estimate:e} must pass the #1529 pass criterion \
+         against the measured actual {:e}",
+        fixture.measured_actual
+    );
+}
+
+/// The estimator returns `None` for an output neuron (output activations are
+/// governed by the loss contract, not change-squash candidates) and for a neuron
+/// absent from the topology.
+#[test]
+fn change_squash_gain_is_none_for_non_candidates() {
+    let creature = load_network();
+    assert!(
+        estimate_change_squash_gain(&creature, "neuron-does-not-exist", 1.0, 0.5).is_none(),
+        "absent neuron must not be a change-squash candidate"
+    );
+    let output_uuid = creature
+        .neurons
+        .iter()
+        .find(|n| n.neuron_type == "output")
+        .map(|n| n.uuid.clone())
+        .expect("production creature must have at least one output neuron");
+    assert!(
+        estimate_change_squash_gain(&creature, &output_uuid, 1.0, 0.5).is_none(),
+        "output neuron must not be a change-squash candidate"
+    );
+}
+
+/// A swap that does not reduce the neuron's local error induces no perturbation,
+/// so the honest gain is zero (never a fabricated win). Guards the `max(0.0)`
+/// floor on the local perturbation.
+#[test]
+fn change_squash_non_improving_swap_yields_zero_gain() {
+    let creature = load_network();
+    // proposed_local_error >= current_local_error → no local improvement.
+    let gain = estimate_change_squash_gain(&creature, TARGET_NEURON, 100.0, 100.0)
+        .expect("estimator must return a gain for the target hidden neuron");
+    assert_eq!(
+        gain, 0.0,
+        "a non-improving swap must yield exactly zero gain"
+    );
+
+    let worse = estimate_change_squash_gain(&creature, TARGET_NEURON, 100.0, 250.0)
+        .expect("estimator must return a gain for the target hidden neuron");
+    assert_eq!(
+        worse, 0.0,
+        "a swap that increases local error must not fabricate a non-zero gain"
+    );
+}
+
+/// The honest gain is always non-positive: a change-squash on a converged network
+/// disrupts the downstream layers trained around the original activation.
+#[test]
+fn change_squash_gain_is_non_positive() {
+    let fixture = load_failure_fixture();
+    let creature = load_network();
+    let estimate = estimate_change_squash_gain(
+        &creature,
+        &fixture.neuron_uuid,
+        fixture.current_local_error,
+        fixture.proposed_local_error,
+    )
+    .expect("estimator must return a gain for the target hidden neuron");
+    assert!(
+        estimate <= 0.0,
+        "propagation-aware change-squash gain {estimate:e} must be non-positive"
+    );
+}

--- a/tests/fixtures/change_squash_propagation/README.md
+++ b/tests/fixtures/change_squash_propagation/README.md
@@ -1,0 +1,36 @@
+# change-squash propagation fixtures (Issue #1532)
+
+Hermetic fixtures for `tests/change_squash_propagation.rs`. They are committed
+here so the test is reproducible offline and does not reach out to other
+repositories at runtime.
+
+| File | Source | Purpose |
+|------|--------|---------|
+| `v2_change-squash_neuron-1481550544.json` | `stSoftwareAU/GRQ-Discovery` `failures/247b83ab/change-squash/…` (commit `2d07afca`) | Recorded change-squash failure. Carries the near-zero placeholder gain (`expectedCreatureScoreGain = 8.6e-10`) and the empirically measured effect (`actualErrorReduction = -0.000341`) for `neuron-1481550544` (`SELU → SQUARE`). This is the second cited failure on GRQ-Discovery commit `2596f073`. |
+
+The **network topology** is shared with the remove-neuron fixture: the recorded
+failure is on the same production creature (identical `originalScore`
+`0.4236678629467732`), so the test loads the 1,666-neuron / 21,532-synapse
+GRQ-cluster creature from `../remove_neuron_propagation/network.json` rather than
+committing a second 3 MB copy (single source of truth).
+
+## Why these values matter
+
+The placeholder gain (`8.6e-10`) is ~400,000× *smaller* than — and opposite in
+sign to — the measured actual effect (`-0.000341`). The change-squash effect is
+driven by how much the neuron's emitted output changes when its activation
+function is swapped (`SELU → SQUARE` amplifies the output by orders of
+magnitude), so the pure small-perturbation structural influence (~`4.3e-7` for
+this neuron) under-predicts the effect ~800×.
+
+The propagation-aware estimator (`estimate_change_squash_gain`, Issue #1532)
+combines the neuron's propagation-aware downstream influence
+(`compute_impacts_public`, reused from the #1518 remove-neuron estimator) with
+the local perturbation the swap induces (the reduction in the neuron's local
+error, `currentError − improvedError`). Its signed estimate is a small negative
+value within an order of magnitude of the measured `~3.4e-4` and hundreds of
+thousands of times above the placeholder. See Issue #1516/#1518 for the
+remove-neuron precedent and #1529 for the accuracy milestone.
+
+Do not edit these fixtures by hand. If the upstream source changes, refresh the
+file and re-validate `change_squash_placeholder_is_wrong_at_depth`.

--- a/tests/fixtures/change_squash_propagation/v2_change-squash_neuron-1481550544.json
+++ b/tests/fixtures/change_squash_propagation/v2_change-squash_neuron-1481550544.json
@@ -1,0 +1,25 @@
+{
+  "wireSchemaVersion": 2,
+  "key": "v2_change-squash_n_00145990-82d3-480c-9d52-36ca494cca57_ReLU_e-1_n_00169d7e-b3ee-49e2-a6c3-ce031b7a83ce_Cube_e0_n_00b24bc1-3bbb-4987-bed7-11954fbc9c65_HARD_TANH_e0_n_00d84909-1ed1-400d-a8b2-bf6bcbca5e",
+  "changeType": "change-squash",
+  "description": "🎨 Changed activation function for 81550544 (SELU -> SQUARE expected: 0.0%)",
+  "originalScore": 0.4236678629467732,
+  "candidateScore": 0.4233264681405012,
+  "scoreDelta": -0.000341394806272044,
+  "error": 0.5762918528595746,
+  "originalError": 0.5759504580533026,
+  "timestamp": "2026-07-06T00:01:51.350691895Z",
+  "discoveryVersion": "0.74.117",
+  "rustRequest": {
+    "squashCandidate": {
+      "neuronUuid": "neuron-1481550544",
+      "previousSquash": "SELU",
+      "squash": "SQUARE",
+      "expectedCreatureScoreGain": 8.602393603479653e-10,
+      "improvedError": 2993.292796432284,
+      "currentError": 9461.31753830839
+    }
+  },
+  "expectedErrorReduction": 8.602393603479653e-10,
+  "actualErrorReduction": -0.000341394806272044
+}


### PR DESCRIPTION
## Summary

Extends the #1518 propagation-aware error-reduction estimate — which fixed the
**remove-neuron** path — to the **change-squash** estimate path, the second
estimate path cited on GRQ-Discovery commit `2596f073`. Closes #1532.

For the recorded failure (`neuron-1481550544`, `SELU → SQUARE`, creature
`247b83ab`) the pipeline emitted a near-zero placeholder gain of `+8.6e-10`
while the empirically measured effect over ~69k samples was `-0.000341` —
~400,000× too small in magnitude and the wrong sign.

New `analysis::change_squash_gain` module exporting:

```rust
estimate_change_squash_gain(creature, neuron_uuid, current_local_error, proposed_local_error) -> Option<f64>
```

It mirrors `estimate_remove_neuron_gain`'s design:

- **Downstream propagation** — reuses `compute_impacts_public` (DRY) for the
  neuron's propagation-aware influence on the output(s); a deep neuron attenuates
  to a tiny value.
- **Local perturbation scale** — unlike remove-neuron (which zeroes the whole
  contribution), a squash swap's effect is driven by *how much the neuron's
  emitted output changes*. `SELU → SQUARE` amplifies the output by orders of
  magnitude, so the pure small-perturbation structural influence (~`4.3e-7` for
  this neuron) under-predicts the effect ~800×. We scale the influence by the
  reduction in the neuron's *local* error the candidate reports
  (`currentError − improvedError`), the amount the swap perturbs the neuron's
  behaviour.
- **Sign** — non-positive: on a converged network the downstream layers were
  trained around the neuron's original activation, so re-fitting it disrupts that
  equilibrium and is expected to *reduce* the trained score. This is the same
  honest prior the remove-neuron estimator uses (and the reason no candidates
  have succeeded for a month — most single edits to a converged net hurt).

The signed estimate is `-2.8e-3` — correct sign and within one order of
magnitude (8.2×) of the measured `-3.4e-4`, i.e. it passes the #1529 accuracy
criterion, while the near-zero placeholder fails it on both sign and magnitude
(ratio ~`2.5e-6`).

### Change-type audit (issue scope)

The issue asked to audit the other change types for the same class of flaw. The
`addNeuron` / `addSynapse` paths already scale their expected error reduction by
`target_neuron_impact` (the same `compute_impacts_public` propagation factor —
see `CandidateNeuronJson` / `CandidateSynapseJson` in `src/ffi_types/candidates.rs`),
so they are already propagation-aware. `removeNeuron` was fixed in #1518. The
outstanding topology-/activation-blind path was **change-squash**, addressed
here. `setWeight` / `setBias` adjust an existing edge/bias in place and were not
cited in the #1529 failures; no change is made to them in this issue to keep the
change scoped.

## Evidence

Backend/CLI Rust change — no web interface to screenshot. Verified via the new
production-scale integration tests against the committed 1,666-neuron /
21,532-synapse GRQ-cluster fixture.

```mermaid
flowchart LR
    subgraph before["BEFORE (placeholder)"]
        P["expectedCreatureScoreGain<br/>+8.6e-10 (near-zero,<br/>topology/activation-blind)"]
    end
    subgraph after["AFTER (propagation-aware)"]
        I["compute_impacts_public<br/>downstream influence ~4.3e-7"]
        L["local perturbation<br/>currentError − improvedError"]
        I --> G["estimate_change_squash_gain<br/>≈ −2.8e-3 (signed, attenuated)"]
        L --> G
    end
    A["measured actual<br/>−3.4e-4"]
    P -. "wrong sign, ~2.5e-6× off — FAILS #1529" .-> A
    G -. "correct sign, within 10× — PASSES #1529" .-> A
```

Test run (all pass):

```
cargo test --test change_squash_propagation
running 5 tests
test change_squash_placeholder_is_wrong_at_depth ... ok
test change_squash_effect_at_production_depth ... ok
test change_squash_gain_is_none_for_non_candidates ... ok
test change_squash_non_improving_swap_yields_zero_gain ... ok
test change_squash_gain_is_non_positive ... ok
test result: ok. 5 passed; 0 failed
```

## Test Plan

New `tests/change_squash_propagation.rs` (mirrors `tests/remove_neuron_propagation.rs`),
run via `cargo test` in CI on every PR/push:

- `change_squash_effect_at_production_depth` — estimator spec / permanent
  regression gate: the estimate matches the measured actual (`≈−0.00034`) in sign
  and within one order of magnitude (the #1529 pass criterion), and the
  placeholder is asserted to fail that same criterion.
- `change_squash_placeholder_is_wrong_at_depth` — placeholder-guard: the estimate
  is never within the retired near-zero `~8.6e-10` placeholder range for this deep
  candidate (fails if a fallback branch resurrects the inaccurate formula).
- `change_squash_gain_is_none_for_non_candidates` — output / absent neurons are
  not change-squash candidates.
- `change_squash_non_improving_swap_yields_zero_gain` — a swap that does not
  reduce local error induces no perturbation (guards the `max(0.0)` floor).
- `change_squash_gain_is_non_positive` — the honest gain is always non-positive.

Fixtures under `tests/fixtures/change_squash_propagation/` (hermetic): the
recorded GRQ-Discovery change-squash failure. The 1,666-neuron GRQ-cluster
topology is shared with the remove-neuron fixture (same creature) and loaded from
`tests/fixtures/remove_neuron_propagation/network.json` rather than duplicated.

Full `cargo test --lib --tests --all-features` and `./quality.sh` gates (fmt,
clippy `-D warnings`, check, doc) pass. Note: `quality.sh`'s
`cargo upgrade --incompatible` step attempts a `wgpu 29 → 30` major bump with
breaking API changes unrelated to this issue; that bump is reverted per the
#1613 "revert a bump that breaks the build" rule (CI does not run the incompatible
upgrade step).



## Milestone
This PR is part of the **#1529 Prove error-reduction estimates are accurate for production-scale creatures** milestone and targets the `milestone/1529-prove-error-reduction-estimates-are-accurate` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrbw2mze-638033`<!-- vibe-worker-issue-1532 -->