### PR TITLE
Disable credential persistence in security job checkout (Issue #1573)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # Don't persist GITHUB_TOKEN in .git/config — this job only reads
+          # the diff and never pushes back (Issue #1571).
+          persist-credentials: false
       - name: Install gitleaks
         # Pin the version AND verify the artefact's SHA-256 before
         # extracting it (Issue #1217). Without an integrity check, a

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,14 @@ jobs:
       # Pinned to actions/checkout v6.0.2 (Node.js 24) to avoid the
       # Node.js 20 deprecation warning that will become a hard error on
       # GitHub-hosted runners from September 2026 onwards.
+      #
+      # persist-credentials: false — this job only checks out the tree to run
+      # the cargo-audit / RustSec / dependency-review scans; it never pushes
+      # back or fetches a private submodule, so keeping the GITHUB_TOKEN on
+      # disk only widens the blast radius of a compromised step (Issue #1573).
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Install Rust toolchain
       # Pinned to a SHA on the action's `stable` branch (Issue #1216).

--- a/docs/archive/pr-summaries/pr-summary-1571.md
+++ b/docs/archive/pr-summaries/pr-summary-1571.md
@@ -1,0 +1,30 @@
+## Summary
+
+Hardened the `gitleaks` workflow checkout step by adding `persist-credentials: false`.
+By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into `.git/config`
+as an auth header, where any later step in the job could read it and act as the token.
+The `gitleaks` job only reads the PR diff and never pushes back to the repository or
+fetches private submodules, so it does not need the persisted credential. Removing it
+narrows the blast radius of a compromised step. Closes #1571.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot.
+
+- The `gitleaks` job scans the diff via `gitleaks detect --log-opts <base>..<head>`
+  against the already-fetched history (`fetch-depth: 0`); it performs no `git push`
+  and clones no private submodule, so no persisted credential is required.
+- Workflow YAML validated with `yaml.safe_load` — parses cleanly.
+
+```mermaid
+flowchart LR
+    A[checkout<br/>persist-credentials: false] --> B[Install gitleaks]
+    B --> C[Scan diff for secrets]
+    C -.->|no push-back<br/>token not needed| A
+```
+
+## Test Plan
+
+- Validated `.github/workflows/gitleaks.yml` parses as valid YAML.
+- Confirmed the checkout step now sets `persist-credentials: false` while retaining
+  `fetch-depth: 0` needed for the diff scan.

--- a/docs/archive/pr-summaries/pr-summary-1573.md
+++ b/docs/archive/pr-summaries/pr-summary-1573.md
@@ -1,0 +1,44 @@
+# PR Summary — Issue #1573
+
+## Summary
+
+The `security` job in `.github/workflows/security.yml` checked out the
+repository with `actions/checkout` but did not set `persist-credentials: false`.
+By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+`.git/config` as an auth header, where any later step in the job — including a
+compromised dependency or an injected script — can read it and act as the token.
+
+The `security` job only checks out the tree to run the cargo-audit / RustSec /
+dependency-review scans; it never pushes back to the repository nor fetches a
+private submodule, so it does not need the persisted credential. Disabling
+persistence narrows the blast radius of a compromised step.
+
+This change adds `persist-credentials: false` to the checkout step, matching the
+established pattern already used by the `ci.yml`, `cargo-quality.yml`,
+`actionlint.yml`, and `gitleaks.yml` workflows.
+
+Closes #1573.
+
+## Evidence
+
+This is a CI workflow / configuration change with no web interface to
+screenshot. It is verified by a new plain-text assertion test that reads the
+real workflow file and confirms the `security` job's checkout step carries
+`persist-credentials: false`.
+
+```mermaid
+flowchart LR
+    A[checkout without persist-credentials] --> B[GITHUB_TOKEN written to .git/config]
+    B --> C[Any later step can read & reuse token]
+    A2[checkout persist-credentials: false] --> D[Token not written to disk]
+    D --> E[Narrowed blast radius]
+```
+
+## Test Plan
+
+- Added `tests/issue_1573_security_checkout_persist_credentials.rs` with
+  `security_checkout_disables_credential_persistence`, which locates the
+  `security` job block in `security.yml` and asserts it still checks out the
+  repository and sets `persist-credentials: false`. The test fails against the
+  unfixed workflow and passes after the fix.
+- `./quality.sh` run clean (fmt, Clippy, cargo check, doc build, tests, build).

--- a/tests/issue_1573_security_checkout_persist_credentials.rs
+++ b/tests/issue_1573_security_checkout_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1573: the `security` job's `actions/checkout` step in
+//! `.github/workflows/security.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency or an injected script — can read it and act as the
+//! token. The `security` job only checks out the tree to run the cargo-audit /
+//! `RustSec` / dependency-review scans; it never pushes back to the repository
+//! nor fetches a private submodule, so it does not need the persisted credential.
+//! Disabling persistence narrows the blast radius of a compromised step.
+//!
+//! This test reads `security.yml` as plain text (no YAML parser is in the
+//! dependency tree) and asserts the checkout step inside the `security` job
+//! carries `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_security_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/security.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn security_checkout_disables_credential_persistence() {
+    let body = load_security_yml();
+    let block = job_block(&body, "security")
+        .expect("`security` job not found in security.yml (Issue #1573)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`security` job should still check out the repository (Issue #1573)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`security` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1573)",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1573

## Summary

The `security` job in `.github/workflows/security.yml` checked out the
repository with `actions/checkout` but did not set `persist-credentials: false`.
By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
`.git/config` as an auth header, where any later step in the job — including a
compromised dependency or an injected script — can read it and act as the token.

The `security` job only checks out the tree to run the cargo-audit / RustSec /
dependency-review scans; it never pushes back to the repository nor fetches a
private submodule, so it does not need the persisted credential. Disabling
persistence narrows the blast radius of a compromised step.

This change adds `persist-credentials: false` to the checkout step, matching the
established pattern already used by the `ci.yml`, `cargo-quality.yml`,
`actionlint.yml`, and `gitleaks.yml` workflows.

Closes #1573.

## Evidence

This is a CI workflow / configuration change with no web interface to
screenshot. It is verified by a new plain-text assertion test that reads the
real workflow file and confirms the `security` job's checkout step carries
`persist-credentials: false`.

```mermaid
flowchart LR
    A[checkout without persist-credentials] --> B[GITHUB_TOKEN written to .git/config]
    B --> C[Any later step can read & reuse token]
    A2[checkout persist-credentials: false] --> D[Token not written to disk]
    D --> E[Narrowed blast radius]
```

## Test Plan

- Added `tests/issue_1573_security_checkout_persist_credentials.rs` with
  `security_checkout_disables_credential_persistence`, which locates the
  `security` job block in `security.yml` and asserts it still checks out the
  repository and sets `persist-credentials: false`. The test fails against the
  unfixed workflow and passes after the fix.
- `./quality.sh` run clean (fmt, Clippy, cargo check, doc build, tests, build).



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgnx5rj-30ed67`<!-- vibe-worker-issue-1573 -->