### PR TITLE
Disable credential persistence in markdownlint checkout (Issue #1572)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       # actions/checkout@v5
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          # Don't persist GITHUB_TOKEN in .git/config — this job only lints
+          # Markdown and never pushes back, so the credential is not needed
+          # and keeping it on disk widens the blast radius (Issue #1572).
+          persist-credentials: false
       # actions/setup-node@v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:

--- a/docs/archive/pr-summaries/pr-summary-1572.md
+++ b/docs/archive/pr-summaries/pr-summary-1572.md
@@ -1,0 +1,58 @@
+# PR Summary — Issue #1572
+
+## Summary
+
+The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — including a compromised dependency — can read it and
+act as the token. This job only lints Markdown; it never pushes back to the
+repository nor fetches a private submodule, so the persisted credential is
+unnecessary and keeping it on disk only widens the blast radius of a compromised
+step.
+
+This PR adds `persist-credentials: false` to the checkout step and a
+text-based regression test that asserts the setting is present. Closes #1572.
+
+```mermaid
+flowchart LR
+    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
+    B --> C[Any later step can read token]
+    A -->|persist-credentials: false| D[No token on disk]
+    D --> E[Blast radius narrowed]
+```
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot.
+
+- New test `tests/issue_1572_markdownlint_persist_credentials.rs` fails against
+  the unfixed workflow and passes after the fix:
+
+  ```
+  running 1 test
+  test markdownlint_checkout_disables_credential_persistence ... ok
+  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+  ```
+
+- `cargo build` (default features) and
+  `cargo clippy --all-targets --all-features -- -D warnings` both pass at the
+  committed dependency versions.
+
+### Quality-gate note (out of scope — tracked by #1594)
+
+`./quality.sh` begins with `cargo upgrade --incompatible`, which force-bumps
+`wgpu` 29 → 30 (plus `pollster` and `naga`). The repo's existing GPU code
+(`src/analysis/gpu/relu_evaluation.rs`) does not compile against wgpu 30, so the
+full gate cannot complete cleanly. This is a pre-existing incompatibility
+unrelated to this workflow change and is already tracked by
+**stSoftwareAU/NEAT-AI-Discovery#1594** (top-priority). This PR keeps the
+dependencies at their committed versions, where the tree — including
+`--all-features` clippy — is clean; the auto-bump has not been included here.
+
+## Test Plan
+
+- Added `tests/issue_1572_markdownlint_persist_credentials.rs::markdownlint_checkout_disables_credential_persistence`,
+  which reads `.github/workflows/markdown-lint.yml`, isolates the `markdownlint`
+  job block, and asserts its checkout step carries `persist-credentials: false`.
+  This reproduces the finding (fails before the fix) and verifies the fix.

--- a/tests/issue_1572_markdownlint_persist_credentials.rs
+++ b/tests/issue_1572_markdownlint_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1572: the `markdownlint` job's `actions/checkout` step in
+//! `.github/workflows/markdown-lint.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency — can read it and act as the token. The
+//! `markdownlint` job only lints Markdown files; it never pushes back to the
+//! repository nor fetches a private submodule, so it does not need the
+//! persisted credential. Disabling persistence narrows the blast radius of a
+//! compromised step.
+//!
+//! This test reads the workflow as plain text (no YAML parser is in the
+//! dependency tree) and asserts the checkout step inside the `markdownlint`
+//! job carries `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_workflow() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/markdown-lint.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn markdownlint_checkout_disables_credential_persistence() {
+    let body = load_workflow();
+    let block = job_block(&body, "markdownlint")
+        .expect("`markdownlint` job not found in markdown-lint.yml (Issue #1572)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`markdownlint` job should still check out the repository (Issue #1572)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`markdownlint` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1572)",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1572

## Summary

The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job — including a compromised dependency — can read it and
act as the token. This job only lints Markdown; it never pushes back to the
repository nor fetches a private submodule, so the persisted credential is
unnecessary and keeping it on disk only widens the blast radius of a compromised
step.

This PR adds `persist-credentials: false` to the checkout step and a
text-based regression test that asserts the setting is present. Closes #1572.

```mermaid
flowchart LR
    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
    B --> C[Any later step can read token]
    A -->|persist-credentials: false| D[No token on disk]
    D --> E[Blast radius narrowed]
```

## Evidence

Backend/CI change — no web interface to screenshot.

- New test `tests/issue_1572_markdownlint_persist_credentials.rs` fails against
  the unfixed workflow and passes after the fix:

  ```
  running 1 test
  test markdownlint_checkout_disables_credential_persistence ... ok
  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  ```

- `cargo build` (default features) and
  `cargo clippy --all-targets --all-features -- -D warnings` both pass at the
  committed dependency versions.

### Quality-gate note (out of scope — tracked by #1594)

`./quality.sh` begins with `cargo upgrade --incompatible`, which force-bumps
`wgpu` 29 → 30 (plus `pollster` and `naga`). The repo's existing GPU code
(`src/analysis/gpu/relu_evaluation.rs`) does not compile against wgpu 30, so the
full gate cannot complete cleanly. This is a pre-existing incompatibility
unrelated to this workflow change and is already tracked by
**stSoftwareAU/NEAT-AI-Discovery#1594** (top-priority). This PR keeps the
dependencies at their committed versions, where the tree — including
`--all-features` clippy — is clean; the auto-bump has not been included here.

## Test Plan

- Added `tests/issue_1572_markdownlint_persist_credentials.rs::markdownlint_checkout_disables_credential_persistence`,
  which reads `.github/workflows/markdown-lint.yml`, isolates the `markdownlint`
  job block, and asserts its checkout step carries `persist-credentials: false`.
  This reproduces the finding (fails before the fix) and verifies the fix.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgnx5rj-30ed67`<!-- vibe-worker-issue-1572 -->