### PR TITLE
Drop push trigger from markdown-lint checker workflow (Issue #1565)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,10 +1,12 @@
 name: Markdown Lint
 
+# As a checker (not a deploy/publish workflow), this lint gate runs on the
+# pull request only. A post-merge `push:` run to the default branch
+# (Develop) would merely duplicate the run that already gated the PR,
+# wasting CI minutes — so no `push:` trigger is declared (Issue #1565).
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [main, master, Develop]
 
 # Cancel superseded runs on the same ref (Issue #1288).
 concurrency:

--- a/docs/archive/pr-summaries/pr-summary-1565.md
+++ b/docs/archive/pr-summaries/pr-summary-1565.md
@@ -1,0 +1,61 @@
+# PR Summary — Issue #1565
+
+## Summary
+
+`.github/workflows/markdown-lint.yml` is a test/lint checker workflow, yet it
+still triggered on `push:` to the default branch (`Develop`). Once required as a
+status check, every merge into `Develop` re-ran the lint that already gated the
+pull request — a duplicate post-merge run that wastes CI minutes and can leave a
+stray red tick on the default branch.
+
+This PR drops the `push:` trigger, leaving the workflow to gate the pull request
+only. This aligns `markdown-lint.yml` with its sibling checker workflows —
+`actionlint.yml` (#1563) and `ci.yml` (#1564) — which are already
+`pull_request:`-only. An explanatory comment records the rationale so the
+trigger is not re-added.
+
+Closes #1565.
+
+### Before / After
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A1[PR opened] --> B1[markdownlint runs]
+        A2[Merge to Develop] --> B2[markdownlint runs AGAIN\nduplicate, wastes CI]
+    end
+    subgraph After
+        C1[PR opened] --> D1[markdownlint runs — gates PR]
+        C2[Merge to Develop] --> D2[no re-run]
+    end
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the new
+Rust test that parses the workflow's `on:` block:
+
+- `tests/issue_1565_markdown_lint_no_push_trigger.rs` — 3 tests, all passing:
+  - `markdown_lint_yml_has_no_push_trigger` — no `push:` key in the `on:` block.
+  - `markdown_lint_yml_on_block_does_not_reference_develop_push` — guards against
+    a `push:` to `Develop` sneaking back in.
+  - `markdown_lint_yml_keeps_pull_request_trigger` — the `pull_request:` trigger
+    is retained so PRs are still gated.
+
+The test mirrors the sibling `tests/issue_1564_ci_no_push_trigger.rs`
+(plain-text parse, no YAML parser in the dependency tree).
+
+### Note on `quality.sh`
+
+The full quality gate passed except for one pre-existing flaky timing test,
+`focus::tests::focus_ranking_aborts_when_budget_exceeded` (expected abort within
+1.125s, observed 1.169s under compile load). It is unrelated to this
+YAML/test-only change and passes reliably (3/3) when run in isolation.
+
+## Test Plan
+
+- Added `tests/issue_1565_markdown_lint_no_push_trigger.rs` (3 tests) — fails
+  against the unfixed workflow (which had `push: branches: [main, master,
+  Develop]`) and passes after the `push:` trigger is removed.
+- Ran the new test suite: `cargo test --test
+  issue_1565_markdown_lint_no_push_trigger -- --test-threads=1` → 3 passed.

--- a/tests/issue_1565_markdown_lint_no_push_trigger.rs
+++ b/tests/issue_1565_markdown_lint_no_push_trigger.rs
@@ -1,0 +1,109 @@
+//! Issue #1565: `markdown-lint.yml` is a test/lint workflow. It must gate the
+//! pull request only — it must NOT trigger on `push:` to the default branch
+//! (`Develop`). A post-merge push run only re-runs the lint that already
+//! passed on the PR, wasting runner capacity and risking a stray red tick on
+//! `Develop`.
+//!
+//! Deploy/publish/release workflows are different — they must keep firing on
+//! push — but a checker gates the PR only. This mirrors the sibling checker
+//! workflows (actionlint #1563, ci #1564) which are `pull_request:` only.
+//!
+//! This test parses `markdown-lint.yml` as plain text (no YAML parser is in
+//! the dependency tree, matching the sibling workflow tests) and asserts the
+//! top-level `on:` block declares neither a `push:` trigger nor the `Develop`
+//! branch under one, while still keeping the `pull_request:` trigger.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workflows_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn read_workflow(file_name: &str) -> String {
+    let path = workflows_dir().join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Return the top-level `on:` block body, from the `on:` header up to the
+/// next top-level key (a line starting at column zero and ending with `:`)
+/// or end of file.
+fn on_block(body: &str) -> Option<String> {
+    let header = "\non:";
+    let start = body.find(header)? + 1; // skip the leading newline
+    let after = &body[start..];
+    let mut search_from = "on:".len();
+    while let Some(nl) = after[search_from..].find('\n') {
+        let line_start = search_from + nl + 1;
+        if line_start >= after.len() {
+            return Some(after.to_string());
+        }
+        let line_end = after[line_start..]
+            .find('\n')
+            .map_or(after.len(), |n| line_start + n);
+        let line = &after[line_start..line_end];
+        // A sibling top-level key: non-space first char, ends with `:`,
+        // and is neither a list item nor a comment.
+        if !line.is_empty()
+            && !line.starts_with(' ')
+            && !line.starts_with('#')
+            && line.trim_end().ends_with(':')
+        {
+            return Some(after[..line_start].to_string());
+        }
+        search_from = line_start;
+    }
+    Some(after.to_string())
+}
+
+#[test]
+fn markdown_lint_yml_has_no_push_trigger() {
+    let body = read_workflow("markdown-lint.yml");
+    let block = on_block(&body).expect("markdown-lint.yml must declare a top-level `on:` block");
+    let has_push = block.lines().any(|l| l.trim_start().starts_with("push:"));
+    assert!(
+        !has_push,
+        "markdown-lint.yml is a checker workflow and must not trigger on `push:` — \
+         it should gate the pull request only (Issue #1565). `on:` block:\n{block}",
+    );
+}
+
+#[test]
+fn markdown_lint_yml_on_block_does_not_reference_develop_push() {
+    // Guard against a `push:` sneaking back in that targets `Develop`.
+    let body = read_workflow("markdown-lint.yml");
+    let block = on_block(&body).expect("markdown-lint.yml must declare a top-level `on:` block");
+    let mut in_push = false;
+    for line in block.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("push:") {
+            in_push = true;
+            continue;
+        }
+        // A new top-level (2-space) trigger key ends the push section.
+        if in_push && line.starts_with("  ") && !line.starts_with("    ") && trimmed.ends_with(':')
+        {
+            in_push = false;
+        }
+        if in_push {
+            assert!(
+                !trimmed.contains("Develop"),
+                "markdown-lint.yml must not trigger on push to `Develop` (Issue #1565). \
+                 Offending line: {line}",
+            );
+        }
+    }
+}
+
+#[test]
+fn markdown_lint_yml_keeps_pull_request_trigger() {
+    let body = read_workflow("markdown-lint.yml");
+    let block = on_block(&body).expect("markdown-lint.yml must declare a top-level `on:` block");
+    assert!(
+        block
+            .lines()
+            .any(|l| l.trim_start().starts_with("pull_request:")),
+        "markdown-lint.yml must keep its `pull_request:` trigger so PRs are still gated \
+         (Issue #1565). `on:` block:\n{block}",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1565

## Summary

`.github/workflows/markdown-lint.yml` is a test/lint checker workflow, yet it
still triggered on `push:` to the default branch (`Develop`). Once required as a
status check, every merge into `Develop` re-ran the lint that already gated the
pull request — a duplicate post-merge run that wastes CI minutes and can leave a
stray red tick on the default branch.

This PR drops the `push:` trigger, leaving the workflow to gate the pull request
only. This aligns `markdown-lint.yml` with its sibling checker workflows —
`actionlint.yml` (#1563) and `ci.yml` (#1564) — which are already
`pull_request:`-only. An explanatory comment records the rationale so the
trigger is not re-added.

Closes #1565.

### Before / After

```mermaid
flowchart LR
    subgraph Before
        A1[PR opened] --> B1[markdownlint runs]
        A2[Merge to Develop] --> B2[markdownlint runs AGAIN\nduplicate, wastes CI]
    end
    subgraph After
        C1[PR opened] --> D1[markdownlint runs — gates PR]
        C2[Merge to Develop] --> D2[no re-run]
    end
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the new
Rust test that parses the workflow's `on:` block:

- `tests/issue_1565_markdown_lint_no_push_trigger.rs` — 3 tests, all passing:
  - `markdown_lint_yml_has_no_push_trigger` — no `push:` key in the `on:` block.
  - `markdown_lint_yml_on_block_does_not_reference_develop_push` — guards against
    a `push:` to `Develop` sneaking back in.
  - `markdown_lint_yml_keeps_pull_request_trigger` — the `pull_request:` trigger
    is retained so PRs are still gated.

The test mirrors the sibling `tests/issue_1564_ci_no_push_trigger.rs`
(plain-text parse, no YAML parser in the dependency tree).

### Note on `quality.sh`

The full quality gate passed except for one pre-existing flaky timing test,
`focus::tests::focus_ranking_aborts_when_budget_exceeded` (expected abort within
1.125s, observed 1.169s under compile load). It is unrelated to this
YAML/test-only change and passes reliably (3/3) when run in isolation.

## Test Plan

- Added `tests/issue_1565_markdown_lint_no_push_trigger.rs` (3 tests) — fails
  against the unfixed workflow (which had `push: branches: [main, master,
  Develop]`) and passes after the `push:` trigger is removed.
- Ran the new test suite: `cargo test --test
  issue_1565_markdown_lint_no_push_trigger -- --test-threads=1` → 3 passed.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrg58hrw-c9cb14`<!-- vibe-worker-issue-1565 -->