### PR TITLE
Disable persist-credentials on validation job checkout (Issue #1570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,12 @@ jobs:
     - name: Checkout code
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # This job only reads the tree (file-presence, Cargo.toml field and
+        # documentation checks) and never pushes back, so the token must not be
+        # written to .git/config where a later compromised step could read it
+        # (Issue #1570).
+        persist-credentials: false
 
     - name: Check for required files
       shell: bash

--- a/docs/archive/pr-summaries/pr-summary-1570.md
+++ b/docs/archive/pr-summaries/pr-summary-1570.md
@@ -1,0 +1,63 @@
+# Disable persist-credentials on the `validation` job checkout
+
+## Summary
+
+The `validation` job in `.github/workflows/ci.yml` ran `actions/checkout`
+without `persist-credentials: false`. By default `actions/checkout` writes the
+workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
+step in the job — including a compromised dependency or an injected script —
+can read it and act as the token.
+
+The `validation` job only reads the tree (checks for required files, validates
+`Cargo.toml` fields, and checks documentation) and never pushes back to the
+repository or fetches private submodules, so it does not need the persisted
+credential. Adding `persist-credentials: false` keeps the token off disk and
+narrows the blast radius of a compromised step, matching the pattern already
+applied to the `quality` job (Issue #1568).
+
+Closes #1570.
+
+## Change
+
+```yaml
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+```
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|writes GITHUB_TOKEN to .git/config| B[later step can read token]
+    C[persist-credentials: false] -->|token never on disk| D[compromised step has no token]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+- New regression test `tests/issue_1570_validation_persist_credentials.rs`
+  fails against the unfixed workflow and passes after the fix.
+- `cargo test --test issue_1570_validation_persist_credentials` → 1 passed.
+- Existing workflow guards stay green:
+  `tests/issue_1568_quality_persist_credentials.rs` (1 passed) and
+  `tests/issue_1292_actionlint_workflow.rs` including
+  `actionlint_workflow_checkout_disables_persist_credentials` (8 passed).
+- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D
+  warnings`, and `cargo build` all pass on the pinned dependency set.
+
+### Note on `quality.sh`
+
+`quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29 → 30 (a
+breaking major release) and fails to compile the pre-existing `src/analysis/gpu`
+code. That breakage is unrelated to this security fix and out of scope; the
+dependency reverted to the pinned versions builds and tests cleanly. The wgpu 30
+API migration should be handled as its own change.
+
+## Test Plan
+
+- Added `tests/issue_1570_validation_persist_credentials.rs`:
+  `validation_checkout_disables_persist_credentials` — reads `ci.yml`, extracts
+  the `validation` job block, and asserts its `actions/checkout` `with:` block
+  declares `persist-credentials: false`.
+- Verified the test fails before the workflow edit and passes after.

--- a/tests/issue_1570_validation_persist_credentials.rs
+++ b/tests/issue_1570_validation_persist_credentials.rs
@@ -1,0 +1,92 @@
+//! Issue #1570: the `validation` job's `actions/checkout` step in
+//! `.github/workflows/ci.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency — can read it and act as the token. The
+//! `validation` job only reads the tree (checks for required files, validates
+//! `Cargo.toml`, checks documentation) and never pushes back, so it does not
+//! need the persisted credential. Disabling persistence narrows the blast
+//! radius of a compromised step.
+//!
+//! This test reads `ci.yml` as plain text (no YAML parser is in the dependency
+//! tree) and asserts that the checkout `with:` block inside the `validation`
+//! job declares `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_ci_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/ci.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Extracts the lines belonging to the named top-level job (2-space indent).
+/// The block runs from the `  <job>:` header until the next column-2 job
+/// header or the end of the file.
+fn extract_job<'a>(body: &'a str, job: &str) -> Vec<&'a str> {
+    let header = format!("  {job}:");
+    let lines: Vec<&str> = body.lines().collect();
+    let mut out = Vec::new();
+    let mut inside = false;
+    for line in lines {
+        if line == header {
+            inside = true;
+            continue;
+        }
+        if inside {
+            // A new column-2 job header (`  something:`) ends the block.
+            let is_job_header = line.starts_with("  ")
+                && !line.starts_with("   ")
+                && line.trim_end().ends_with(':')
+                && !line.trim_start().starts_with('-');
+            if is_job_header {
+                break;
+            }
+            out.push(line);
+        }
+    }
+    out
+}
+
+/// Returns true if the checkout step's `with:` block within `job_lines`
+/// declares `persist-credentials: false`.
+fn checkout_disables_persist_credentials(job_lines: &[&str]) -> bool {
+    let mut in_checkout_with = false;
+    for line in job_lines {
+        let trimmed = line.trim_start();
+        // Enter the with: block that follows a checkout `uses:` line.
+        if trimmed.starts_with("uses: actions/checkout@") {
+            in_checkout_with = false; // reset; wait for its `with:`
+            continue;
+        }
+        if trimmed == "with:" {
+            in_checkout_with = true;
+            continue;
+        }
+        // A new step (`- name:`/`- uses:`) ends the current with: block.
+        if in_checkout_with && trimmed.starts_with('-') {
+            in_checkout_with = false;
+        }
+        if in_checkout_with && trimmed == "persist-credentials: false" {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn validation_checkout_disables_persist_credentials() {
+    let body = load_ci_yml();
+    let validation = extract_job(&body, "validation");
+    assert!(
+        !validation.is_empty(),
+        "ci.yml must define a `validation:` job (Issue #1570)"
+    );
+    assert!(
+        checkout_disables_persist_credentials(&validation),
+        "the `validation` job's actions/checkout step must set \
+         `persist-credentials: false` so the GITHUB_TOKEN is not written to \
+         disk (Issue #1570)"
+    );
+}


### PR DESCRIPTION
# Disable persist-credentials on the `validation` job checkout

## Summary

The `validation` job in `.github/workflows/ci.yml` ran `actions/checkout`
without `persist-credentials: false`. By default `actions/checkout` writes the
workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where any later
step in the job — including a compromised dependency or an injected script —
can read it and act as the token.

The `validation` job only reads the tree (checks for required files, validates
`Cargo.toml` fields, and checks documentation) and never pushes back to the
repository or fetches private submodules, so it does not need the persisted
credential. Adding `persist-credentials: false` keeps the token off disk and
narrows the blast radius of a compromised step, matching the pattern already
applied to the `quality` job (Issue #1568).

Closes #1570.

## Change

```yaml
    - name: Checkout code
      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
      with:
        persist-credentials: false
```

```mermaid
flowchart LR
    A[checkout default] -->|writes GITHUB_TOKEN to .git/config| B[later step can read token]
    C[persist-credentials: false] -->|token never on disk| D[compromised step has no token]
```

## Evidence

Backend/CI-only change — no web interface to screenshot.

- New regression test `tests/issue_1570_validation_persist_credentials.rs`
  fails against the unfixed workflow and passes after the fix.
- `cargo test --test issue_1570_validation_persist_credentials` → 1 passed.
- Existing workflow guards stay green:
  `tests/issue_1568_quality_persist_credentials.rs` (1 passed) and
  `tests/issue_1292_actionlint_workflow.rs` including
  `actionlint_workflow_checkout_disables_persist_credentials` (8 passed).
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D
  warnings`, and `cargo build` all pass on the pinned dependency set.

### Note on `quality.sh`

`quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29 → 30 (a
breaking major release) and fails to compile the pre-existing `src/analysis/gpu`
code. That breakage is unrelated to this security fix and out of scope; the
dependency reverted to the pinned versions builds and tests cleanly. The wgpu 30
API migration should be handled as its own change.

## Test Plan

- Added `tests/issue_1570_validation_persist_credentials.rs`:
  `validation_checkout_disables_persist_credentials` — reads `ci.yml`, extracts
  the `validation` job block, and asserts its `actions/checkout` `with:` block
  declares `persist-credentials: false`.
- Verified the test fails before the workflow edit and passes after.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgj67d7-0d3987`<!-- vibe-worker-issue-1570 -->