### PR TITLE
Disable credential persistence on coverage checkout (Issue #1567)

### DIFF
--- a/.github/workflows/cargo-quality.yml
+++ b/.github/workflows/cargo-quality.yml
@@ -32,7 +32,13 @@ jobs:
     timeout-minutes: 45
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
+      # Do not persist the GITHUB_TOKEN to .git/config: this job only reads
+      # the checkout, builds coverage, and uploads to Codecov — it never
+      # pushes back or fetches a private submodule, so keeping the token on
+      # disk only widens the blast radius of a compromised step (Issue #1567).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         # Pinned to a SHA on the action's `stable` branch (Issue #1216).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.125"
+version = "0.74.126"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.125"
+version = "0.74.126"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/docs/archive/pr-summaries/pr-summary-1567.md
+++ b/docs/archive/pr-summaries/pr-summary-1567.md
@@ -1,0 +1,43 @@
+## Summary
+
+Hardened the `coverage` job in `.github/workflows/cargo-quality.yml` by adding
+`persist-credentials: false` to its `actions/checkout` step. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — including a compromised dependency or injected
+script — can read it and act as the token. The `coverage` job only reads the
+checkout, builds coverage with `cargo llvm-cov`, and uploads the report to
+Codecov; it never pushes back to the repository nor fetches a private submodule,
+so it does not need the persisted credential. Disabling persistence keeps the
+token off disk and narrows the blast radius of a compromised step (defence in
+depth, least privilege). Closes #1567.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verification performed:
+
+- `persist-credentials: false` is now present on the `coverage` checkout step
+  and is the only checkout in the workflow.
+- The workflow YAML parses cleanly (`yaml.safe_load` succeeds).
+- The job's remaining steps confirm it neither pushes to the repo nor fetches a
+  private submodule, so removing the persisted credential does not break it.
+
+```mermaid
+flowchart LR
+    A[checkout<br/>persist-credentials: false] --> B[Install Rust toolchain]
+    B --> C[Install cargo-llvm-cov]
+    C --> D[Generate coverage lcov]
+    D --> E[Upload to Codecov]
+    style A fill:#d5f5e3,stroke:#27ae60
+```
+
+No step after checkout reads `.git/config` credentials — the token is no longer
+written to disk.
+
+## Test Plan
+
+- Change is confined to workflow YAML; no Rust source changed, so the Rust
+  `quality.sh` gate (fmt/clippy/check/test/build) is not applicable.
+- Validated the workflow parses as valid YAML.
+- The repository's own `Coverage` workflow runs on this PR and exercises the
+  amended checkout end-to-end, confirming the coverage build and Codecov upload
+  still succeed without the persisted credential.

--- a/tests/test_cargo_quality_workflow.sh
+++ b/tests/test_cargo_quality_workflow.sh
@@ -92,6 +92,16 @@ assert_pattern_present \
   "contents:[[:space:]]+read" \
   "$WORKFLOW_FILE"
 
+# --- Test: checkout does not persist credentials (Issue #1567) ---
+# The coverage job only reads the tree and uploads coverage; it never
+# pushes back or fetches private submodules, so the workflow's
+# GITHUB_TOKEN must not be written to .git/config where a later
+# compromised step could read it.
+assert_pattern_present \
+  "checkout sets persist-credentials: false" \
+  "persist-credentials:[[:space:]]+false" \
+  "$WORKFLOW_FILE"
+
 # --- Test: duplicate fmt/clippy gates removed (Issue #1289) ---
 # These steps live in ci.yml/quality and re-running them here doubles
 # CI runtime for no extra signal. Their absence is part of the


### PR DESCRIPTION
## Summary

Hardened the `coverage` job in `.github/workflows/cargo-quality.yml` by adding
`persist-credentials: false` to its `actions/checkout` step. By default checkout
writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job — including a compromised dependency or injected
script — can read it and act as the token. The `coverage` job only reads the
checkout, builds coverage with `cargo llvm-cov`, and uploads the report to
Codecov; it never pushes back to the repository nor fetches a private submodule,
so it does not need the persisted credential. Disabling persistence keeps the
token off disk and narrows the blast radius of a compromised step (defence in
depth, least privilege). Closes #1567.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verification performed:

- `persist-credentials: false` is now present on the `coverage` checkout step
  and is the only checkout in the workflow.
- The workflow YAML parses cleanly (`yaml.safe_load` succeeds).
- The job's remaining steps confirm it neither pushes to the repo nor fetches a
  private submodule, so removing the persisted credential does not break it.

```mermaid
flowchart LR
    A[checkout<br/>persist-credentials: false] --> B[Install Rust toolchain]
    B --> C[Install cargo-llvm-cov]
    C --> D[Generate coverage lcov]
    D --> E[Upload to Codecov]
    style A fill:#d5f5e3,stroke:#27ae60
```

No step after checkout reads `.git/config` credentials — the token is no longer
written to disk.

## Test Plan

- Change is confined to workflow YAML; no Rust source changed, so the Rust
  `quality.sh` gate (fmt/clippy/check/test/build) is not applicable.
- Validated the workflow parses as valid YAML.
- The repository's own `Coverage` workflow runs on this PR and exercises the
  amended checkout end-to-end, confirming the coverage build and Codecov upload
  still succeed without the persisted credential.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrgev0sw-461cde`<!-- vibe-worker-issue-1567 -->