### PR TITLE
Disable credential persistence in shellcheck checkout (Issue #1575)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,7 +24,13 @@ jobs:
     timeout-minutes: 10
     steps:
       # Pinned to actions/checkout v6.0.2 (Node.js 24). Replaces v4.2.2.
+      # Do not persist the GITHUB_TOKEN to .git/config: this job only reads
+      # the tree to lint bash scripts and never pushes back, so the persisted
+      # credential is unnecessary and only widens the blast radius of a
+      # compromised step (Issue #1575).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run ShellCheck (koalaman/shellcheck)
         # Pinned to a 40-char commit SHA (Issue #1215) to mitigate
         # supply-chain risk from mutable upstream branches. Update via

--- a/docs/archive/pr-summaries/pr-summary-1575.md
+++ b/docs/archive/pr-summaries/pr-summary-1575.md
@@ -1,0 +1,54 @@
+# Disable credential persistence in `shellcheck` checkout
+
+## Summary
+
+The `shellcheck` job in `.github/workflows/shellcheck.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job — including a compromised dependency or an injected
+script — can read it and act as the token. The `shellcheck` job only reads the
+tree to lint bash scripts; it never pushes back to the repository nor fetches a
+private submodule, so it does not need the persisted credential. Disabling
+persistence narrows the blast radius of a compromised step.
+
+This change adds `persist-credentials: false` to the checkout step, matching the
+already-hardened `actionlint`, `security`, `semgrep`, and `gitleaks` workflows
+in this repository. Closes #1575.
+
+```mermaid
+flowchart LR
+    A[checkout default] -->|persist-credentials: true| B[GITHUB_TOKEN in .git/config]
+    B --> C{Compromised later step}
+    C -->|reads token| D[Acts as workflow token]
+    A2[checkout hardened] -->|persist-credentials: false| E[No token on disk]
+    E --> F[Blast radius reduced]
+```
+
+## Evidence
+
+Backend/CI change with no web interface to screenshot. Verified via a new Rust
+test that reads the workflow file and asserts the fix, plus the repository's
+bash-syntax and ShellCheck gates:
+
+- `cargo test --test issue_1575_shellcheck_checkout_persist_credentials` — passes.
+- Sibling workflow tests (`issue_1573_*`, `issue_1574_*`) still pass.
+- `bash -n` syntax check and `shellcheck -s bash` over all scripts — pass.
+
+## Test Plan
+
+- Added `tests/issue_1575_shellcheck_checkout_persist_credentials.rs`, which
+  locates the `shellcheck` job block in the workflow and asserts its checkout
+  step carries `persist-credentials: false`. The test fails against the unfixed
+  workflow and passes after the fix (verified locally).
+
+## Notes for reviewers — dependency bump intentionally omitted
+
+`quality.sh` runs `cargo upgrade --incompatible`, which force-bumps `wgpu`
+29→30, `pollster` 0.4→1.0, and `naga` 29→30. That is a breaking major migration
+that fails to compile the GPU code (`src/analysis/gpu/*`) across ~9 call sites
+and is unrelated to this security fix. It is already tracked by the open
+top-priority issue **#1594** ("quality.sh cargo upgrade --incompatible breaks
+build: GPU code not migrated to wgpu 30 / pollster 1.0 / naga 30"). Per the
+Issue #1613 audit gate (revert a bump that breaks the build), this PR keeps the
+working dependency versions so the scoped security fix lands cleanly; the wgpu
+30 migration remains with #1594.

--- a/tests/issue_1575_shellcheck_checkout_persist_credentials.rs
+++ b/tests/issue_1575_shellcheck_checkout_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1575: the `shellcheck` job's `actions/checkout` step in
+//! `.github/workflows/shellcheck.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency or an injected script — can read it and act as the
+//! token. The `shellcheck` job only checks out the tree to lint bash scripts;
+//! it never pushes back to the repository nor fetches a private submodule, so
+//! it does not need the persisted credential. Disabling persistence narrows
+//! the blast radius of a compromised step.
+//!
+//! This test reads `shellcheck.yml` as plain text (no YAML parser is in the
+//! dependency tree) and asserts the checkout step inside the `shellcheck` job
+//! carries `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_shellcheck_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/shellcheck.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn shellcheck_checkout_disables_credential_persistence() {
+    let body = load_shellcheck_yml();
+    let block = job_block(&body, "shellcheck")
+        .expect("`shellcheck` job not found in shellcheck.yml (Issue #1575)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`shellcheck` job should still check out the repository (Issue #1575)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`shellcheck` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1575)",
+    );
+}


### PR DESCRIPTION
# Disable credential persistence in `shellcheck` checkout

## Summary

The `shellcheck` job in `.github/workflows/shellcheck.yml` ran
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job — including a compromised dependency or an injected
script — can read it and act as the token. The `shellcheck` job only reads the
tree to lint bash scripts; it never pushes back to the repository nor fetches a
private submodule, so it does not need the persisted credential. Disabling
persistence narrows the blast radius of a compromised step.

This change adds `persist-credentials: false` to the checkout step, matching the
already-hardened `actionlint`, `security`, `semgrep`, and `gitleaks` workflows
in this repository. Closes #1575.

```mermaid
flowchart LR
    A[checkout default] -->|persist-credentials: true| B[GITHUB_TOKEN in .git/config]
    B --> C{Compromised later step}
    C -->|reads token| D[Acts as workflow token]
    A2[checkout hardened] -->|persist-credentials: false| E[No token on disk]
    E --> F[Blast radius reduced]
```

## Evidence

Backend/CI change with no web interface to screenshot. Verified via a new Rust
test that reads the workflow file and asserts the fix, plus the repository's
bash-syntax and ShellCheck gates:

- `cargo test --test issue_1575_shellcheck_checkout_persist_credentials` — passes.
- Sibling workflow tests (`issue_1573_*`, `issue_1574_*`) still pass.
- `bash -n` syntax check and `shellcheck -s bash` over all scripts — pass.

## Test Plan

- Added `tests/issue_1575_shellcheck_checkout_persist_credentials.rs`, which
  locates the `shellcheck` job block in the workflow and asserts its checkout
  step carries `persist-credentials: false`. The test fails against the unfixed
  workflow and passes after the fix (verified locally).

## Notes for reviewers — dependency bump intentionally omitted

`quality.sh` runs `cargo upgrade --incompatible`, which force-bumps `wgpu`
29→30, `pollster` 0.4→1.0, and `naga` 29→30. That is a breaking major migration
that fails to compile the GPU code (`src/analysis/gpu/*`) across ~9 call sites
and is unrelated to this security fix. It is already tracked by the open
top-priority issue **#1594** ("quality.sh cargo upgrade --incompatible breaks
build: GPU code not migrated to wgpu 30 / pollster 1.0 / naga 30"). Per the
Issue #1613 audit gate (revert a bump that breaks the build), this PR keeps the
working dependency versions so the scoped security fix lands cleanly; the wgpu
30 migration remains with #1594.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgqgtto-7c7d9d`<!-- vibe-worker-issue-1575 -->