### PR TITLE
Set persist-credentials: false on actionlint checkout (Issue #1566)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -37,6 +37,12 @@ jobs:
       # Pinned to actions/checkout v6.0.2 (Node.js 24) to match the
       # rest of the workflows in this repository (Issue #1216).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # actionlint only reads workflow files; it never pushes back or
+        # fetches private submodules, so the GITHUB_TOKEN must not be
+        # persisted to .git/config where a later step could read it
+        # (Issue #1566).
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         # Pinned to raven-actions/actionlint v2.1.2 commit SHA

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -36,11 +36,11 @@ jobs:
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24) to match the
       # rest of the workflows in this repository (Issue #1216).
+      # Do not persist the GITHUB_TOKEN to .git/config: this job only reads
+      # the checkout and runs actionlint over .github/workflows — it never
+      # pushes back or fetches a private submodule, so keeping the token on
+      # disk only widens the blast radius of a compromised step (Issue #1566).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        # actionlint only reads workflow files; it never pushes back or
-        # fetches private submodules, so the GITHUB_TOKEN must not be
-        # persisted to .git/config where a later step could read it
-        # (Issue #1566).
         with:
           persist-credentials: false
 

--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -32,7 +32,13 @@ jobs:
     timeout-minutes: 45
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
+      # Do not persist the GITHUB_TOKEN to .git/config: this job only reads
+      # the checkout, builds coverage, and uploads to Codecov — it never
+      # pushes back or fetches a private submodule, so keeping the token on
+      # disk only widens the blast radius of a compromised step (Issue #1567).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # Pinned to a SHA on the action's `stable` branch (Issue #1216).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.125"
+version = "0.74.126"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.125"
+version = "0.74.126"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1566.md
+++ b/docs/archive/pr-summaries/pr-summary-1566.md
@@ -1,0 +1,45 @@
+## Summary
+
+Hardened the `actionlint` workflow's checkout step against `GITHUB_TOKEN`
+leakage. By default `actions/checkout` persists the workflow token into
+`.git/config` as an auth header, where any later step in the job — including a
+compromised dependency or injected script — can read it and act as the token.
+The `actionlint` job only reads workflow files; it never pushes back to the
+repository nor fetches private submodules, so it does not need the persisted
+credential. Added `persist-credentials: false` to stop the token being written
+to disk, shrinking the blast radius of a compromised step.
+
+Closes #1566.
+
+## Evidence
+
+Pure CI/workflow change — no application code or web interface to screenshot.
+Verified locally with `actionlint`:
+
+```
+$ actionlint .github/workflows/actionlint.yml
+actionlint PASS
+```
+
+The checkout step now reads:
+
+```yaml
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+```
+
+```mermaid
+flowchart LR
+    A[checkout step] -->|persist-credentials: false| B[token NOT written to .git/config]
+    B --> C[later steps cannot read GITHUB_TOKEN]
+```
+
+## Test Plan
+
+- Ran `actionlint .github/workflows/actionlint.yml` — passes, confirming the
+  workflow remains syntactically valid after the change.
+- Change addresses the `github-actions-audit` finding
+  `BP-PERSIST-CREDS-actionlint-actionlint-0` by adding
+  `persist-credentials: false` to the flagged checkout step
+  (`.github/workflows/actionlint.yml`).

--- a/docs/archive/pr-summaries/pr-summary-1566.md
+++ b/docs/archive/pr-summaries/pr-summary-1566.md
@@ -4,23 +4,17 @@ Hardened the `actionlint` workflow's checkout step against `GITHUB_TOKEN`
 leakage. By default `actions/checkout` persists the workflow token into
 `.git/config` as an auth header, where any later step in the job — including a
 compromised dependency or injected script — can read it and act as the token.
-The `actionlint` job only reads workflow files; it never pushes back to the
-repository nor fetches private submodules, so it does not need the persisted
-credential. Added `persist-credentials: false` to stop the token being written
-to disk, shrinking the blast radius of a compromised step.
+The `actionlint` job only reads workflow files under `.github/workflows`; it
+never pushes back to the repository nor fetches private submodules, so it does
+not need the persisted credential. Added `persist-credentials: false` to stop the
+token being written to disk, shrinking the blast radius of a compromised step.
+Mirrors the sibling fix applied to `cargo-quality.yml` (Issue #1567).
 
 Closes #1566.
 
 ## Evidence
 
 Pure CI/workflow change — no application code or web interface to screenshot.
-Verified locally with `actionlint`:
-
-```
-$ actionlint .github/workflows/actionlint.yml
-actionlint PASS
-```
-
 The checkout step now reads:
 
 ```yaml
@@ -31,15 +25,32 @@ The checkout step now reads:
 
 ```mermaid
 flowchart LR
-    A[checkout step] -->|persist-credentials: false| B[token NOT written to .git/config]
-    B --> C[later steps cannot read GITHUB_TOKEN]
+    A[checkout without persist-credentials] --> B[GITHUB_TOKEN written to .git/config]
+    B --> C[Any later step can read the token]
+    D[checkout with persist-credentials: false] --> E[Token never written to disk]
+    E --> F[Reduced blast radius]
 ```
+
+TDD confirmation: the new test `actionlint_workflow_checkout_disables_persist_credentials`
+was verified to FAIL against the unfixed workflow and PASS after the fix.
 
 ## Test Plan
 
-- Ran `actionlint .github/workflows/actionlint.yml` — passes, confirming the
-  workflow remains syntactically valid after the change.
-- Change addresses the `github-actions-audit` finding
-  `BP-PERSIST-CREDS-actionlint-actionlint-0` by adding
-  `persist-credentials: false` to the flagged checkout step
-  (`.github/workflows/actionlint.yml`).
+- Added `tests/issue_1292_actionlint_workflow.rs::actionlint_workflow_checkout_disables_persist_credentials`,
+  which parses the checkout step's `with:` block and asserts
+  `persist-credentials: false` is present. This addresses the
+  `github-actions-audit` finding `BP-PERSIST-CREDS-actionlint-actionlint-0`.
+- Ran `cargo test --test issue_1292_actionlint_workflow -- --test-threads=2` —
+  all 8 tests pass (7 existing structural checks + the new credential check).
+- `cargo fmt --all -- --check` and
+  `cargo clippy --test issue_1292_actionlint_workflow --all-features -- -D warnings`
+  pass cleanly.
+
+## Note on quality.sh
+
+`./quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30 —
+a breaking API change (`BufferSlice::map_range`/`get_mapped_range` now return
+`Result`) that fails to compile. This is a pre-existing dependency-upgrade
+breakage unrelated to this YAML/test-only change; the out-of-scope `Cargo.toml`
+/ `Cargo.lock` bumps were reverted. The affected files here (`.github/workflows/`,
+`tests/`) compile, format, lint, and test cleanly against the pinned dependency set.

--- a/docs/archive/pr-summaries/pr-summary-1567.md
+++ b/docs/archive/pr-summaries/pr-summary-1567.md
@@ -1,0 +1,43 @@
+## Summary
+
+Hardened the `coverage` job in `.github/workflows/cargo-quality.yml` by adding
+`persist-credentials: false` to its `actions/checkout` step. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — including a compromised dependency or injected
+script — can read it and act as the token. The `coverage` job only reads the
+checkout, builds coverage with `cargo llvm-cov`, and uploads the report to
+Codecov; it never pushes back to the repository nor fetches a private submodule,
+so it does not need the persisted credential. Disabling persistence keeps the
+token off disk and narrows the blast radius of a compromised step (defence in
+depth, least privilege). Closes #1567.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verification performed:
+
+- `persist-credentials: false` is now present on the `coverage` checkout step
+  and is the only checkout in the workflow.
+- The workflow YAML parses cleanly (`yaml.safe_load` succeeds).
+- The job's remaining steps confirm it neither pushes to the repo nor fetches a
+  private submodule, so removing the persisted credential does not break it.
+
+```mermaid
+flowchart LR
+    A[checkout<br/>persist-credentials: false] --> B[Install Rust toolchain]
+    B --> C[Install cargo-llvm-cov]
+    C --> D[Generate coverage lcov]
+    D --> E[Upload to Codecov]
+    style A fill:#d5f5e3,stroke:#27ae60
+```
+
+No step after checkout reads `.git/config` credentials — the token is no longer
+written to disk.
+
+## Test Plan
+
+- Change is confined to workflow YAML; no Rust source changed, so the Rust
+  `quality.sh` gate (fmt/clippy/check/test/build) is not applicable.
+- Validated the workflow parses as valid YAML.
+- The repository's own `Coverage` workflow runs on this PR and exercises the
+  amended checkout end-to-end, confirming the coverage build and Codecov upload
+  still succeed without the persisted credential.

--- a/tests/issue_1292_actionlint_workflow.rs
+++ b/tests/issue_1292_actionlint_workflow.rs
@@ -200,6 +200,54 @@ fn actionlint_workflow_declares_concurrency() {
 }
 
 #[test]
+fn actionlint_workflow_checkout_disables_persist_credentials() {
+    // Issue #1566: the `actions/checkout` step must set
+    // `persist-credentials: false` so the workflow's GITHUB_TOKEN is not
+    // written to `.git/config`, where a later compromised step could read
+    // it. This job only reads the checkout to lint workflow files — it
+    // never pushes back or fetches a private submodule — so it does not
+    // need the persisted credential.
+    let body = load_workflow();
+    let mut checkout_line: Option<usize> = None;
+    for (idx, line) in body.lines().enumerate() {
+        if line.contains("uses:") && line.contains("actions/checkout@") {
+            checkout_line = Some(idx);
+            break;
+        }
+    }
+    let checkout_idx =
+        checkout_line.expect("actionlint workflow must use actions/checkout (Issue #1566)");
+
+    // Scan the checkout step's `with:` block — the indented lines that
+    // follow the `uses:` line until the next step (`- ...`) or a
+    // dedent to the step-list column.
+    let lines: Vec<&str> = body.lines().collect();
+    let uses_indent = lines[checkout_idx].len() - lines[checkout_idx].trim_start().len();
+    let mut found = false;
+    for line in &lines[checkout_idx + 1..] {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - trimmed.len();
+        // A new list item at or below the `uses:` indent ends this step.
+        if indent <= uses_indent {
+            break;
+        }
+        if trimmed == "persist-credentials: false" {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "actionlint workflow's actions/checkout step must set \
+         `persist-credentials: false` so the GITHUB_TOKEN is not written \
+         to .git/config (Issue #1566)"
+    );
+}
+
+#[test]
 fn actionlint_workflow_invokes_actionlint() {
     let body = load_workflow();
     // Sanity: ensure the workflow actually runs actionlint, either via

--- a/tests/test_cargo_quality_workflow.sh
+++ b/tests/test_cargo_quality_workflow.sh
@@ -92,6 +92,16 @@ assert_pattern_present \
   "contents:[[:space:]]+read" \
   "$WORKFLOW_FILE"
 
+# --- Test: checkout does not persist credentials (Issue #1567) ---
+# The coverage job only reads the tree and uploads coverage; it never
+# pushes back or fetches private submodules, so the workflow's
+# GITHUB_TOKEN must not be written to .git/config where a later
+# compromised step could read it.
+assert_pattern_present \
+  "checkout sets persist-credentials: false" \
+  "persist-credentials:[[:space:]]+false" \
+  "$WORKFLOW_FILE"
+
 # --- Test: duplicate fmt/clippy gates removed (Issue #1289) ---
 # These steps live in ci.yml/quality and re-running them here doubles
 # CI runtime for no extra signal. Their absence is part of the


### PR DESCRIPTION
## Summary

Hardened the `actionlint` workflow's checkout step against `GITHUB_TOKEN`
leakage. By default `actions/checkout` persists the workflow token into
`.git/config` as an auth header, where any later step in the job — including a
compromised dependency or injected script — can read it and act as the token.
The `actionlint` job only reads workflow files under `.github/workflows`; it
never pushes back to the repository nor fetches private submodules, so it does
not need the persisted credential. Added `persist-credentials: false` to stop the
token being written to disk, shrinking the blast radius of a compromised step.
Mirrors the sibling fix applied to `cargo-quality.yml` (Issue #1567).

Closes #1566.

## Evidence

Pure CI/workflow change — no application code or web interface to screenshot.
The checkout step now reads:

```yaml
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
        with:
          persist-credentials: false
```

```mermaid
flowchart LR
    A[checkout without persist-credentials] --> B[GITHUB_TOKEN written to .git/config]
    B --> C[Any later step can read the token]
    D[checkout with persist-credentials: false] --> E[Token never written to disk]
    E --> F[Reduced blast radius]
```

TDD confirmation: the new test `actionlint_workflow_checkout_disables_persist_credentials`
was verified to FAIL against the unfixed workflow and PASS after the fix.

## Test Plan

- Added `tests/issue_1292_actionlint_workflow.rs::actionlint_workflow_checkout_disables_persist_credentials`,
  which parses the checkout step's `with:` block and asserts
  `persist-credentials: false` is present. This addresses the
  `github-actions-audit` finding `BP-PERSIST-CREDS-actionlint-actionlint-0`.
- Ran `cargo test --test issue_1292_actionlint_workflow -- --test-threads=2` —
  all 8 tests pass (7 existing structural checks + the new credential check).
- `cargo fmt --all -- --check` and
  `cargo clippy --test issue_1292_actionlint_workflow --all-features -- -D warnings`
  pass cleanly.

## Note on quality.sh

`./quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30 —
a breaking API change (`BufferSlice::map_range`/`get_mapped_range` now return
`Result`) that fails to compile. This is a pre-existing dependency-upgrade
breakage unrelated to this YAML/test-only change; the out-of-scope `Cargo.toml`
/ `Cargo.lock` bumps were reverted. The affected files here (`.github/workflows/`,
`tests/`) compile, format, lint, and test cleanly against the pinned dependency set.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrggg0fi-ca2840`<!-- vibe-worker-issue-1566 -->