### PR TITLE
perf: eliminate HelpfulSample Vec clones on GPU queue submit (#1548)

### DIFF
--- a/benches/queue_submission_copies.rs
+++ b/benches/queue_submission_copies.rs
@@ -13,10 +13,15 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use neat_ai_discovery::analysis::gpu::{GpuAnalyzer, GpuEvaluator};
 use neat_ai_discovery::analysis::samples::HelpfulSample;
 use std::hint::black_box;
+use std::sync::Arc;
 
 /// Sample sizes to benchmark, matching the range used by the GPU batch size tuning
 /// (64–4096 from `NEAT_AI_DISCOVERY_GPU_BATCH_SIZE`).
 const SAMPLE_SIZES: &[usize] = &[64, 256, 1024, 4096];
+
+/// Number of work items in a simulated helpful submit batch (locality-grouped
+/// sources for one target). Mirrors the fan-out seen at GRQ scale.
+const BATCH_ITEMS: usize = 32;
 
 /// Create test samples with realistic variance for benchmarking.
 fn create_samples(count: usize) -> Vec<HelpfulSample> {
@@ -82,5 +87,59 @@ fn bench_sample_copy_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_direct_relu_eval, bench_sample_copy_overhead,);
+/// Issue #1548: Benchmark building a helpful submit batch by deep-cloning every
+/// work item's sample `Vec` (the pre-fix behaviour).
+///
+/// This is the cost eliminated by Arc-sharing: `submit_helpful_gpu_work`
+/// previously ran `helpful_work_batch.iter().map(|w| w.samples.clone())` on
+/// every batch submit, allocating and copying every sample for queue ownership.
+fn bench_submit_batch_deep_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("submit_batch_deep_clone");
+    for &size in SAMPLE_SIZES {
+        // One Arc-shared sample Vec per work item (as HelpfulWork now holds).
+        let batch: Vec<Arc<Vec<HelpfulSample>>> = (0..BATCH_ITEMS)
+            .map(|_| Arc::new(create_samples(size)))
+            .collect();
+        group.bench_with_input(BenchmarkId::from_parameter(size), &batch, |b, batch| {
+            b.iter(|| {
+                // Pre-fix: deep-copy every sample Vec for queue ownership.
+                let copied: Vec<Vec<HelpfulSample>> =
+                    black_box(batch).iter().map(|w| (**w).clone()).collect();
+                black_box(copied);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Issue #1548: Benchmark building a helpful submit batch by Arc refcount clone
+/// (the post-fix behaviour).
+///
+/// The GPU thread only borrows the samples during evaluation, so a refcount
+/// clone is sufficient and avoids the per-submit deep copy.
+fn bench_submit_batch_arc_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group("submit_batch_arc_clone");
+    for &size in SAMPLE_SIZES {
+        let batch: Vec<Arc<Vec<HelpfulSample>>> = (0..BATCH_ITEMS)
+            .map(|_| Arc::new(create_samples(size)))
+            .collect();
+        group.bench_with_input(BenchmarkId::from_parameter(size), &batch, |b, batch| {
+            b.iter(|| {
+                // Post-fix: share each buffer via a cheap refcount clone.
+                let shared: Vec<Arc<Vec<HelpfulSample>>> =
+                    black_box(batch).iter().map(Arc::clone).collect();
+                black_box(shared);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_direct_relu_eval,
+    bench_sample_copy_overhead,
+    bench_submit_batch_deep_clone,
+    bench_submit_batch_arc_clone,
+);
 criterion_main!(benches);

--- a/docs/archive/pr-summaries/pr-summary-1548.md
+++ b/docs/archive/pr-summaries/pr-summary-1548.md
@@ -1,0 +1,141 @@
+# PR Summary — Issue #1548
+
+## Summary
+
+Eliminated the per-submit deep copy of `HelpfulSample` sample vectors on the GPU
+queue submit path. Previously `submit_helpful_gpu_work` (and the harmful
+counterpart) ran `helpful_work_batch.iter().map(|w| w.samples.clone())` on
+**every** batch submit, allocating and copying every source's sample `Vec` purely
+to satisfy queue ownership. At GRQ scale, locality groups hold large
+`Vec<HelpfulSample>`, so this created multi-GB transient allocations and cache
+thrash on the already CPU-bound sample-build path.
+
+The fix wraps each work item's samples in `Arc<Vec<HelpfulSample>>` once at build
+time, so the submit path takes a **cheap refcount clone** instead of a deep copy.
+The GPU thread only ever borrows the samples (via `as_slice()`) during
+evaluation, so sharing the buffer is safe; the CPU still reads the same buffer
+during result post-processing (shared, not moved), and `Arc` makes the
+deadline-cancellation / drop paths use-after-free-free by construction.
+
+`Closes #1548.`
+
+### What changed
+
+- `HelpfulWork.samples` and `PreparedHarmfulWork.samples` are now
+  `Arc<Vec<HelpfulSample>>`.
+- `GpuWorkRequest::HelpfulBatch.samples` → `Vec<Arc<Vec<HelpfulSample>>>` and
+  `HarmfulBatch.samples_with_weights` → `Vec<(Arc<Vec<HelpfulSample>>, f32)>`.
+- `GpuWorkQueue::submit_helpful_batch` / `evaluate_helpful_batch` /
+  `evaluate_harmful_batch` accept the `Arc`-shared forms.
+- The GPU thread (`execution.rs`) borrows each `Arc` buffer as a slice — no
+  ownership transfer, no copy.
+- The two hot-path submit builders now `Arc::clone` instead of deep-cloning.
+
+The one remaining deep clone — building `SourceContribution` for accepted
+new-synapse candidates — is intentionally left as-is: `build_source_contribution`
+has ~40 call sites across the test suite and `SourceContribution` genuinely owns
+its samples for downstream epistatic detection. That clone is conditional
+(post-processing, per accepted candidate) rather than the unconditional
+per-submit copy this issue targets, so it is out of scope here.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    subgraph Build["Sample building (CPU, once)"]
+        S[build_samples_for_locality_group] --> A["HelpfulWork.samples:<br/>Arc&lt;Vec&lt;HelpfulSample&gt;&gt;"]
+    end
+    A -- "Arc::clone (refcount, ~122 ns)" --> Q[GPU queue submit]
+    A -- "same buffer, shared" --> P[CPU post-processing]
+    Q -- "borrow as_slice()" --> G[GPU thread evaluate]
+    G --> R[HelpfulStats]
+    R --> P
+```
+
+Before: every submit deep-copied the whole batch of sample vectors. After: the
+submit shares the existing buffers by refcount; the GPU borrows them and the CPU
+keeps reading them.
+
+## Evidence
+
+Backend/library change — no web UI to screenshot. Verified via Criterion
+benchmarks and the unit/integration test suite.
+
+### Benchmark — `queue_submission_copies` (Issue #1548 additions)
+
+Two new benches build a simulated helpful submit batch (`BATCH_ITEMS = 32` work
+items) the pre-fix way (deep clone every sample `Vec`) vs the post-fix way
+(`Arc::clone`). Median times:
+
+| samples/item | before: `submit_batch_deep_clone` | after: `submit_batch_arc_clone` | reduction |
+|-------------:|----------------------------------:|--------------------------------:|----------:|
+| 64           | 3.03 µs                           | 0.123 µs                        | ~96%      |
+| 256          | 11.12 µs                          | 0.123 µs                        | ~98.9%    |
+| 1024         | 25.86 µs                          | ~0.123 µs                       | ~99.5%    |
+| 4096         | 111.80 µs                         | ~0.123 µs                       | ~99.9%    |
+
+`Arc::clone` cost is **flat (~122 ns)** and independent of sample-vector length,
+because it is a per-item atomic refcount increment rather than an allocation +
+memcpy. The deep-copy cost scales linearly with sample size. This far exceeds the
+issue's **≥20% win on the `queue_submission_copies` Criterion suite** success
+bar, and — because the deep copy is removed entirely — eliminates the transient
+per-submit allocation that drove peak-RSS growth during helpful submit at GRQ
+scale.
+
+Run with:
+
+```
+cargo bench --bench queue_submission_copies -- submit_batch
+```
+
+> Note: the GRQ production fixtures (`../GRQ/.trainData-binary_115`) are not
+> available in this environment, so the production-fixture RSS/ms measurement in
+> the issue's benchmark plan could not be captured here. The structural win is
+> unconditional: the hot submit path no longer allocates or copies the sample
+> data.
+
+## Test Plan
+
+New unit tests in `src/analysis/gpu/queue/submission.rs` (run without a GPU):
+
+- `submit_helpful_batch_shares_samples_without_deep_copy` — submits an
+  `Arc`-shared batch and asserts, via pointer identity of the enqueued buffer,
+  that **no deep copy** crossed the submit boundary, that the strong count
+  reflects sharing, and that the caller retains read access afterwards.
+- `submit_helpful_batch_empty_is_preresolved` — empty batch resolves to empty
+  stats without enqueuing work.
+- `evaluate_harmful_batch_empty_returns_empty` — harmful API accepts the
+  `Arc`-shared form; empty input returns empty stats.
+
+Regression coverage (unchanged, still green):
+
+- `tests/gpu/gpu_work_queue.rs`, `tests/gpu/issue_953_gpu_queue_deadline.rs` —
+  submit/round-trip and deadline-cancellation drop paths (GPU-gated).
+- `tests/analysis/issue_568_async_pipeline.rs`,
+  `tests/analysis/issue_611_end_to_end_discovery_pipeline.rs` — fixed-seed
+  stats/candidate determinism (GPU-gated).
+
+`./quality.sh` passes for every stage relevant to this change — bash syntax,
+shellcheck, `cargo build`, `cargo fmt --all`, `cargo clippy --all-targets
+--all-features -- -D warnings`, `cargo check --all-targets --all-features`, and
+`cargo build --release --lib` — and all 3 new tests plus the full GPU-queue and
+epistatic suites are green.
+
+### Known pre-existing flaky test (unrelated)
+
+The full `cargo test --lib -- --test-threads=2` run intermittently fails
+`focus::tests::focus_ranking_aborts_when_budget_exceeded` — a **wall-clock**
+timing assertion in `src/focus/tests.rs` (untouched by this PR). It asserts a
+budget abort completes within `50 ms + 1 s grace + 3×25 ms = 1125 ms`; under the
+contention of ~1250 tests sharing two threads (the test drives a real-sleep
+`SleepyProvider`) it overshot by ~68 ms (1.193 s). It **passes in isolation**
+(1.10 s):
+
+```
+cargo test --lib focus::tests::focus_ranking_aborts_when_budget_exceeded
+# test result: ok. 1 passed ... finished in 1.10s
+```
+
+There is no causal path from this PR's change (Arc-sharing sample buffers on the
+GPU submit path) to focus-ranking timing; the flake is environmental and
+pre-existing.

--- a/src/analysis/gpu/queue/execution.rs
+++ b/src/analysis/gpu/queue/execution.rs
@@ -60,15 +60,17 @@ fn execute_request(
             samples,
             response_tx,
         } => {
-            let sample_count: usize = samples.iter().map(std::vec::Vec::len).sum();
+            let sample_count: usize = samples.iter().map(|s| s.len()).sum();
             let start = if track_metrics {
                 Some(Instant::now())
             } else {
                 None
             };
 
+            // Issue #1548: borrow each Arc-shared sample Vec as a slice — the
+            // GPU thread never takes ownership, so refcount sharing is safe.
             let samples_refs: Vec<&[HelpfulSample]> =
-                samples.iter().map(std::vec::Vec::as_slice).collect();
+                samples.iter().map(|s| s.as_slice()).collect();
             let result = analyzer.evaluate_helpful_batch(&samples_refs);
 
             if let Some(start) = start {

--- a/src/analysis/gpu/queue/mod.rs
+++ b/src/analysis/gpu/queue/mod.rs
@@ -50,6 +50,7 @@ mod submission;
 
 use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime};
 
@@ -100,7 +101,11 @@ pub(crate) enum GpuWorkRequest {
     /// Each item is a slice of samples to evaluate.
     HelpfulBatch {
         /// Samples for each evaluation, indexed by request ID.
-        samples: Vec<Vec<HelpfulSample>>,
+        ///
+        /// Issue #1548: `Arc`-shared so submitting caller passes a refcount
+        /// clone rather than a deep copy of every sample `Vec`. The GPU thread
+        /// only borrows the samples (via `as_slice`) during evaluation.
+        samples: Vec<Arc<Vec<HelpfulSample>>>,
         /// Channel to send results back.
         response_tx: Sender<Result<Vec<HelpfulStats>>>,
     },
@@ -108,7 +113,9 @@ pub(crate) enum GpuWorkRequest {
     /// Each item is (samples, weight) pair.
     HarmfulBatch {
         /// (samples, weight) pairs for each evaluation.
-        samples_with_weights: Vec<(Vec<HelpfulSample>, f32)>,
+        ///
+        /// Issue #1548: samples are `Arc`-shared to avoid a deep copy on submit.
+        samples_with_weights: Vec<(Arc<Vec<HelpfulSample>>, f32)>,
         /// Channel to send results back.
         response_tx: Sender<Result<Vec<HarmfulStats>>>,
     },

--- a/src/analysis/gpu/queue/submission.rs
+++ b/src/analysis/gpu/queue/submission.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Result, anyhow};
 use crossbeam_channel::bounded;
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::{GpuFuture, GpuWorkQueue, GpuWorkRequest};
@@ -21,7 +22,7 @@ impl GpuWorkQueue {
     /// processes the helpful batch.
     pub(crate) fn submit_helpful_batch(
         &self,
-        samples: Vec<Vec<HelpfulSample>>,
+        samples: Vec<Arc<Vec<HelpfulSample>>>,
         deadline: &Option<std::time::SystemTime>,
     ) -> Result<GpuFuture<Vec<HelpfulStats>>> {
         if samples.is_empty() {
@@ -79,7 +80,7 @@ impl GpuWorkQueue {
     /// - Without deadline: uses maximum timeout (5 minutes)
     pub fn evaluate_helpful_batch(
         &self,
-        samples: Vec<Vec<HelpfulSample>>,
+        samples: Vec<Arc<Vec<HelpfulSample>>>,
         deadline: &Option<std::time::SystemTime>,
     ) -> Result<Vec<HelpfulStats>> {
         if samples.is_empty() {
@@ -136,7 +137,7 @@ impl GpuWorkQueue {
     /// The `deadline` parameter is used to calculate an adaptive timeout (60s-5min).
     pub fn evaluate_harmful_batch(
         &self,
-        samples_with_weights: Vec<(Vec<HelpfulSample>, f32)>,
+        samples_with_weights: Vec<(Arc<Vec<HelpfulSample>>, f32)>,
         deadline: &Option<std::time::SystemTime>,
     ) -> Result<Vec<HarmfulStats>> {
         if samples_with_weights.is_empty() {
@@ -371,5 +372,101 @@ impl GpuWorkQueue {
                 Err(anyhow!("GPU response channel closed unexpectedly"))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Issue #1548: verify the GPU submit path shares `Arc`-wrapped sample
+    //! buffers with the queue instead of deep-copying them for ownership.
+    use super::*;
+
+    fn sample(v: f32) -> HelpfulSample {
+        HelpfulSample {
+            activation: v,
+            avg_error: 0.0,
+            target_value: None,
+            target_activation: None,
+        }
+    }
+
+    /// Build a queue whose work receiver is returned so tests can inspect the
+    /// enqueued request. No GPU thread is spawned.
+    fn test_queue() -> (GpuWorkQueue, crossbeam_channel::Receiver<GpuWorkRequest>) {
+        let (work_tx, work_rx) = bounded::<GpuWorkRequest>(1);
+        let (_exit_tx, exit_rx) = bounded::<()>(1);
+        let queue = GpuWorkQueue {
+            work_tx,
+            thread_handle: None,
+            exit_rx,
+            deadline: None,
+        };
+        (queue, work_rx)
+    }
+
+    /// Issue #1548: submitting a helpful batch shares the sample buffer with the
+    /// queue via `Arc` (pointer identity preserved) rather than deep-copying it,
+    /// and the caller retains read access afterwards.
+    #[test]
+    fn submit_helpful_batch_shares_samples_without_deep_copy() {
+        let (queue, work_rx) = test_queue();
+
+        let samples = Arc::new(vec![sample(1.0), sample(2.0), sample(3.0)]);
+        let original_ptr = Arc::as_ptr(&samples);
+
+        // Caller keeps its own handle; the submit batch takes a refcount clone.
+        let batch = vec![Arc::clone(&samples)];
+        assert_eq!(
+            Arc::strong_count(&samples),
+            2,
+            "submit batch must share the buffer, not copy it"
+        );
+
+        let _future = queue
+            .submit_helpful_batch(batch, &None)
+            .expect("submit should enqueue");
+
+        // The queued request holds the SAME buffer — no deep copy crossed the
+        // submit boundary.
+        match work_rx.recv().expect("request should be enqueued") {
+            GpuWorkRequest::HelpfulBatch {
+                samples: queued, ..
+            } => {
+                assert_eq!(queued.len(), 1, "one work item enqueued");
+                assert!(
+                    std::ptr::eq(Arc::as_ptr(&queued[0]), original_ptr),
+                    "queued samples must be the shared buffer, not a copy"
+                );
+                assert_eq!(queued[0].len(), 3, "sample contents preserved");
+            }
+            _ => panic!("expected HelpfulBatch request variant"),
+        }
+
+        // Caller can still read its samples after submit (shared, not moved).
+        assert_eq!(samples.len(), 3, "caller retains access after submit");
+    }
+
+    /// Issue #1548: an empty helpful batch resolves immediately to empty stats
+    /// without enqueuing any work.
+    #[test]
+    fn submit_helpful_batch_empty_is_preresolved() {
+        let (queue, _work_rx) = test_queue();
+        let future = queue
+            .submit_helpful_batch(Vec::new(), &None)
+            .expect("empty batch should succeed");
+        let stats = future.collect().expect("empty batch resolves");
+        assert!(stats.is_empty(), "empty batch yields no stats");
+    }
+
+    /// Issue #1548: the harmful batch API accepts `Arc`-shared samples; the
+    /// empty-input fast path returns empty stats without a GPU.
+    #[test]
+    fn evaluate_harmful_batch_empty_returns_empty() {
+        let (queue, _work_rx) = test_queue();
+        let batch: Vec<(Arc<Vec<HelpfulSample>>, f32)> = Vec::new();
+        let stats = queue
+            .evaluate_harmful_batch(batch, &None)
+            .expect("empty harmful batch should succeed");
+        assert!(stats.is_empty(), "empty harmful batch yields no stats");
     }
 }

--- a/src/analysis/synapse/target_analysis/evaluation.rs
+++ b/src/analysis/synapse/target_analysis/evaluation.rs
@@ -20,6 +20,7 @@ use crate::analysis::scoring::weights::{
 };
 use crate::analysis::shared::TimingScope;
 use anyhow::Result;
+use std::sync::Arc;
 
 use super::statistics::PreparedHarmfulWork;
 use super::{HelpfulWork, TargetAnalysisContext, TargetAnalysisResults};
@@ -37,9 +38,13 @@ pub(crate) fn submit_helpful_gpu_work(
     ctx: &TargetAnalysisContext,
     results: &mut TargetAnalysisResults,
 ) -> Result<crate::analysis::gpu::queue::GpuFuture<Vec<HelpfulStats>>> {
-    let helpful_samples: Vec<Vec<HelpfulSample>> = helpful_work_batch
+    // Issue #1548: share each work item's samples with the GPU queue via a
+    // cheap Arc refcount clone instead of deep-copying the sample Vec. The CPU
+    // still reads `work.samples` during result post-processing, so the buffer
+    // is shared (not moved); dropping either side is safe (Arc handles it).
+    let helpful_samples: Vec<Arc<Vec<HelpfulSample>>> = helpful_work_batch
         .iter()
-        .map(|w| w.samples.clone()) // Clone required: GPU queue takes ownership of sample data
+        .map(|w| Arc::clone(&w.samples))
         .collect();
 
     // Track metadata
@@ -326,7 +331,9 @@ pub(crate) fn collect_and_process_helpful_results(
             if work.existing_weight.is_none() {
                 source_contributions.push(build_source_contribution(
                     &work.source_uuid,
-                    work.samples.clone(), // Clone required: SourceContribution takes ownership
+                    // SourceContribution owns its samples; deep-clone from the
+                    // Arc-shared buffer (only for accepted new-synapse candidates).
+                    work.samples.as_ref().clone(),
                     *stats,
                     applied_weight,
                     neuron_error_improvement,
@@ -473,7 +480,7 @@ pub(crate) fn collect_and_process_helpful_results(
                     let mut act_max = f32::NEG_INFINITY;
                     let mut act_sum = 0.0f64;
                     let mut act_count: u32 = 0;
-                    for s in &work.samples {
+                    for s in work.samples.iter() {
                         if s.activation.is_finite() {
                             act_min = act_min.min(s.activation);
                             act_max = act_max.max(s.activation);
@@ -605,9 +612,12 @@ pub(crate) fn process_harmful_batch_from_prepared(
     cache: &RecordCache,
     results: &mut TargetAnalysisResults,
 ) -> Result<()> {
-    let batch_input: Vec<(Vec<HelpfulSample>, f32)> = harmful_work
+    // Issue #1548: share samples with the GPU queue via an Arc refcount clone
+    // instead of deep-copying each sample Vec for queue ownership. The CPU
+    // still reads `work.samples` when building candidates below.
+    let batch_input: Vec<(Arc<Vec<HelpfulSample>>, f32)> = harmful_work
         .iter()
-        .map(|w| (w.samples.clone(), w.weight)) // Clone required: GPU queue takes ownership
+        .map(|w| (Arc::clone(&w.samples), w.weight))
         .collect();
 
     let batch_stats = {

--- a/src/analysis/synapse/target_analysis/mod.rs
+++ b/src/analysis/synapse/target_analysis/mod.rs
@@ -98,10 +98,15 @@ pub(crate) struct InputMetadata {
 }
 
 /// Work item for helpful synapse evaluation via GPU.
+///
+/// Issue #1548: `samples` is `Arc`-shared so the GPU submit path can take a
+/// cheap refcount clone instead of deep-copying the whole sample `Vec` for
+/// queue ownership. The CPU still reads the samples during post-processing,
+/// so the buffer is shared (not moved) between the queue and the caller.
 struct HelpfulWork {
     source_uuid: String,
     target_uuid: String,
-    samples: Vec<HelpfulSample>,
+    samples: Arc<Vec<HelpfulSample>>,
     /// Existing synapse weight (when the synapse already exists).
     existing_weight: Option<f32>,
 }

--- a/src/analysis/synapse/target_analysis/statistics.rs
+++ b/src/analysis/synapse/target_analysis/statistics.rs
@@ -197,7 +197,9 @@ pub(crate) fn build_helpful_work_items(
                             Some(HelpfulWork {
                                 source_uuid: source_uuid.to_string(),
                                 target_uuid: target_uuid.to_string(),
-                                samples,
+                                // Issue #1548: Arc-wrap once so the GPU submit
+                                // path clones a refcount, not the sample Vec.
+                                samples: Arc::new(samples),
                                 existing_weight: None,
                             })
                         } else {
@@ -262,10 +264,13 @@ pub(crate) fn build_existing_edge_work(
         .collect();
 
     // Create work items by cloning samples from contributions (single clone instead of double).
+    // Issue #1548: the contribution keeps its own copy for redundant-path
+    // detection, so one deep clone is unavoidable here; wrapping in Arc lets
+    // the subsequent GPU submit share the buffer without re-cloning.
     helpful_work_batch.extend(existing_path_contributions.iter().map(|c| HelpfulWork {
         source_uuid: c.source_uuid.clone(),
         target_uuid: target_uuid.to_string(),
-        samples: c.samples.clone(), // Clone required: GPU queue takes ownership
+        samples: Arc::new(c.samples.clone()),
         existing_weight: Some(c.existing_weight),
     }));
 
@@ -302,7 +307,9 @@ pub(crate) fn prepare_harmful_samples<'a>(
             from_uuid: synapse.from_uuid.as_str(),
             to_uuid: synapse.to_uuid.as_str(),
             weight: synapse.weight,
-            samples,
+            // Issue #1548: Arc-wrap so the harmful GPU submit shares the buffer
+            // rather than deep-copying it for queue ownership.
+            samples: Arc::new(samples),
         });
     }
 
@@ -317,5 +324,7 @@ pub(crate) struct PreparedHarmfulWork<'a> {
     pub from_uuid: &'a str,
     pub to_uuid: &'a str,
     pub weight: f32,
-    pub samples: Vec<HelpfulSample>,
+    /// Issue #1548: `Arc`-shared so the GPU submit path takes a refcount clone
+    /// instead of deep-copying the sample `Vec` for queue ownership.
+    pub samples: Arc<Vec<HelpfulSample>>,
 }


### PR DESCRIPTION
# PR Summary — Issue #1548

## Summary

Eliminated the per-submit deep copy of `HelpfulSample` sample vectors on the GPU
queue submit path. Previously `submit_helpful_gpu_work` (and the harmful
counterpart) ran `helpful_work_batch.iter().map(|w| w.samples.clone())` on
**every** batch submit, allocating and copying every source's sample `Vec` purely
to satisfy queue ownership. At GRQ scale, locality groups hold large
`Vec<HelpfulSample>`, so this created multi-GB transient allocations and cache
thrash on the already CPU-bound sample-build path.

The fix wraps each work item's samples in `Arc<Vec<HelpfulSample>>` once at build
time, so the submit path takes a **cheap refcount clone** instead of a deep copy.
The GPU thread only ever borrows the samples (via `as_slice()`) during
evaluation, so sharing the buffer is safe; the CPU still reads the same buffer
during result post-processing (shared, not moved), and `Arc` makes the
deadline-cancellation / drop paths use-after-free-free by construction.

`Closes #1548.`

### What changed

- `HelpfulWork.samples` and `PreparedHarmfulWork.samples` are now
  `Arc<Vec<HelpfulSample>>`.
- `GpuWorkRequest::HelpfulBatch.samples` → `Vec<Arc<Vec<HelpfulSample>>>` and
  `HarmfulBatch.samples_with_weights` → `Vec<(Arc<Vec<HelpfulSample>>, f32)>`.
- `GpuWorkQueue::submit_helpful_batch` / `evaluate_helpful_batch` /
  `evaluate_harmful_batch` accept the `Arc`-shared forms.
- The GPU thread (`execution.rs`) borrows each `Arc` buffer as a slice — no
  ownership transfer, no copy.
- The two hot-path submit builders now `Arc::clone` instead of deep-cloning.

The one remaining deep clone — building `SourceContribution` for accepted
new-synapse candidates — is intentionally left as-is: `build_source_contribution`
has ~40 call sites across the test suite and `SourceContribution` genuinely owns
its samples for downstream epistatic detection. That clone is conditional
(post-processing, per accepted candidate) rather than the unconditional
per-submit copy this issue targets, so it is out of scope here.

### Data flow

```mermaid
flowchart LR
    subgraph Build["Sample building (CPU, once)"]
        S[build_samples_for_locality_group] --> A["HelpfulWork.samples:<br/>Arc&lt;Vec&lt;HelpfulSample&gt;&gt;"]
    end
    A -- "Arc::clone (refcount, ~122 ns)" --> Q[GPU queue submit]
    A -- "same buffer, shared" --> P[CPU post-processing]
    Q -- "borrow as_slice()" --> G[GPU thread evaluate]
    G --> R[HelpfulStats]
    R --> P
```

Before: every submit deep-copied the whole batch of sample vectors. After: the
submit shares the existing buffers by refcount; the GPU borrows them and the CPU
keeps reading them.

## Evidence

Backend/library change — no web UI to screenshot. Verified via Criterion
benchmarks and the unit/integration test suite.

### Benchmark — `queue_submission_copies` (Issue #1548 additions)

Two new benches build a simulated helpful submit batch (`BATCH_ITEMS = 32` work
items) the pre-fix way (deep clone every sample `Vec`) vs the post-fix way
(`Arc::clone`). Median times:

| samples/item | before: `submit_batch_deep_clone` | after: `submit_batch_arc_clone` | reduction |
|-------------:|----------------------------------:|--------------------------------:|----------:|
| 64           | 3.03 µs                           | 0.123 µs                        | ~96%      |
| 256          | 11.12 µs                          | 0.123 µs                        | ~98.9%    |
| 1024         | 25.86 µs                          | ~0.123 µs                       | ~99.5%    |
| 4096         | 111.80 µs                         | ~0.123 µs                       | ~99.9%    |

`Arc::clone` cost is **flat (~122 ns)** and independent of sample-vector length,
because it is a per-item atomic refcount increment rather than an allocation +
memcpy. The deep-copy cost scales linearly with sample size. This far exceeds the
issue's **≥20% win on the `queue_submission_copies` Criterion suite** success
bar, and — because the deep copy is removed entirely — eliminates the transient
per-submit allocation that drove peak-RSS growth during helpful submit at GRQ
scale.

Run with:

```
cargo bench --bench queue_submission_copies -- submit_batch
```

> Note: the GRQ production fixtures (`../GRQ/.trainData-binary_115`) are not
> available in this environment, so the production-fixture RSS/ms measurement in
> the issue's benchmark plan could not be captured here. The structural win is
> unconditional: the hot submit path no longer allocates or copies the sample
> data.

## Test Plan

New unit tests in `src/analysis/gpu/queue/submission.rs` (run without a GPU):

- `submit_helpful_batch_shares_samples_without_deep_copy` — submits an
  `Arc`-shared batch and asserts, via pointer identity of the enqueued buffer,
  that **no deep copy** crossed the submit boundary, that the strong count
  reflects sharing, and that the caller retains read access afterwards.
- `submit_helpful_batch_empty_is_preresolved` — empty batch resolves to empty
  stats without enqueuing work.
- `evaluate_harmful_batch_empty_returns_empty` — harmful API accepts the
  `Arc`-shared form; empty input returns empty stats.

Regression coverage (unchanged, still green):

- `tests/gpu/gpu_work_queue.rs`, `tests/gpu/issue_953_gpu_queue_deadline.rs` —
  submit/round-trip and deadline-cancellation drop paths (GPU-gated).
- `tests/analysis/issue_568_async_pipeline.rs`,
  `tests/analysis/issue_611_end_to_end_discovery_pipeline.rs` — fixed-seed
  stats/candidate determinism (GPU-gated).

`./quality.sh` passes for every stage relevant to this change — bash syntax,
shellcheck, `cargo build`, `cargo fmt --all`, `cargo clippy --all-targets
--all-features -- -D warnings`, `cargo check --all-targets --all-features`, and
`cargo build --release --lib` — and all 3 new tests plus the full GPU-queue and
epistatic suites are green.

### Known pre-existing flaky test (unrelated)

The full `cargo test --lib -- --test-threads=2` run intermittently fails
`focus::tests::focus_ranking_aborts_when_budget_exceeded` — a **wall-clock**
timing assertion in `src/focus/tests.rs` (untouched by this PR). It asserts a
budget abort completes within `50 ms + 1 s grace + 3×25 ms = 1125 ms`; under the
contention of ~1250 tests sharing two threads (the test drives a real-sleep
`SleepyProvider`) it overshot by ~68 ms (1.193 s). It **passes in isolation**
(1.10 s):

```
cargo test --lib focus::tests::focus_ranking_aborts_when_budget_exceeded
# test result: ok. 1 passed ... finished in 1.10s
```

There is no causal path from this PR's change (Arc-sharing sample buffers on the
GPU submit path) to focus-ranking timing; the flake is environmental and
pre-existing.



## Milestone
This PR is part of the **#1541 perf: production-scale evolution performance proposals (GRQ ed71b732 / trainData-binary_115)** milestone and targets the `milestone/1541-perf-production-scale-evolution-performance-p` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrdqhwvy-46af41`<!-- vibe-worker-issue-1548 -->