### PR TITLE
Disable credential persistence in quality job checkout (Issue #1568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,10 @@ jobs:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+        # This job only reads the tree (fmt, clippy, check, build, test) and
+        # never pushes back, so the token must not be written to .git/config
+        # where a later compromised step could read it (Issue #1568).
+        persist-credentials: false
 
     - name: Free up runner disk space
       shell: bash

--- a/docs/archive/pr-summaries/pr-summary-1568.md
+++ b/docs/archive/pr-summaries/pr-summary-1568.md
@@ -1,0 +1,45 @@
+## Summary
+
+The `quality` job's `actions/checkout` step in `.github/workflows/ci.yml` ran
+without `persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
+including a compromised dependency or injected script — could read it and act as
+the token. The `quality` job only reads the tree (fmt, clippy, check, build,
+test) and never pushes back or fetches private submodules, so it does not need
+the persisted credential.
+
+Added `persist-credentials: false` to that checkout step so the token is used
+only for the initial fetch and is never written to disk, narrowing the blast
+radius of a compromised step. Closes #1568.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot. Verified via a
+new plain-text validation test that parses `ci.yml` and asserts the `quality`
+job's checkout step disables credential persistence.
+
+```mermaid
+flowchart LR
+    A[checkout with token] -->|persist-credentials: false| B[token used for fetch only]
+    B --> C[NOT written to .git/config]
+    C --> D[later steps cannot read GITHUB_TOKEN]
+```
+
+Test run:
+
+```
+test quality_checkout_disables_persist_credentials ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+The pre-existing workflow-validation tests (`issue_1286`, `issue_1288`,
+`issue_1564`) still pass, confirming the edit did not regress other ci.yml
+invariants.
+
+## Test Plan
+
+- Added `tests/issue_1568_quality_persist_credentials.rs::quality_checkout_disables_persist_credentials`,
+  which reproduces the finding (fails against the unfixed workflow) and passes
+  after adding `persist-credentials: false`.
+- Re-ran `issue_1286_workflow_permissions`, `issue_1288_workflow_concurrency`,
+  and `issue_1564_ci_no_push_trigger` to confirm no regressions.

--- a/tests/issue_1568_quality_persist_credentials.rs
+++ b/tests/issue_1568_quality_persist_credentials.rs
@@ -1,0 +1,91 @@
+//! Issue #1568: the `quality` job's `actions/checkout` step in
+//! `.github/workflows/ci.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency — can read it and act as the token. The `quality`
+//! job only reads the tree (fmt, clippy, check, build, test) and never pushes
+//! back, so it does not need the persisted credential. Disabling persistence
+//! narrows the blast radius of a compromised step.
+//!
+//! This test reads `ci.yml` as plain text (no YAML parser is in the dependency
+//! tree) and asserts that the checkout `with:` block inside the `quality` job
+//! declares `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_ci_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Extracts the lines belonging to the named top-level job (2-space indent).
+/// The block runs from the `  <job>:` header until the next column-2 job
+/// header or the end of the file.
+fn extract_job<'a>(body: &'a str, job: &str) -> Vec<&'a str> {
+    let header = format!("  {job}:");
+    let lines: Vec<&str> = body.lines().collect();
+    let mut out = Vec::new();
+    let mut inside = false;
+    for line in lines {
+        if line == header {
+            inside = true;
+            continue;
+        }
+        if inside {
+            // A new column-2 job header (`  something:`) ends the block.
+            let is_job_header = line.starts_with("  ")
+                && !line.starts_with("   ")
+                && line.trim_end().ends_with(':')
+                && !line.trim_start().starts_with('-');
+            if is_job_header {
+                break;
+            }
+            out.push(line);
+        }
+    }
+    out
+}
+
+/// Returns true if the checkout step's `with:` block within `job_lines`
+/// declares `persist-credentials: false`.
+fn checkout_disables_persist_credentials(job_lines: &[&str]) -> bool {
+    let mut in_checkout_with = false;
+    for line in job_lines {
+        let trimmed = line.trim_start();
+        // Enter the with: block that follows a checkout `uses:` line.
+        if trimmed.starts_with("uses: actions/checkout@") {
+            in_checkout_with = false; // reset; wait for its `with:`
+            continue;
+        }
+        if trimmed == "with:" {
+            in_checkout_with = true;
+            continue;
+        }
+        // A new step (`- name:`/`- uses:`) ends the current with: block.
+        if in_checkout_with && trimmed.starts_with('-') {
+            in_checkout_with = false;
+        }
+        if in_checkout_with && trimmed == "persist-credentials: false" {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn quality_checkout_disables_persist_credentials() {
+    let body = load_ci_yml();
+    let quality = extract_job(&body, "quality");
+    assert!(
+        !quality.is_empty(),
+        "ci.yml must define a `quality:` job (Issue #1568)"
+    );
+    assert!(
+        checkout_disables_persist_credentials(&quality),
+        "the `quality` job's actions/checkout step must set \
+         `persist-credentials: false` so the GITHUB_TOKEN is not written to \
+         disk (Issue #1568)"
+    );
+}


### PR DESCRIPTION
## Summary

The `quality` job's `actions/checkout` step in `.github/workflows/ci.yml` ran
without `persist-credentials: false`, so `actions/checkout` wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
including a compromised dependency or injected script — could read it and act as
the token. The `quality` job only reads the tree (fmt, clippy, check, build,
test) and never pushes back or fetches private submodules, so it does not need
the persisted credential.

Added `persist-credentials: false` to that checkout step so the token is used
only for the initial fetch and is never written to disk, narrowing the blast
radius of a compromised step. Closes #1568.

## Evidence

Backend/CI-only change — there is no web interface to screenshot. Verified via a
new plain-text validation test that parses `ci.yml` and asserts the `quality`
job's checkout step disables credential persistence.

```mermaid
flowchart LR
    A[checkout with token] -->|persist-credentials: false| B[token used for fetch only]
    B --> C[NOT written to .git/config]
    C --> D[later steps cannot read GITHUB_TOKEN]
```

Test run:

```
test quality_checkout_disables_persist_credentials ... ok
test result: ok. 1 passed; 0 failed
```

The pre-existing workflow-validation tests (`issue_1286`, `issue_1288`,
`issue_1564`) still pass, confirming the edit did not regress other ci.yml
invariants.

## Test Plan

- Added `tests/issue_1568_quality_persist_credentials.rs::quality_checkout_disables_persist_credentials`,
  which reproduces the finding (fails against the unfixed workflow) and passes
  after adding `persist-credentials: false`.
- Re-ran `issue_1286_workflow_permissions`, `issue_1288_workflow_concurrency`,
  and `issue_1564_ci_no_push_trigger` to confirm no regressions.