### PR TITLE
Disable credential persistence in markdownlint checkout (Issue #1572)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       # actions/checkout@v5
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          # Lint-only job: no push-back or private submodule fetch, so the
+          # GITHUB_TOKEN must not be persisted to .git/config (Issue #1572).
+          persist-credentials: false
       # actions/setup-node@v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:

--- a/docs/archive/pr-summaries/pr-summary-1572.md
+++ b/docs/archive/pr-summaries/pr-summary-1572.md
@@ -1,0 +1,61 @@
+# PR Summary — Issue #1572
+
+## Summary
+
+The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header,
+where any later step in the job — including a compromised dependency or an
+injected script — can read it and act as the token. This lint-only job never
+pushes back to the repository nor fetches a private submodule, so it does not
+need the persisted credential; keeping it on disk only widens the blast radius
+of a compromised step.
+
+This PR adds `persist-credentials: false` to the checkout step so the token is
+never written to disk, and adds a regression test asserting the setting is
+present. Closes #1572.
+
+## Change
+
+```yaml
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          # Lint-only job: no push-back or private submodule fetch, so the
+          # GITHUB_TOKEN must not be persisted to .git/config (Issue #1572).
+          persist-credentials: false
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via:
+
+- `cargo test --test issue_1572_markdown_lint_persist_credentials` — passes.
+- `cargo test --test issue_1292_actionlint_workflow` — all 8 workflow-hardening
+  assertions still pass.
+- `actionlint .github/workflows/markdown-lint.yml` — clean.
+- `cargo fmt --check` and `cargo clippy` on the new test — clean.
+
+```mermaid
+flowchart LR
+    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
+    B --> C[readable by any later step]
+    A2[checkout<br/>persist-credentials: false] --> D[no token on disk]
+    D --> E[compromised step cannot read token]
+```
+
+## Test Plan
+
+- Added `tests/issue_1572_markdown_lint_persist_credentials.rs` —
+  `markdownlint_checkout_disables_credential_persistence` reads
+  `markdown-lint.yml`, isolates the `markdownlint` job block, and asserts the
+  checkout step carries `persist-credentials: false`. This test fails against
+  the pre-fix workflow and passes after the fix.
+
+## Note
+
+`quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30 and
+breaks unrelated GPU code (`src/analysis/gpu/relu_evaluation.rs`) at compile
+time. That auto-upgrade is out of scope for this credential-persistence fix, so
+the unrelated `Cargo.toml`/`Cargo.lock` bump was reverted and not included here.
+The change compiles and all relevant tests pass against the repository's pinned
+dependencies.

--- a/tests/issue_1572_markdown_lint_persist_credentials.rs
+++ b/tests/issue_1572_markdown_lint_persist_credentials.rs
@@ -1,0 +1,72 @@
+//! Issue #1572: the `markdownlint` job's `actions/checkout` step in
+//! `.github/workflows/markdown-lint.yml` must set `persist-credentials: false`.
+//!
+//! By default `actions/checkout` writes the workflow's `GITHUB_TOKEN` into
+//! `.git/config` as an auth header, where any later step in the job — including
+//! a compromised dependency or an injected script — can read it and act as the
+//! token. The `markdownlint` job only checks out the tree to run the
+//! markdownlint-cli2 lint gate; it never pushes back to the repository nor
+//! fetches a private submodule, so it does not need the persisted credential.
+//! Disabling persistence narrows the blast radius of a compromised step.
+//!
+//! This test reads `markdown-lint.yml` as plain text (no YAML parser is in the
+//! dependency tree) and asserts the checkout step inside the `markdownlint` job
+//! carries `persist-credentials: false`.
+
+use std::fs;
+use std::path::Path;
+
+fn load_markdown_lint_yml() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/markdown-lint.yml");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Locate a job block by name (`<job>:` at two-space indent under `jobs:`) and
+/// return the block body up to the next sibling job or end of file.
+fn job_block<'a>(body: &'a str, job_name: &str) -> Option<&'a str> {
+    let header = format!("  {job_name}:");
+    let start = body.find(&header)?;
+    let after = &body[start..];
+    let bytes = after.as_bytes();
+    let mut search_from = header.len();
+    while search_from < bytes.len() {
+        if let Some(nl) = after[search_from..].find('\n') {
+            let line_start = search_from + nl + 1;
+            if line_start >= bytes.len() {
+                return Some(after);
+            }
+            let line_end = after[line_start..]
+                .find('\n')
+                .map_or(bytes.len(), |n| line_start + n);
+            let line = &after[line_start..line_end];
+            // Sibling job: exactly two spaces then a non-space char, ends `:`.
+            if line.starts_with("  ")
+                && line.as_bytes().get(2).is_some_and(|b| *b != b' ')
+                && line.trim_end().ends_with(':')
+            {
+                return Some(&after[..line_start]);
+            }
+            search_from = line_start;
+        } else {
+            return Some(after);
+        }
+    }
+    Some(after)
+}
+
+#[test]
+fn markdownlint_checkout_disables_credential_persistence() {
+    let body = load_markdown_lint_yml();
+    let block = job_block(&body, "markdownlint")
+        .expect("`markdownlint` job not found in markdown-lint.yml (Issue #1572)");
+
+    assert!(
+        block.contains("uses: actions/checkout@"),
+        "`markdownlint` job should still check out the repository (Issue #1572)",
+    );
+    assert!(
+        block.contains("persist-credentials: false"),
+        "`markdownlint` job's checkout step must set `persist-credentials: false` \
+         so the GITHUB_TOKEN is not written to disk (Issue #1572)",
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #1572

## Summary

The `markdownlint` job in `.github/workflows/markdown-lint.yml` ran
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header,
where any later step in the job — including a compromised dependency or an
injected script — can read it and act as the token. This lint-only job never
pushes back to the repository nor fetches a private submodule, so it does not
need the persisted credential; keeping it on disk only widens the blast radius
of a compromised step.

This PR adds `persist-credentials: false` to the checkout step so the token is
never written to disk, and adds a regression test asserting the setting is
present. Closes #1572.

## Change

```yaml
      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
        with:
          # Lint-only job: no push-back or private submodule fetch, so the
          # GITHUB_TOKEN must not be persisted to .git/config (Issue #1572).
          persist-credentials: false
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via:

- `cargo test --test issue_1572_markdown_lint_persist_credentials` — passes.
- `cargo test --test issue_1292_actionlint_workflow` — all 8 workflow-hardening
  assertions still pass.
- `actionlint .github/workflows/markdown-lint.yml` — clean.
- `cargo fmt --check` and `cargo clippy` on the new test — clean.

```mermaid
flowchart LR
    A[checkout] -->|default| B[GITHUB_TOKEN written to .git/config]
    B --> C[readable by any later step]
    A2[checkout<br/>persist-credentials: false] --> D[no token on disk]
    D --> E[compromised step cannot read token]
```

## Test Plan

- Added `tests/issue_1572_markdown_lint_persist_credentials.rs` —
  `markdownlint_checkout_disables_credential_persistence` reads
  `markdown-lint.yml`, isolates the `markdownlint` job block, and asserts the
  checkout step carries `persist-credentials: false`. This test fails against
  the pre-fix workflow and passes after the fix.

## Note

`quality.sh` runs `cargo upgrade --incompatible`, which bumps `wgpu` 29→30 and
breaks unrelated GPU code (`src/analysis/gpu/relu_evaluation.rs`) at compile
time. That auto-upgrade is out of scope for this credential-persistence fix, so
the unrelated `Cargo.toml`/`Cargo.lock` bump was reverted and not included here.
The change compiles and all relevant tests pass against the repository's pinned
dependencies.



## Milestone
This PR is part of the **Clean up** milestone and targets the `milestone/clean-up` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrgqgtto-7c7d9d`<!-- vibe-worker-issue-1572 -->