### PR TITLE
Migrate GPU code to wgpu 30 / pollster 1.0 / naga 30 (Issue #1594)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec 0.9.1",
 ]
@@ -753,12 +753,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -886,26 +880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,22 +899,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -948,12 +913,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1218,28 +1180,40 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.16.1",
- "hexf-parse",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "log",
+ "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash",
  "spirv",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash",
+ "thiserror",
 ]
 
 [[package]]
@@ -1348,6 +1322,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1344,17 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags",
  "objc2",
@@ -1385,6 +1382,7 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
 ]
@@ -1516,9 +1514,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "portable-atomic"
@@ -2287,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -2297,7 +2295,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "log",
  "naga",
@@ -2317,21 +2315,22 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
 dependencies = [
  "arrayvec",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bit-vec 0.9.1",
  "bitflags",
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "log",
  "naga",
+ "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -2350,41 +2349,41 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.9.1",
+ "bit-set 0.10.0",
  "bitflags",
  "block2",
  "bytemuck",
@@ -2393,17 +2392,18 @@ dependencies = [
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading",
  "log",
  "naga",
+ "naga-types",
  "ndk-sys",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
  "objc2-quartz-core",
@@ -2418,6 +2418,7 @@ dependencies = [
  "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wayland-sys",
@@ -2431,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -2441,15 +2442,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.4"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags",
  "bytemuck",
  "js-sys",
  "log",
+ "naga-types",
  "raw-window-handle",
+ "static_assertions",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "neat_ai_discovery"
-version = "0.74.126"
+version = "0.74.127"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neat_ai_discovery"
-version = "0.74.126"
+version = "0.74.127"
 edition = "2024"
 license = "Apache-2.0"
 description = "High-performance Rust library for recording neuron activations and errors during NEAT-AI discovery, and scanning the recorded data to identify beneficial new synapses/neurons."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
 thiserror = "2"  # Typed domain error enums (Issue #677)
-parquet = "59.0"  # Apache Parquet format (viewable with standard tools)
-arrow = { version = "59.0", default-features = false }  # Arrow arrays for Parquet
-wgpu = "29"
-pollster = "0.4"
+parquet = "59.1"  # Apache Parquet format (viewable with standard tools)
+arrow = { version = "59.1", default-features = false }  # Arrow arrays for Parquet
+wgpu = "30"
+pollster = "1.0"
 bytemuck = { version = "1.25", features = ["derive"] }
 rayon = "1.12"
 rand = "0.10"
@@ -37,7 +37,7 @@ tempfile = "3.27"
 serial_test = "3.5"
 criterion = { version = "0.8", default-features = false, features = ["rayon", "cargo_bench_support"] }
 proptest = "1.11"  # Property-based testing for mathematical functions (Issue #573)
-naga = { version = "29", features = ["wgsl-in"] }  # WGSL parse/validate for shader behaviour tests (Issue #1467)
+naga = { version = "30", features = ["wgsl-in"] }  # WGSL parse/validate for shader behaviour tests (Issue #1467)
 
 [[bench]]
 name = "synapse_counts"

--- a/docs/archive/pr-summaries/pr-summary-1594.md
+++ b/docs/archive/pr-summaries/pr-summary-1594.md
@@ -1,0 +1,88 @@
+# PR Summary — Issue #1594
+
+## Summary
+
+`quality.sh` runs `cargo upgrade --incompatible` before building, which
+force-bumps `wgpu` 29→30, `pollster` 0.4→1.0, `naga` 29→30 and
+`parquet`/`arrow` 59.0→59.1. The committed GPU source under
+`src/analysis/gpu/*.rs` had not been migrated to the wgpu 30 API, so the build
+failed with 9 errors and the local quality gate could not pass — blocking the
+#1613 dependency-bump-on-every-PR flow.
+
+This PR migrates the GPU code to the wgpu 30 API and bumps
+`Cargo.toml`/`Cargo.lock` to the upgraded versions in the same PR (#1613).
+`Closes #1594`.
+
+### Changes
+
+1. **`RequestAdapterOptions` gained a field.** wgpu 30 added
+   `apply_limit_buckets: bool`. Added `apply_limit_buckets: false` (the correct
+   value for a trusted native app — limit bucketing only matters for
+   fingerprint-resistance when exposing `wgpu` to untrusted web content) to each
+   initializer: `analyzer.rs` (×2) and `device.rs`.
+
+2. **`Buffer::get_mapped_range()` now returns `Result`.** wgpu 30 changed the
+   buffer read-back API to return `Result<BufferView, MapRangeError>`. Each of
+   the six read-back paths (`relu_evaluation.rs`, `bias_evaluation.rs`,
+   `activation_evaluation.rs` ×2, `harmful_evaluation.rs`,
+   `helpful_evaluation.rs`) now unwraps that `Result` with `.context(...)?`
+   **before** `bytemuck::cast_slice`. All six enclosing functions already return
+   `anyhow::Result`, so a map failure now surfaces loudly (Issue #3234 — never
+   fail silently) instead of being masked.
+
+3. **`AdapterInfo` test helper updated for wgpu 30.** In `device.rs`,
+   `transient_saves_memory` changed from `bool` to `Option<bool>`
+   (`Some(false)`), and the new `limit_bucket: Option<AdapterLimitBucketInfo>`
+   field was added as `None`.
+
+4. **`pollster` 1.0 and `naga` 30 verified.** `pollster::block_on` usage
+   compiles unchanged under 1.0; the `naga` 30 (`wgsl-in`) shader
+   parse/validate tests in `shaders.rs` compile and pass unchanged.
+
+```mermaid
+flowchart LR
+    A["cargo upgrade --incompatible"] --> B["wgpu 29 → 30"]
+    B --> C["RequestAdapterOptions<br/>+ apply_limit_buckets"]
+    B --> D["get_mapped_range()<br/>→ Result"]
+    B --> E["AdapterInfo test helper<br/>Option&lt;bool&gt; + limit_bucket"]
+    C --> F["quality.sh green"]
+    D --> F
+    E --> F
+```
+
+## Evidence
+
+Backend/GPU library change — no web interface to screenshot. Verification is via
+the full quality gate, which reproduces the original failure path
+(`cargo upgrade --incompatible` → build) and now passes end-to-end:
+
+- **Before:** 9 compile errors (3× `E0063 missing field apply_limit_buckets`,
+  6× `E0308 mismatched types` at the `get_mapped_range` call sites), plus 2
+  further test-only errors surfaced by `--all-targets` (`AdapterInfo`).
+- **After:** `./quality.sh < /dev/null` passes cleanly — `cargo deny`, debug
+  build, `cargo fmt`, `clippy -D warnings`, `cargo check --all-targets
+  --all-features`, full test suite, `cargo doc -D warnings`, and release build.
+
+Test suite (unchanged, now compiling and passing against wgpu 30 / naga 30):
+
+```
+test result: ok. 171 passed; 0 failed  (lib)
+test result: ok. 289 passed; 0 failed
+test result: ok. 236 passed; 0 failed
+... (all suites green, 0 failed)
+```
+
+## Test Plan
+
+No new synthetic test was added: this is a dependency-migration/build fix, and
+the repo's guidance forbids source-grep tests. The regression guard is the
+existing suite compiling and passing against the upgraded deps — it fails on the
+unfixed tree (build errors) and passes after the migration. Specifically:
+
+- The wgpu 30 `AdapterInfo` construction is exercised by the existing
+  `src/analysis/gpu/device.rs` tests (via the `test_adapter_info` helper, which
+  would not compile with the old field set).
+- The `naga` 30 `wgsl-in` parse/validate path is exercised by the existing
+  shader-validation tests in `src/analysis/gpu/shaders.rs`.
+- The GPU buffer read-back paths run only on real hardware; their correctness is
+  covered by the existing GPU-gated tests where a device is available.

--- a/src/analysis/gpu/activation_evaluation.rs
+++ b/src/analysis/gpu/activation_evaluation.rs
@@ -283,7 +283,9 @@ impl GpuAnalyzer {
         wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("Activation buffer mapping failed")?;
 
-        let data = buffer_slice.get_mapped_range();
+        let data = buffer_slice
+            .get_mapped_range()
+            .context("Activation staging buffer get_mapped_range failed")?;
         let outputs: &[ActivationOutput] = bytemuck::cast_slice(&data);
 
         let mut sum_activation_sq = 0.0f32;
@@ -641,7 +643,9 @@ impl GpuAnalyzer {
         let mut results = Vec::with_capacity(activation_configs.len());
         for staging_buffer in &staging_buffers {
             let buffer_slice = staging_buffer.slice(..);
-            let data = buffer_slice.get_mapped_range();
+            let data = buffer_slice
+                .get_mapped_range()
+                .context("Batched activation staging buffer get_mapped_range failed")?;
             let outputs: &[ActivationOutput] = bytemuck::cast_slice(&data);
 
             let mut sum_activation_sq = 0.0f32;

--- a/src/analysis/gpu/analyzer.rs
+++ b/src/analysis/gpu/analyzer.rs
@@ -279,6 +279,7 @@ impl GpuAnalyzer {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }));
 
         let adapter = match adapter {
@@ -364,6 +365,7 @@ impl GpuAnalyzer {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }));
 
         let adapter = match adapter {

--- a/src/analysis/gpu/bias_evaluation.rs
+++ b/src/analysis/gpu/bias_evaluation.rs
@@ -199,7 +199,9 @@ impl GpuAnalyzer {
         wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("Bias buffer mapping failed")?;
 
-        let data = buffer_slice.get_mapped_range();
+        let data = buffer_slice
+            .get_mapped_range()
+            .context("Bias staging buffer get_mapped_range failed")?;
         let results: &[BiasResult] = bytemuck::cast_slice(&data);
 
         // Find bias with best error reduction

--- a/src/analysis/gpu/device.rs
+++ b/src/analysis/gpu/device.rs
@@ -431,6 +431,7 @@ pub fn get_adapter_info_internal() -> Option<wgpu::AdapterInfo> {
         power_preference: wgpu::PowerPreference::HighPerformance,
         compatible_surface: None,
         force_fallback_adapter: false,
+        apply_limit_buckets: false,
     }))
     .ok()?;
 
@@ -463,7 +464,8 @@ mod tests {
             backend,
             subgroup_min_size: 0,
             subgroup_max_size: 0,
-            transient_saves_memory: false,
+            transient_saves_memory: Some(false),
+            limit_bucket: None,
         }
     }
 

--- a/src/analysis/gpu/harmful_evaluation.rs
+++ b/src/analysis/gpu/harmful_evaluation.rs
@@ -382,7 +382,9 @@ impl GpuAnalyzer {
                     // Buffer is already mapped and verified by wait_for_buffer_maps_batch
                     let staging_buffer = &batch_staging_buffers[buffer_idx];
                     let buffer_slice = staging_buffer.slice(..);
-                    let data = buffer_slice.get_mapped_range();
+                    let data = buffer_slice
+                        .get_mapped_range()
+                        .context("Harmful staging buffer get_mapped_range failed")?;
                     let contributions: &[HarmfulContribution] = bytemuck::cast_slice(&data);
 
                     let mut stats = HarmfulStats::default();

--- a/src/analysis/gpu/helpful_evaluation.rs
+++ b/src/analysis/gpu/helpful_evaluation.rs
@@ -434,7 +434,9 @@ impl GpuAnalyzer {
             let mut batch_results = Vec::with_capacity(used.len());
             for &(slot, copy_size, count, is_reduction) in &used {
                 let buffer_slice = pool[slot].staging_buffer.slice(0..copy_size);
-                let data = buffer_slice.get_mapped_range();
+                let data = buffer_slice
+                    .get_mapped_range()
+                    .context("Helpful staging buffer get_mapped_range failed")?;
                 let contributions: &[HelpfulContribution] = bytemuck::cast_slice(&data);
 
                 let mut stats = HelpfulStats::default();

--- a/src/analysis/gpu/relu_evaluation.rs
+++ b/src/analysis/gpu/relu_evaluation.rs
@@ -177,7 +177,9 @@ impl GpuAnalyzer {
         wait_for_buffer_map(device, &receiver, GPU_BUFFER_MAP_TIMEOUT_SECS)
             .context("ReLU buffer mapping failed")?;
 
-        let data = buffer_slice.get_mapped_range();
+        let data = buffer_slice
+            .get_mapped_range()
+            .context("ReLU staging buffer get_mapped_range failed")?;
         let contributions: &[ReluContribution] = bytemuck::cast_slice(&data);
 
         let mut positive_stats = ReluStats::new(ReluOrientation::Positive);


### PR DESCRIPTION
# PR Summary — Issue #1594

## Summary

`quality.sh` runs `cargo upgrade --incompatible` before building, which
force-bumps `wgpu` 29→30, `pollster` 0.4→1.0, `naga` 29→30 and
`parquet`/`arrow` 59.0→59.1. The committed GPU source under
`src/analysis/gpu/*.rs` had not been migrated to the wgpu 30 API, so the build
failed with 9 errors and the local quality gate could not pass — blocking the
#1613 dependency-bump-on-every-PR flow.

This PR migrates the GPU code to the wgpu 30 API and bumps
`Cargo.toml`/`Cargo.lock` to the upgraded versions in the same PR (#1613).
`Closes #1594`.

### Changes

1. **`RequestAdapterOptions` gained a field.** wgpu 30 added
   `apply_limit_buckets: bool`. Added `apply_limit_buckets: false` (the correct
   value for a trusted native app — limit bucketing only matters for
   fingerprint-resistance when exposing `wgpu` to untrusted web content) to each
   initializer: `analyzer.rs` (×2) and `device.rs`.

2. **`Buffer::get_mapped_range()` now returns `Result`.** wgpu 30 changed the
   buffer read-back API to return `Result<BufferView, MapRangeError>`. Each of
   the six read-back paths (`relu_evaluation.rs`, `bias_evaluation.rs`,
   `activation_evaluation.rs` ×2, `harmful_evaluation.rs`,
   `helpful_evaluation.rs`) now unwraps that `Result` with `.context(...)?`
   **before** `bytemuck::cast_slice`. All six enclosing functions already return
   `anyhow::Result`, so a map failure now surfaces loudly (Issue #3234 — never
   fail silently) instead of being masked.

3. **`AdapterInfo` test helper updated for wgpu 30.** In `device.rs`,
   `transient_saves_memory` changed from `bool` to `Option<bool>`
   (`Some(false)`), and the new `limit_bucket: Option<AdapterLimitBucketInfo>`
   field was added as `None`.

4. **`pollster` 1.0 and `naga` 30 verified.** `pollster::block_on` usage
   compiles unchanged under 1.0; the `naga` 30 (`wgsl-in`) shader
   parse/validate tests in `shaders.rs` compile and pass unchanged.

```mermaid
flowchart LR
    A["cargo upgrade --incompatible"] --> B["wgpu 29 → 30"]
    B --> C["RequestAdapterOptions<br/>+ apply_limit_buckets"]
    B --> D["get_mapped_range()<br/>→ Result"]
    B --> E["AdapterInfo test helper<br/>Option&lt;bool&gt; + limit_bucket"]
    C --> F["quality.sh green"]
    D --> F
    E --> F
```

## Evidence

Backend/GPU library change — no web interface to screenshot. Verification is via
the full quality gate, which reproduces the original failure path
(`cargo upgrade --incompatible` → build) and now passes end-to-end:

- **Before:** 9 compile errors (3× `E0063 missing field apply_limit_buckets`,
  6× `E0308 mismatched types` at the `get_mapped_range` call sites), plus 2
  further test-only errors surfaced by `--all-targets` (`AdapterInfo`).
- **After:** `./quality.sh < /dev/null` passes cleanly — `cargo deny`, debug
  build, `cargo fmt`, `clippy -D warnings`, `cargo check --all-targets
  --all-features`, full test suite, `cargo doc -D warnings`, and release build.

Test suite (unchanged, now compiling and passing against wgpu 30 / naga 30):

```
test result: ok. 171 passed; 0 failed  (lib)
test result: ok. 289 passed; 0 failed
test result: ok. 236 passed; 0 failed
... (all suites green, 0 failed)
```

## Test Plan

No new synthetic test was added: this is a dependency-migration/build fix, and
the repo's guidance forbids source-grep tests. The regression guard is the
existing suite compiling and passing against the upgraded deps — it fails on the
unfixed tree (build errors) and passes after the migration. Specifically:

- The wgpu 30 `AdapterInfo` construction is exercised by the existing
  `src/analysis/gpu/device.rs` tests (via the `test_adapter_info` helper, which
  would not compile with the old field set).
- The `naga` 30 `wgsl-in` parse/validate path is exercised by the existing
  shader-validation tests in `src/analysis/gpu/shaders.rs`.
- The GPU buffer read-back paths run only on real hardware; their correctness is
  covered by the existing GPU-gated tests where a device is available.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgnx5rj-30ed67`<!-- vibe-worker-issue-1594 -->