### PR TITLE
Disable credential persistence in semgrep checkout (Issue #1574)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Don't persist GITHUB_TOKEN in .git/config — this job only checks
+          # out the tree to run the semgrep SAST scan and never pushes back
+          # or fetches a private submodule (Issue #1574).
+          persist-credentials: false
       # Exclude renovate-missing-minimum-release-age (Issue #1490): this
       # repo enforces a deliberate, tested supply-chain quarantine of
       # >=24h (Issue #1234; stSoftwareAU/VibeCoding#1614) via an explicit

--- a/docs/archive/pr-summaries/pr-summary-1574.md
+++ b/docs/archive/pr-summaries/pr-summary-1574.md
@@ -1,0 +1,55 @@
+# PR Summary — Issue #1574
+
+## Summary
+
+The `semgrep` job in `.github/workflows/semgrep.yml` ran `actions/checkout`
+without `persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+job — including a compromised dependency or an injected script — can read it and
+act as the token. This job is SAST-only: it checks out the tree to run
+`semgrep ci` and never pushes back to the repository nor fetches a private
+submodule, so the persisted credential is unneeded and only widens the blast
+radius of a compromised step.
+
+Added `persist-credentials: false` to the checkout step, matching the sibling
+fixes already applied to `security.yml` (#1573) and `gitleaks.yml` (#1571).
+
+Closes #1574.
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. The behaviour is
+verified by an integration test plus `actionlint`.
+
+Checkout step before → after:
+
+```mermaid
+flowchart LR
+    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
+    B --> C[readable by any later step]
+    A2[checkout + persist-credentials: false] -->|fixed| D[no token on disk]
+```
+
+Verification:
+
+- `cargo test --test issue_1574_semgrep_checkout_persist_credentials` → 1 passed.
+- `actionlint .github/workflows/semgrep.yml` → OK.
+- `cargo fmt --all -- --check` → clean.
+- `cargo clippy --test issue_1574_... --all-features` (`-D warnings`) → clean.
+- `cargo build --lib` at the pinned dependency versions → clean.
+
+## Test Plan
+
+- Added `tests/issue_1574_semgrep_checkout_persist_credentials.rs`, which reads
+  `semgrep.yml`, isolates the `semgrep` job block, and asserts the checkout step
+  carries `persist-credentials: false`. It reproduces the finding: it fails
+  against the unfixed workflow and passes after the fix.
+
+## Scope note — quality gate dependency bump
+
+`./quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30
+(plus `pollster`, `naga`). `wgpu` 30 is a breaking API change that fails to
+compile the pre-existing GPU code in `src/analysis/gpu/*` (unrelated to this
+issue). That incompatible bump is out of scope for this credentials-only fix, so
+the PR keeps the pinned dependency versions; the lib builds cleanly at those
+pins. The `wgpu` 30 migration is a separate, repo-wide concern.

--- a/tests/issue_1574_semgrep_checkout_persist_credentials.rs
+++ b/tests/issue_1574_semgrep_checkout_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1574: the `semgrep` job's `actions/checkout` step in
+//! `.github/workflows/semgrep.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency or an injected script — can read it and act as the
+//! token. The `semgrep` job only checks out the tree to run the `semgrep ci`
+//! SAST scan; it never pushes back to the repository nor fetches a private
+//! submodule, so it does not need the persisted credential. Disabling
+//! persistence narrows the blast radius of a compromised step.
+//!
+//! This test reads `semgrep.yml` as plain text (no YAML parser is in the
+//! dependency tree) and asserts the checkout step inside the `semgrep` job
+//! carries `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_semgrep_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/semgrep.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn semgrep_checkout_disables_credential_persistence() {
+    let body = load_semgrep_yml();
+    let block =
+        job_block(&body, "semgrep").expect("`semgrep` job not found in semgrep.yml (Issue #1574)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`semgrep` job should still check out the repository (Issue #1574)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`semgrep` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1574)",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1574

## Summary

The `semgrep` job in `.github/workflows/semgrep.yml` ran `actions/checkout`
without `persist-credentials: false`. By default checkout writes the workflow's
`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
job — including a compromised dependency or an injected script — can read it and
act as the token. This job is SAST-only: it checks out the tree to run
`semgrep ci` and never pushes back to the repository nor fetches a private
submodule, so the persisted credential is unneeded and only widens the blast
radius of a compromised step.

Added `persist-credentials: false` to the checkout step, matching the sibling
fixes already applied to `security.yml` (#1573) and `gitleaks.yml` (#1571).

Closes #1574.

## Evidence

Backend/CI change only — no web interface to screenshot. The behaviour is
verified by an integration test plus `actionlint`.

Checkout step before → after:

```mermaid
flowchart LR
    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
    B --> C[readable by any later step]
    A2[checkout + persist-credentials: false] -->|fixed| D[no token on disk]
```

Verification:

- `cargo test --test issue_1574_semgrep_checkout_persist_credentials` → 1 passed.
- `actionlint .github/workflows/semgrep.yml` → OK.
- `cargo fmt --all -- --check` → clean.
- `cargo clippy --test issue_1574_... --all-features` (`-D warnings`) → clean.
- `cargo build --lib` at the pinned dependency versions → clean.

## Test Plan

- Added `tests/issue_1574_semgrep_checkout_persist_credentials.rs`, which reads
  `semgrep.yml`, isolates the `semgrep` job block, and asserts the checkout step
  carries `persist-credentials: false`. It reproduces the finding: it fails
  against the unfixed workflow and passes after the fix.

## Scope note — quality gate dependency bump

`./quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30
(plus `pollster`, `naga`). `wgpu` 30 is a breaking API change that fails to
compile the pre-existing GPU code in `src/analysis/gpu/*` (unrelated to this
issue). That incompatible bump is out of scope for this credentials-only fix, so
the PR keeps the pinned dependency versions; the lib builds cleanly at those
pins. The `wgpu` 30 migration is a separate, repo-wide concern.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgnx5rj-30ed67`<!-- vibe-worker-issue-1574 -->