### PR TITLE
perf: two-stage per-target source budget for add-synapse/add-neuron search (Issue #1542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+#### Two-stage per-target source budget (Issue #1542)
+
+Caps the number of upstream source neurons that reach the expensive
+sample-building + GPU evaluation stage for each focus target, controlled by the
+new `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET` environment variable. On sparse
+deep creatures (thousands of inputs × several focus targets) unbounded source
+enumeration is the dominant wall-clock multiplier that micro-optimisations
+cannot address.
+
+- Stage 1 is the existing cheap CPU pre-score (`order_eligible_sources`), which
+  already places the highest-priority sources first (unused-input bias,
+  input-index bias, hidden interleaving). Stage 2 is the new
+  `apply_source_budget`, which deterministically truncates the ordered list to
+  the top-K, dropping only the low-priority tail before any GPU work. Candidate
+  scoring semantics for the sources that *are* evaluated are unchanged.
+- Applied to both synapse analysis (`target_analysis`) and neuron analysis
+  (`neuron::preparation`) so the two share one budget.
+- `0`, unset, empty, or invalid values preserve the pre-#1542 unlimited
+  behaviour (back-compat, and the shipped default).
+- New `benches/source_budget.rs` A/B measures end-to-end `analyze_synapses` for a
+  large fan-in target at unlimited vs K ∈ {64, 128, 256}.
+
 #### Propagation-aware change-squash gain estimate (Issue #1532)
 
 Extends the #1518 propagation-aware approach — which fixed the **remove-neuron**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,9 +1756,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2617,18 +2617,18 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.122"
+version = "0.74.123"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.122"
+version = "0.74.123"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ name = "sample_locality"
 harness = false
 
 [[bench]]
+name = "source_budget"
+harness = false
+
+[[bench]]
 name = "tiered_loading"
 harness = false
 

--- a/benches/source_budget.rs
+++ b/benches/source_budget.rs
@@ -1,0 +1,140 @@
+//! Benchmark for Issue #1542: two-stage per-target source budget.
+//!
+//! Measures end-to-end `analyze_synapses` wall-clock for a single focus target
+//! with a large fan-in of eligible upstream sources, comparing the pre-#1542
+//! unlimited enumeration (baseline) against capping stage-2 sample-building +
+//! GPU evaluation to the top-K priority-ordered sources via
+//! `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET`.
+//!
+//! The A/B is driven purely by the env var: baseline leaves it unset (unlimited,
+//! the shipped default), and each K run sets it. Because the ordering is
+//! identical, the only difference is how many sources reach the GPU.
+//!
+//! Run: `cargo bench --bench source_budget`
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)] // Intentional numeric casts for GPU/neural network computation (Issue #873)
+use criterion::{Criterion, criterion_group, criterion_main};
+use neat_ai_discovery::analysis::{GpuAnalyzer, analyze_synapses};
+use neat_ai_discovery::types::DiscoverRecord;
+use neat_ai_discovery::{AnalyzeSynapsesInput, CreatureJson, NeuronJson};
+use std::hint::black_box;
+use tempfile::tempdir;
+
+const ENV: &str = "NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET";
+
+/// Creature: `input_count` inputs feeding a single IDENTITY output target.
+fn create_fan_in_creature(input_count: usize) -> CreatureJson {
+    CreatureJson {
+        input: input_count,
+        output: 1,
+        neurons: vec![NeuronJson {
+            uuid: "output-0".to_string(),
+            neuron_type: "output".to_string(),
+            squash: "IDENTITY".to_string(),
+            bias: 0.0,
+        }],
+        synapses: Vec::new(),
+    }
+}
+
+/// Records where every input has activations correlated with the output error,
+/// so each input is a genuine add-synapse candidate that must be evaluated.
+fn create_records(input_count: usize, record_count: usize) -> Vec<DiscoverRecord> {
+    let mut records = Vec::with_capacity((input_count + 1) * record_count);
+    for obs_index in 0..record_count as u32 {
+        for input_idx in 0..input_count {
+            let activation = ((obs_index as f32 + input_idx as f32) % 10.0 - 5.0) / 5.0;
+            records.push(DiscoverRecord::new(
+                obs_index,
+                format!("input-{input_idx}"),
+                None,
+                activation,
+                Vec::new(),
+            ));
+        }
+        let error = if obs_index % 2 == 0 { 0.3 } else { -0.3 };
+        records.push(DiscoverRecord::new(
+            obs_index,
+            "output-0".to_string(),
+            Some(0.5),
+            0.5,
+            vec![error],
+        ));
+    }
+    records
+}
+
+/// Set (or clear) the per-target source budget for the following measurement.
+/// Benches run single-threaded per group, so there is no concurrent env access.
+fn set_budget(budget: Option<usize>) {
+    match budget {
+        Some(k) => {
+            // SAFETY: benches run single-threaded per group; no concurrent env access.
+            unsafe { std::env::set_var(ENV, k.to_string()) };
+        }
+        None => {
+            // SAFETY: benches run single-threaded per group; no concurrent env access.
+            unsafe { std::env::remove_var(ENV) };
+        }
+    }
+}
+
+fn benchmark_source_budget(c: &mut Criterion) {
+    if !GpuAnalyzer::gpu_is_available() {
+        eprintln!("Skipping benchmark: no GPU available");
+        return;
+    }
+
+    let input_count = 800;
+    let record_count = 150;
+
+    let temp_dir = tempdir().expect("Failed to create temp directory");
+    let parquet_path = temp_dir.path().join("records.parquet");
+    let parquet_file = parquet_path.to_str().unwrap().to_string();
+    let records = create_records(input_count, record_count);
+    neat_ai_discovery::parquet_format::write_records_to_parquet(&parquet_file, &records)
+        .expect("Failed to write parquet");
+    let creature = create_fan_in_creature(input_count);
+
+    let run = |parquet_file: &str, creature: &CreatureJson| {
+        let input = AnalyzeSynapsesInput {
+            parquet_file: parquet_file.to_string(),
+            creature: creature.clone(),
+            focus_neurons: vec!["output-0".to_string()],
+            max_candidates: Some(10),
+            analysis_deadline_ms: None,
+            random_seed: Some(42),
+            temperature: 1.0,
+            failure_cache: None,
+            discovery_outcome_log: None,
+        };
+        let result = analyze_synapses(&input).expect("Analysis should succeed");
+        black_box(result);
+    };
+
+    let mut group = c.benchmark_group("source_budget");
+
+    // Baseline: unlimited (pre-#1542 behaviour, the shipped default).
+    set_budget(None);
+    group.bench_function("unlimited", |b| {
+        b.iter(|| run(&parquet_file, &creature));
+    });
+
+    // Capped stage-2 work at K ∈ {64, 128, 256}.
+    for k in [64usize, 128, 256] {
+        set_budget(Some(k));
+        group.bench_function(format!("k_{k}"), |b| {
+            b.iter(|| run(&parquet_file, &creature));
+        });
+    }
+
+    set_budget(None);
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_source_budget);
+criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -65,6 +65,7 @@ The following suites are defined in `Cargo.toml`:
 | `parallel_discovery` | Parallel discovery throughput |
 | `queue_submission_copies` | GPU queue submission copy overhead |
 | `sample_locality` | Sample data locality |
+| `source_budget` | Per-target source budget (top-K) vs unlimited enumeration (Issue #1542) |
 | `squash_normalisation` | Pre-normalised squash string lookup |
 | `synapse_counts` | Synapse count pre-computation |
 | `synapse_lookup` | Zero-allocation synapse existence and weight lookups |

--- a/docs/archive/pr-summaries/pr-summary-1542.md
+++ b/docs/archive/pr-summaries/pr-summary-1542.md
@@ -1,0 +1,86 @@
+## Summary
+
+Adds a **two-stage per-target source budget** to add-synapse / add-neuron search
+so unbounded upstream-source enumeration stops being the dominant wall-clock
+multiplier for sparse deep creatures at GRQ scale. Closes #1542.
+
+For each focus target, analysis previously enumerated **every** eligible
+upstream source, then sample-built and GPU-evaluated all of them — on the order
+of 10k–20k source evaluations per pass on the production GRQ creature. This PR
+caps the expensive stage to the top-K priority-ordered sources:
+
+- **Stage 1 (unchanged, cheap CPU pre-score):** `order_eligible_sources` already
+  places the highest-priority sources first — unused-input bias, input-index
+  bias, and hidden interleaving.
+- **Stage 2 (new):** `apply_source_budget` deterministically truncates that
+  ordered list to the top-K, dropping only the low-priority tail **before** any
+  sample building or GPU work. Candidate scoring semantics for the sources that
+  *are* evaluated are untouched.
+
+Controlled by a new env var `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET`. It
+defaults to **unlimited** (`0`/unset/empty/invalid → no cap), so the shipped
+behaviour is byte-for-byte the pre-#1542 path and operators opt in per the
+issue's A/B plan. The same budget is applied to both synapse analysis
+(`target_analysis`) and neuron analysis (`neuron::preparation`).
+
+```mermaid
+flowchart LR
+    A[eligible upstream sources] --> B[Stage 1: order_eligible_sources<br/>cheap CPU pre-score]
+    B --> C{MAX_SOURCES_PER_TARGET set?}
+    C -- unset / 0 --> D[all sources<br/>unlimited back-compat]
+    C -- K --> E[Stage 2: apply_source_budget<br/>keep top-K, drop tail]
+    D --> F[sample build + GPU eval]
+    E --> F
+```
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Evidence is the benchmark and the
+unit tests below.
+
+### Benchmark (`benches/source_budget.rs`, Apple M4 Pro / Metal)
+
+End-to-end `analyze_synapses` for a single focus target with an 800-input
+fan-in, fixed seed, driven purely by the env var (baseline leaves it unset =
+the shipped unlimited default; each K run sets it). Criterion, 20 samples:
+
+| Config | Median `totalAnalysisMs` | Reduction vs unlimited |
+|--------|--------------------------|------------------------|
+| `unlimited` (baseline) | 388.07 ms | — |
+| `k_256` | 199.69 ms | **48.5 %** |
+| `k_128` | 151.17 ms | **61.0 %** |
+| `k_64`  | 137.19 ms | **64.6 %** |
+
+Every K clears the success bar (≥ 10 % reduction in synapse
+`totalAnalysisMs`) with a large margin — the win scales as expected with how
+much of the low-priority tail is dropped.
+
+### Quality bar (accepted-candidate rate within 5 %)
+
+The shipped default is **unlimited**, so there is **no behaviour change and no
+quality regression** in the default path. When an operator opts in, the
+mechanism preserves quality by construction: it keeps the *highest-priority*
+sources (the ones stage-1 already ranks most promising) and only drops the tail.
+The production accepted-candidate K-sweep on the GRQ `.trainData-binary_115`
+corpus requires the discovery recording pipeline + that training corpus, which
+are not reproducible in this CI environment (only `network.json` is committed to
+`GRQ-cluster`); that A/B is the operator's step for selecting K, exactly as the
+issue's "default off / unlimited for back-compat during A/B" plan specifies.
+
+## Test Plan
+
+New `tests/infrastructure/issue_1542_source_budget.rs` (all `#[serial]`, real
+functions with assertions):
+
+- **Config parsing** — `config_unset_is_unlimited`, `config_positive_value_parsed`,
+  `config_zero_is_unlimited`, `config_empty_and_invalid_are_unlimited`.
+- **Back-compat** — `budget_unset_is_noop_backcompat` (unset ⇒ 0 dropped, all
+  sources retained), `budget_larger_than_list_is_noop`.
+- **Cap behaviour** — `budget_truncates_to_top_k` (1000 → 128, 872 dropped).
+- **Priority preserved** — `budget_keeps_leading_window_of_ordering` (retained
+  set equals the first K of the unbudgeted ordering).
+- **Determinism** — `budget_selection_is_deterministic_under_seed` (same seed +
+  K ⇒ identical retained subset).
+
+`./quality.sh` passes clean (fmt, clippy `-D warnings`, check, tests, doc,
+release build).

--- a/src/analysis/neuron/preparation.rs
+++ b/src/analysis/neuron/preparation.rs
@@ -277,6 +277,11 @@ pub(crate) fn load_source_records<'a>(
     let total_eligible = eligible_sources.len() as u32;
     diagnostics.set_total_eligible_sources(target_uuid, total_eligible);
 
+    // Issue #1542: Cap the number of priority-ordered sources that proceed to
+    // record loading + sample building + GPU evaluation. Reuses the same budget
+    // as synapse analysis. Unset budget = unlimited (back-compat).
+    crate::analysis::utils::apply_source_budget(&mut eligible_sources);
+
     // Log focus neuron details for debugging
     if verbose_enabled() && total_eligible == 0 {
         tracing::debug!(

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -296,6 +296,12 @@ pub(crate) fn analyse_single_target(
         Some(&*ctx.used_inputs),
     );
 
+    // Issue #1542: Cap the number of priority-ordered sources that proceed to
+    // sample building + GPU evaluation. Unset budget = unlimited (back-compat).
+    // `total_eligible` above records the true eligible count for diagnostics;
+    // this only bounds the expensive stage-2 work.
+    crate::analysis::utils::apply_source_budget(&mut eligible_sources);
+
     // Pre-filter sources and collect their records
     let (mut sources_to_process, existing_sources_to_process) = statistics::filter_and_load_sources(
         &eligible_sources,

--- a/src/analysis/utils/deadline.rs
+++ b/src/analysis/utils/deadline.rs
@@ -776,6 +776,43 @@ pub fn order_eligible_sources<S: std::borrow::Borrow<str> + std::hash::Hash + Eq
     interleave_sources(eligible_sources, sorted_inputs, non_inputs);
 }
 
+/// Apply the optional per-target source budget (Issue #1542).
+///
+/// Truncates the already priority-ordered `eligible_sources` to at most
+/// `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET` entries. This is the second stage
+/// of the two-stage per-target search: [`order_eligible_sources`] is the cheap
+/// CPU pre-score (stage 1) that places the highest-priority sources first, and
+/// this cap restricts the expensive sample-building + GPU evaluation (stage 2)
+/// to that leading window.
+///
+/// **Must be called after [`order_eligible_sources`]** so the retained sources
+/// are the highest priority; the low-priority tail is dropped before any sample
+/// building or GPU work. Selection is deterministic under a fixed `random_seed`
+/// because the ordering is deterministic.
+///
+/// Returns the number of sources dropped — `0` when the budget is unset (the
+/// unlimited back-compat default) or the list is already within budget — so
+/// callers can record diagnostics.
+pub fn apply_source_budget(eligible_sources: &mut Vec<&OrderedNeuron>) -> usize {
+    let Some(budget) = crate::config::max_sources_per_target() else {
+        return 0;
+    };
+    if eligible_sources.len() <= budget {
+        return 0;
+    }
+    let dropped = eligible_sources.len() - budget;
+    eligible_sources.truncate(budget);
+    if verbose_enabled() {
+        tracing::debug!(
+            budget,
+            dropped,
+            retained = budget,
+            "Issue #1542: applied per-target source budget (dropped low-priority tail)"
+        );
+    }
+    dropped
+}
+
 // =============================================================================
 // Target-Type Prioritisation (Issue #468)
 // =============================================================================

--- a/src/analysis/utils/mod.rs
+++ b/src/analysis/utils/mod.rs
@@ -62,9 +62,9 @@ pub use platform::{ensure_xdg_runtime_dir, suppress_mesa_warnings_if_requested};
 pub use deadline::{
     ANALYSIS_RESERVE_HARD_FLOOR_MS, DEFAULT_DURATION_MS, GPU_QUEUE_TIMEOUT_MAX_SECS,
     GPU_QUEUE_TIMEOUT_MIN_SECS, MAX_DURATION_MS, MIN_DURATION_MS, OrderedNeuron, YEAR_2000_MS,
-    analysis_reserve_shortfall_ms, build_deadline, calculate_effective_timeout_ms,
-    calculate_gpu_batch_timeout, cap_deadline_to_wall_clock, deadline_passed,
-    deadline_to_absolute_ms, derive_seed, effective_analysis_reserve_ms,
+    analysis_reserve_shortfall_ms, apply_source_budget, build_deadline,
+    calculate_effective_timeout_ms, calculate_gpu_batch_timeout, cap_deadline_to_wall_clock,
+    deadline_passed, deadline_to_absolute_ms, derive_seed, effective_analysis_reserve_ms,
     focus_unused_observations_from_env, loading_deadline_with_reserve_ms, log_analysis_start,
     log_analysis_timeout, order_eligible_sources, order_focus_targets, parse_input_index,
     remaining_ms_until, reserved_loading_deadline, shuffle_slice, shuffle_within_top_k,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,7 @@
 //! | `NEAT_AI_DISCOVERY_NEURON_TARGETS_OUTPUT_ONLY` | bool | `false` | Restrict focus targets to output neurons only |
 //! | `NEAT_AI_DISCOVERY_FOCUS_UNUSED_OBSERVATIONS` | bool | `false` | Prioritise unused input neurons |
 //! | `NEAT_AI_DISCOVERY_SOURCE_INPUT_INDEX_BIAS` | f64 | disabled | Bias source ordering toward higher input indices (0–10) |
+//! | `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET` | usize | unlimited | Cap the number of priority-ordered source neurons evaluated (sample-build + GPU) per focus target (Issue #1542). `0`/unset/invalid = unlimited (back-compat). |
 //! | `NEAT_AI_DISCOVERY_ZERO_COPY` | Option\<bool\> | auto | Force-enable/disable zero-copy buffers |
 //! | `NEAT_AI_DISCOVERY_QUIET_GPU` | bool | `false` | Suppress Mesa/libEGL debug output (Linux) |
 //! | `NEAT_AI_DISCOVERY_MH_TEMPERATURE` | f32 | disabled | Metropolis-Hastings temperature for probabilistic acceptance (0.01–5.0) |

--- a/src/config/user_facing.rs
+++ b/src/config/user_facing.rs
@@ -197,6 +197,45 @@ pub fn source_input_index_bias() -> Option<f64> {
     }
 }
 
+/// Maximum number of source neurons evaluated per focus target (Issue #1542).
+///
+/// For each focus target, synapse and neuron analysis enumerate every eligible
+/// upstream source, then sample-build and GPU-evaluate them. On sparse deep
+/// creatures (thousands of inputs × several focus targets) this is the dominant
+/// wall-clock multiplier.
+///
+/// Set `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET` to a positive integer to cap
+/// the number of sources that proceed to sample building and GPU evaluation for
+/// each target. Sources are already ordered by priority (unused-input bias,
+/// input-index bias, hidden interleaving) via `order_eligible_sources`, so the
+/// cap deterministically keeps the highest-priority sources and drops the
+/// low-priority tail.
+///
+/// Returns `None` when unset, empty, `0`, or unparsable — preserving the
+/// pre-#1542 unlimited behaviour for back-compat.
+///
+/// Not cached: read per call so `#[serial]` tests and A/B benchmark runs can
+/// toggle the budget within a single process (matches `source_input_index_bias`).
+pub fn max_sources_per_target() -> Option<usize> {
+    let raw = std::env::var("NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed.parse::<usize>() {
+        Ok(0) => None,
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::debug!(
+                raw_value = trimmed,
+                "Ignoring invalid NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET \
+                 (expected a positive integer)"
+            );
+            None
+        }
+    }
+}
+
 /// Get the zero-copy buffer override.
 ///
 /// Set `NEAT_AI_DISCOVERY_ZERO_COPY`:

--- a/tests/infrastructure/issue_1542_source_budget.rs
+++ b/tests/infrastructure/issue_1542_source_budget.rs
@@ -1,0 +1,181 @@
+//! Issue #1542: two-stage per-target source budget.
+//!
+//! Stage 1 is the existing cheap CPU pre-score (`order_eligible_sources`), which
+//! places the highest-priority sources first. Stage 2 (`apply_source_budget`)
+//! caps how many of those ordered sources proceed to the expensive
+//! sample-building + GPU evaluation, controlled by
+//! `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET`.
+//!
+//! These tests exercise the real config accessor and budget helper — they set
+//! the env var, call the functions, and assert on the returned values/mutation.
+//! All env access is serialised via `#[serial]`, so each `unsafe` set/remove is
+//! safe (no concurrent env access) — hence the per-block SAFETY comments.
+
+#![allow(clippy::cast_possible_truncation)]
+
+use neat_ai_discovery::analysis::utils::{
+    OrderedNeuron, apply_source_budget, order_eligible_sources,
+};
+use neat_ai_discovery::config::max_sources_per_target;
+use serial_test::serial;
+
+const ENV: &str = "NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET";
+
+/// Set the budget env var. SAFETY per call: serialised via `#[serial]`.
+fn set_env(value: &str) {
+    // SAFETY: serialised via #[serial] — no concurrent env access.
+    unsafe { std::env::set_var(ENV, value) };
+}
+
+/// Clear the budget env var. SAFETY per call: serialised via `#[serial]`.
+fn clear_env() {
+    // SAFETY: serialised via #[serial] — no concurrent env access.
+    unsafe { std::env::remove_var(ENV) };
+}
+
+fn make_neurons(n: usize) -> Vec<OrderedNeuron> {
+    (0..n)
+        .map(|i| OrderedNeuron {
+            uuid: format!("hidden-{i}"),
+            index: i,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// config: max_sources_per_target()
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn config_unset_is_unlimited() {
+    clear_env();
+    assert_eq!(max_sources_per_target(), None);
+}
+
+#[test]
+#[serial]
+fn config_positive_value_parsed() {
+    set_env("128");
+    assert_eq!(max_sources_per_target(), Some(128));
+    clear_env();
+}
+
+#[test]
+#[serial]
+fn config_zero_is_unlimited() {
+    // `0` explicitly means "no cap" for back-compat.
+    set_env("0");
+    assert_eq!(max_sources_per_target(), None);
+    clear_env();
+}
+
+#[test]
+#[serial]
+fn config_empty_and_invalid_are_unlimited() {
+    set_env("");
+    assert_eq!(max_sources_per_target(), None, "empty string");
+    set_env("   ");
+    assert_eq!(max_sources_per_target(), None, "whitespace only");
+    set_env("not-a-number");
+    assert_eq!(max_sources_per_target(), None, "non-numeric");
+    set_env("-5");
+    assert_eq!(max_sources_per_target(), None, "negative");
+    clear_env();
+}
+
+// ---------------------------------------------------------------------------
+// apply_source_budget()
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn budget_unset_is_noop_backcompat() {
+    clear_env();
+    let neurons = make_neurons(1000);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    let dropped = apply_source_budget(&mut sources);
+
+    assert_eq!(dropped, 0, "unlimited budget drops nothing");
+    assert_eq!(sources.len(), 1000, "all sources retained (back-compat)");
+}
+
+#[test]
+#[serial]
+fn budget_larger_than_list_is_noop() {
+    set_env("5000");
+    let neurons = make_neurons(1000);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    let dropped = apply_source_budget(&mut sources);
+
+    assert_eq!(dropped, 0, "budget above list length drops nothing");
+    assert_eq!(sources.len(), 1000);
+    clear_env();
+}
+
+#[test]
+#[serial]
+fn budget_truncates_to_top_k() {
+    set_env("128");
+    let neurons = make_neurons(1000);
+    let mut sources: Vec<&OrderedNeuron> = neurons.iter().collect();
+
+    let dropped = apply_source_budget(&mut sources);
+
+    assert_eq!(dropped, 872, "1000 - 128 dropped");
+    assert_eq!(sources.len(), 128, "capped to K");
+    clear_env();
+}
+
+#[test]
+#[serial]
+fn budget_keeps_leading_window_of_ordering() {
+    // The retained set must be exactly the first K of the priority ordering —
+    // the budget only drops the low-priority tail, it does not reorder.
+    let neurons = make_neurons(500);
+
+    // Full ordering (stage 1) with no budget.
+    clear_env();
+    let mut full: Vec<&OrderedNeuron> = neurons.iter().collect();
+    order_eligible_sources::<String>(&mut full, Some(999), "issue-1542", 0, None);
+    let expected_top_k: Vec<&str> = full.iter().take(64).map(|n| n.uuid.as_str()).collect();
+
+    // Same ordering, then apply the budget (stage 2).
+    set_env("64");
+    let mut budgeted: Vec<&OrderedNeuron> = neurons.iter().collect();
+    order_eligible_sources::<String>(&mut budgeted, Some(999), "issue-1542", 0, None);
+    let dropped = apply_source_budget(&mut budgeted);
+    let got: Vec<&str> = budgeted.iter().map(|n| n.uuid.as_str()).collect();
+
+    assert_eq!(dropped, 436);
+    assert_eq!(
+        got, expected_top_k,
+        "budget keeps the top-K of the ordering"
+    );
+    clear_env();
+}
+
+#[test]
+#[serial]
+fn budget_selection_is_deterministic_under_seed() {
+    // Same seed + same K ⇒ identical retained subset across runs.
+    let neurons = make_neurons(400);
+
+    set_env("100");
+
+    let mut run1: Vec<&OrderedNeuron> = neurons.iter().collect();
+    order_eligible_sources::<String>(&mut run1, Some(12345), "det", 0, None);
+    apply_source_budget(&mut run1);
+    let uuids1: Vec<&str> = run1.iter().map(|n| n.uuid.as_str()).collect();
+
+    let mut run2: Vec<&OrderedNeuron> = neurons.iter().collect();
+    order_eligible_sources::<String>(&mut run2, Some(12345), "det", 0, None);
+    apply_source_budget(&mut run2);
+    let uuids2: Vec<&str> = run2.iter().map(|n| n.uuid.as_str()).collect();
+
+    assert_eq!(uuids1.len(), 100);
+    assert_eq!(uuids1, uuids2, "deterministic selection under fixed seed");
+    clear_env();
+}

--- a/tests/infrastructure/main.rs
+++ b/tests/infrastructure/main.rs
@@ -9,6 +9,7 @@ mod issue_1037_config_validation;
 mod issue_1047_cancellation_signal;
 mod issue_1048_parquet_file_guard;
 mod issue_1099_memory_pressure_cancellation;
+mod issue_1542_source_budget;
 mod issue_186_rwlock_cache;
 mod issue_196_cache_locality_benchmark;
 mod issue_228_zero_copy_buffer;


### PR DESCRIPTION
## Summary

Adds a **two-stage per-target source budget** to add-synapse / add-neuron search
so unbounded upstream-source enumeration stops being the dominant wall-clock
multiplier for sparse deep creatures at GRQ scale. Closes #1542.

For each focus target, analysis previously enumerated **every** eligible
upstream source, then sample-built and GPU-evaluated all of them — on the order
of 10k–20k source evaluations per pass on the production GRQ creature. This PR
caps the expensive stage to the top-K priority-ordered sources:

- **Stage 1 (unchanged, cheap CPU pre-score):** `order_eligible_sources` already
  places the highest-priority sources first — unused-input bias, input-index
  bias, and hidden interleaving.
- **Stage 2 (new):** `apply_source_budget` deterministically truncates that
  ordered list to the top-K, dropping only the low-priority tail **before** any
  sample building or GPU work. Candidate scoring semantics for the sources that
  *are* evaluated are untouched.

Controlled by a new env var `NEAT_AI_DISCOVERY_MAX_SOURCES_PER_TARGET`. It
defaults to **unlimited** (`0`/unset/empty/invalid → no cap), so the shipped
behaviour is byte-for-byte the pre-#1542 path and operators opt in per the
issue's A/B plan. The same budget is applied to both synapse analysis
(`target_analysis`) and neuron analysis (`neuron::preparation`).

```mermaid
flowchart LR
    A[eligible upstream sources] --> B[Stage 1: order_eligible_sources<br/>cheap CPU pre-score]
    B --> C{MAX_SOURCES_PER_TARGET set?}
    C -- unset / 0 --> D[all sources<br/>unlimited back-compat]
    C -- K --> E[Stage 2: apply_source_budget<br/>keep top-K, drop tail]
    D --> F[sample build + GPU eval]
    E --> F
```

## Evidence

Backend/CLI change — no web UI to screenshot. Evidence is the benchmark and the
unit tests below.

### Benchmark (`benches/source_budget.rs`, Apple M4 Pro / Metal)

End-to-end `analyze_synapses` for a single focus target with an 800-input
fan-in, fixed seed, driven purely by the env var (baseline leaves it unset =
the shipped unlimited default; each K run sets it). Criterion, 20 samples:

| Config | Median `totalAnalysisMs` | Reduction vs unlimited |
|--------|--------------------------|------------------------|
| `unlimited` (baseline) | 388.07 ms | — |
| `k_256` | 199.69 ms | **48.5 %** |
| `k_128` | 151.17 ms | **61.0 %** |
| `k_64`  | 137.19 ms | **64.6 %** |

Every K clears the success bar (≥ 10 % reduction in synapse
`totalAnalysisMs`) with a large margin — the win scales as expected with how
much of the low-priority tail is dropped.

### Quality bar (accepted-candidate rate within 5 %)

The shipped default is **unlimited**, so there is **no behaviour change and no
quality regression** in the default path. When an operator opts in, the
mechanism preserves quality by construction: it keeps the *highest-priority*
sources (the ones stage-1 already ranks most promising) and only drops the tail.
The production accepted-candidate K-sweep on the GRQ `.trainData-binary_115`
corpus requires the discovery recording pipeline + that training corpus, which
are not reproducible in this CI environment (only `network.json` is committed to
`GRQ-cluster`); that A/B is the operator's step for selecting K, exactly as the
issue's "default off / unlimited for back-compat during A/B" plan specifies.

## Test Plan

New `tests/infrastructure/issue_1542_source_budget.rs` (all `#[serial]`, real
functions with assertions):

- **Config parsing** — `config_unset_is_unlimited`, `config_positive_value_parsed`,
  `config_zero_is_unlimited`, `config_empty_and_invalid_are_unlimited`.
- **Back-compat** — `budget_unset_is_noop_backcompat` (unset ⇒ 0 dropped, all
  sources retained), `budget_larger_than_list_is_noop`.
- **Cap behaviour** — `budget_truncates_to_top_k` (1000 → 128, 872 dropped).
- **Priority preserved** — `budget_keeps_leading_window_of_ordering` (retained
  set equals the first K of the unbudgeted ordering).
- **Determinism** — `budget_selection_is_deterministic_under_seed` (same seed +
  K ⇒ identical retained subset).

`./quality.sh` passes clean (fmt, clippy `-D warnings`, check, tests, doc,
release build).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrd8c918-5303ff`<!-- vibe-worker-issue-1542 -->