### PR TITLE
Disable credential persistence for spell-check checkout (Issue #1569)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,10 @@ jobs:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+        # Spell-check only reads the tree (codespell); it never pushes back nor
+        # fetches a private submodule, so the token must not be persisted to
+        # .git/config where a later step could read it (Issue #1569).
+        persist-credentials: false
 
     - name: Run codespell
       # Pinned to a 40-char commit SHA (Issue #1216).

--- a/docs/archive/pr-summaries/pr-summary-1569.md
+++ b/docs/archive/pr-summaries/pr-summary-1569.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `spell-check` job in `.github/workflows/ci.yml` ran `actions/checkout`
+without `persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+job — including a compromised dependency or injected script — can read it and
+act as the token. The job only runs codespell over the tree; it never pushes
+back to the repository nor fetches a private submodule, so it does not need the
+persisted credential. Setting `persist-credentials: false` keeps the token off
+disk and narrows the blast radius of a compromised step. Closes #1569.
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot.
+
+Before: the checkout step relied on the default `persist-credentials: true`,
+writing `GITHUB_TOKEN` to `.git/config`. After: the token is not persisted.
+
+```mermaid
+flowchart LR
+    A[checkout] -->|persist-credentials false| B[token NOT in .git/config]
+    B --> C[codespell step cannot read token]
+```
+
+Test results:
+
+```
+test spell_check_checkout_disables_credential_persistence ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+`./quality.sh` passes cleanly (fmt, clippy, check, full test suite, release
+build).
+
+## Test Plan
+
+- Added `tests/issue_1569_spell_check_persist_credentials.rs` — locates the
+  `spell-check` job block in `ci.yml` and asserts its checkout step sets
+  `persist-credentials: false`. The test fails against the unfixed workflow and
+  passes after the change.

--- a/tests/issue_1569_spell_check_persist_credentials.rs
+++ b/tests/issue_1569_spell_check_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1569: the `spell-check` job's `actions/checkout` step in
+//! `.github/workflows/ci.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency — can read it and act as the token. The
+//! `spell-check` job only runs codespell over the tree; it never pushes back to
+//! the repository nor fetches a private submodule, so it does not need the
+//! persisted credential. Disabling persistence narrows the blast radius of a
+//! compromised step.
+//!
+//! This test reads `ci.yml` as plain text (no YAML parser is in the dependency
+//! tree) and asserts the checkout step inside the `spell-check` job carries
+//! `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_ci_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn spell_check_checkout_disables_credential_persistence() {
+    let body = load_ci_yml();
+    let block = job_block(&body, "spell-check")
+        .expect("`spell-check` job not found in ci.yml (Issue #1569)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`spell-check` job should still check out the repository (Issue #1569)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`spell-check` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1569)",
+    );
+}


### PR DESCRIPTION
## Summary

The `spell-check` job in `.github/workflows/ci.yml` ran `actions/checkout`
without `persist-credentials: false`. By default checkout writes the workflow's
`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
job — including a compromised dependency or injected script — can read it and
act as the token. The job only runs codespell over the tree; it never pushes
back to the repository nor fetches a private submodule, so it does not need the
persisted credential. Setting `persist-credentials: false` keeps the token off
disk and narrows the blast radius of a compromised step. Closes #1569.

## Evidence

Backend/CI change only — no web interface to screenshot.

Before: the checkout step relied on the default `persist-credentials: true`,
writing `GITHUB_TOKEN` to `.git/config`. After: the token is not persisted.

```mermaid
flowchart LR
    A[checkout] -->|persist-credentials false| B[token NOT in .git/config]
    B --> C[codespell step cannot read token]
```

Test results:

```
test spell_check_checkout_disables_credential_persistence ... ok
test result: ok. 1 passed; 0 failed
```

`./quality.sh` passes cleanly (fmt, clippy, check, full test suite, release
build).

## Test Plan

- Added `tests/issue_1569_spell_check_persist_credentials.rs` — locates the
  `spell-check` job block in `ci.yml` and asserts its checkout step sets
  `persist-credentials: false`. The test fails against the unfixed workflow and
  passes after the change.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrghzux2-1f0455`<!-- vibe-worker-issue-1569 -->