### PR TITLE
Remove push trigger to Develop from ci.yml checker workflow (Issue #1564)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,10 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches:
-      - Develop
-    paths-ignore:
-      - '**.md'          # Skip CI for documentation-only changes
-      - 'docs/**'
+  # Checker workflow — gate the pull request only. No `push:` trigger to
+  # `Develop`: every job here is guarded `if: github.event_name ==
+  # 'pull_request'`, so a post-merge push run would only re-run checks that
+  # already passed on the PR, wasting runner capacity (Issue #1564).
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/docs/archive/pr-summaries/pr-summary-1564.md
+++ b/docs/archive/pr-summaries/pr-summary-1564.md
@@ -1,0 +1,56 @@
+## Summary
+
+`ci.yml` is a test/lint/scan **checker** workflow — every job is guarded
+`if: github.event_name == 'pull_request'`. It still triggered on `push:` to the
+default branch (`Develop`), so each merge kicked off a post-merge run that only
+re-ran checks already gated on the PR (and, given the job guards, started an
+otherwise empty run). That wasted runner capacity and risked a stray red tick on
+`Develop`.
+
+This PR drops the `push:` trigger from the `on:` block, keeping the
+`pull_request:` and `workflow_dispatch:` triggers so PRs are still gated and
+manual runs remain available. Deploy/publish/release workflows must keep firing
+on push — a checker gates the PR only.
+
+Closes #1564.
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via new Rust
+tests that parse `.github/workflows/ci.yml` (matching the sibling
+`issue_1288_workflow_concurrency.rs` text-parsing pattern; no YAML parser is in
+the dependency tree) and via `actionlint` (my `on:`-block edit introduced no new
+findings).
+
+```mermaid
+flowchart LR
+    PR[Open / update PR] -->|pull_request| CI[ci.yml checks run]
+    CI --> Merge[Merge to Develop]
+    Merge -.->|push trigger removed #1564| X[no duplicate post-merge run]
+    Manual[Manual dispatch] -->|workflow_dispatch| CI
+```
+
+Before / after `on:` block:
+
+| Trigger            | Before        | After         |
+| ------------------ | ------------- | ------------- |
+| `push: Develop`    | ✅ (duplicate) | ❌ removed     |
+| `pull_request`     | ✅             | ✅ kept        |
+| `workflow_dispatch`| ✅             | ✅ kept        |
+
+## Test Plan
+
+Added `tests/issue_1564_ci_no_push_trigger.rs`:
+
+- `ci_yml_has_no_push_trigger` — reproduces #1564: fails against the unfixed
+  workflow (a `push:` key exists in the `on:` block), passes after removal.
+- `ci_yml_on_block_does_not_reference_develop_push` — guards against a `push:`
+  targeting `Develop` sneaking back in.
+- `ci_yml_keeps_pull_request_and_dispatch_triggers` — asserts the PR and manual
+  triggers are retained.
+
+All three pass; the sibling workflow tests
+(`issue_1288_workflow_concurrency`, `issue_1292_actionlint_workflow`) still pass.
+The full `./quality.sh` suite passes bar one timing-sensitive flake
+(`focus::tests::focus_ranking_aborts_when_budget_exceeded`, 1.189s vs 1.125s
+budget) that is unrelated to this YAML change and passes in isolation.

--- a/tests/issue_1564_ci_no_push_trigger.rs
+++ b/tests/issue_1564_ci_no_push_trigger.rs
@@ -1,0 +1,118 @@
+//! Issue #1564: `ci.yml` is a test/lint/scan workflow whose jobs are all
+//! gated `if: github.event_name == 'pull_request'`. It must gate the pull
+//! request only — it must NOT trigger on `push:` to the default branch
+//! (`Develop`). A post-merge push run only re-runs checks that already
+//! passed on the PR (or, given the job guards, starts an empty run),
+//! wasting runner capacity and risking a stray red tick on `Develop`.
+//!
+//! Deploy/publish/release workflows are different — they must keep firing
+//! on push — but a checker gates the PR only.
+//!
+//! This test parses `ci.yml` as plain text (no YAML parser is in the
+//! dependency tree, matching the sibling workflow tests) and asserts the
+//! top-level `on:` block declares neither a `push:` trigger nor the
+//! `Develop` branch under one, while still keeping the `pull_request:`
+//! and `workflow_dispatch:` triggers.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Return the top-level `on:` block body, from the `on:` header up to the
+/// next top-level key (a line starting at column zero and ending with
+/// `:`) or end of file.
+fn on_block(body: &str) -> Option<String> {
+    let header = "\non:";
+    let start = body.find(header)? + 1; // skip the leading newline
+    let after = &body[start..];
+    let mut search_from = "on:".len();
+    while let Some(nl) = after[search_from..].find('\n') {
+        let line_start = search_from + nl + 1;
+        if line_start >= after.len() {
+            return Some(after.to_string());
+        }
+        let line_end = after[line_start..]
+            .find('\n')
+            .map_or(after.len(), |n| line_start + n);
+        let line = &after[line_start..line_end];
+        // A sibling top-level key: non-space first char, ends with `:`,
+        // and is neither a list item nor a comment.
+        if !line.is_empty()
+            && !line.starts_with(' ')
+            && !line.starts_with('#')
+            && line.trim_end().ends_with(':')
+        {
+            return Some(after[..line_start].to_string());
+        }
+        search_from = line_start;
+    }
+    Some(after.to_string())
+}
+
+#[test]
+fn ci_yml_has_no_push_trigger() {
+    let body = read_workflow("ci.yml");
+    let block = on_block(&body).expect("ci.yml must declare a top-level `on:` block");
+    // No `push:` key at any indentation inside the `on:` block.
+    let has_push = block.lines().any(|l| l.trim_start().starts_with("push:"));
+    assert!(
+        !has_push,
+        "ci.yml is a checker workflow and must not trigger on `push:` — \
+         it should gate the pull request only (Issue #1564). `on:` block:\n{block}",
+    );
+}
+
+#[test]
+fn ci_yml_on_block_does_not_reference_develop_push() {
+    // Guard against a `push:` sneaking back in that targets `Develop`.
+    let body = read_workflow("ci.yml");
+    let block = on_block(&body).expect("ci.yml must declare a top-level `on:` block");
+    let mut in_push = false;
+    for line in block.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("push:") {
+            in_push = true;
+            continue;
+        }
+        // A new top-level (2-space) trigger key ends the push section.
+        if in_push && line.starts_with("  ") && !line.starts_with("    ") && trimmed.ends_with(':')
+        {
+            in_push = false;
+        }
+        if in_push {
+            assert!(
+                !trimmed.contains("Develop"),
+                "ci.yml must not trigger on push to `Develop` (Issue #1564). \
+                 Offending line: {line}",
+            );
+        }
+    }
+}
+
+#[test]
+fn ci_yml_keeps_pull_request_and_dispatch_triggers() {
+    let body = read_workflow("ci.yml");
+    let block = on_block(&body).expect("ci.yml must declare a top-level `on:` block");
+    assert!(
+        block
+            .lines()
+            .any(|l| l.trim_start().starts_with("pull_request:")),
+        "ci.yml must keep its `pull_request:` trigger so PRs are still gated \
+         (Issue #1564). `on:` block:\n{block}",
+    );
+    assert!(
+        block
+            .lines()
+            .any(|l| l.trim_start().starts_with("workflow_dispatch:")),
+        "ci.yml must keep its `workflow_dispatch:` trigger for manual runs \
+         (Issue #1564). `on:` block:\n{block}",
+    );
+}


### PR DESCRIPTION
## Summary

`ci.yml` is a test/lint/scan **checker** workflow — every job is guarded
`if: github.event_name == 'pull_request'`. It still triggered on `push:` to the
default branch (`Develop`), so each merge kicked off a post-merge run that only
re-ran checks already gated on the PR (and, given the job guards, started an
otherwise empty run). That wasted runner capacity and risked a stray red tick on
`Develop`.

This PR drops the `push:` trigger from the `on:` block, keeping the
`pull_request:` and `workflow_dispatch:` triggers so PRs are still gated and
manual runs remain available. Deploy/publish/release workflows must keep firing
on push — a checker gates the PR only.

Closes #1564.

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via new Rust
tests that parse `.github/workflows/ci.yml` (matching the sibling
`issue_1288_workflow_concurrency.rs` text-parsing pattern; no YAML parser is in
the dependency tree) and via `actionlint` (my `on:`-block edit introduced no new
findings).

```mermaid
flowchart LR
    PR[Open / update PR] -->|pull_request| CI[ci.yml checks run]
    CI --> Merge[Merge to Develop]
    Merge -.->|push trigger removed #1564| X[no duplicate post-merge run]
    Manual[Manual dispatch] -->|workflow_dispatch| CI
```

Before / after `on:` block:

| Trigger            | Before        | After         |
| ------------------ | ------------- | ------------- |
| `push: Develop`    | ✅ (duplicate) | ❌ removed     |
| `pull_request`     | ✅             | ✅ kept        |
| `workflow_dispatch`| ✅             | ✅ kept        |

## Test Plan

Added `tests/issue_1564_ci_no_push_trigger.rs`:

- `ci_yml_has_no_push_trigger` — reproduces #1564: fails against the unfixed
  workflow (a `push:` key exists in the `on:` block), passes after removal.
- `ci_yml_on_block_does_not_reference_develop_push` — guards against a `push:`
  targeting `Develop` sneaking back in.
- `ci_yml_keeps_pull_request_and_dispatch_triggers` — asserts the PR and manual
  triggers are retained.

All three pass; the sibling workflow tests
(`issue_1288_workflow_concurrency`, `issue_1292_actionlint_workflow`) still pass.
The full `./quality.sh` suite passes bar one timing-sensitive flake
(`focus::tests::focus_ranking_aborts_when_budget_exceeded`, 1.189s vs 1.125s
budget) that is unrelated to this YAML change and passes in isolation.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrg2rwt2-05ef31`<!-- vibe-worker-issue-1564 -->