### PR TITLE
Drop push-to-Develop trigger from actionlint checker workflow (Issue #1563)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,15 +4,18 @@ name: actionlint
 # rhysd/actionlint — https://github.com/rhysd/actionlint). This is the
 # CI lint gate for the `github-actions` bucket — workflow regressions
 # (bad expressions, missing context, unsupported runner labels, etc.)
-# fail the build before they reach Develop
+# fail the build on the pull request, before they reach Develop.
+#
+# As a checker (not a deploy/publish workflow), this gate runs on the
+# pull request only. A post-merge `push:` run to the default branch
+# (Develop) would merely duplicate the run that already gated the PR,
+# wasting CI minutes — so no `push:` trigger is declared (Issue #1563).
 #
 # Issue #1292.
 
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [main, master, Develop]
 
 # Cancel superseded runs on the same ref (Issue #1288).
 concurrency:

--- a/docs/archive/pr-summaries/pr-summary-1563.md
+++ b/docs/archive/pr-summaries/pr-summary-1563.md
@@ -1,0 +1,66 @@
+## Summary
+
+`.github/workflows/actionlint.yml` is a **checker** workflow — it lints the
+repository's GitHub Actions workflow files. It was triggering on `push` to the
+default branch `Develop` (and `main`/`master`), so every merge into `Develop`
+re-ran the exact lint that had already gated the pull request. That duplicate
+post-merge run wastes CI minutes and can leave a red tick on `Develop` for a
+check that already passed on the PR.
+
+This change drops the `push:` trigger entirely, leaving the `pull_request`
+trigger so the gate runs on the pull request only. This matches the sibling
+checker workflows in this repo (`gitleaks.yml`, `semgrep.yml`, `shellcheck.yml`,
+`cargo-quality.yml`), which are all `pull_request`-only. Deploy/publish/release
+workflows are unaffected — only this checker changed.
+
+Closes #1563.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        PR1[Pull request] --> R1[actionlint runs]
+        M1[Merge to Develop] --> R2[actionlint re-runs<br/>duplicate, wasted]
+    end
+    subgraph After
+        PR2[Pull request] --> R3[actionlint runs]
+        M2[Merge to Develop] --> X[no re-run]
+    end
+```
+
+## Evidence
+
+Backend/CI-config change — no web UI to screenshot. Verified via the workflow
+unit tests in `tests/issue_1292_actionlint_workflow.rs`:
+
+- `actionlint_workflow_triggers_on_pull_request_not_push_develop` — asserts the
+  `on:` block keeps `pull_request` and that no `push:` trigger reaches the
+  default branch `Develop`. Confirmed it **fails** against the pre-fix workflow
+  (with `push: branches: [main, master, Develop]`) and **passes** after the fix
+  — a genuine regression test.
+- The remaining six structural checks (existence, minimal `permissions:`, SHA
+  pinning, job timeout, concurrency, actionlint invocation) still pass
+  unchanged.
+
+## Documented business-logic change
+
+Issue #1292's original test `actionlint_workflow_triggers_on_pull_request_and_push`
+asserted the workflow triggers on `push`. Issue #1563 intentionally removes that
+`push` trigger, so this test was reworked (not deleted) into
+`actionlint_workflow_triggers_on_pull_request_not_push_develop`, which now
+asserts the checker gates the pull request only and does not re-run on push to
+`Develop`. The module doc comment records this supersession.
+
+## Test Plan
+
+- Reworked `tests/issue_1292_actionlint_workflow.rs` trigger test (see above);
+  verified fail-before / pass-after.
+- `cargo test --test issue_1292_actionlint_workflow` — 7 passed.
+- `./quality.sh` — `cargo fmt`, `clippy`, `check` and the release build pass.
+  The test run reported **1259 passed, 1 failed**. The single failure is
+  `focus::tests::focus_ranking_aborts_when_budget_exceeded` — a timing-sensitive
+  regression guard whose ceiling is `budget + grace = 1125ms`; under the loaded
+  build machine the abort took 1150ms (a ~25ms scheduling overshoot). It is
+  **pre-existing and unrelated to this change**: it reproduces identically on the
+  clean base tree (verified via `git stash`), and this PR only edits a workflow
+  YAML trigger and its text-only test — nothing that touches `focus` timing.
+

--- a/tests/issue_1292_actionlint_workflow.rs
+++ b/tests/issue_1292_actionlint_workflow.rs
@@ -5,7 +5,12 @@
 //!
 //! This test reads `.github/workflows/actionlint.yml` and asserts:
 //!   1. The workflow file exists.
-//!   2. It triggers on both `pull_request` and `push`.
+//!   2. It triggers on `pull_request` and does NOT re-run on `push` to
+//!      the default branch `Develop` (Issue #1563): as a checker it
+//!      gates the pull request only, so a duplicate post-merge run is
+//!      not declared. (This point relaxes the original Issue #1292
+//!      requirement of a `push:` trigger — see the note on
+//!      `actionlint_workflow_triggers_on_pull_request_not_push_develop`.)
 //!   3. It declares a top-level minimal `permissions:` block with
 //!      `contents: read` (Issue #1286).
 //!   4. It pins the third-party `raven-actions/actionlint` step to a
@@ -32,20 +37,63 @@ fn actionlint_workflow_exists() {
     );
 }
 
+/// Extract the top-level `on:` block: from the `on:` line to the next
+/// top-level key (a non-space, non-comment line ending in `:`).
+fn on_block(body: &str) -> String {
+    let mut lines = body.lines();
+    let mut block = String::new();
+    let mut in_block = false;
+    for line in lines.by_ref() {
+        if line == "on:" || line.starts_with("on:") && !line.starts_with(' ') {
+            in_block = true;
+            block.push_str(line);
+            block.push('\n');
+            continue;
+        }
+        if in_block {
+            // A sibling top-level key ends the `on:` block.
+            if !line.is_empty()
+                && !line.starts_with(' ')
+                && !line.starts_with('#')
+                && line.trim_end().ends_with(':')
+            {
+                break;
+            }
+            block.push_str(line);
+            block.push('\n');
+        }
+    }
+    block
+}
+
 #[test]
-fn actionlint_workflow_triggers_on_pull_request_and_push() {
+fn actionlint_workflow_triggers_on_pull_request_not_push_develop() {
+    // Issue #1563: as a checker (not a deploy/publish workflow) this
+    // gate must fire on the pull request but must NOT re-run on `push`
+    // to the default branch `Develop`. A post-merge push run would
+    // duplicate the run that already gated the PR — wasting CI minutes
+    // and risking a red tick on Develop for a check that already
+    // passed. This assertion intentionally supersedes the original
+    // Issue #1292 requirement that the workflow trigger on `push`.
     let body = load_workflow();
-    // The `on:` mapping must include both pull_request and push so the
-    // gate fires on PRs (catching regressions) and on direct pushes to
-    // protected branches (catching anything that bypasses PR review).
+    let on = on_block(&body);
     assert!(
-        body.contains("pull_request:"),
-        "actionlint workflow must trigger on pull_request (Issue #1292)"
+        on.contains("pull_request:"),
+        "actionlint workflow must trigger on pull_request (Issue #1292 / #1563)"
     );
-    assert!(
-        body.contains("push:"),
-        "actionlint workflow must trigger on push (Issue #1292)"
-    );
+    // No `push:` trigger may reach the default branch `Develop`. The
+    // finding permits either dropping `push:` entirely or narrowing its
+    // `branches:` to exclude `Develop`; both satisfy this check because
+    // `Develop` must not appear anywhere inside a push trigger.
+    if let Some(push_idx) = on.find("push:") {
+        let push_section = &on[push_idx..];
+        assert!(
+            !push_section.contains("Develop"),
+            "actionlint workflow must not re-run on push to the default \
+             branch `Develop` — drop `push:` or exclude `Develop` from \
+             its branches filter (Issue #1563). Found:\n{on}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`.github/workflows/actionlint.yml` is a **checker** workflow — it lints the
repository's GitHub Actions workflow files. It was triggering on `push` to the
default branch `Develop` (and `main`/`master`), so every merge into `Develop`
re-ran the exact lint that had already gated the pull request. That duplicate
post-merge run wastes CI minutes and can leave a red tick on `Develop` for a
check that already passed on the PR.

This change drops the `push:` trigger entirely, leaving the `pull_request`
trigger so the gate runs on the pull request only. This matches the sibling
checker workflows in this repo (`gitleaks.yml`, `semgrep.yml`, `shellcheck.yml`,
`cargo-quality.yml`), which are all `pull_request`-only. Deploy/publish/release
workflows are unaffected — only this checker changed.

Closes #1563.

```mermaid
flowchart LR
    subgraph Before
        PR1[Pull request] --> R1[actionlint runs]
        M1[Merge to Develop] --> R2[actionlint re-runs<br/>duplicate, wasted]
    end
    subgraph After
        PR2[Pull request] --> R3[actionlint runs]
        M2[Merge to Develop] --> X[no re-run]
    end
```

## Evidence

Backend/CI-config change — no web UI to screenshot. Verified via the workflow
unit tests in `tests/issue_1292_actionlint_workflow.rs`:

- `actionlint_workflow_triggers_on_pull_request_not_push_develop` — asserts the
  `on:` block keeps `pull_request` and that no `push:` trigger reaches the
  default branch `Develop`. Confirmed it **fails** against the pre-fix workflow
  (with `push: branches: [main, master, Develop]`) and **passes** after the fix
  — a genuine regression test.
- The remaining six structural checks (existence, minimal `permissions:`, SHA
  pinning, job timeout, concurrency, actionlint invocation) still pass
  unchanged.

## Documented business-logic change

Issue #1292's original test `actionlint_workflow_triggers_on_pull_request_and_push`
asserted the workflow triggers on `push`. Issue #1563 intentionally removes that
`push` trigger, so this test was reworked (not deleted) into
`actionlint_workflow_triggers_on_pull_request_not_push_develop`, which now
asserts the checker gates the pull request only and does not re-run on push to
`Develop`. The module doc comment records this supersession.

## Test Plan

- Reworked `tests/issue_1292_actionlint_workflow.rs` trigger test (see above);
  verified fail-before / pass-after.
- `cargo test --test issue_1292_actionlint_workflow` — 7 passed.
- `./quality.sh` — `cargo fmt`, `clippy`, `check` and the release build pass.
  The test run reported **1259 passed, 1 failed**. The single failure is
  `focus::tests::focus_ranking_aborts_when_budget_exceeded` — a timing-sensitive
  regression guard whose ceiling is `budget + grace = 1125ms`; under the loaded
  build machine the abort took 1150ms (a ~25ms scheduling overshoot). It is
  **pre-existing and unrelated to this change**: it reproduces identically on the
  clean base tree (verified via `git stash`), and this PR only edits a workflow
  YAML trigger and its text-only test — nothing that touches `focus` timing.




## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrg2rwt2-05ef31`<!-- vibe-worker-issue-1563 -->